### PR TITLE
[pytest][fixture] Added fixture to generate backend ASICs on a multi ASIC platform

### DIFF
--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -4,4 +4,3 @@ DEFAULT_NAMESPACE = None
 NAMESPACE_PREFIX = 'asic'
 ASIC_PARAM_TYPE_ALL = 'num_asics'
 ASIC_PARAM_TYPE_FRONTEND = 'frontend_asics'
-ASIC_PARAM_TYPE_BACKEND = 'backend_asics'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,6 @@ from tests.common.devices.duthosts import DutHosts
 from tests.common.devices.vmhost import VMHost
 from tests.common.helpers.constants import (
     ASIC_PARAM_TYPE_ALL, ASIC_PARAM_TYPE_FRONTEND, DEFAULT_ASIC_ID,
-    ASIC_PARAM_TYPE_BACKEND
 )
 from tests.common.helpers.dut_ports import encode_dut_port_name
 from tests.common.system_utils import docker

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -837,9 +837,8 @@ def generate_param_asic_index(request, dut_hostnames, param_type, random_asic=Fa
                     dut_asic_params = range(int(inv_data[ASIC_PARAM_TYPE_ALL]))
             elif param_type == ASIC_PARAM_TYPE_FRONTEND and ASIC_PARAM_TYPE_FRONTEND in inv_data:
                 dut_asic_params = inv_data[ASIC_PARAM_TYPE_FRONTEND]
-            elif param_type == ASIC_PARAM_TYPE_BACKEND and ASIC_PARAM_TYPE_BACKEND in inv_data:
-                dut_asic_params = inv_data[ASIC_PARAM_TYPE_BACKEND]
             logging.info("dut name {}  asics params = {}".format(dut, dut_asic_params))
+
         if random_asic:
             asic_index_params.append(random.sample(dut_asic_params, 1))
         else:
@@ -952,20 +951,20 @@ def generate_dut_feature_container_list(request):
 
 
 def generate_dut_backend_asics(request, duts_selected):
-    asic_list = []
+    dut_asic_list = []
 
     metadata = get_testbed_metadata(request)
 
     if metadata is None:
-        return asic_list
+        return [[None]]
 
     for dut in duts_selected:
         mdata = metadata.get(dut)
         if mdata is None:
             continue
-        asic_list.append(mdata.get("backend_asics", []))
+        dut_asic_list.append(mdata.get("backend_asics", [None]))
 
-    return asic_list
+    return dut_asic_list
 
 
 def generate_priority_lists(request, prio_scope):

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -782,6 +782,9 @@ class TestQosSaiMasic(QosSaiBaseMasic):
         if not duthost.sonichost.is_multi_asic:
             pytest.skip("Test applies to only multi ASIC platform")
 
+        if enum_backend_asic_index is None:
+            pytest.skip("Backend ASIC is None")
+
         try:
             # Bring down port (channel) towards ASICs other than the ASIC
             # under test, so that traffic always goes via ASIC under test

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -76,14 +76,21 @@ def collect_dut_info(dut):
                 dut.get_docker_name(service, asic_index=be)
             ]
 
-    return {
+    dut_info = {
         "intf_status": status,
         "features": features,
         "asic_services": asic_services,
-        "frontend_asics": front_end_asics,
-        "backend_asics": back_end_asics
     }
 
+    if dut.sonichost.is_multi_asic:
+        dut_info.update(
+            {
+                "frontend_asics": front_end_asics,
+                "backend_asics": back_end_asics
+            }
+        )
+
+    return dut_info
 
 def test_update_testbed_metadata(duthosts, tbinfo):
     metadata = {}

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -62,7 +62,7 @@ def collect_dut_info(dut):
 
     if dut.sonichost.is_multi_asic:
         front_end_asics = dut.get_frontend_asic_ids()
-        back_end_asic = dut.get_backend_asic_ids()
+        back_end_asics = dut.get_backend_asic_ids()
 
     asic_services = defaultdict(list)
     for service in dut.sonichost.DEFAULT_ASIC_SERVICES:
@@ -70,7 +70,7 @@ def collect_dut_info(dut):
         # and one backend ASIC
         if dut.sonichost.is_multi_asic:
             fe = random.choice(front_end_asics)
-            be = random.choice(back_end_asic)
+            be = random.choice(back_end_asics)
             asic_services[service] = [
                 dut.get_docker_name(service, asic_index=fe),
                 dut.get_docker_name(service, asic_index=be)
@@ -80,6 +80,8 @@ def collect_dut_info(dut):
         "intf_status": status,
         "features": features,
         "asic_services": asic_services,
+        "frontend_asics": front_end_asics,
+        "backend_asics": back_end_asics
     }
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added a fixture to return a list of backend ASIC index used for pytest parameterization

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
Using metadata file to get the list of backend ASICs. Metadata file is generated as part of 'test_pretest.py'.

```
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ grep backend metadata/vms13-t1-nmasic-2.json -B1 -A6
        "str-nmasic-acs-2": {
            "backend_asics": [
                4,
                5
            ],
            "asic_services": {
                "lldp": [

```

#### What is the motivation for this PR?
Parameterize backend ASIC indices

#### How did you do it?
Get the ASIC list from metadata file for the testbed.

#### How did you verify/test it?
Single ASIC
```
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ pytest test_pretest.py --testbed vms12-t1-lag-1 --inventory=../ansible/str,../ansible/veos --testbed_file=../ansible/testbed.csv --host-pattern=str-s6000-acs-8  --module-path=../ansible/library --disable_loganalyzer --skip_sanity -k metadata
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================================= test session starts =============================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 12 items / 11 deselected / 1 selected

test_pretest.py .                                                                                                               [100%]

========================================================== warnings summary ===========================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannotbe rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================== 1 passed, 11 deselected, 1 warnings in 25.34 seconds =========================================

```

Multi ASIC

```
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ pytest test_pretest.py --testbed=vms13-t1-n3164-2 --inventory=../ansible/veos,../ansible/str,../ansible/str2 --testbed_file=../ansible/testbed.csv --host-pattern=str-n3164-acs-2 --module-path=../ansible/library --disable_loganalyzer --skip_sanity -k metadata
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================================= test session starts =============================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 12 items / 11 deselected / 1 selected

test_pretest.py .                                                                                                                                                                                                                                                       [100%]

============================================================================================================================== warnings summary ===============================================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================================================================================ 1 passed, 11 deselected, 1 warnings in 24.06 seconds =============================================================================================================
```

Single ASIC

```
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ pytest dummy/test_params_dummy2.py --testbed vms12-t1-lag-1 --inventory=../ansible/str,../ansible/veos --testbed_file=../ansible/testbed.csv --host-pattern=str-s6000-acs-8  --module-path=../ansible/library --disable_loganalyzer --skip_sanity -s -k params0 --log-level INFO | grep "Backend ASIC index"
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
WARNING: No route found for IPv6 destination :: (no default route?)
INFO:root:Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
INFO:root:Test has no defined levels. Continue without test completeness checks
INFO:root:-------------------- fixture copy_saitests_directory setup starts --------------------
INFO:tests.common.fixtures.ptfhost_utils:Copy SAI test files to PTF host 'v12-11'
INFO:root:-------------------- fixture copy_saitests_directory setup ends --------------------
INFO:root:Using DUTs ['str-s6000-acs-8'] in testbed 'vms12-t1-lag-1'
INFO:tests.conftest:Randomly select dut str-s6000-acs-8 for testing
INFO:tests.conftest:dut str-s6000-acs-8 belongs to groups [u'sonic', u'sonic_dell32_40', u'str', 'fanout']
INFO:root:skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
INFO:root:skip empty var file ../ansible/group_vars/all/README.yml
[WARNING]: Unable to parse /var/sonic-mgmt/tests/localhost as an inventory source
[WARNING]: No inventory was parsed, only implicit localhost is available
INFO:tests.common.plugins.sanity_check:Prepare sanity check
INFO:tests.common.plugins.sanity_check:Found marker: m.name=topology, m.args=('any',), m.kwargs={}
INFO:tests.common.plugins.sanity_check:Found marker: m.name=device_type, m.args=('vs',), m.kwargs={}
INFO:tests.common.plugins.sanity_check:Skip sanity check according to command line argument or configuration of test script.
INFO:root:Log analyzer is disabled
INFO:test_params_dummy2:Backend ASIC index None
INFO:root:-------------------- fixture copy_saitests_directory teardown starts --------------------
INFO:tests.common.fixtures.ptfhost_utils:Delete SAI test files from PTF host 'v12-11'
INFO:root:-------------------- fixture copy_saitests_directory teardown ends --------------------

```

Multi ASIC

```
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ pytest dummy/test_params_dummy2.py --testbed=vms13-t1-nmasic-2 --inventory=../ansible/veos,../ansible/str,../ansible/str2 --testbed_file=../ansible/testbed.csv --host-pattern=str-nmasic-acs-2 --module-path=../ansible/library --disable_loganalyzer --skip_sanity --log-level INFO -s -k params0 | grep "Backend ASIC index"
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
WARNING: No route found for IPv6 destination :: (no default route?)
INFO:root:Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
INFO:root:Test has no defined levels. Continue without test completeness checks
INFO:root:-------------------- fixture copy_saitests_directory setup starts --------------------
INFO:tests.common.fixtures.ptfhost_utils:Copy SAI test files to PTF host 'vms13-5'
INFO:root:-------------------- fixture copy_saitests_directory setup ends --------------------
INFO:root:Using DUTs ['str-nmasic-acs-2'] in testbed 'vms13-t1-nmasic-2'
INFO:tests.conftest:Randomly select dut str-nmasic-acs-2 for testing
INFO:tests.conftest:dut str-nmasic-acs-2 belongs to groups [u'sonic', u'sonic_nexus_masic', u'str', u'str2', 'fanout']
INFO:root:skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
INFO:root:skip empty var file ../ansible/group_vars/all/README.yml
[WARNING]: Unable to parse /var/sonic-mgmt/tests/localhost as an inventory source
[WARNING]: No inventory was parsed, only implicit localhost is available
INFO:tests.common.plugins.sanity_check:Prepare sanity check
INFO:tests.common.plugins.sanity_check:Found marker: m.name=topology, m.args=('any',), m.kwargs={}
INFO:tests.common.plugins.sanity_check:Found marker: m.name=device_type, m.args=('vs',), m.kwargs={}
INFO:tests.common.plugins.sanity_check:Skip sanity check according to command line argument or configuration of test script.
INFO:root:Log analyzer is disabled
INFO:test_params_dummy2:Backend ASIC index 4
INFO:root:Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
INFO:root:Test has no defined levels. Continue without test completeness checks
INFO:root:Log analyzer is disabled
INFO:test_params_dummy2:Backend ASIC index 5
INFO:root:-------------------- fixture copy_saitests_directory teardown starts --------------------
INFO:tests.common.fixtures.ptfhost_utils:Delete SAI test files from PTF host 'vms13-5'
INFO:root:-------------------- fixture copy_saitests_directory teardown ends --------------------

```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
