### PR TITLE
[Vrf] Skip redirect test cases if ACL redirect not supported

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -680,6 +680,17 @@ class TestVrfAclRedirect():
     c_vars = {}
 
     @pytest.fixture(scope="class", autouse=True)
+    def is_redirect_supported(self, duthosts, rand_one_dut_hostname):
+        """
+        Check if switch supports acl redirect_action, if not then skip test cases
+        """
+        duthost = duthosts[rand_one_dut_hostname]
+        switch_cap = duthost.switch_capabilities_facts()['ansible_facts']['switch_capabilities']['switch']
+        res = [capabilities for capabilities in switch_cap.values() if "REDIRECT_ACTION" in capabilities]
+        if not res:
+            pytest.skip("Switch does not support ACL REDIRECT_ACTION")
+
+    @pytest.fixture(scope="class", autouse=True)
     def setup_acl_redirect(self, duthosts, rand_one_dut_hostname, cfg_facts):
         duthost = duthosts[rand_one_dut_hostname]
         # -------- Setup ----------

--- a/tests/vrf/test_vrf_attr.py
+++ b/tests/vrf/test_vrf_attr.py
@@ -41,7 +41,7 @@ class TestVrfAttrSrcMac():
         # -------- Teardown ----------
         extra_vars = { 'router_mac': dut_facts['router_mac'] }
         duthost.host.options['variable_manager'].extra_vars.update(extra_vars)
-        duthost.template(src="vrf_attr_src_mac.j2", dest="/tmp/vrf_attr_src_mac.json")
+        duthost.template(src="vrf/vrf_attr_src_mac.j2", dest="/tmp/vrf_attr_src_mac.json")
 
         duthost.shell("config load -y /tmp/vrf_attr_src_mac.json")
 


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This PR adds a fixture which will check if Switch supports Acl `REDIRECT_ACTION`, and if redirect is not supported then Vrf testcases defined under test class `TestVrfAclRedirect` will be skipped.
Also fixed incorrect path in test_vrf_attr.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Skip test cases on devices that don't have redirect support.
#### How did you do it?

#### How did you verify/test it?
Run testcases on device that don't have redirect support:
```
vrf/test_vrf.py::TestVrfAclRedirect::test_origin_ports_recv_no_pkts_v4 SKIPPED                                                                                    
vrf/test_vrf.py::TestVrfAclRedirect::test_origin_ports_recv_no_pkts_v6 SKIPPED                                                                                    
vrf/test_vrf.py::TestVrfAclRedirect::test_redirect_to_new_ports_v4 SKIPPED                                                                                        
vrf/test_vrf.py::TestVrfAclRedirect::test_redirect_to_new_ports_v6 SKIPPED  
```
#### Any platform specific information?
```
SONiC Software Version: SONiC.202012.28274-0162cee66
Distribution: Debian 10.10
Kernel: 4.19.0-12-2-amd64
Build commit: 0162cee66
Build date: Tue Aug 10 14:00:00 UTC 2021
Built by: AzDevOps@sonic-build-workers-000KZF
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
