### PR TITLE
testbed: Fix incorrect instruction

### DIFF
--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -263,7 +263,7 @@ Once the topology has been created, we need to give the DUT an initial configura
 2. Verify that you can login to the SONiC KVM using Mgmt IP = 10.250.0.101 and admin:password.
 ```
 ssh admin@10.250.0.101
-admin@10.250.0.101's password: <password_in_password.txt>
+admin@10.250.0.101's password: password
 ```
 3. After logged in to the SONiC KVM, you should be able to see BGP sessions with:
 ```


### PR DESCRIPTION
* Password to SONiC KVM should be password in VsSetup.

Signed-off-by: Xichen Lin <xichenlin@microsoft.com>

### Description of PR

Summary:
Minor fix in instructions of VsSetup, password should be "password" and not "password in password.txt".

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Password in README does not match reality.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
