### PR TITLE
[202012] [test_autonegotiation] Skip autoneg testcase on older images - unsupported CLI

### DIFF
--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -16,6 +16,7 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.helpers.dut_ports import decode_dut_port_name
 from tests.common.utilities import wait_until
 from tests.platform_tests.link_flap.link_flap_utils import build_test_candidates
+from tests.common.utilities import skip_version
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -37,6 +38,17 @@ PORT_STATUS_CHECK_INTERVAL = 10
 # Key: dut host object, value: a list of candidate ports tuple
 cadidate_test_ports = {}
 
+@pytest.fixture(autouse=True, scope="module")
+def check_image_version(duthost):
+    """Skips this test if the SONiC image installed on DUT is older than 202106
+
+    Args:
+        duthost: Hostname of DUT.
+
+    Returns:
+        None.
+    """
+    skip_version(duthost, ["201811", "201911", "202012"])
 
 @pytest.fixture(scope='module', autouse=True)
 def recover_ports(duthosts, enum_dut_portname_module_fixture, fanouthosts):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Autoneg CLI used in test_autonegotiation cases are supported on 202106 image version or later. These cases currently fail on older images
Fixes https://github.com/Azure/sonic-buildimage/issues/8490

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Prevent test case failure for autoneg cases on older images. 

#### How did you do it?
Added image version check for older images

#### How did you verify/test it?
Verified that platform_tests/test_autonegotiation.py is skipped on 202012, but triggered on 202106

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
