### PR TITLE
[test_acl] Backup and restore config_db.json on all DUTs

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 from tests.common import reboot, port_toggle
 from tests.common.helpers.assertions import pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
-from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_module
+from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py, run_garp_service, change_mac_addresses
 from tests.common.utilities import wait_until
 from tests.conftest import duthost
@@ -29,6 +29,7 @@ pytestmark = [
     pytest.mark.acl,
     pytest.mark.disable_loganalyzer,  # Disable automatic loganalyzer, since we use it for the test
     pytest.mark.topology("any"),
+    pytest.mark.usefixtures('backup_and_restore_config_db_on_duts')
 ]
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -311,7 +312,7 @@ def create_or_remove_acl_table(duthost, acl_table_config, setup, op):
             sonic_host_or_asic_inst.command("config acl remove table {}".format(acl_table_config["table_name"]))
 
 @pytest.fixture(scope="module")
-def acl_table(duthosts, rand_one_dut_hostname, setup, stage, ip_version, backup_and_restore_config_db_module):
+def acl_table(duthosts, rand_one_dut_hostname, setup, stage, ip_version):
     """Apply ACL table configuration and remove after tests.
 
     Args:
@@ -319,9 +320,7 @@ def acl_table(duthosts, rand_one_dut_hostname, setup, stage, ip_version, backup_
         rand_one_dut_hostname: hostname of a random chosen dut to run test.
         setup: Parameters for the ACL tests.
         stage: The ACL stage under test.
-        ip_version: The IP version under test.
-        backup_and_restore_config_db_module: A fixture that handles restoring Config DB
-                after the tests are over.
+        ip_version: The IP version under test
 
     Yields:
         The ACL table configuration.


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
```test_acl.py::TestAclWithReboot``` will run ```config save -y``` on both DUTs, but the fixture ```backup_and_restore_config_db_module``` only backup ```config_db.json``` on the randomly selected DUT. As a result, ```config_db.json``` on the other DUT will be changed, and test ACL rules are included.
This PR addressed the issue by adding a new fixture to backup ```config_db.json``` file on both DUTs.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to address the issue that ```config_db.json``` is modified after ```test_acl``` on dualtor testbed.

#### How did you do it?
This PR addressed the issue by adding a new fixture to backup ```config_db.json``` file on both DUTs.

#### How did you verify/test it?
Verified on both dualtor and single tor testbed, and confirm that ```config_db.json``` were restored after test running.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
