### PR TITLE
Fixed RPC regression which is executed on ptf32 topology

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -376,7 +376,7 @@ def nbrhosts(ansible_adhoc, tbinfo, creds, request):
     """
 
     devices = {}
-    if not tbinfo['vm_base'] and 'tgen' in tbinfo['topo']['name']:
+    if (not tbinfo['vm_base'] and 'tgen' in tbinfo['topo']['name']) or 'ptf' in tbinfo['topo']['name']:
         logger.info("No VMs exist for this topology: {}".format(tbinfo['topo']['name']))
         return devices
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Community introduced change to clean up topology #3656, which assumes
that topo_ptf32.yml will have VMs, but it did not.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
ptf32 topology has no VMs, but fixture nbrhosts expectes to have VMs
    @pytest.fixture(scope="module") 
    def nbrhosts(ansible_adhoc, tbinfo, creds, request): 
        """ 
        Shortcut fixture for getting VM host 
        """ 
        devices = {} 
        if not tbinfo['vm_base'] and 'tgen' in tbinfo['topo']['name']: 
            logger.info("No VMs exist for this topology: {}".format(tbinfo['topo']['name'])) 
            return devices  
        vm_base = int(tbinfo['vm_base'][2:]) 
        neighbor_type = request.config.getoption("--neighbor_type") 
>       for k, v in tbinfo['topo']['properties']['topology']['VMs'].items(): 
>E       KeyError: 'VMs' 
#### How did you do it?

#### How did you verify/test it?
Executed the test, it did not failed on setup stage

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
