### PR TITLE
[memory_checker] Parameterize with combination of DuT and container.

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -180,3 +180,40 @@ def get_disabled_container_list(duthost):
             disabled_containers.append(container_name)
 
     return disabled_containers
+
+
+def encode_dut_and_container_name(dut_name, container_name):
+    """Gets a string by combining dut name and container name.
+
+    Args:
+      dut_name: A string represents name of DuT.
+      container_name: A string represents name of container.
+
+    Returns:
+      A string includes the DuT and container names.
+    """
+
+    return dut_name + "|" + container_name
+
+
+def decode_dut_and_container_name(name_str):
+    """Gets DuT name and container name by parsing the string 'name_str'.
+
+    Args:
+      A string includes the DuT and container names.
+
+    Returns:
+      dut_name: A string represents name of DuT.
+      container_name: A string represents name of container.
+    """
+    dut_name = ""
+    container_name = ""
+
+    name_list = name_str.strip().split("|")
+    if len(name_list) >= 2:
+        dut_name = name_list[0]
+        container_name = name_list[1]
+    elif len(name_list) == 1:
+        container_name = name_list[0]
+
+    return dut_name, container_name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ from tests.common.helpers.constants import (
     ASIC_PARAM_TYPE_BACKEND
 )
 from tests.common.helpers.dut_ports import encode_dut_port_name
+from tests.common.helpers.dut_utils import encode_dut_and_container_name
 from tests.common.system_utils import docker
 from tests.common.testbed import TestbedInfo
 from tests.common.utilities import get_inventory_files
@@ -915,7 +916,7 @@ def generate_dut_feature_container_list(request):
     List of features and container names are both obtained from
     metadata file
     """
-    empty = [ encode_dut_port_name('unknown', 'unknown') ]
+    empty = [ encode_dut_and_container_name("unknown", "unknown") ]
 
     tbname = request.config.getoption("--testbed")
     if not tbname:
@@ -945,9 +946,9 @@ def generate_dut_feature_container_list(request):
 
             if services is not None:
                 for service in services:
-                    container_list.append(encode_dut_port_name(dut, service))
+                    container_list.append(encode_dut_and_container_name(dut, service))
             else:
-                container_list.append(encode_dut_port_name(dut, feature))
+                container_list.append(encode_dut_and_container_name(dut, feature))
 
     return container_list
 

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -39,7 +39,7 @@ def modify_monit_config_and_restart(duthosts, enum_dut_feature_container, enum_r
         None.
     """
     dut_name, container_name = decode_dut_port_name(enum_dut_feature_container)
-    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname and feature == "telemetry",
+    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname and container_name == "telemetry",
                    "Skips testing memory_checker of container '{}' on the DuT '{}' since another DuT '{}' was chosen."
                    .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))
     duthost = duthosts[dut_name]
@@ -215,7 +215,7 @@ def test_memory_checker(duthosts, enum_dut_feature_container, creds, enum_rand_o
         None.
     """
     dut_name, container_name = decode_dut_port_name(enum_dut_feature_container)
-    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname and feature == "telemetry",
+    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname and container_name == "telemetry",
                    "Skips testing memory_checker of container '{}' on the DuT '{}' since another DuT '{}' was chosen."
                    .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))
     duthost = duthosts[dut_name]

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -8,9 +8,10 @@ import pytest
 
 from pkg_resources import parse_version
 from tests.common.utilities import wait_until
-from tests.common.helpers.dut_utils import check_container_state
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
+from tests.common.helpers.dut_ports import decode_dut_port_name
+from tests.common.helpers.dut_utils import check_container_state
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 
 logger = logging.getLogger(__name__)
@@ -25,8 +26,9 @@ CONTAINER_RESTART_THRESHOLD_SECS = 180
 CONTAINER_CHECK_INTERVAL_SECS = 1
 
 
-@pytest.fixture(autouse=True, scope="module")
-def modify_monit_config_and_restart(duthost):
+@pytest.fixture(autouse=True)
+def modify_monit_config_and_restart(duthosts, enum_dut_feature_container, enum_rand_one_per_hwsku_frontend_hostname):
+
     """Backup Monit configuration files, then customize and restart it before testing.
     Restore original Monit configuration files and restart Monit service after testing.
 
@@ -36,6 +38,12 @@ def modify_monit_config_and_restart(duthost):
     Returns:
         None.
     """
+    dut_name, container_name = decode_dut_port_name(enum_dut_feature_container)
+    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname and feature == "telemetry",
+                   "Skips testing memory_checker of container '{}' on the DuT '{}' since another DuT '{}' was chosen."
+                   .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))
+    duthost = duthosts[dut_name]
+
     logger.info("Back up Monit configuration files on DuT '{}' ...".format(duthost.hostname))
     duthost.shell("sudo cp -f /etc/monit/monitrc /tmp/")
     duthost.shell("sudo cp -f /etc/monit/conf.d/monit_telemetry /tmp/")
@@ -193,7 +201,7 @@ def postcheck_critical_processes(duthost, container_name):
     logger.info("All critical processes in '{}' container are running.".format(container_name))
 
 
-def test_memory_checker(duthosts, creds, enum_rand_one_per_hwsku_frontend_hostname):
+def test_memory_checker(duthosts, enum_dut_feature_container, creds, enum_rand_one_per_hwsku_frontend_hostname):
     """Checks whether the telemetry container can be restarted or not if the memory
     usage of it is beyond the threshold. The `stress` utility is leveraged as
     the memory stressing tool.
@@ -206,7 +214,12 @@ def test_memory_checker(duthosts, creds, enum_rand_one_per_hwsku_frontend_hostna
     Returns:
         None.
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    dut_name, container_name = decode_dut_port_name(enum_dut_feature_container)
+    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname and feature == "telemetry",
+                   "Skips testing memory_checker of container '{}' on the DuT '{}' since another DuT '{}' was chosen."
+                   .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))
+    duthost = duthosts[dut_name]
+
     # TODO: Currently we only test 'telemetry' container which has the memory threshold 400MB
     # and number of vm_workers is hard coded. We will extend this testing on all containers after
     # the feature 'memory_checker' is fully implemented.
@@ -217,7 +230,6 @@ def test_memory_checker(duthosts, creds, enum_rand_one_per_hwsku_frontend_hostna
                    and (("20191130" in duthost.os_version and parse_version(duthost.os_version) > parse_version("20191130.72"))
                    or parse_version(duthost.kernel_version) > parse_version("4.9.0")),
                    "Test is not supported for platform Celestica E1031, 20191130.72 and older image versions!")
-
 
     expected_alerting_messages = []
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="container_restart_due_to_memory")

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -10,8 +10,8 @@ from pkg_resources import parse_version
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
-from tests.common.helpers.dut_ports import decode_dut_port_name
 from tests.common.helpers.dut_utils import check_container_state
+from tests.common.helpers.dut_utils import decode_dut_and_container_name
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 
 logger = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ def modify_monit_config_and_restart(duthosts, enum_dut_feature_container, enum_r
     Returns:
         None.
     """
-    dut_name, container_name = decode_dut_port_name(enum_dut_feature_container)
+    dut_name, container_name = decode_dut_and_container_name(enum_dut_feature_container)
     pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname and container_name == "telemetry",
                    "Skips testing memory_checker of container '{}' on the DuT '{}' since another DuT '{}' was chosen."
                    .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))
@@ -214,7 +214,7 @@ def test_memory_checker(duthosts, enum_dut_feature_container, creds, enum_rand_o
     Returns:
         None.
     """
-    dut_name, container_name = decode_dut_port_name(enum_dut_feature_container)
+    dut_name, container_name = decode_dut_and_container_name(enum_dut_feature_container)
     pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname and container_name == "telemetry",
                    "Skips testing memory_checker of container '{}' on the DuT '{}' since another DuT '{}' was chosen."
                    .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ x] 201911

### Approach
#### What is the motivation for this PR?
This PR aims to parameterize this test case with different container names such that individual test case will be ran against each container. This method will avoid using a loop to iterate each container in a single test case. For testing on Dual ToR, this method can avoid the fixture function runs on upper ToR and test case runs on lower ToR. This PR will fix https://github.com/Azure/sonic-buildimage/issues/8430. 

#### How did you do it?
Currently we already has this infrastructure. The parameter `enum_dut_feature_container`  will be initialized with the combination of DuT and container names. The function `decode_dut_port_name(...)` will parse each string to get DuT name and container name.

#### How did you verify/test it?
I tested this change on Dual ToR `str2-7050cx3-acs-06, str2-7050cx3-acs-07` and single ToR `str-msn2700-03`.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
