### PR TITLE
Clarify negative test for hash key 'ingress-port' in comments

### DIFF
--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -133,8 +133,9 @@ class HashTest(BaseTest):
 
         hit_count_map = {}
         if hash_key == 'ingress-port':
-            # Unenough samples for hash_key ingress-port, check it loosely
-            # Just verify if the asic actually use the hash field as a load-balancing factor
+            # The 'ingress-port' key is not used in hash by design. We are doing negative test for 'ingress-port'.
+            # When 'ingress-port' is included in HASH_KEYS, the PTF test will try to inject same packet to different
+            # ingress ports and expect that they are forwarded from same egress port.
             for ingress_port in self.get_ingress_ports(exp_port_list, dst_ip):
                 logging.info('Checking hash key {}, src_port={}, exp_ports={}, dst_ip={}'\
                     .format(hash_key, ingress_port, exp_port_list, dst_ip))

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -27,6 +27,9 @@ pytestmark = [
 ]
 
 # Usually src-mac, dst-mac, vlan-id are optional hash keys. Not all the platform supports these optional hash keys. Not enable these three by default.
+# The 'ingress-port' key is not used in hash by design. We are doing negative test for 'ingress-port'.
+# When 'ingress-port' is included in HASH_KEYS, the PTF test will try to inject same packet to different ingress ports
+# and expect that they are forwarded from same egress port.
 # HASH_KEYS = ['src-ip', 'dst-ip', 'src-port', 'dst-port', 'ingress-port', 'src-mac', 'dst-mac', 'ip-proto', 'vlan-id']
 HASH_KEYS = ['src-ip', 'dst-ip', 'src-port', 'dst-port', 'ingress-port', 'ip-proto']
 SRC_IP_RANGE = ['8.0.0.0', '8.255.255.255']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The 'ingress-port' key is not used in hash of FIB forwarding. If the 'ingress-port'
key is included in HASH_KEYS of the FIB hash testing, a negative test will be run.
The PTF script will try to inject same packet to different ingress ports and expect
that they are forwarded from same egress port. 

#### How did you do it?
This change added comments in test scripts to clarify this to avoid confusion.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
