### PR TITLE
[test_bgp_bounce] Fix BGP template issues

### DIFF
--- a/tests/bgp/templates/bgp_no_export.j2
+++ b/tests/bgp/templates/bgp_no_export.j2
@@ -19,7 +19,7 @@ enable password zebra
 !
 ! bgp multiple-instance
 !
-{% if DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
+{% if 'LeafRouter' in DEVICE_METADATA['localhost']['type'] %}
 route-map TO_TIER0_V4 permit 30
  set community no-export additive
 !
@@ -32,6 +32,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   bgp log-neighbor-changes
   bgp bestpath as-path multipath-relax
   no bgp default ipv4-unicast
+  no bgp ebgp-requires-policy
 {# Advertise graceful restart capability for ToR #}
 {% if DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
   bgp graceful-restart
@@ -69,7 +70,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% if bgp_session['asn'] | int != 0 %}
   neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
   neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}
-{% if DEVICE_METADATA['localhost']['type'] == 'LeafRouter' and DEVICE_NEIGHBOR_METADATA[bgp_session['name']]['type'] == 'ToRRouter' or DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
+{% if 'LeafRouter' in DEVICE_METADATA['localhost']['type'] and 'ToRRouter' in DEVICE_NEIGHBOR_METADATA[bgp_session['name']]['type'] or 'ToRRouter' in DEVICE_METADATA['localhost']['type'] %}
   neighbor {{ neighbor_addr }} allowas-in 1
 {% endif %}
 {% if 'admin_status' in bgp_session and bgp_session['admin_status'] == 'down' or 'admin_status' not in bgp_session and 'default_bgp_status' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['default_bgp_status'] == 'down' and DEVICE_METADATA.localhost.type != 'ToRRouter' %}
@@ -79,8 +80,8 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   address-family ipv4
     neighbor {{ neighbor_addr }} activate
     maximum-paths 64
-{% if DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
- {%- if DEVICE_NEIGHBOR_METADATA[bgp_session['name']]['type'] == 'ToRRouter' %}
+{% if 'LeafRouter' in DEVICE_METADATA['localhost']['type'] %}
+ {%- if 'ToRRouter' in DEVICE_NEIGHBOR_METADATA[bgp_session['name']]['type'] %}
     neighbor {{ neighbor_addr }} route-map TO_TIER0_V4 out
     neighbor {{ neighbor_addr }} send-community
     neighbor {{ neighbor_addr }} allowas-in 1

--- a/tests/bgp/templates/bgp_plain.j2
+++ b/tests/bgp/templates/bgp_plain.j2
@@ -27,6 +27,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   bgp log-neighbor-changes
   bgp bestpath as-path multipath-relax
   no bgp default ipv4-unicast
+  no bgp ebgp-requires-policy
 {# Advertise graceful restart capability for ToR #}
 {% if DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
   bgp graceful-restart

--- a/tests/bgp/test_bgp_bounce.py
+++ b/tests/bgp/test_bgp_bounce.py
@@ -4,6 +4,7 @@ Test bgp no-export community in SONiC.
 
 import random
 import pytest
+import time
 
 from tests.common.helpers.assertions import pytest_assert
 from bgp_helpers import apply_bgp_config


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3837
Fixes https://github.com/Azure/sonic-buildimage/issues/8514

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
There are two main issues for the BGP templates used in
`test_bgp_bounce`:
1. By default, FRR now rejects updates(both inbound/outbound) if BGP
session has no filter applied. Add `no bgp ebgp-requires-policy` to
remove this limitation so neighbors could receives BGP routes.
2. The templates uses `ToRRouter` and `LeafRouter` to check device
type, which should be either `BackEndLeafRouter` or `BackEndToRRouter`
for devices in storage backend topologies. So let's check if the devices
type contains substring(either `ToRRouter` or `LeafRouter`) to adapt to
storage backend topos.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Fix the templates used `bgp_plain.j2` and `bgp_no_export.j2`

#### How did you verify/test it?
Run over both `t1` and `t1-backend`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
