### PR TITLE
[chassis] Fix T2 fib_info for routes present a multiple asics in a chassi

### DIFF
--- a/tests/common/fixtures/fib_utils.py
+++ b/tests/common/fixtures/fib_utils.py
@@ -58,15 +58,19 @@ def get_t2_fib_info(duthosts, duts_cfg_facts, duts_mg_facts):
                             # ignore the prefix, if the prefix nexthop is not a frontend port
                             if 'members' in po[ifname]:
                                 if 'role' in ports[po[ifname]['members'][0]] and ports[po[ifname]['members'][0]]['role'] == 'Int':
-                                    skip = True
+                                    if len(oports) == 0:
+                                        skip = True
                                 else:
                                     oports.append([str(mg_facts['minigraph_ptf_indices'][x]) for x in po[ifname]['members']])
+                                    skip = False
                         else:
                             if ports.has_key(ifname):
                                 if 'role' in ports[ifname] and ports[ifname]['role'] == 'Int':
-                                    skip = True
+                                    if len(oports) == 0:
+                                        skip = True
                                 else:
                                     oports.append([str(mg_facts['minigraph_ptf_indices'][ifname])])
+                                    skip = False
                             else:
                                 logger.info("Route point to non front panel port {}:{}".format(k, v))
                                 skip = True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
In a T2 topology, the same route being advertised on multiple asics. In this case, the route entry would have both the eBGP via front-panel port and the inband port as nexthops. When generating the t2 fib, we were skipping routes that had inband port as nexthop (The nexthop port in 'Int'). Thus, these routes were getting discarded in the fib_info.

#### How did you do it?
Fix is not check if there are any other 'Ext' nexthops, and if so, don't skip this route.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
