### PR TITLE
[dualtor] Fix incorrect FDB used count in test_standby_tor_upstream_mux_toggle

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -807,8 +807,12 @@ def verify_upstream_traffic(host, ptfadapter, tbinfo, itfs, server_ip, pkt_num =
     vlan_name = list(vlan_table.keys())[0]
     vlan_mac = host.get_dut_iface_mac(vlan_name)
     router_mac = host.facts['router_mac']
+    mg_facts = host.get_extended_minigraph_facts(tbinfo)
+    tx_port = mg_facts['minigraph_ptf_indices'][itfs]
+    eth_src = ptfadapter.dataplane.get_mac(0, tx_port)
     # Generate packets from server to a random IP address, which goes default routes
-    pkt = testutils.simple_ip_packet(eth_dst=vlan_mac,
+    pkt = testutils.simple_ip_packet(eth_src=eth_src,
+                                    eth_dst=vlan_mac,
                                     ip_src=server_ip,
                                     ip_dst=random_ip)
     # Generate packet forwarded to portchannels
@@ -837,8 +841,6 @@ def verify_upstream_traffic(host, ptfadapter, tbinfo, itfs, server_ip, pkt_num =
         rx_ports += v
     rx_ports = [int(x.strip('eth')) for x in rx_ports]
 
-    mg_facts = host.get_extended_minigraph_facts(tbinfo)
-    tx_port = mg_facts['minigraph_ptf_indices'][itfs]
     logger.info("Verifying upstream traffic. packet number = {} interface = {} server_ip = {} expect_drop = {}".format(pkt_num, itfs, server_ip, drop))
     for i in range(0, pkt_num):
         ptfadapter.dataplane.flush()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Use server MAC instead of default MAC to send packet. This is to avoid extra use of FDB resources and prevent test failure due to that.

Fixes https://github.com/Azure/sonic-buildimage/issues/8471

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Failure seen in `test_standby_tor_upstream_mux_toggle`, where test is expecting no increase in count for CRM resources (fdb_entry), but there is ONE extra fdb_entry

```
>       pt_assert(len(unmatched_crm_facts)==0, 'Unmatched CRM facts: {}'.format(json.dumps(unmatched_crm_facts, indent=4)))
E       Failed: Unmatched CRM facts: [
E           {
E               "right": {
E                   "fdb_entry": {
E                       "available": 32742, 
E                       "used": 25
E                   }
E               }, 
E               "left": {
E                   "fdb_entry": {
E                       "available": 32743, 
E                       "used": 24
E                   }
E               }
E           }
E       ]

PKT_NUM    = 100
crm_facts0 = {'acl_group': [{'available count': '996', 'bind point': 'PORT', 'resource name': 'acl_group', 'stage': 'INGRESS', ...}...'used': 24}, 'ipmc_entry': {'available': 8192, 'used': 0}, 'ipv4_neighbor': {'available': 16352, 'used': 4}, ...}, ...}
crm_facts1 = {'acl_group': [{'available count': '996', 'bind point': 'PORT', 'resource name': 'acl_group', 'stage': 'INGRESS', ...}...'used': 25}, 'ipmc_entry': {'available': 8192, 'used': 0}, 'ipv4_neighbor': {'available': 16352, 'used': 4}, ...}, ...}
ip         = {'server_ipv4': '192.168.0.6/32', 'server_ipv6': 'fc02:1000::6/128', 'state': 'auto'}
itfs       = 'Ethernet20'
ptfadapter = <tests.common.plugins.ptfadapter.ptfadapter.PtfTestAdapter testMethod=runTest>
rand_selected_dut = <MultiAsicSonicHost> str2-7050cx3-acs-01
rand_selected_interface = ('Ethernet20', {'server_ipv4': '192.168.0.6/32', 'server_ipv6': 'fc02:1000::6/128', 'state': 'auto'})
require_mocked_dualtor = None
set_crm_polling_interval = None
tbinfo     = {'auto_recover': 'True', 'comment': 'lawlee', 'conf-name': 'vms20-t0-7050cx3-1', 'duts': ['str2-7050cx3-acs-01'], ...}
toggle_all_simulator_ports = <function _toggle at 0x7fc704faae50>
unmatched_crm_facts = [{'left': {'fdb_entry': {'available': 32743, 'used': 24}}, 'right': {'fdb_entry': {'available': 32742, 'used': 25}}}]

dualtor/test_standby_tor_upstream_mux_toggle.py:106: Failed
```

#### How did you do it?


The extra FDB entry seems to be created by the test when a packet is send without src_address. If `simple_ip_packet` does not receive a src MAC as an argument, the default is set to `00:06:07:08:09:0A` (https://github.com/p4lang/ptf/blob/master/src/ptf/testutils.py#L1756)

```
admin@str2-7050cx3-acs-01:~$ fdbshow 
  No.    Vlan  MacAddress         Port        Type
-----  ------  -----------------  ----------  -------
    1    1000  98:03:9B:03:22:12  Ethernet72  Dynamic
    2    1000  98:03:9B:03:22:07  Ethernet28  Dynamic
    3    1000  98:03:9B:03:22:08  Ethernet32  Dynamic
    4    1000  98:03:9B:03:22:18  Ethernet96  Dynamic
    5    1000  98:03:9B:03:22:02  Ethernet8   Dynamic
    6    1000  98:03:9B:03:22:17  Ethernet92  Dynamic
    7    1000  98:03:9B:03:22:16  Ethernet88  Dynamic
    8    1000  98:03:9B:03:22:0B  Ethernet44  Dynamic
    9    1000  98:03:9B:03:22:0D  Ethernet52  Dynamic
   10    1000  98:03:9B:03:22:14  Ethernet80  Dynamic
   11    1000  98:03:9B:03:22:0F  Ethernet60  Dynamic
   12    1000  98:03:9B:03:22:13  Ethernet76  Dynamic
   13    1000  98:03:9B:03:22:10  Ethernet64  Dynamic
   14    1000  98:03:9B:03:22:09  Ethernet36  Dynamic
   15    1000  98:03:9B:03:22:05  Ethernet20  Dynamic    <<<---------- SERVER MAC
   16    1000  98:03:9B:03:22:15  Ethernet84  Dynamic
   17    1000  98:03:9B:03:22:03  Ethernet12  Dynamic
   18    1000  98:03:9B:03:22:04  Ethernet16  Dynamic
   19    1000  98:03:9B:03:22:01  Ethernet4   Dynamic
   20    1000  98:03:9B:03:22:11  Ethernet68  Dynamic
   21    1000  98:03:9B:03:22:0A  Ethernet40  Dynamic
   22    1000  98:03:9B:03:22:06  Ethernet24  Dynamic
   23    1000  00:06:07:08:09:0A  Ethernet20  Dynamic   <<<---------- TEST MAC
   24    1000  98:03:9B:03:22:0C  Ethernet48  Dynamic
   25    1000  98:03:9B:03:22:0E  Ethernet56  Dynamic
Total number of entries 25
admin@str2-7050cx3-acs-01:~$
```

This is THAT extra MAC which uses FDB resources, and fails the test. However, this is not totally incorrect behavior, but it can be improved if `simple_ip_packet` is called with SRC MAC of the server which is attached to the VLAN port.


So, this change finds the MAC of the ptf port, and uses it to create and send upstream packets.

#### How did you verify/test it?
Ran the test successfully with the fix, and verified on the DUT too that no extra FDB resources are used.
```
------------------------------------------------------ live log call ------------------------------------------------------
19:30:13 dual_tor_mock.set_dual_tor_state_to_orch L0067 INFO   | Applying standby state to orchagent
19:30:33 dual_tor_utils.verify_upstream_traffic   L0844 INFO   | Verifying upstream traffic. packet number = 100 interface= Ethernet64 server_ip = 192.168.0.17 expect_drop = True
19:31:18 dual_tor_mock.set_dual_tor_state_to_orch L0067 INFO   | Applying active state to orchagent
19:31:36 dual_tor_utils.verify_upstream_traffic   L0844 INFO   | Verifying upstream traffic. packet number = 100 interface = Ethernet64 server_ip = 192.168.0.17 expect_drop = False
19:31:36 dual_tor_mock.set_dual_tor_state_to_orch L0067 INFO   | Applying standby state to orchagent
19:31:53 dual_tor_utils.verify_upstream_traffic   L0844 INFO   | Verifying upstream traffic. packet number = 100 interface = Ethernet64 server_ip = 192.168.0.17 expect_drop = True
PASSED                                                                                                                                                                                     [100%]
--------------------------------------------------------------------------------------- live log teardown ----------------------------------------------------------------------------------------
19:32:38 conftest.set_crm_polling_interval        L0025 INFO   | Setting crm polling interval to 300 seconds
19:32:39 __init__.loganalyzer                     L0063 INFO   | Starting to analyse on all DUTs
19:32:44 parallel.parallel_run                    L0126 INFO   | Completed running processes for target "analyze_logs" in 0:00:05.439634 seconds
19:32:44 dual_tor_mock.apply_peer_switch_table_to L0320 INFO   | Removing peer switch table
19:32:46 dual_tor_mock.cleanup_mocked_configs     L0426 INFO   | Load minigraph to reset the DUT str2-7050cx3-acs-01
19:32:47 config_reload.config_reload              L0058 INFO   | reloading minigraph


19:36:00 __init__._fixture_generator_decorator    L0082 INFO   | -------------------- fixture test_cleanup teardown starts --------------------
19:36:02 config_reload.config_reload              L0058 INFO   | reloading config_db
19:39:09 __init__._fixture_generator_decorator    L0091 INFO   | -------------------- fixture test_cleanup teardown ends --------------------
19:39:09 ptfhost_utils.run_garp_service           L0271 INFO   | Stopping GARP service on PTF host
19:39:11 ptfhost_utils.run_icmp_responder         L0223 INFO   | Stop running icmp_responder


------------------------ generated xml file: /var/src/sonic-mgmt-int/tests/logs/dualtor/test_standby_tor_upstream_mux_toggle.py::test_standby_tor_upstream_mux_toggle.xml ------------------------
------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------
19:39:13 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
========================== 1 passed in 592.24 seconds ==========================
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
