### PR TITLE
Bring in changes in preparation for Bullseye

### DIFF
--- a/ansible/library/config_facts.py
+++ b/ansible/library/config_facts.py
@@ -54,7 +54,10 @@ def format_config(json_data):
                 data.setdefault(key_l1, {})[key_l2] = entry
             except ValueError:
                 # This is a single level key
-                data.setdefault(key, entry)
+                if key not in data:
+                    data[key] = entry
+                else:
+                    data[key].update(entry)
 
         res.setdefault(table, data)
 

--- a/ansible/library/interface_facts.py
+++ b/ansible/library/interface_facts.py
@@ -90,7 +90,7 @@ def get_default_interfaces(ip_path):
             # v6 routing may result in
             #   RTNETLINK answers: Invalid argument
             continue
-        words = out.split('\n')[0].split()
+        words = out.decode('utf8').split('\n')[0].split()
         # A valid output starts with the queried address on the first line
         if len(words) > 0 and words[0] == command[key][-1]:
             for i in range(len(words) - 1):
@@ -188,7 +188,7 @@ def gather_ip_interface_info():
             interfaces[device]['promisc'] = promisc_mode
 
         def parse_ip_output(output, secondary=False):
-            for line in output.split('\n'):
+            for line in output.decode('utf8').split('\n'):
                 if not line:
                     continue
                 words = line.split()
@@ -284,7 +284,7 @@ def gather_ip_interface_info():
         parse_ip_output(secondary_data, secondary=True)
 
     buffer = {'interfaces':interfaces, 'ips':ips}
-    print json.dumps(buffer)
+    print(json.dumps(buffer))
 
 gather_ip_interface_info()
 """

--- a/tests/arp/test_arp_dualtor.py
+++ b/tests/arp/test_arp_dualtor.py
@@ -25,10 +25,13 @@ def setup_ptf_arp(config_facts, ptfhost, intfs_for_test):
     intf_ipv4_addr = None
 
     for addr in vlan_addrs:
-        if type(ip_network(addr, strict=False)) is IPv6Network:
-            intf_ipv6_addr = ip_network(addr, strict=False)
-        elif type(ip_network(addr, strict=False)) is IPv4Network:
-            intf_ipv4_addr = ip_network(addr, strict=False)
+        try:
+            if type(ip_network(addr, strict=False)) is IPv6Network:
+                intf_ipv6_addr = ip_network(addr, strict=False)
+            elif type(ip_network(addr, strict=False)) is IPv4Network:
+                intf_ipv4_addr = ip_network(addr, strict=False)
+        except ValueError:
+            continue
 
     # The VLAN interface on the DUT has an x.x.x.1 address assigned (or x::1 in the case of IPv6)
     # But the network_address property returns an x.x.x.0 address (or x::0 for IPv6) so we increment by two to avoid conflict

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -37,7 +37,13 @@ NEIGHBOR_PORT1 = 11001
 @contextlib.contextmanager
 def log_bgp_updates(duthost, iface, save_path):
     """Capture bgp packets to file."""
-    start_pcap = "tcpdump -i %s -w %s port 179" % (iface, save_path)
+    if iface == "any":
+        # Scapy doesn't support LINUX_SLL2 (Linux cooked v2), and tcpdump on Bullseye
+        # defaults to writing in that format when listening on any interface. Therefore,
+        # have it use LINUX_SLL (Linux cooked) instead.
+        start_pcap = "tcpdump -y LINUX_SLL -i %s -w %s port 179" % (iface, save_path)
+    else:
+        start_pcap = "tcpdump -i %s -w %s port 179" % (iface, save_path)
     stop_pcap = "pkill -f '%s'" % start_pcap
     start_pcap = "nohup %s &" % start_pcap
     duthost.shell(start_pcap)

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -851,6 +851,13 @@ raw data
         nexthop via 10.0.0.5  dev PortChannel0002 weight 1
         nexthop via 10.0.0.9  dev PortChannel0003 weight 1
         nexthop via 10.0.0.13  dev PortChannel0004 weight 1
+
+raw data (starting from Bullseye)
+192.168.8.0/25 nhid 296 proto bgp src 10.1.0.32 metric 20
+        nexthop via 10.0.0.57 dev PortChannel0001 weight 1
+        nexthop via 10.0.0.59 dev PortChannel0002 weight 1
+        nexthop via 10.0.0.61 dev PortChannel0003 weight 1
+        nexthop via 10.0.0.63 dev PortChannel0004 weight 1
 ----------------
 get_ip_route_info(ipaddress.ip_address(unicode("20c0:a818::")))
 returns {'set_src': IPv6Address(u'fc00:1::32'), 'nexthops': [(IPv6Address(u'fc00::1a'), u'PortChannel0004')]}
@@ -866,6 +873,13 @@ raw data
 20c0:a818::/64 via fc00::a dev PortChannel0002 proto 186 src fc00:1::32 metric 20  pref medium
 20c0:a818::/64 via fc00::12 dev PortChannel0003 proto 186 src fc00:1::32 metric 20  pref medium
 20c0:a818::/64 via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pref medium
+
+raw data (starting from Bullseye)
+20c0:a818::/64 nhid 224 proto bgp src fc00:1::32 metric 20 pref medium
+        nexthop via fc00::72 dev PortChannel0001 weight 1
+        nexthop via fc00::76 dev PortChannel0002 weight 1
+        nexthop via fc00::7a dev PortChannel0003 weight 1
+        nexthop via fc00::7e dev PortChannel0004 weight 1
 ----------------
 get_ip_route_info(ipaddress.ip_network(unicode("0.0.0.0/0")))
 returns {'set_src': IPv4Address(u'10.1.0.32'), 'nexthops': [(IPv4Address(u'10.0.0.1'), u'PortChannel0001'), (IPv4Address(u'10.0.0.5'), u'PortChannel0002'), (IPv4Address(u'10.0.0.9'), u'PortChannel0003'), (IPv4Address(u'10.0.0.13'), u'PortChannel0004')]}
@@ -876,6 +890,13 @@ default proto 186 src 10.1.0.32 metric 20
         nexthop via 10.0.0.5  dev PortChannel0002 weight 1
         nexthop via 10.0.0.9  dev PortChannel0003 weight 1
         nexthop via 10.0.0.13  dev PortChannel0004 weight 1
+
+raw data (starting from Bullseye)
+default nhid 296 proto bgp src 10.1.0.32 metric 20
+        nexthop via 10.0.0.57 dev PortChannel0001 weight 1
+        nexthop via 10.0.0.59 dev PortChannel0002 weight 1
+        nexthop via 10.0.0.61 dev PortChannel0003 weight 1
+        nexthop via 10.0.0.63 dev PortChannel0004 weight 1
 ----------------
 get_ip_route_info(ipaddress.ip_network(unicode("::/0")))
 returns {'set_src': IPv6Address(u'fc00:1::32'), 'nexthops': [(IPv6Address(u'fc00::2'), u'PortChannel0001'), (IPv6Address(u'fc00::a'), u'PortChannel0002'), (IPv6Address(u'fc00::12'), u'PortChannel0003'), (IPv6Address(u'fc00::1a'), u'PortChannel0004')]}
@@ -885,6 +906,13 @@ default via fc00::2 dev PortChannel0001 proto 186 src fc00:1::32 metric 20  pref
 default via fc00::a dev PortChannel0002 proto 186 src fc00:1::32 metric 20  pref medium
 default via fc00::12 dev PortChannel0003 proto 186 src fc00:1::32 metric 20  pref medium
 default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pref medium
+
+raw data (starting from Bullseye)
+default nhid 224 proto bgp src fc00:1::32 metric 20 pref medium
+        nexthop via fc00::72 dev PortChannel0001 weight 1
+        nexthop via fc00::76 dev PortChannel0002 weight 1
+        nexthop via fc00::7a dev PortChannel0003 weight 1
+        nexthop via fc00::7e dev PortChannel0004 weight 1
 ----------------
         """
 
@@ -904,10 +932,13 @@ default via fc00::1a dev PortChannel0004 proto 186 src fc00:1::32 metric 20  pre
             # parse set_src
             m = re.match(r"^(default|\S+) proto (zebra|bgp|186) src (\S+)", rt[0])
             m1 = re.match(r"^(default|\S+) via (\S+) dev (\S+) proto (zebra|bgp|186) src (\S+)", rt[0])
+            m2 = re.match(r"^(default|\S+) nhid (\d+) proto (zebra|bgp|186) src (\S+)", rt[0])
             if m:
                 rtinfo['set_src'] = ipaddress.ip_address(unicode(m.group(3)))
             elif m1:
                 rtinfo['set_src'] = ipaddress.ip_address(unicode(m1.group(5)))
+            elif m2:
+                rtinfo['set_src'] = ipaddress.ip_address(unicode(m2.group(4)))
 
             # parse nexthops
             for l in rt:


### PR DESCRIPTION

### Description of PR

1. Make Python 3 changes in `interface_facts.py`.
2. Force tcpdump to use Linux cooked v1 format when listening on `any` interface.,
3. Update `ip route` syntax for Bullseye.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911