### PR TITLE
[dualtor] Remove acl-drop verification from mux_toggle testcase

### DIFF
--- a/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
+++ b/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
@@ -20,10 +20,6 @@ pytestmark = [
 PAUSE_TIME = 10
 
 
-def clear_portstat(dut):
-    dut.shell("portstat -c")
-
-
 @pytest.fixture(scope='module', autouse=True)
 def test_cleanup(rand_selected_dut):
     """

--- a/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
+++ b/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
@@ -1,8 +1,6 @@
 import pytest
 import logging
-import ipaddress
 import json
-import re
 import time
 from tests.common.dualtor.dual_tor_mock import *
 from tests.common.helpers.assertions import pytest_assert as pt_assert

--- a/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
+++ b/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
@@ -21,18 +21,6 @@ pytestmark = [
 
 PAUSE_TIME = 10
 
-def get_l2_rx_drop(host, itfs):
-    """
-    Return L2 rx packet drop counter for given interface
-    """
-    res = {}
-    stdout = host.shell("portstat -j")['stdout']
-    match = re.search("Last cached time was.*\n", stdout)
-    if match:
-        stdout = re.sub("Last cached time was.*\n", "", stdout)
-    data = json.loads(stdout)
-    return int(data[itfs]['RX_DRP'])
-
 
 def clear_portstat(dut):
     dut.shell("portstat -c")
@@ -67,11 +55,6 @@ def test_standby_tor_upstream_mux_toggle(
                             drop=True)
 
     time.sleep(5)
-    # Verify dropcounter is increased
-    drop_counter = get_l2_rx_drop(rand_selected_dut, itfs)
-    pt_assert(drop_counter >= PKT_NUM,
-                "RX_DRP for {} is expected to increase by {} actually {}".format(itfs, PKT_NUM, drop_counter))
-
     # Step 2. Toggle mux state to active, and verify traffic is not dropped by ACL and fwd-ed to uplinks; verify CRM show and no nexthop objects are stale
     set_mux_state(rand_selected_dut, tbinfo, 'active', [itfs], toggle_all_simulator_ports)
     # Wait sometime for mux toggle
@@ -97,10 +80,6 @@ def test_standby_tor_upstream_mux_toggle(
                             server_ip=ip['server_ipv4'].split('/')[0],
                             pkt_num=PKT_NUM,
                             drop=True)
-    # Verify dropcounter is increased
-    drop_counter = get_l2_rx_drop(rand_selected_dut, itfs)
-    pt_assert(drop_counter >= PKT_NUM,
-                "RX_DRP for {} is expected to increase by {} actually {}".format(itfs, PKT_NUM, drop_counter))
     crm_facts1 = rand_selected_dut.get_crm_facts()
     unmatched_crm_facts = compare_crm_facts(crm_facts0, crm_facts1)
     pt_assert(len(unmatched_crm_facts)==0, 'Unmatched CRM facts: {}'.format(json.dumps(unmatched_crm_facts, indent=4)))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Remove verification of RX_DRP counters from test `test_standby_tor_upstream_mux_toggle`
Fixes https://github.com/Azure/sonic-buildimage/issues/8091

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Related image change: https://github.com/Azure/sonic-buildimage/pull/8383

Do not verify ACL RX_DRP as the counters will not be increased in this case.

#### How did you do it?
Removed drop counter verification from the test.

#### How did you verify/test it?
Tested on mocked dualtor and the older issue (failure to verify drops) is not seen anymore.
There is another CRM issue in this testcase, which will be handled in differerent issue/PR.

```
dualtor/test_standby_tor_upstream_mux_toggle.py::test_standby_tor_upstream_mux_toggle
------------------------------------------------------------------------------------------------------------------------ live log setup ------------------------------------------------------------------------------------------------------------------------
17:55:01 __init__.set_default                     L0049 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
17:55:01 __init__.check_test_completeness         L0139 INFO   | Test has no defined levels. Continue without test completeness checks
17:55:01 facts_cache.read                         L0093 INFO   | Load cache file "/var/src/sonic-mgmt-int/tests/_cache/str2-7050cx3-acs-01/basic_facts.pickle" failed with exception: IOError(2, 'No such file or directory')
17:55:08 facts_cache.write                        L0114 INFO   | Create cache dir /var/src/sonic-mgmt-int/tests/_cache/str2-7050cx3-acs-01
17:55:08 facts_cache.write                        L0120 INFO   | Cached facts "str2-7050cx3-acs-01.basic_facts" to /var/src/sonic-mgmt-int/tests/_cache/str2-7050cx3-acs-01/basic_facts.pickle
17:55:10 facts_cache.read                         L0093 INFO   | Load cache file "/var/src/sonic-mgmt-int/tests/_cache/str2-7050cx3-acs-01/host_visible_vars.pickle" failed with exception: IOError(2, 'No such file or directory')
17:55:11 facts_cache.write                        L0120 INFO   | Cached facts "str2-7050cx3-acs-01.host_visible_vars" to /var/src/sonic-mgmt-int/tests/_cache/str2-7050cx3-acs-01/host_visible_vars.pickle
17:55:11 ptfhost_utils.change_mac_addresses       L0121 INFO   | Change interface MAC addresses on ptfhost 'vms20-5'
17:55:14 ptfhost_utils.run_icmp_responder         L0205 INFO   | Start running icmp_responder
17:55:14 facts_cache.read                         L0093 INFO   | Load cache file "/var/src/sonic-mgmt-int/tests/_cache/str2-7050cx3-acs-01/mg_facts.pickle" failed with exception: IOError(2, 'No such file or directory')
17:55:14 facts_cache.write                        L0120 INFO   | Cached facts "str2-7050cx3-acs-01.mg_facts" to /var/src/sonic-mgmt-int/tests/_cache/str2-7050cx3-acs-01/mg_facts.pickle
17:55:21 conftest.generate_params_dut_hostname    L0861 INFO   | Using DUTs ['str2-7050cx3-acs-01'] in testbed 'vms20-t0-7050cx3-1'
17:55:21 conftest.rand_one_dut_hostname           L0275 INFO   | Randomly select dut str2-7050cx3-acs-01 for testing
17:55:21 conftest.creds_on_dut                    L0496 INFO   | dut str2-7050cx3-acs-01 belongs to groups [u'sonic', u'sonic_arista', u'str2', 'fanout']
17:55:21 conftest.creds_on_dut                    L0508 INFO   | skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
17:55:21 conftest.creds_on_dut                    L0508 INFO   | skip empty var file ../ansible/group_vars/all/README.yml
17:55:25 __init__.sanity_check                    L0130 INFO   | Prepare sanity check
17:55:25 __init__.sanity_check                    L0140 INFO   | Found marker: m.name=topology, m.args=('t0',), m.kwargs={}
17:55:25 __init__.sanity_check                    L0140 INFO   | Found marker: m.name=usefixtures, m.args=('apply_mock_dual_tor_tables', 'apply_mock_dual_tor_kernel_configs', 'run_garp_service', 'run_icmp_responder'), m.kwargs={}
17:55:25 __init__.sanity_check                    L0166 INFO   | Skip sanity check according to command line argument or configuration of test script.
17:55:26 ptfhost_utils.run_garp_service           L0245 INFO   | Generating GARP service config file
17:55:29 ptfhost_utils.run_garp_service           L0262 INFO   | Starting GARP Service on PTF host
17:55:31 __init__._fixture_generator_decorator    L0070 INFO   | -------------------- fixture test_cleanup setup starts --------------------
17:58:21 dual_tor_mock.cleanup_mocked_configs     L0426 INFO   | Load minigraph to reset the DUT str2-7050cx3-acs-01          ------------
17:58:21 __init__._fixture_generator_decorator    L0082 INFO   | -------------------- fixture test_cleanup teardown starts --------------------
17:58:21 __init__._fixture_generator_decorator    L0091 INFO   | -------------------- fixture test_cleanup teardown ends --------------------
17:58:21 ptfhost_utils.run_garp_service           L0271 INFO   | Stopping GARP service on PTF host
17:58:23 ptfhost_utils.run_icmp_responder         L0223 INFO   | Stop running icmp_responder


------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/dualtor/test_stn 0:00:01.176790 secondsandby_tor_upstream_mux_toggle.py::test_standby_tor_upstream_mux_toggle.xml -------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------- live log sessionfinish ----------------------------------------------------------------------------------------------------------------in 0:00:01.875227 seconds----
17:58:25 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
========================== 1 passed in 206.02 seconds ==========================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
