### PR TITLE
Improve ```test_proxy_arp``` on single tor testbed

### DIFF
--- a/tests/arp/test_arp_dualtor.py
+++ b/tests/arp/test_arp_dualtor.py
@@ -194,7 +194,7 @@ def test_proxy_arp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup_pt
             dut_macs.append(vlan_details['mac'].lower())
     else:
         router_mac = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
-        dut_macs = [router_mac]
+        dut_macs = [router_mac.lower()]
 
     pytest_assert(ping_addr in neighbor_table.keys())
     pytest_assert(neighbor_table[ping_addr]['macaddress'].lower() in dut_macs)


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to improve ```test_proxy_arp``` on single tor testbed.
```test_proxy_arp``` failed on some single tor test bed because dutmac is in upper case. This PR addressed the issue by converting all MAC addresses into lower case.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to improve ```test_proxy_arp``` on single tor testbed.

#### How did you do it?
This PR addressed the issue by converting all MAC addresses into lower case.

#### How did you verify/test it?
Verified on SN4600. Test cases passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
