### PR TITLE
[test_bgp_speaker] Enable storage backend topologies

### DIFF
--- a/tests/bgp/templates/bgp_speaker_route.j2
+++ b/tests/bgp/templates/bgp_speaker_route.j2
@@ -1,3 +1,3 @@
-0.0.0.0/0 {% for portchannel, v in minigraph_portchannels.iteritems() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
+0.0.0.0/0 {% if is_backend %}[]{% else %}{% for portchannel, v in minigraph_portchannels.iteritems() %}[{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}{% endif %}
 
 {{announce_prefix}} {% for vlan, v in minigraph_vlans.iteritems() %}{% for member in v.members %}[{{ '%d' % minigraph_port_indices[member]}}]{% if not loop.last %} {% endif %}{% endfor %}{% if not loop.last %} {% endif %}{% endfor %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4075

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Run `test_bgp_speaker` over `t0-backend`

#### How did you do it?
1. Use ptf sub interface as IO port for BGP sessions and fib test.

#### How did you verify/test it?
Run `test_bgp_speaker` over both `t0` and `t0-backend`
```
bgp/test_bgp_speaker.py::test_bgp_speaker_bgp_sessions PASSED                                                                                                                                                                                                          [ 33%]
bgp/test_bgp_speaker.py::test_bgp_speaker_announce_routes[True-False-1514] PASSED                                                                                                                                                                                      [ 66%]
bgp/test_bgp_speaker.py::test_bgp_speaker_announce_routes_v6[False-True-1514] PASSED                                                                                                                                                                                   [100%]

========================================================================================================================= 3 passed in 230.81 seconds =========================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
