### PR TITLE
[qos] Add support for backend topology

### DIFF
--- a/tests/qos/files/qos.yml
+++ b/tests/qos/files/qos.yml
@@ -152,6 +152,228 @@ qos_params:
                 lossy_weight: 8
                 lossless_weight: 8
     td2:
+        topo-t0-backend:
+            40000_300m:
+                pkts_num_leak_out: 48
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 4703
+                    pkts_num_trig_ingr_drp: 5006
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 4703
+                    pkts_num_trig_ingr_drp: 5006
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 4703
+                    pkts_num_trig_ingr_drp: 5006
+                    pkts_num_margin: 2
+                    cell_size: 208
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 5006
+                    cell_size: 208
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 6
+                    pkts_num_trig_pfc: 4703
+                    pkts_num_trig_ingr_drp: 5006
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 208
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 4703
+                    pkts_num_dismiss_pfc: 16
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 4703
+                    pkts_num_dismiss_pfc: 16
+                wm_pg_shared_lossless:
+                        dscp: 3
+                        ecn: 1
+                        pg: 3
+                        pkts_num_fill_min: 6
+                        pkts_num_trig_pfc: 4703
+                        packet_size: 64
+                        cell_size: 208
+            lossy_queue_1:
+                dscp: 1
+                ecn: 1
+                pg: 0
+                pkts_num_trig_egr_drp: 31322
+            wm_pg_shared_lossy:
+                dscp: 1
+                ecn: 1
+                pg: 0
+                pkts_num_fill_min: 0
+                pkts_num_trig_egr_drp: 31322
+                packet_size: 64
+                cell_size: 208
+            wrr:
+                ecn: 1
+                q0_num_of_pkts: 140
+                q1_num_of_pkts: 140
+                q2_num_of_pkts: 140
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 140
+                q6_num_of_pkts: 140
+                limit: 80
+            wrr_chg:
+                ecn: 1
+                q0_num_of_pkts: 80
+                q1_num_of_pkts: 80
+                q2_num_of_pkts: 80
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 80
+                q6_num_of_pkts: 80
+                limit: 80
+                lossy_weight: 8
+                lossless_weight: 30
+            wm_q_shared_lossy:
+                dscp: 1
+                ecn: 1
+                queue: 0
+                pkts_num_fill_min: 8
+                pkts_num_trig_egr_drp: 31322
+                cell_size: 208
+            wm_buf_pool_lossy:
+                dscp: 1
+                ecn: 1
+                pg: 0
+                queue: 0
+                pkts_num_fill_ingr_min: 0
+                pkts_num_trig_egr_drp: 31322
+                pkts_num_fill_egr_min: 8
+                cell_size: 208
+        topo-t1-backend:
+            40000_300m:
+                pkts_num_leak_out: 48
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 6004
+                    pkts_num_trig_ingr_drp: 6307
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 6004
+                    pkts_num_trig_ingr_drp: 6307
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 6004
+                    pkts_num_trig_ingr_drp: 6307
+                    pkts_num_margin: 2
+                    cell_size: 208
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 6307
+                    cell_size: 208
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 6
+                    pkts_num_trig_pfc: 6004
+                    pkts_num_trig_ingr_drp: 6307
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 208
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 6004
+                    pkts_num_dismiss_pfc: 17
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 6004
+                    pkts_num_dismiss_pfc: 17
+                wm_pg_shared_lossless:
+                        dscp: 3
+                        ecn: 1
+                        pg: 3
+                        pkts_num_fill_min: 6
+                        pkts_num_trig_pfc: 6004
+                        packet_size: 64
+                        cell_size: 208
+            lossy_queue_1:
+                dscp: 1
+                ecn: 1
+                pg: 0
+                pkts_num_trig_egr_drp: 31322
+            wm_pg_shared_lossy:
+                dscp: 1
+                ecn: 1
+                pg: 0
+                pkts_num_fill_min: 0
+                pkts_num_trig_egr_drp: 31322
+                packet_size: 64
+                cell_size: 208
+            wrr:
+                ecn: 1
+                q0_num_of_pkts: 140
+                q1_num_of_pkts: 140
+                q2_num_of_pkts: 140
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 140
+                q6_num_of_pkts: 140
+                limit: 80
+            wrr_chg:
+                ecn: 1
+                q0_num_of_pkts: 80
+                q1_num_of_pkts: 80
+                q2_num_of_pkts: 80
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 80
+                q6_num_of_pkts: 80
+                limit: 80
+                lossy_weight: 8
+                lossless_weight: 30
+            wm_q_shared_lossy:
+                dscp: 1
+                ecn: 1
+                queue: 0
+                pkts_num_fill_min: 8
+                pkts_num_trig_egr_drp: 31322
+                cell_size: 208
+            wm_buf_pool_lossy:
+                dscp: 1
+                ecn: 1
+                pg: 0
+                queue: 0
+                pkts_num_fill_ingr_min: 0
+                pkts_num_trig_egr_drp: 31322
+                pkts_num_fill_egr_min: 8
+                cell_size: 208
         topo-any:
             40000_5m:
                 pkts_num_leak_out: 48

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -16,8 +16,8 @@ class QosBase:
     """
     Common APIs
     """
-    SUPPORTED_T0_TOPOS = ["t0", "t0-64", "t0-116", "t0-35", "dualtor-56", "dualtor", "t0-80"]
-    SUPPORTED_T1_TOPOS = {"t1-lag", "t1-64-lag"}
+    SUPPORTED_T0_TOPOS = ["t0", "t0-64", "t0-116", "t0-35", "dualtor-56", "dualtor", "t0-80", "t0-backend"]
+    SUPPORTED_T1_TOPOS = ["t1-lag", "t1-64-lag", "t1-backend"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
     SUPPORTED_ASIC_LIST = ["td2", "th", "th2", "spc1", "spc2", "spc3", "td3", "th3"]
 
@@ -350,9 +350,18 @@ class QosSaiBase(QosBase):
                     break
             pytest_assert(testVlanIp, "Failed to obtain vlan IP")
 
+            vlan_id = None
+            if 'type' in mgFacts["minigraph_vlans"][testVlan]:
+                vlan_type = mgFacts["minigraph_vlans"][testVlan]['type']
+                if vlan_type is not None and "Tagged" in vlan_type:
+                    vlan_id =  mgFacts["minigraph_vlans"][testVlan]['vlanid']
+
             for i in range(len(testVlanMembers)):
                 portIndex = mgFacts["minigraph_ptf_indices"][testVlanMembers[i]]
-                dutPortIps.update({portIndex: str(testVlanIp + portIndex + 1)})
+                portIpMap = {'peer_addr': str(testVlanIp + portIndex + 1)}
+                if vlan_id is not None:
+                    portIpMap['vlan_id'] = vlan_id
+                dutPortIps.update({portIndex: portIpMap})
 
         return dutPortIps
 
@@ -411,15 +420,27 @@ class QosSaiBase(QosBase):
 
 
         #TODO: Randomize port selection
+        dstPort = dstPorts[0] if dst_port_ids else testPortIds[dstPorts[0]]
+        dstVlan = testPortIps[dstPort]['vlan_id'] if 'vlan_id' in testPortIps[dstPort] else None
+        dstPort2 = dstPorts[1] if dst_port_ids else testPortIds[dstPorts[1]]
+        dstVlan2 = testPortIps[dstPort2]['vlan_id'] if 'vlan_id' in testPortIps[dstPort2] else None
+        dstPort3 = dstPorts[2] if dst_port_ids else testPortIds[dstPorts[2]]
+        dstVlan3 = testPortIps[dstPort3]['vlan_id'] if 'vlan_id' in testPortIps[dstPort3] else None
+        srcPort = srcPorts[0] if src_port_ids else testPortIds[srcPorts[0]]
+        srcVlan = testPortIps[srcPort]['vlan_id'] if 'vlan_id' in testPortIps[srcPort] else None
         return {
-            "dst_port_id": dstPorts[0] if dst_port_ids else testPortIds[dstPorts[0]],
-            "dst_port_ip": testPortIps[dstPorts[0] if dst_port_ids else testPortIds[dstPorts[0]]],
-            "dst_port_2_id": dstPorts[1] if dst_port_ids else testPortIds[dstPorts[1]],
-            "dst_port_2_ip": testPortIps[dstPorts[1] if dst_port_ids else testPortIds[dstPorts[1]]],
-            'dst_port_3_id': dstPorts[2] if dst_port_ids else testPortIds[dstPorts[2]],
-            "dst_port_3_ip": testPortIps[dstPorts[2] if dst_port_ids else testPortIds[dstPorts[2]]],
+            "dst_port_id": dstPort,
+            "dst_port_ip": testPortIps[dstPort]['peer_addr'],
+            "dst_port_vlan": dstVlan,
+            "dst_port_2_id": dstPort2,
+            "dst_port_2_ip": testPortIps[dstPort2]['peer_addr'],
+            "dst_port_2_vlan": dstVlan2,
+            'dst_port_3_id': dstPort3,
+            "dst_port_3_ip": testPortIps[dstPort3]['peer_addr'],
+            "dst_port_3_vlan": dstVlan3,
             "src_port_id": srcPorts[0] if src_port_ids else testPortIds[srcPorts[0]],
-            "src_port_ip": testPortIps[srcPorts[0] if src_port_ids else testPortIds[srcPorts[0]]],
+            "src_port_ip": testPortIps[srcPorts[0] if src_port_ids else testPortIds[srcPorts[0]]]["peer_addr"],
+            "src_port_vlan": srcVlan
         }
 
     @pytest.fixture(scope='class', autouse=True)
@@ -468,25 +489,40 @@ class QosSaiBase(QosBase):
 
             # get current DUT port IPs
             dutPortIps = {}
-            for portConfig in mgFacts["minigraph_interfaces"]:
+            if 'backend' in topo:
+                intf_map = mgFacts["minigraph_vlan_sub_interfaces"]
+            else:
+                intf_map = mgFacts["minigraph_interfaces"]
+            for portConfig in intf_map:
+                intf = portConfig["attachto"].split(".")[0]
                 if ipaddress.ip_interface(portConfig['peer_addr']).ip.version == 4:
-                    portIndex = mgFacts["minigraph_ptf_indices"][portConfig["attachto"]]
+                    portIndex = mgFacts["minigraph_ptf_indices"][intf]
                     if portIndex in testPortIds:
-                        dutPortIps.update({portIndex: portConfig["peer_addr"]})
+                        portIpMap = {'peer_addr': portConfig["peer_addr"]}
+                        if 'vlan' in portConfig:
+                            portIpMap['vlan_id'] = portConfig['vlan']
+                        dutPortIps.update({portIndex: portIpMap})
 
             testPortIps = self.__assignTestPortIps(mgFacts)
 
         elif topo in self.SUPPORTED_T1_TOPOS:
             for iface,addr in dut_asic.get_active_ip_interfaces().items():
+                vlan_id = None
                 if iface.startswith("Ethernet"):
+                    if "." in iface:
+                        iface, vlan_id = iface.split(".")
                     portIndex = mgFacts["minigraph_ptf_indices"][iface]
-                    dutPortIps.update({portIndex: addr["peer_ipv4"]})
+                    portIpMap = {'peer_addr': addr["peer_ipv4"]}
+                    if vlan_id is not None:
+                        portIpMap['vlan_id'] = vlan_id
+                    dutPortIps.update({portIndex: portIpMap})
                 elif iface.startswith("PortChannel"):
                     portName = next(
                         iter(mgFacts["minigraph_portchannels"][iface]["members"])
                     )
                     portIndex = mgFacts["minigraph_ptf_indices"][portName]
-                    dutPortIps.update({portIndex: addr["peer_ipv4"]})
+                    portIpMap = {'peer_addr': addr["peer_ipv4"]}
+                    dutPortIps.update({portIndex: portIpMap})
 
             testPortIds = sorted(dutPortIps.keys())
         else:
@@ -1332,6 +1368,8 @@ class QosSaiBaseMasic(QosBase):
         topo = tbinfo["topo"]["name"]
         if topo not in self.SUPPORTED_T1_TOPOS:
             pytest.skip("unsupported topology {}".format(topo))
+
+        pytest_require(duthost.is_multi_asic, "Not a multi asic platform")
 
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
         ip_ifaces = duthost.get_active_ip_interfaces(asic_index="all")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Enable qos sai runs on backend T0 and T1

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

#### How did you verify/test it?
Ran the qos testcases on backend T0, T1 and Th (backward compatibility)

some failures seen on Th but not related to changes
```
======================================================================== short test summary info ========================================================================
SKIPPED [2] /var/nejo/Networking-acs-sonic-mgmt/tests/qos/test_qos_sai.py:351: Buffer Pool watermark test is disabled
SKIPPED [1] /var/nejo/Networking-acs-sonic-mgmt/tests/common/helpers/assertions.py:13: Not a multi asic platform
SKIPPED [1] /var/nejo/Networking-acs-sonic-mgmt/tests/qos/test_qos_sai.py:723: DSCP to PG mapping test disabled
FAILED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[None-xon_1] - RunAnsibleModuleFail: run module shell failed, Ansible Results =>
FAILED qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[None] - RunAnsibleModuleFail: run module shell failed, Ansible Results =>
FAILED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[None-xon_2] - RunAnsibleModuleFail: run module shell failed, Ansible Results =>
=========================================================== 3 failed, 13 passed, 4 skipped in 1725.37 seconds ===========================================================

nejo@98d1c349dc9f:/var/nejo/Networking-acs-sonic-mgmt/tests$ ./run_tests.sh -u -t t0,any -i ../ansible/str2,../ansible/veos -n vms20-t1-dx010-6 -e "--disable_loganalyzer --skip_sanity" -c qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr                                                                                                       
=== Running tests in groups ===
========================================================================== test session starts ==========================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/nejo/Networking-acs-sonic-mgmt/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collected 1 item                                                                                                                                                        

qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[None] PASSED                                                                                                      [100%]
```

on backend-t1, few failures seen which will be addressed later
```
======================================================================== short test summary info ========================================================================
SKIPPED [2] /var/nejo/Networking-acs-sonic-mgmt/tests/qos/test_qos_sai.py:351: Buffer Pool watermark test is disabled
SKIPPED [1] /var/nejo/Networking-acs-sonic-mgmt/tests/common/helpers/assertions.py:13: Not a multi asic platform
SKIPPED [1] /var/nejo/Networking-acs-sonic-mgmt/tests/qos/test_qos_sai.py:723: DSCP to PG mapping test disabled
SKIPPED [1] /var/nejo/Networking-acs-sonic-mgmt/tests/qos/test_qos_sai.py:464: Dscp-queue mapping is not supported on t1-backend
SKIPPED [1] /var/nejo/Networking-acs-sonic-mgmt/tests/qos/test_qos_sai.py:289: Headroom pool watermark is not supported
SKIPPED [1] /var/nejo/Networking-acs-sonic-mgmt/tests/qos/test_qos_sai.py:216: Headroom pool size not supported
FAILED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[None-xoff_1] - RunAnsibleModuleFail: run module shell failed, Ansible Results =>
FAILED qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[None] - RunAnsibleModuleFail: run module shell failed, Ansible Results =>
FAILED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[None-xon_2] - RunAnsibleModuleFail: run module shell failed, Ansible Results =>
=========================================================== 3 failed, 10 passed, 7 skipped in 1293.82 seconds ===========================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
