### PR TITLE
[console] Fix issue where the reverse ssh failed due to invalid hostkey

### DIFF
--- a/tests/console/test_console_loopback.py
+++ b/tests/console/test_console_loopback.py
@@ -82,7 +82,7 @@ def test_console_loopback_pingpong(duthost, creds, src_line, dst_line):
 
 def create_ssh_client(ip, user, pwd):
     # Set 'echo=False' is very important since pexpect will echo back all inputs to buffer by default
-    client = pexpect.spawn('ssh {}@{} -o StrictHostKeyChecking=no'.format(user, ip), echo=False)
+    client = pexpect.spawn('ssh {}@{} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'.format(user, ip), echo=False)
     client.expect('[Pp]assword:')
     client.sendline(pwd)
     return client

--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -60,7 +60,7 @@ def test_console_reversessh_force_interrupt(duthost, creds, target_line):
 
     ressh_user = "{}:{}".format(dutuser, target_line)
     try:
-        client = pexpect.spawn('ssh {}@{}'.format(ressh_user, dutip))
+        client = pexpect.spawn('ssh {}@{} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'.format(ressh_user, dutip))
         client.expect('[Pp]assword:')
         client.sendline(dutpass)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is for fixing the issue where the reverse ssh failed due to invalid hostkey.
Impacted tests:
- test_console_reversessh
- test_console_loopback

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix issue where the reverse ssh failed due to invalid hostkey

#### How did you do it?
By-pass the host key checking by adding options to ssh command

#### How did you verify/test it?
Run impacted tests on a physical DUT

#### Any platform specific information?
Only impact platform that enabled console switch feature

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
