### PR TITLE
[console] Fix issue where the reverse ssh failed due to invalid hostkey

### DIFF
--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -25,7 +25,7 @@ def test_console_reversessh_connectivity(duthost, creds, target_line):
 
     ressh_user = "{}:{}".format(dutuser, target_line)
     try:
-        client = pexpect.spawn('ssh {}@{}'.format(ressh_user, dutip))
+        client = pexpect.spawn('ssh {}@{} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'.format(ressh_user, dutip))
         client.expect('[Pp]assword:')
         client.sendline(dutpass)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This is an additional fix of: https://github.com/Azure/sonic-mgmt/pull/4047 which doesn't fixed all parts.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This is an additional fix of: https://github.com/Azure/sonic-mgmt/pull/4047 which doesn't fixed all parts.

#### How did you do it?
By-pass the hostkey validation by adding `-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null` to ssh command

#### How did you verify/test it?
Run test on a physical DUT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
