### PR TITLE
[ansible] fix duplicate docker repository

### DIFF
--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -3,33 +3,49 @@
   become: yes
   environment: "{{ proxy_env | default({}) }}"
 
+- name: Check docker repository
+  find:
+    paths: /etc/apt/sources.list.d/
+    patterns: "*docker*"
+  register: docker_repo
+
+- name: Report docker repository exists
+  debug:
+    msg: "Docker repository already exists"
+  when: docker_repo.matched > 0
+
+- name: Report docker repository not exists
+  debug:
+    msg: "Docker repository does not exist"
+  when: docker_repo.matched == 0
+
 - name: Add docker repository for 16.04
   apt_repository:
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
     state: present
   become: yes
-  when: host_distribution_version.stdout == "16.04"
+  when: host_distribution_version.stdout == "16.04" and docker_repo.matched == 0
 
 - name: Add docker repository for 17.04
   apt_repository:
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu zesty stable
     state: present
   become: yes
-  when: host_distribution_version == "17.04"
+  when: host_distribution_version == "17.04" and docker_repo.matched == 0
 
 - name: Add docker repository for 18.04
   apt_repository:
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
     state: present
   become: yes
-  when: host_distribution_version.stdout == "18.04"
+  when: host_distribution_version.stdout == "18.04" and docker_repo.matched == 0
 
 - name: Add docker repository for 20.04
   apt_repository:
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable
     state: present
   become: yes
-  when: host_distribution_version.stdout == "20.04"
+  when: host_distribution_version.stdout == "20.04" and docker_repo.matched == 0
 
 - name: Install docker-ce
   apt: pkg=docker-ce update_cache=yes


### PR DESCRIPTION
* fix problem where too many docker repo added

Signed-off-by: Xichen Lin <xichenlin@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In VsSetup, mgmt container will attempt to add docker repo, even though in this case a docker repo already exists, causing apt update failure.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Bug fix.

#### How did you do it?
Before installing new docker repo, ansible will check for files under /etc/apt/sources.list.d with name "docker" to avoid conflict.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
