### PR TITLE
Skip python coredump check for 201911

### DIFF
--- a/tests/platform_tests/verify_dut_health.py
+++ b/tests/platform_tests/verify_dut_health.py
@@ -107,7 +107,10 @@ def check_neighbors(duthost, tbinfo):
 
 @handle_test_error
 def verify_no_coredumps(duthost, pre_existing_cores):
-    coredumps_count = duthost.shell('ls /var/core/ | wc -l')['stdout']
+    if "20191130" in duthost.os_version :
+        coredumps_count = duthost.shell('ls /var/core/ | grep -v python | wc -l')['stdout']
+    else:
+        coredumps_count = duthost.shell('ls /var/core/ | wc -l')['stdout']
     if int(coredumps_count) > int(pre_existing_cores):
         raise RebootHealthError("Core dumps found. Expected: {} Found: {}".format(pre_existing_cores,\
             coredumps_count))
@@ -134,7 +137,10 @@ def verify_dut_health(request, duthosts, rand_one_dut_hostname, tbinfo):
     check_services(duthost)
     check_interfaces_and_transceivers(duthost, request)
     check_neighbors(duthost, tbinfo)
-    pre_existing_cores = duthost.shell('ls /var/core/ | wc -l')['stdout']
+    if "20191130" in duthost.os_version :
+        pre_existing_cores = duthost.shell('ls /var/core/ | grep -v python | wc -l')['stdout']
+    else:
+        pre_existing_cores = duthost.shell('ls /var/core/ | wc -l')['stdout']
     pytest_assert(all(list(test_report.values())), "DUT not ready for test. Health check failed before reboot: {}"
         .format(test_report))
 

--- a/tests/platform_tests/verify_dut_health.py
+++ b/tests/platform_tests/verify_dut_health.py
@@ -107,7 +107,7 @@ def check_neighbors(duthost, tbinfo):
 
 @handle_test_error
 def verify_no_coredumps(duthost, pre_existing_cores):
-    if "20191130" in duthost.os_version :
+    if "20191130" in duthost.os_version:
         coredumps_count = duthost.shell('ls /var/core/ | grep -v python | wc -l')['stdout']
     else:
         coredumps_count = duthost.shell('ls /var/core/ | wc -l')['stdout']
@@ -137,7 +137,7 @@ def verify_dut_health(request, duthosts, rand_one_dut_hostname, tbinfo):
     check_services(duthost)
     check_interfaces_and_transceivers(duthost, request)
     check_neighbors(duthost, tbinfo)
-    if "20191130" in duthost.os_version :
+    if "20191130" in duthost.os_version:
         pre_existing_cores = duthost.shell('ls /var/core/ | grep -v python | wc -l')['stdout']
     else:
         pre_existing_cores = duthost.shell('ls /var/core/ | wc -l')['stdout']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In 201911 image, the caclmgrd crashes when fast-reboot command is called thereby generating a python coredump. The new check for coredump introduced in sonic-mgmt is causing tests to fail because of this coredump. This check is not relevant for 201911. Hence introducing a change to ignore python coredumps only for 201911

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Python coredumps which are not a concern are produced during  fast-reboot and need to be ignored in the `verify_no_coredumps` method
#### How did you do it?

#### How did you verify/test it?
Ran the tests which were failing earlier and now they pass with the change.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
