### PR TITLE
minigraph_interfaces in minigraph_facts for an asic was returning asic ifname instead of front panel port name

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -325,7 +325,12 @@ def parse_dpg(dpg, hname):
         intfs = []
         for ipintf in ipintfs.findall(str(QName(ns, "IPInterface"))):
             intfalias = ipintf.find(str(QName(ns, "AttachTo"))).text
-            intfname = port_alias_to_name_map.get(intfalias, intfalias)
+            if port_alias_to_name_map.has_key(intfalias):
+                intfname = port_alias_to_name_map[intfalias]
+            elif port_alias_asic_map.has_key(intfalias):
+                intfname = port_alias_asic_map[intfalias]
+            else:
+                intfname = intfalias
             ipprefix = ipintf.find(str(QName(ns, "Prefix"))).text
             intfs.append(_parse_intf(intfname, ipprefix))
             ports[intfname] = {'name': intfname, 'alias': intfalias}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

In the generated minigraph for a multi-asic box, the DPG section for an asic (hostname: ASIC<#>) has the IPInterface defined for a routed (non-lag) port with "AttachTo" field as the asic interface name

```
        <IPInterface>
          <Name i:nil="true"/>
          <AttachTo>Eth5-ASIC0</AttachTo>
          <Prefix>10.0.0.4/31</Prefix>
        </IPInterface>
```

In minigraph_facts, when we parse this IPInterface in the DPG section, we derive the intfname by mapping the "AttachTo" value, in the "port_alias_to_name_map". 

```
intfname = port_alias_to_name_map.get(intfalias, intfalias)
```
However, port_alias_to_name_map for a multi-asic box has keys as the front panel port name, and the alias, and not the asic_ ifnames. Thus, intfname is set to the asic_ifname, instead of the frontpanel port name, and we store the asic_ifname as the key in the minigraph_interfaces in the minigraph_facts.

Test test_interfaces.py::test_interfaces get the minigraph facts for an asic, and compares the mac address against host_facts (which is based on the frontpanel port name), and fails.
```
verify_mac_address(host_facts, mg_facts['minigraph_interfaces'], router_mac)
```
 
#### How did you do it?
Similar to what is done for portchannel members in minigraph_facts https://github.com/Azure/sonic-mgmt/blob/master/ansible/library/minigraph_facts.py#L367, we need to check if "AttachTo" for IPInterface is in the port_alias_asic_map and if so, use that value for the intfname

#### How did you verify/test it?
Tested test_interfaces on a single asic and multi-asic box.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
