### PR TITLE
[inner hashing] extend inner hashing test with dynamic Policy Base Hashing configurations

### DIFF
--- a/ansible/roles/test/files/ptftests/inner_hash_test.py
+++ b/ansible/roles/test/files/ptftests/inner_hash_test.py
@@ -66,13 +66,13 @@ class InnerHashTest(BaseTest):
 
         inner_src_ip_range = [unicode(x) for x in self.test_params['inner_src_ip_range'].split(',')]
         inner_dst_ip_range = [unicode(x) for x in self.test_params['inner_dst_ip_range'].split(',')]
-        self.inner_src_ip_interval = lpm.LpmDict.IpInterval(ip_address(inner_src_ip_range[0]), ip_address(inner_src_ip_range[1]))
-        self.inner_dst_ip_interval = lpm.LpmDict.IpInterval(ip_address(inner_dst_ip_range[0]), ip_address(inner_dst_ip_range[1]))
+        self.inner_src_ip_interval = lpm.LpmDict.IpInterval(ip_address(inner_src_ip_range[0])+1, ip_address(inner_src_ip_range[1]))
+        self.inner_dst_ip_interval = lpm.LpmDict.IpInterval(ip_address(inner_dst_ip_range[0])+1, ip_address(inner_dst_ip_range[1]))
 
         outer_src_ip_range = [unicode(x) for x in self.test_params['outer_src_ip_range'].split(',')]
         outer_dst_ip_range = [unicode(x) for x in self.test_params['outer_dst_ip_range'].split(',')]
-        self.outer_src_ip_interval = lpm.LpmDict.IpInterval(ip_address(outer_src_ip_range[0]), ip_address(outer_src_ip_range[1]))
-        self.outer_dst_ip_interval = lpm.LpmDict.IpInterval(ip_address(outer_dst_ip_range[0]), ip_address(outer_dst_ip_range[1]))
+        self.outer_src_ip_interval = lpm.LpmDict.IpInterval(ip_address(outer_src_ip_range[0])+1, ip_address(outer_src_ip_range[1]))
+        self.outer_dst_ip_interval = lpm.LpmDict.IpInterval(ip_address(outer_dst_ip_range[0])+1, ip_address(outer_dst_ip_range[1]))
 
         self.hash_keys = self.test_params.get('hash_keys', ['src-ip', 'dst-ip', 'src-port', 'dst-port'])
         self.src_ports = self.test_params['src_ports']
@@ -154,16 +154,30 @@ class InnerHashTest(BaseTest):
         rand_int = random.randint(1, 99)
         src_mac = '00:12:ab:34:cd:' + str(rand_int)
         dst_mac = str(rand_int) + ':12:ab:34:cd:00'
-        pkt = simple_tcp_packet(
-                        eth_dst=dst_mac,
-                        eth_src=src_mac,
-                        ip_src=ip_src,
-                        ip_dst=ip_dst,
-                        tcp_sport=sport,
-                        tcp_dport=dport,
-                        ip_ttl=64)
+        if ip_network(unicode(ip_src)).version == 4:
+            pkt = simple_tcp_packet(
+                eth_dst=dst_mac,
+                eth_src=src_mac,
+                ip_dst=ip_dst,
+                ip_src=ip_src,
+                tcp_sport=sport,
+                tcp_dport=dport,
+                ip_ttl=64
+            )
 
-        pkt['IP'].proto = ip_proto
+            pkt["IP"].proto = ip_proto
+        else:
+            pkt = simple_tcpv6_packet(
+                eth_dst=dst_mac,
+                eth_src=src_mac,
+                ipv6_dst=ip_dst,
+                ipv6_src=ip_src,
+                tcp_sport=sport,
+                tcp_dport=dport,
+                ipv6_hlim=64
+            )
+
+            pkt["IPv6"].nh = ip_proto
         return pkt
 
 

--- a/ansible/roles/test/files/ptftests/inner_hash_test.py
+++ b/ansible/roles/test/files/ptftests/inner_hash_test.py
@@ -66,13 +66,13 @@ class InnerHashTest(BaseTest):
 
         inner_src_ip_range = [unicode(x) for x in self.test_params['inner_src_ip_range'].split(',')]
         inner_dst_ip_range = [unicode(x) for x in self.test_params['inner_dst_ip_range'].split(',')]
-        self.inner_src_ip_interval = lpm.LpmDict.IpInterval(ip_address(inner_src_ip_range[0])+1, ip_address(inner_src_ip_range[1]))
-        self.inner_dst_ip_interval = lpm.LpmDict.IpInterval(ip_address(inner_dst_ip_range[0])+1, ip_address(inner_dst_ip_range[1]))
+        self.inner_src_ip_interval = lpm.LpmDict.IpInterval(ip_address(inner_src_ip_range[0]), ip_address(inner_src_ip_range[1]))
+        self.inner_dst_ip_interval = lpm.LpmDict.IpInterval(ip_address(inner_dst_ip_range[0]), ip_address(inner_dst_ip_range[1]))
 
         outer_src_ip_range = [unicode(x) for x in self.test_params['outer_src_ip_range'].split(',')]
         outer_dst_ip_range = [unicode(x) for x in self.test_params['outer_dst_ip_range'].split(',')]
-        self.outer_src_ip_interval = lpm.LpmDict.IpInterval(ip_address(outer_src_ip_range[0])+1, ip_address(outer_src_ip_range[1]))
-        self.outer_dst_ip_interval = lpm.LpmDict.IpInterval(ip_address(outer_dst_ip_range[0])+1, ip_address(outer_dst_ip_range[1]))
+        self.outer_src_ip_interval = lpm.LpmDict.IpInterval(ip_address(outer_src_ip_range[0]), ip_address(outer_src_ip_range[1]))
+        self.outer_dst_ip_interval = lpm.LpmDict.IpInterval(ip_address(outer_dst_ip_range[0]), ip_address(outer_dst_ip_range[1]))
 
         self.hash_keys = self.test_params.get('hash_keys', ['src-ip', 'dst-ip', 'src-port', 'dst-port'])
         self.src_ports = self.test_params['src_ports']

--- a/tests/ecmp/test_inner_hashing.py
+++ b/tests/ecmp/test_inner_hashing.py
@@ -70,8 +70,8 @@ HASH_FIELD_CONFIG = {
     "inner_l4_src_port": {"field": "INNER_L4_SRC_PORT", "sequence": "2"},
     "inner_src_ipv4": {"field": "INNER_SRC_IPV4", "sequence": "3", "mask": "255.255.255.255"},
     "inner_dst_ipv4": {"field": "INNER_DST_IPV4", "sequence": "3", "mask": "255.255.255.255"},
-    "inner_src_ipv6": {"field": "INNER_SRC_IPV6", "sequence": "4", "mask": "ffff:ffff::"},
-    "inner_dst_ipv6": {"field": "INNER_DST_IPV6", "sequence": "4", "mask": "ffff:ffff::"}
+    "inner_src_ipv6": {"field": "INNER_SRC_IPV6", "sequence": "4", "mask": "::ffff:ffff"},
+    "inner_dst_ipv6": {"field": "INNER_DST_IPV6", "sequence": "4", "mask": "::ffff:ffff"}
 }
 
 

--- a/tests/ecmp/test_inner_hashing.py
+++ b/tests/ecmp/test_inner_hashing.py
@@ -199,7 +199,7 @@ def inner_ipver(request):
 
 
 @pytest.fixture(scope="module")
-def dynamic_pbh(request):
+def setup_dynamic_pbh(request):
     request.getfixturevalue("config_pbh_table")
     request.getfixturevalue("config_hash_fields")
     request.getfixturevalue("config_hash")
@@ -333,7 +333,7 @@ def get_src_dst_ip_range(ipver):
 
 
 def test_inner_hashing(duthost, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
-                       vlan_ptf_ports, symmetric_hashing, build_fib, setup, dynamic_pbh):
+                       vlan_ptf_ports, symmetric_hashing, build_fib, setup, setup_dynamic_pbh):
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
     log_file = "/tmp/inner_hash_test.InnerHashTest.{}.{}.{}.log".format(outer_ipver, inner_ipver, timestamp)
     logging.info("PTF log file: %s" % log_file)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
extending of inner hashing test with dynamic Policy Base Hashing configurations.

Include 4 parametrized tests:
outer_ipver - inner_ipver
     ipv4  -  ipv4
     ipv6  -  ipv4
     ipv6  -  ipv4
     ipv6  -  ipv6 



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Validation of PBH feature


#### How did you verify/test it?
The test executed on different MLNX platforms, supported the PBH feature



#### Supported testbed topology if it's a new test case?
t0

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

https://github.com/anish-n/SONiC/blob/c27b933b0b3e7a13ebabc7b294ae15f7e5c6340e/doc/ecmp/inner_packet_hashing_test_plan.md

Azure/SONiC#824

