### PR TITLE
[test_bgpmon] Skip for storage backend topologies

### DIFF
--- a/tests/bgp/test_bgpmon.py
+++ b/tests/bgp/test_bgpmon.py
@@ -23,6 +23,13 @@ ZERO_ADDR = r'0.0.0.0/0'
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope="module", autouse=True)
+def skip_test_bgpmon_on_backend(tbinfo):
+    """Skip test_bgpmon over storage backend topologies."""
+    if "backend" in tbinfo["topo"]["name"]:
+        pytest.skip("Skipping test_bgpmon. Unsupported topology %s." % tbinfo["topo"]["name"])
+
+
 def get_default_route_ports(host, tbinfo):
     mg_facts = host.get_extended_minigraph_facts(tbinfo)
     route_info = json.loads(host.shell("show ip route {} json".format(ZERO_ADDR))['stdout'])


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3841

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
If the topology is either t0-backend or t1-backend, mark test_bgpmon as
skipped as BGP monitor is not a valid scenario on such topos.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Skip the test if the testbed is storage backend.

#### How did you verify/test it?
* run over testbed of storage backend topology:
```
bgp/test_bgpmon.py::test_bgpmon SKIPPED                                                                          [ 50%]
bgp/test_bgpmon.py::test_bgpmon_no_resolve_via_default SKIPPED                                                   [100%]

============================================== 2 skipped in 30.46 seconds ==============================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
