### PR TITLE
Test code for simulating RO disk and attempt tacacs access.

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -125,6 +125,7 @@ test_t0() {
     syslog/test_syslog.py \
     tacacs/test_rw_user.py \
     tacacs/test_ro_user.py \
+    tacacs/test_ro_disk.py \
     tacacs/test_jit_user.py \
     telemetry/test_telemetry.py \
     test_features.py \
@@ -204,6 +205,7 @@ test_multi_asic_t1_lag() {
     snmp/test_snmp_default_route.py \
     tacacs/test_rw_user.py \
     tacacs/test_ro_user.py \
+    tacacs/test_ro_disk.py \
     tacacs/test_jit_user.py"
 
     pushd $SONIC_MGMT_DIR/tests

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -1,0 +1,81 @@
+import pytest
+import crypt
+import json
+import logging
+import time
+from pkg_resources import parse_version
+
+from tests.common.utilities import wait_until
+from tests.common.reboot import reboot
+from .test_ro_user import ssh_remote_run
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any')
+]
+
+logger = logging.getLogger(__name__)
+
+def skip_201911_and_older(duthost):
+    """ Skip the current test if the DUT version is 201911 or older.
+    """
+    if parse_version(duthost.kernel_version) <= parse_version('4.9.0'):
+        pytest.skip("Test not supported for 201911 images or older. Skipping the test")
+
+
+def simulate_ro(duthost):
+    duthost.shell("echo u > /proc/sysrq-trigger")
+    logger.info("Disk turned to RO state; pause for 30s before attempting to ssh")
+    time.sleep(30)
+
+
+def chk_ssh_remote_run(localhost, remote_ip, username, password, cmd):
+    rc = -1
+    try:
+        res = ssh_remote_run(localhost, remote_ip, username, password, cmd)
+        rc = res["rc"]
+    finally:
+        logger.debug("ssh rc={}".format(rc))
+    return rc == 0
+
+
+def test_ro_disk(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, test_tacacs):
+    """test tacacs rw user
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    skip_201911_and_older(duthost)
+
+    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+
+    ro_user = creds_all_duts[duthost]['tacacs_ro_user']
+    ro_pass = creds_all_duts[duthost]['tacacs_ro_user_passwd']
+
+    rw_user = creds_all_duts[duthost]['tacacs_rw_user']
+    rw_pass = creds_all_duts[duthost]['tacacs_rw_user_passwd']
+
+    res = duthost.shell("ls -l /home/{}".format(ro_user), module_ignore_errors=True)
+    assert res["rc"] != 0, "ro user pre-exists"
+
+    try:
+        # Ensure rw user can get in, as we need this to be able to reboot
+        ret = chk_ssh_remote_run(localhost, dutip, rw_user, rw_pass, "ls")
+        
+        assert ret, "Failed to ssh as rw user"
+
+        # Set disk in RO state
+        simulate_ro(duthost)
+
+        logger.debug("user={}".format(ro_user))
+
+        assert wait_until(600, 20, chk_ssh_remote_run, localhost, dutip,
+                ro_user, ro_pass, "cat /etc/passwd"), "Failed to ssh as ro user"
+
+    finally:
+        logger.debug("START: reboot {} to restore disk RW state".
+                format(enum_rand_one_per_hwsku_hostname))
+        chk_ssh_remote_run(localhost, dutip, rw_user, rw_pass, "sudo /sbin/reboot")
+        time.sleep(120)
+        logger.debug("  END: reboot {} to restore disk RW state".
+                format(enum_rand_one_per_hwsku_hostname))
+
+       

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -11,7 +11,8 @@ from .test_ro_user import ssh_remote_run
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
New test code
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Test disk_check.py & associated use of TACACS access when disk in RO state.

#### How did you do it?
1) login as rw user
2) Ensure ro user does not pre-exist
3) Simulate disk RO state
4) attempt to login as RO user
5) Finally issue reboot command to recover from RO state

#### How did you verify/test it?
Run test to success.

#### Any platform specific information?
Only in Physical duts

#### Supported testbed topology if it's a new test case?
Any

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
