### PR TITLE
[nbr_health] Do not skip sanity checks for test_nbr_health

### DIFF
--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -9,7 +9,6 @@ from common.devices.sonic import SonicHost
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
     pytest.mark.pretest,
     pytest.mark.topology('util') #special marker


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Do not skip sanity for test_nbr_health
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 201911

### Approach
#### What is the motivation for this PR?
To continue testing cases if the testbed health is recovered. Presently, `test_nbr_health` skips sanity due to `skip_sanity` marker. 
So if testbed is unhealthy, no adaptive recovery will be done as part of sanity checks. Since this test has a `pytest.mark.pretest` marker, run_tests.sh will execute this test as part of `prepare_dut` and will not execute the remaining tests in nightly suite if this test fails (even if test_pretest cases recover the testbed health).

#### How did you do it?

Remove the skip sanity marker.

#### How did you verify/test it?
With the fix, if testbed has non-established BGP neighbors, the sanity check attempted to restore the DUT. And after that rest of the cases were executed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
