### PR TITLE
Skip test_null_route_helper on dualtor testbed

### DIFF
--- a/tests/acl/null_route/test_null_route_helper.py
+++ b/tests/acl/null_route/test_null_route_helper.py
@@ -54,6 +54,12 @@ TEST_DATA = [
 ]
 
 
+@pytest.fixture(scope="module", autouse=True)
+def skip_on_dualtor_testbed(tbinfo):
+    if 'dualtor' in tbinfo['topo']['name']:
+        pytest.skip("Skip running on dualtor testbed")
+
+
 @pytest.fixture(scope="module")
 def create_acl_table(rand_selected_dut, tbinfo):
     """


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to skip ```test_null_route_helper``` on dualtor testbed.
Since there is no enough ACL resources on dualtor testbed, running ```test_null_route_helper``` will cause some exceptions.
Hence the test case is skipped.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to skip ```test_null_route_helper``` on dualtor testbed.

#### How did you do it?
Add a module level fixture to check topo name, and skip if the testbed is dualtor.

#### How did you verify/test it?
Verified on dualtor-2, and confirm the test case is skipped.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
