### PR TITLE
Fix for сhecking hwsku name in port_utils

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -204,7 +204,7 @@ def get_port_alias_to_name_map(hwsku, asic_id=None):
         else:
             for i in range(1,9):
                 port_alias_to_name_map["Ethernet1/%d" % i] = "Ethernet%d" % ((i - 1) * 4)
-    elif hwsku == "B6510-48VS8CQ" or "RA-B6510-48V8C":
+    elif hwsku == "B6510-48VS8CQ" or hwsku == "RA-B6510-48V8C":
         for i in range(1,49):
             port_alias_to_name_map["twentyfiveGigE0/%d" % i] = "Ethernet%d" % i
         for i in range(49,57):


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Minor fix for сhecking hwsku name in port_utils

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Changes from [3765](https://github.com/Azure/sonic-mgmt/pull/3765) cause minor issue in `get_port_alias_to_name_mop` function of `port_utils.py` module. Value of condition always is True and `else `block will be skipped. Example:
```
>>> hwsku = 'hwsku_name'
>>> if hwsku == "B6510-48VS8CQ" or "RA-B6510-48V8C":
...   print(True)
... 
True
```
#### How did you do it?
Uptated if…elif…else statement in `get_port_alias_to_name_mop` function of `port_utils.py` module.
#### How did you verify/test it?
Run tests. Test passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
