### PR TITLE
test_check_sfputil_error_status missed adding xcvr_skip_list fixture to its arguements

### DIFF
--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -45,7 +45,7 @@ def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostn
             assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
 @pytest.mark.parametrize("cmd_sfp_error_status", ["sudo sfputil show error-status", "sudo sfputil show error-status --fetch-from-hardware"])
-def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, cmd_sfp_error_status):
+def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, cmd_sfp_error_status, xcvr_skip_list):
     """
     @summary: Check SFP error status using 'sfputil show error-status' and 'sfputil show error-status --fetch-from-hardware'
               This feature is supported on 202106 and above


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
https://github.com/Azure/sonic-mgmt/pull/3994 introduced using xcvr_skip_list to skip interfaces that don't have xcvr in them.

The fixture xcvr_skip_list was used within test_check_sfputil_error_status in tests/platform_tests/sfp/test_sfputil.py. However, this was not defined in the arguments of the test and thus would get the following error:

```
        for intf in dev_conn:
>           if intf not in xcvr_skip_list[duthost.hostname]:
E           NameError: global name 'xcvr_skip_list' is not defined
```
#### How did you do it?
Added xcvr_skip_list as an argument to the tests

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
