### PR TITLE
[upgrade_path] Move the upgrade_path function to upgrade_helpers script

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,13 +124,32 @@ def pytest_addoption(parser):
     ############################
     # platform sfp api options #
     ############################
-
     # Allow user to skip the absent sfp modules. User can use it like below:
     # "--skip-absent-sfp=True"
     # If this option is not specified, False will be used by default.
     parser.addoption("--skip-absent-sfp", action="store", type=bool, default=False,
         help="Skip test on absent SFP",
     )
+
+    ############################
+    # upgrade_path options     #
+    ############################
+    parser.addoption("--upgrade_type", default="warm",
+        help="Specify the type (warm/fast/cold/soft) of upgrade that is needed from source to target image",
+    )
+
+    parser.addoption("--base_image_list", default="",
+        help="Specify the base image(s) for upgrade (comma seperated list is allowed)",
+    )
+
+    parser.addoption("--target_image_list", default="",
+        help="Specify the target image(s) for upgrade (comma seperated list is allowed)",
+    )
+
+    parser.addoption("--restore_to_image", default="",
+        help="Specify the target image to restore to, or stay in target image if empty",
+    )
+
 
 @pytest.fixture(scope="session", autouse=True)
 def enhance_inventory(request):

--- a/tests/upgrade_path/conftest.py
+++ b/tests/upgrade_path/conftest.py
@@ -1,35 +1,6 @@
 import pytest
 
 
-# upgrade_path pytest arguments
-def pytest_addoption(parser):
-    options_group = parser.getgroup("Upgrade_path test suite options")
-
-    options_group.addoption(
-        "--upgrade_type",
-        default="warm",
-        help="Specify the type (warm/fast/cold/soft) of upgrade that is needed from source to target image",
-    )
-
-    options_group.addoption(
-        "--base_image_list",
-        default="",
-        help="Specify the base image(s) for upgrade (comma seperated list is allowed)",
-    )
-
-    options_group.addoption(
-        "--target_image_list",
-        default="",
-        help="Specify the target image(s) for upgrade (comma seperated list is allowed)",
-    )
-
-    options_group.addoption(
-        "--restore_to_image",
-        default="",
-        help="Specify the target image to restore to, or stay in target image if empty",
-    )
-
-
 def pytest_runtest_setup(item):
     from_list = item.config.getoption('base_image_list')
     to_list = item.config.getoption('target_image_list')

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -1,22 +1,14 @@
 import pytest
 import logging
-import json
-import os
-import time
-from urlparse import urlparse
 from datetime import datetime
-from jinja2 import Template
-import ipaddr
-import ipaddress
 from tests.ptf_runner import ptf_runner
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.ssh_utils import prepare_testbed_ssh_keys
 from tests.common import reboot
 from tests.common.reboot import get_reboot_cause, reboot_ctrl_dict
-from tests.common.reboot import REBOOT_TYPE_WARM, REBOOT_TYPE_COLD, REBOOT_TYPE_SOFT
-from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
-
-
+from tests.common.reboot import REBOOT_TYPE_COLD
+from tests.upgrade_path.upgrade_helpers import check_services, install_sonic, check_sonic_version, get_reboot_command
+from tests.upgrade_path.upgrade_helpers import ptf_params, setup  # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses      # lgtm[py/unused-import]
@@ -31,193 +23,45 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 
-TMP_VLAN_PORTCHANNEL_FILE = '/tmp/portchannel_interfaces.json'
-TMP_VLAN_FILE = '/tmp/vlan_interfaces.json'
-TMP_PORTS_FILE = '/tmp/ports.json'
+# upgrade_path pytest arguments
+def pytest_addoption(parser):
+    options_group = parser.getgroup("Upgrade_path test suite options")
 
+    options_group.addoption(
+        "--upgrade_type",
+        default="warm",
+        help="Specify the type (warm/fast/cold) of upgrade that is needed from source to target image",
+    )
+
+    options_group.addoption(
+        "--base_image_list",
+        default="",
+        help="Specify the base image(s) for upgrade (comma seperated list is allowed)",
+    )
+
+    options_group.addoption(
+        "--target_image_list",
+        default="",
+        help="Specify the target image(s) for upgrade (comma seperated list is allowed)",
+    )
+
+    options_group.addoption(
+        "--restore_to_image",
+        default="",
+        help="Specify the target image to restore to, or stay in target image if empty",
+    )
 
 @pytest.fixture(scope="module")
-def setup(localhost, ptfhost, duthosts, rand_one_dut_hostname, upgrade_path_lists, tbinfo):
-    duthost = duthosts[rand_one_dut_hostname]
-    prepare_ptf(ptfhost, duthost, tbinfo)
-    yield
-    cleanup(localhost, ptfhost, duthost, upgrade_path_lists, tbinfo)
+def upgrade_path_lists(request):
+    upgrade_type = request.config.getoption('upgrade_type')
+    from_list = request.config.getoption('base_image_list')
+    to_list = request.config.getoption('target_image_list')
+    restore_to_image = request.config.getoption('restore_to_image')
+    return upgrade_type, from_list, to_list, restore_to_image
 
-
-def cleanup(localhost, ptfhost, duthost, upgrade_path_lists, tbinfo):
-    _, _, _, restore_to_image = upgrade_path_lists
-    if restore_to_image:
-        logger.info("Preparing to cleanup and restore to {}".format(restore_to_image))
-        # restore orignial image
-        install_sonic(duthost, restore_to_image, tbinfo)
-        # Perform a cold reboot
-        reboot(duthost, localhost)
-    # cleanup
-    ptfhost.shell("rm -f {} {} {}".format(TMP_VLAN_FILE, TMP_VLAN_PORTCHANNEL_FILE, TMP_PORTS_FILE),
-                  module_ignore_errors=True)
-    os.remove(TMP_VLAN_FILE)
-    os.remove(TMP_VLAN_PORTCHANNEL_FILE)
-    os.remove(TMP_PORTS_FILE)
-
-
-def prepare_ptf(ptfhost, duthost, tbinfo):
-    logger.info("Preparing ptfhost")
-
-    # Prapare vlan conf file
-    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-
-    with open(TMP_VLAN_PORTCHANNEL_FILE, "w") as file:
-        file.write(json.dumps(mg_facts['minigraph_portchannels']))
-    ptfhost.copy(src=TMP_VLAN_PORTCHANNEL_FILE,
-                 dest=TMP_VLAN_PORTCHANNEL_FILE)
-
-    with open(TMP_VLAN_FILE, "w") as file:
-        file.write(json.dumps(mg_facts['minigraph_vlans']))
-    ptfhost.copy(src=TMP_VLAN_FILE,
-                 dest=TMP_VLAN_FILE)
-
-    with open(TMP_PORTS_FILE, "w") as file:
-        file.write(json.dumps(mg_facts['minigraph_ptf_indices']))
-    ptfhost.copy(src=TMP_PORTS_FILE,
-                 dest=TMP_PORTS_FILE)
-
-    arp_responder_conf = Template(open("../ansible/roles/test/templates/arp_responder.conf.j2").read())
-    ptfhost.copy(content=arp_responder_conf.render(arp_responder_args="-e"),
-                 dest="/etc/supervisor/conf.d/arp_responder.conf")
-
-    ptfhost.shell("supervisorctl reread")
-    ptfhost.shell("supervisorctl update")
-
-
-def ptf_params(duthost, creds, tbinfo, upgrade_type):
-
-    reboot_command = get_reboot_command(duthost, upgrade_type)
-    if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
-        reboot_limit_in_seconds = 200
-    elif 'warm-reboot' in reboot_command:
-        if isMellanoxDevice(duthost):
-            reboot_limit_in_seconds = 1
-        else:
-            reboot_limit_in_seconds = 0
-    else:
-        reboot_limit_in_seconds = 30
-
-    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    lo_v6_prefix = ""
-    for intf in mg_facts["minigraph_lo_interfaces"]:
-        ipn = ipaddr.IPNetwork(intf['addr'])
-        if ipn.version == 6:
-            lo_v6_prefix = str(ipaddr.IPNetwork(intf['addr'] + '/64').network) + '/64'
-            break
-
-    mgFacts = duthost.get_extended_minigraph_facts(tbinfo)
-    vm_hosts = [
-            attr['mgmt_addr'] for dev, attr in mgFacts['minigraph_devices'].items() if attr['hwsku'] == 'Arista-VM'
-        ]
-    sonicadmin_alt_password = duthost.host.options['variable_manager']._hostvars[duthost.hostname].get("ansible_altpassword")
-    vlan_ip_range = dict()
-    for vlan in mgFacts['minigraph_vlan_interfaces']:
-        if type(ipaddress.ip_network(vlan['subnet'])) is ipaddress.IPv4Network:
-            vlan_ip_range[vlan['attachto']] = vlan['subnet']
-    ptf_params = {
-        "verbose": False,
-        "dut_username": creds.get('sonicadmin_user'),
-        "dut_password": creds.get('sonicadmin_password'),
-        "alt_password": sonicadmin_alt_password,
-        "dut_hostname": duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host'],
-        "reboot_limit_in_seconds": reboot_limit_in_seconds,
-        "reboot_type": reboot_command,
-        "portchannel_ports_file": TMP_VLAN_PORTCHANNEL_FILE,
-        "vlan_ports_file": TMP_VLAN_FILE,
-        "ports_file": TMP_PORTS_FILE,
-        "dut_mac": duthost.facts["router_mac"],
-        "default_ip_range": "192.168.100.0/18",
-        "vlan_ip_range": json.dumps(vlan_ip_range),
-        "lo_v6_prefix": lo_v6_prefix,
-        "arista_vms": vm_hosts,
-        "setup_fdb_before_test": True,
-        "target_version": "Unknown"
-    }
-    return ptf_params
-
-
-def get_reboot_command(duthost, upgrade_type):
-    reboot_command = reboot_ctrl_dict.get(upgrade_type).get("command")
-    if upgrade_type == REBOOT_TYPE_WARM:
-        next_os_version = duthost.shell('sonic_installer list | grep Next | cut -f2 -d " "')['stdout']
-        current_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
-        # warm-reboot has to be forced for an upgrade from 201811 to 201811+ to bypass ASIC config changed error
-        if 'SONiC-OS-201811' in current_os_version and 'SONiC-OS-201811' not in next_os_version:
-            reboot_command = "warm-reboot -f"
-    return reboot_command
-
-
-def check_sonic_version(duthost, target_version):
-    current_version = duthost.image_facts()['ansible_facts']['ansible_image_facts']['current']
-    assert current_version == target_version, \
-        "Upgrade sonic failed: target={} current={}".format(target_version, current_version)
-
-
-def install_sonic(duthost, image_url, tbinfo):
-    new_route_added = False
-    if urlparse(image_url).scheme in ('http', 'https',):
-        mg_gwaddr = duthost.get_extended_minigraph_facts(tbinfo).get("minigraph_mgmt_interface", {}).get("gwaddr")
-        mg_gwaddr = ipaddress.IPv4Address(mg_gwaddr)
-        rtinfo_v4 = duthost.get_ip_route_info(ipaddress.ip_network(u'0.0.0.0/0'))
-        for nexthop in rtinfo_v4['nexthops']:
-            if mg_gwaddr == nexthop[0]:
-                break
-        else:
-            # Temporarily change the default route to mgmt-gateway address. This is done so that
-            # DUT can download an image from a remote host over the mgmt network.
-            logger.info("Add default mgmt-gateway-route to the device via {}".format(mg_gwaddr))
-            duthost.shell("ip route add default via {}".format(mg_gwaddr), module_ignore_errors=True)
-            new_route_added = True
-        res = duthost.reduce_and_add_sonic_images(new_image_url=image_url)
-    else:
-        out = duthost.command("df -BM --output=avail /host",
-                        module_ignore_errors=True)["stdout"]
-        avail = int(out.split('\n')[1][:-1])
-        if avail >= 2000:
-            # There is enough space to install directly
-            save_as = "/host/downloaded-sonic-image"
-        else:
-            save_as = "/tmp/tmpfs/downloaded-sonic-image"
-            # Create a tmpfs partition to download image to install
-            duthost.shell("mkdir -p /tmp/tmpfs", module_ignore_errors=True)
-            duthost.shell("umount /tmp/tmpfs", module_ignore_errors=True)
-            duthost.shell("mount -t tmpfs -o size=1300M tmpfs /tmp/tmpfs", module_ignore_errors=True)
-        logger.info("Image exists locally. Copying the image {} into the device path {}".format(image_url, save_as))
-        duthost.copy(src=image_url, dest=save_as)
-        res = duthost.reduce_and_add_sonic_images(save_as=save_as)
-
-    # if the new default mgmt-gateway route was added, remove it. This is done so that
-    # default route src address matches Loopback0 address
-    if new_route_added:
-        logger.info("Remove default mgmt-gateway-route earlier added")
-        duthost.shell("ip route del default via {}".format(mg_gwaddr), module_ignore_errors=True)
-    return res['ansible_facts']['downloaded_image_version']
-
-
-def check_services(duthost):
-    """
-    Perform a health check of services
-    """
-    logging.info("Wait until DUT uptime reaches {}s".format(300))
-    while duthost.get_uptime().total_seconds() < 300:
-            time.sleep(1)
-    logging.info("Wait until all critical services are fully started")
-    logging.info("Check critical service status")
-    pytest_assert(duthost.critical_services_fully_started(), "dut.critical_services_fully_started is False")
-
-    for service in duthost.critical_services:
-        status = duthost.get_service_props(service)
-        pytest_assert(status["ActiveState"] == "active", "ActiveState of {} is {}, expected: active".format(service, status["ActiveState"]))
-        pytest_assert(status["SubState"] == "running", "SubState of {} is {}, expected: running".format(service, status["SubState"]))
-        
 
 @pytest.mark.device_type('vs')
-def test_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, upgrade_path_lists, setup, creds, tbinfo):
+def test_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, upgrade_path_lists, ptf_params, setup, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
     upgrade_type, from_list_images, to_list_images, _ = upgrade_path_lists
     from_list = from_list_images.split(',')
@@ -237,28 +81,24 @@ def test_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, upgra
             # Install target image
             logger.info("Upgrading to {}".format(to_image))
             target_version = install_sonic(duthost, to_image, tbinfo)
-            test_params = ptf_params(duthost, creds, tbinfo, upgrade_type)
+            test_params = ptf_params
             test_params['target_version'] = target_version
+            test_params['reboot_type'] = get_reboot_command(duthost, upgrade_type)
             prepare_testbed_ssh_keys(duthost, ptfhost, test_params['dut_username'])
             log_file = "/tmp/advanced-reboot.ReloadTest.{}.log".format(datetime.now().strftime('%Y-%m-%d-%H:%M:%S'))
             if test_params['reboot_type'] == reboot_ctrl_dict.get(REBOOT_TYPE_COLD).get("command"):
                 # advance-reboot test (on ptf) does not support cold reboot yet
                 reboot(duthost, localhost)
             else:
-                if test_params['reboot_type'] == reboot_ctrl_dict.get(REBOOT_TYPE_SOFT).get("command"):
-                    # advance-reboot test (on ptf) does not support SOFT reboot yet
-                    reboot(duthost, localhost, REBOOT_TYPE_SOFT)
-                else:
-                    ptf_runner(ptfhost,
-                            "ptftests",
-                            "advanced-reboot.ReloadTest",
-                            platform_dir="ptftests",
-                            params=test_params,
-                            platform="remote",
-                            qlen=10000,
-                            log_file=log_file)
+                ptf_runner(ptfhost,
+                        "ptftests",
+                        "advanced-reboot.ReloadTest",
+                        platform_dir="ptftests",
+                        params=test_params,
+                        platform="remote",
+                        qlen=10000,
+                        log_file=log_file)
             reboot_cause = get_reboot_cause(duthost)
             logger.info("Check reboot cause. Expected cause {}".format(upgrade_type))
             pytest_assert(reboot_cause == upgrade_type, "Reboot cause {} did not match the trigger - {}".format(reboot_cause, upgrade_type))
             check_services(duthost)
-

--- a/tests/upgrade_path/upgrade_helpers.py
+++ b/tests/upgrade_path/upgrade_helpers.py
@@ -4,21 +4,13 @@ import json
 import os
 import time
 from urlparse import urlparse
-from datetime import datetime
 from jinja2 import Template
 import ipaddr
 import ipaddress
-from tests.ptf_runner import ptf_runner
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.platform.ssh_utils import prepare_testbed_ssh_keys
 from tests.common import reboot
 from tests.common.reboot import get_reboot_cause, reboot_ctrl_dict
-from tests.common.reboot import REBOOT_TYPE_WARM, REBOOT_TYPE_COLD
-
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import remove_ip_addresses      # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # lgtm[py/unused-import]
+from tests.common.reboot import REBOOT_TYPE_WARM
 
 logger = logging.getLogger(__name__)
 

--- a/tests/upgrade_path/upgrade_helpers.py
+++ b/tests/upgrade_path/upgrade_helpers.py
@@ -1,0 +1,219 @@
+import pytest
+import logging
+import json
+import os
+import time
+from urlparse import urlparse
+from datetime import datetime
+from jinja2 import Template
+import ipaddr
+import ipaddress
+from tests.ptf_runner import ptf_runner
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.ssh_utils import prepare_testbed_ssh_keys
+from tests.common import reboot
+from tests.common.reboot import get_reboot_cause, reboot_ctrl_dict
+from tests.common.reboot import REBOOT_TYPE_WARM, REBOOT_TYPE_COLD
+
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # lgtm[py/unused-import]
+
+logger = logging.getLogger(__name__)
+
+TMP_VLAN_PORTCHANNEL_FILE = '/tmp/portchannel_interfaces.json'
+TMP_VLAN_FILE = '/tmp/vlan_interfaces.json'
+TMP_PORTS_FILE = '/tmp/ports.json'
+
+
+def pytest_runtest_setup(item):
+    from_list = item.config.getoption('base_image_list')
+    to_list = item.config.getoption('target_image_list')
+    if not from_list or not to_list:
+        pytest.skip("base_image_list or target_image_list is empty")
+
+
+def cleanup(localhost, ptfhost, duthost, upgrade_path_lists, tbinfo):
+    _, _, _, restore_to_image = upgrade_path_lists
+    if restore_to_image:
+        logger.info("Preparing to cleanup and restore to {}".format(restore_to_image))
+        # restore orignial image
+        install_sonic(duthost, restore_to_image, tbinfo)
+        # Perform a cold reboot
+        reboot(duthost, localhost)
+    # cleanup
+    ptfhost.shell("rm -f {} {} {}".format(TMP_VLAN_FILE, TMP_VLAN_PORTCHANNEL_FILE, TMP_PORTS_FILE),
+                  module_ignore_errors=True)
+    os.remove(TMP_VLAN_FILE)
+    os.remove(TMP_VLAN_PORTCHANNEL_FILE)
+    os.remove(TMP_PORTS_FILE)
+
+
+def prepare_ptf(ptfhost, duthost, tbinfo):
+    logger.info("Preparing ptfhost")
+
+    # Prapare vlan conf file
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+
+    with open(TMP_VLAN_PORTCHANNEL_FILE, "w") as file:
+        file.write(json.dumps(mg_facts['minigraph_portchannels']))
+    ptfhost.copy(src=TMP_VLAN_PORTCHANNEL_FILE,
+                 dest=TMP_VLAN_PORTCHANNEL_FILE)
+
+    with open(TMP_VLAN_FILE, "w") as file:
+        file.write(json.dumps(mg_facts['minigraph_vlans']))
+    ptfhost.copy(src=TMP_VLAN_FILE,
+                 dest=TMP_VLAN_FILE)
+
+    with open(TMP_PORTS_FILE, "w") as file:
+        file.write(json.dumps(mg_facts['minigraph_ptf_indices']))
+    ptfhost.copy(src=TMP_PORTS_FILE,
+                 dest=TMP_PORTS_FILE)
+
+    arp_responder_conf = Template(open("../ansible/roles/test/templates/arp_responder.conf.j2").read())
+    ptfhost.copy(content=arp_responder_conf.render(arp_responder_args="-e"),
+                 dest="/etc/supervisor/conf.d/arp_responder.conf")
+
+    ptfhost.shell("supervisorctl reread")
+    ptfhost.shell("supervisorctl update")
+
+
+def get_reboot_command(duthost, upgrade_type):
+    reboot_command = reboot_ctrl_dict.get(upgrade_type).get("command")
+    if upgrade_type == REBOOT_TYPE_WARM:
+        next_os_version = duthost.shell('sonic_installer list | grep Next | cut -f2 -d " "')['stdout']
+        current_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
+        # warm-reboot has to be forced for an upgrade from 201811 to 201811+ to bypass ASIC config changed error
+        if 'SONiC-OS-201811' in current_os_version and 'SONiC-OS-201811' not in next_os_version:
+            reboot_command = "warm-reboot -f"
+    return reboot_command
+
+
+def check_sonic_version(duthost, target_version):
+    current_version = duthost.image_facts()['ansible_facts']['ansible_image_facts']['current']
+    assert current_version == target_version, \
+        "Upgrade sonic failed: target={} current={}".format(target_version, current_version)
+
+
+def install_sonic(duthost, image_url, tbinfo):
+    new_route_added = False
+    if urlparse(image_url).scheme in ('http', 'https',):
+        mg_gwaddr = duthost.get_extended_minigraph_facts(tbinfo).get("minigraph_mgmt_interface", {}).get("gwaddr")
+        mg_gwaddr = ipaddress.IPv4Address(mg_gwaddr)
+        rtinfo_v4 = duthost.get_ip_route_info(ipaddress.ip_network(u'0.0.0.0/0'))
+        for nexthop in rtinfo_v4['nexthops']:
+            if mg_gwaddr == nexthop[0]:
+                break
+        else:
+            # Temporarily change the default route to mgmt-gateway address. This is done so that
+            # DUT can download an image from a remote host over the mgmt network.
+            logger.info("Add default mgmt-gateway-route to the device via {}".format(mg_gwaddr))
+            duthost.shell("ip route add default via {}".format(mg_gwaddr), module_ignore_errors=True)
+            new_route_added = True
+        res = duthost.reduce_and_add_sonic_images(new_image_url=image_url)
+    else:
+        out = duthost.command("df -BM --output=avail /host",
+                        module_ignore_errors=True)["stdout"]
+        avail = int(out.split('\n')[1][:-1])
+        if avail >= 2000:
+            # There is enough space to install directly
+            save_as = "/host/downloaded-sonic-image"
+        else:
+            save_as = "/tmp/tmpfs/downloaded-sonic-image"
+            # Create a tmpfs partition to download image to install
+            duthost.shell("mkdir -p /tmp/tmpfs", module_ignore_errors=True)
+            duthost.shell("umount /tmp/tmpfs", module_ignore_errors=True)
+            duthost.shell("mount -t tmpfs -o size=1300M tmpfs /tmp/tmpfs", module_ignore_errors=True)
+        logger.info("Image exists locally. Copying the image {} into the device path {}".format(image_url, save_as))
+        duthost.copy(src=image_url, dest=save_as)
+        res = duthost.reduce_and_add_sonic_images(save_as=save_as)
+
+    # if the new default mgmt-gateway route was added, remove it. This is done so that
+    # default route src address matches Loopback0 address
+    if new_route_added:
+        logger.info("Remove default mgmt-gateway-route earlier added")
+        duthost.shell("ip route del default via {}".format(mg_gwaddr), module_ignore_errors=True)
+    return res['ansible_facts']['downloaded_image_version']
+
+
+def check_services(duthost):
+    """
+    Perform a health check of services
+    """
+    logging.info("Wait until DUT uptime reaches {}s".format(300))
+    while duthost.get_uptime().total_seconds() < 300:
+            time.sleep(1)
+    logging.info("Wait until all critical services are fully started")
+    logging.info("Check critical service status")
+    pytest_assert(duthost.critical_services_fully_started(), "dut.critical_services_fully_started is False")
+
+    for service in duthost.critical_services:
+        status = duthost.get_service_props(service)
+        pytest_assert(status["ActiveState"] == "active", "ActiveState of {} is {}, expected: active".format(service, status["ActiveState"]))
+        pytest_assert(status["SubState"] == "running", "SubState of {} is {}, expected: running".format(service, status["SubState"]))
+
+
+def check_reboot_cause(duthost, expected_cause):
+    reboot_cause = get_reboot_cause(duthost)
+    logging.info("Checking cause from dut {} to expected {}".format(reboot_cause, expected_cause))
+    return reboot_cause == expected_cause
+
+
+@pytest.fixture(scope="module")
+def setup(localhost, ptfhost, duthosts, rand_one_dut_hostname, upgrade_path_lists, tbinfo):
+    duthost = duthosts[rand_one_dut_hostname]
+    prepare_ptf(ptfhost, duthost, tbinfo)
+    yield
+    cleanup(localhost, ptfhost, duthost, upgrade_path_lists, tbinfo)
+
+
+@pytest.fixture(scope="module")
+def ptf_params(duthosts, rand_one_dut_hostname, creds, tbinfo):
+    duthost = duthosts[rand_one_dut_hostname]
+
+    if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
+        reboot_limit_in_seconds = 150
+    else:
+        reboot_limit_in_seconds = 30
+
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    lo_v6_prefix = ""
+    for intf in mg_facts["minigraph_lo_interfaces"]:
+        ipn = ipaddr.IPNetwork(intf['addr'])
+        if ipn.version == 6:
+            lo_v6_prefix = str(ipaddr.IPNetwork(intf['addr'] + '/64').network) + '/64'
+            break
+
+    mgFacts = duthost.get_extended_minigraph_facts(tbinfo)
+    vm_hosts = [
+            attr['mgmt_addr'] for dev, attr in mgFacts['minigraph_devices'].items() if attr['hwsku'] == 'Arista-VM'
+        ]
+
+    vlan_ip_range = dict()
+    for vlan in mgFacts['minigraph_vlan_interfaces']:
+        if type(ipaddress.ip_network(vlan['subnet'])) is ipaddress.IPv4Network:
+            vlan_ip_range[vlan['attachto']] = vlan['subnet']
+
+    sonicadmin_alt_password = duthost.host.options['variable_manager']._hostvars[duthost.hostname].get("ansible_altpassword")
+    ptf_params = {
+        "verbose": False,
+        "dut_username": creds.get('sonicadmin_user'),
+        "dut_password": creds.get('sonicadmin_password'),
+        "alt_password": sonicadmin_alt_password,
+        "dut_hostname": duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host'],
+        "reboot_limit_in_seconds": reboot_limit_in_seconds,
+        "reboot_type": "warm-reboot",
+        "portchannel_ports_file": TMP_VLAN_PORTCHANNEL_FILE,
+        "vlan_ports_file": TMP_VLAN_FILE,
+        "ports_file": TMP_PORTS_FILE,
+        "dut_mac": duthost.facts["router_mac"],
+        "dut_vlan_ip": "192.168.0.1",
+        "default_ip_range": "192.168.100.0/18",
+        "vlan_ip_range": json.dumps(vlan_ip_range),
+        "lo_v6_prefix": lo_v6_prefix,
+        "arista_vms": vm_hosts,
+        "setup_fdb_before_test": True,
+        "target_version": "Unknown"
+    }
+    return ptf_params


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: For reuse of functions defined in test_upgrade_path (by other tests), move these function to a helper utility.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [x] 201911

### Approach

#### What is the motivation for this PR?
The functions defined in test_upgrade_path script are not reusable. Move these functions to a common helper script, so that other tests can reuse these functions.

#### How did you do it?
Moved helper functions in test_upgrade_path to upgrade_helpers.py

#### How did you verify/test it?
Tested in a physical device - warm upgrade from prev 202012 to latest 202012 passed.
```
------------------------------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------------------------------
21:16:16 test_upgrade_path.test_upgrade_path      L0072 INFO   | Test upgrade path from http://100.127.20.23/pipelines/Networking-acs-buildimage-Official/broadcom/internal-202012/tagged/sonic-aboot-broadcom.swi.PREV.1 to http://1.2.3.4/pipelines/Networking-acs-buildimage-Official/broadcom/internal-202012/tagged/sonic-aboot-broadcom.swi
21:16:16 test_upgrade_path.test_upgrade_path      L0074 INFO   | Installing http://1.2.3.4/pipelines/Networking-acs-buildimage-Official/broadcom/internal-202012/tagged/sonic-aboot-broadcom.swi.PREV.1
21:16:17 sonic.get_ip_route_info                  L0899 INFO   | route raw info for 0.0.0.0/0: [u'default proto bgp src 10.1.0.32 metric 20 ', u'\tnexthop via 10.0.0.33 dev PortChannel0001 weight 1 ', u'\tnexthop via 10.0.0.35 dev PortChannel0002 weight 1 ', u'\tnexthop via 10.0.0.37 dev PortChannel0003 weight 1 ', u'\tnexthop via 10.0.0.39 dev PortChannel0004 weight 1 ']
21:16:17 sonic.get_ip_route_info                  L0934 INFO   | route parsed info for 0.0.0.0/0: {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.33'), u'PortChannel0001'), (IPv4Address(u'10.0.0.35'), u'PortChannel0002'), (IPv4Address(u'10.0.0.37'), u'PortChannel0003'), (IPv4Address(u'10.0.0.39'), u'PortChannel0004')]}
21:16:17 upgrade_helpers.install_sonic            L0111 INFO   | Add default mgmt-gateway-route to the device via 10.64.246.1
21:17:47 upgrade_helpers.install_sonic            L0135 INFO   | Remove default mgmt-gateway-route earlier added
21:17:48 test_upgrade_path.test_upgrade_path      L0077 INFO   | Cold reboot the DUT to make the base image as current
21:17:48 reboot.reboot                            L0132 INFO   | waiting for ssh to drop on str-7260cx3-acs-1
21:17:48 reboot.execute_reboot_command            L0116 INFO   | rebooting str-7260cx3-acs-1 with command "reboot"
21:18:05 reboot.reboot                            L0153 INFO   | waiting for ssh to startup on str-7260cx3-acs-1
21:18:55 reboot.reboot                            L0164 INFO   | ssh has started up on str-7260cx3-acs-1
21:18:55 reboot.reboot                            L0166 INFO   | waiting for switch str-7260cx3-acs-1 to initialize
21:20:55 reboot.reboot                            L0194 INFO   | cold reboot finished on str-7260cx3-acs-1
21:20:57 reboot.reboot                            L0197 INFO   | DUT str-7260cx3-acs-1 up since 2021-08-12 21:18:28
21:20:57 test_upgrade_path.test_upgrade_path      L0082 INFO   | Upgrading to http://1.2.3.4/pipelines/Networking-acs-buildimage-Official/broadcom/internal-202012/tagged/sonic-aboot-broadcom.swi
21:20:58 sonic.get_ip_route_info                  L0899 INFO   | route raw info for 0.0.0.0/0: [u'default proto bgp src 10.1.0.32 metric 20 ', u'\tnexthop via 10.0.0.33 dev PortChannel0001 weight 1 ', u'\tnexthop via 10.0.0.35 dev PortChannel0002 weight 1 ', u'\tnexthop via 10.0.0.37 dev PortChannel0003 weight 1 ', u'\tnexthop via 10.0.0.39 dev PortChannel0004 weight 1 ']
21:20:58 sonic.get_ip_route_info                  L0934 INFO   | route parsed info for 0.0.0.0/0: {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.33'), u'PortChannel0001'), (IPv4Address(u'10.0.0.35'), u'PortChannel0002'), (IPv4Address(u'10.0.0.37'), u'PortChannel0003'), (IPv4Address(u'10.0.0.39'), u'PortChannel0004')]}
21:20:58 upgrade_helpers.install_sonic            L0111 INFO   | Add default mgmt-gateway-route to the device via 10.64.246.1
21:22:27 upgrade_helpers.install_sonic            L0135 INFO   | Remove default mgmt-gateway-route earlier added
21:22:28 ssh_utils.prepare_testbed_ssh_keys       L0017 INFO   | Remove old keys from ptfhost
21:22:31 ssh_utils.prepare_testbed_ssh_keys       L0026 INFO   | Generate public key for ptf host


21:35:13 reboot.get_reboot_cause                  L0206 INFO   | Getting reboot cause from dut str-7260cx3-acs-1
21:35:15 test_upgrade_path.test_upgrade_path      L0102 INFO   | Check reboot cause. Expected cause warm
21:35:15 upgrade_helpers.check_services           L0144 INFO   | Wait until DUT uptime reaches 300s
21:35:16 upgrade_helpers.check_services           L0147 INFO   | Wait until all critical services are fully started
21:35:16 upgrade_helpers.check_services           L0148 INFO   | Check critical service status
PASSED                                                                                                                                                                                                                                                   [100%]
---------------------------------------------------------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------------------------------------------------------
21:35:25 __init__._fixture_generator_decorator    L0082 INFO   | -------------------- fixture setup teardown starts --------------------
21:35:26 __init__._fixture_generator_decorator    L0091 INFO   | -------------------- fixture setup teardown ends --------------------
21:35:26 __init__._fixture_generator_decorator    L0082 INFO   | -------------------- fixture remove_ip_addresses teardown starts --------------------
21:35:26 ptfhost_utils.remove_ip_addresses        L0140 INFO   | Remove IPs to restore ptfhost 'vms7-7'
21:35:27 __init__._fixture_generator_decorator    L0091 INFO   | -------------------- fixture remove_ip_addresses teardown ends --------------------
21:35:27 __init__._fixture_generator_decorator    L0082 INFO   | -------------------- fixture copy_ptftests_directory teardown starts --------------------
21:35:27 ptfhost_utils.copy_ptftests_directory    L0071 INFO   | Delete PTF test files from PTF host 'vms7-7'
21:35:27 __init__._fixture_generator_decorator    L0091 INFO   | -------------------- fixture copy_ptftests_directory teardown ends --------------------
21:35:27 __init__._fixture_generator_decorator    L0082 INFO   | -------------------- fixture copy_arp_responder_py teardown starts --------------------
21:35:27 ptfhost_utils.copy_arp_responder_py      L0159 INFO   | Delete arp_responder.py from ptfhost 'vms7-7'
21:35:28 __init__._fixture_generator_decorator    L0091 INFO   | -------------------- fixture copy_arp_responder_py teardown ends --------------------


------------------------------------------------------------------------------------------------ generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------------------------------------
21:35:28 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
========================= 1 passed in 1206.57 seconds ==========================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
