### PR TITLE
Adding support for Nokia Linecard and supervisor card in port_utils

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -167,6 +167,17 @@ def get_port_alias_to_name_map(hwsku, asic_id=None):
     elif hwsku == "et6448m" or hwsku == "Nokia-7215":
         for i in range(0, 52):
             port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
+    elif hwsku == "Nokia-IXR7250E-36x400G":
+        if asic_id is not None:
+            asic_offset = int(asic_id) * 18
+            for i in range(0, 18):
+                port_alias_to_name_map["Ethernet%d" % (asic_offset + i)] = "Ethernet%d" % ((asic_offset + i))
+                port_alias_asic_map["Eth%d-ASIC%d" % (i, int(asic_id))] = "Ethernet%d" % ((asic_offset + i))
+        else:
+            for i in range(0, 36):
+                port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
+    elif hwsku == 'Nokia-IXR7250E-SUP-10':
+        port_alias_to_name_map = {}
     elif hwsku == "newport":
         for i in range(0, 256, 8):
             port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Need to provide support for the port_alias_to_name_map and port_alias_asic_map for the port_alias ansible module for the following Nokia hwsku:

- Nokia-IXR7259E-36x400G - Linecard
- Nokia-IXR7250E-SUP-10 - Supervisor card.

#### How did you do it?
Added the code in port_utils.py 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
