### PR TITLE
[snmp] test_snmp_interfaces_mibs fix KEY_ERROR issue on L2 config

### DIFF
--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -41,7 +41,7 @@ def collect_all_facts(duthost, ports_list, namespace=None):
             result[portname].update({'adminstatus': admin})
             oper = duthost.shell('{} APPL_DB HGET "PORT_TABLE:{}" "oper_status"'.format(sonic_db_cmd, name), module_ignore_errors=False)['stdout']
             result[portname].update({'operstatus': oper})
-            result[portname].update({'description': config_facts.get('PORT', {})[name]['description']})
+            result[portname].update({'description': config_facts.get('PORT', {})[name].get('description', '')})
         elif name.startswith("PortChannel"):
             result.setdefault(name, {})
             key_word = "PORTCHANNEL"
@@ -52,7 +52,7 @@ def collect_all_facts(duthost, ports_list, namespace=None):
             result[name].update({'operstatus': oper['stdout']})
             result[name].update({'description': config_facts.get(key_word, {})[name].get('description', '')})
         else:
-            key_word = "MGMT_PORT" 
+            key_word = "MGMT_PORT"
             result.setdefault(name, {})
             result[name].update({'mtu': str(setup[key]['mtu'])})
             result[name].update({'type': if_type})


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Changed the way value was extracted from dict by using **get('description', '')** function, in order to fix test case fail with L2 config deployed on DUT.  
Fix https://github.com/Azure/sonic-buildimage/issues/8310

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix test fail with L2 configuration deployed on DUT. 
#### How did you do it?
Changed the way value was extracted from dict. 
#### How did you verify/test it?
Run test case with L2 config deployed on DUT: 
snmp/test_snmp_interfaces.py::test_snmp_interfaces_mibs PASSED
#### Any platform specific information?
```
SONiC Software Version: SONiC.202012.28274-0162cee66
Distribution: Debian 10.10
Kernel: 4.19.0-12-2-amd64
Build commit: 0162cee66
Build date: Tue Aug 10 14:00:00 UTC 2021
Built by: AzDevOps@sonic-build-workers-000KZF
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
