### PR TITLE
FIX: wait/restart cEOS container, to make sure mgmt-ip reachable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ ansible.log
 tests/logs
 tests/_cache
 tests/metadata
+ansible/plugins/*/*.pyc
 
 # Dev tools
 .vscode/
+.idea/
+
+# Credential files
+ansible/group_vars/all/secrets.json

--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,8 @@ ansible.log
 tests/logs
 tests/_cache
 tests/metadata
-ansible/plugins/*/*.pyc
 
 # Dev tools
 .vscode/
 .idea/
 
-# Credential files
-ansible/group_vars/all/secrets.json

--- a/ansible/roles/eos/tasks/ceos.yml
+++ b/ansible/roles/eos/tasks/ceos.yml
@@ -6,13 +6,13 @@
 - name: set force_restart=yes for ceos container
   set_fact: force_restart=yes
 
-- name: set farce_restart=no for ceos container
+- name: set force_restart=no for ceos container
   set_fact: force_restart=no
   when: snmp_data.ansible_facts.ansible_sysname is defined
 
 - include_tasks: ceos_config.yml
 
-- name: Create cEOS container ceos_{{ vm_set_name }}_{{ inventory_hostname }}
+- name: Create cEOS container
   become: yes
   docker_container:
     name: ceos_{{ vm_set_name }}_{{ inventory_hostname }}
@@ -38,3 +38,15 @@
     volumes:
       - /{{ ceos_image_mount_dir }}/ceos_{{ vm_set_name }}_{{ inventory_hostname }}:/mnt/flash
   delegate_to: "{{ VM_host[0] }}"
+
+- name: set container_reachable=False for ceos container
+  set_fact: container_reachable=False
+
+# loop four times, if all containers are reachable in any iteration, the rest loop will be skipped
+- name: make sure container's mgmt-ip is reachable
+  include_tasks: ceos_ensure_reachable.yml
+  loop:
+    - 1
+    - 2
+    - 3
+    - 4

--- a/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
+++ b/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
@@ -1,6 +1,7 @@
 - block:
   - name: set time out threshold
-    set_fact: timeout_threshold=120
+    set_fact:
+      timeout_threshold: 120
     
   - name: wait for container's mgmt-ip reachable
     wait_for:
@@ -14,7 +15,7 @@
     delegate_to: "{{ VM_host[0] }}"
 
   - name: restart cEOS container
-    when: ip_ssh_result.failed and ip_ssh_result.elapsed >= "{{ timeout_threshold }}"
+    when: ip_ssh_result.failed and ip_ssh_result.elapsed >= timeout_threshold
     become: yes
     docker_container:
       name: ceos_{{ vm_set_name }}_{{ inventory_hostname }}

--- a/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
+++ b/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
@@ -1,0 +1,49 @@
+- block:
+  - name: wait for container's mgmt-ip reachable
+    wait_for:
+      port: 22
+      host: "{{ ansible_host }}"
+      search_regex: OpenSSH
+      delay: 0
+      timeout: 120
+    register: ip_result
+    ignore_errors: yes
+    delegate_to: "{{ VM_host[0] }}"
+
+  - name: restart cEOS container
+    when: ip_result.failed == true and 'Timeout when waiting' in ip_result.msg
+    become: yes
+    docker_container:
+      name: ceos_{{ vm_set_name }}_{{ inventory_hostname }}
+      image: "{{ ceos_image }}"
+      command: /sbin/init systemd.setenv=INTFTYPE=eth systemd.setenv=ETBA=1 systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 systemd.setenv=CEOS=1 systemd.setenv=EOS_PLATFORM=ceoslab systemd.setenv=container=docker systemd.setenv=MGMT_INTF=eth0
+      pull: no
+      state: started
+      tty: yes
+      network_mode: container:net_{{ vm_set_name }}_{{ inventory_hostname }}
+      detach: True
+      restart: yes
+      capabilities:
+        - net_admin
+      privileged: yes
+      env:
+        CEOS=1
+        container=docker
+        EOS_PLATFORM=ceoslab
+        SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1
+        ETBA=1
+        INTFTYPE=eth
+        MGMT_INTF=eth0
+      volumes:
+      - /{{ ceos_image_mount_dir }}/ceos_{{ vm_set_name }}_{{ inventory_hostname }}:/mnt/flash
+    delegate_to: "{{ VM_host[0] }}"
+
+  - name: set container_reachable=True for ceos container
+    when: ip_result.failed == false
+    set_fact: container_reachable=True
+
+  - name: set container_reachable=False for ceos container
+    when: ip_result.failed == true
+    set_fact: container_reachable=False
+
+  when: not container_reachable

--- a/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
+++ b/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
@@ -1,17 +1,20 @@
 - block:
+  - name: set time out threshold
+    set_fact: timeout_threshold=120
+    
   - name: wait for container's mgmt-ip reachable
     wait_for:
       port: 22
       host: "{{ ansible_host }}"
       search_regex: OpenSSH
       delay: 0
-      timeout: 120
-    register: ip_result
+      timeout: "{{ timeout_threshold }}"
+    register: ip_ssh_result
     ignore_errors: yes
     delegate_to: "{{ VM_host[0] }}"
 
   - name: restart cEOS container
-    when: ip_result.failed == true and 'Timeout when waiting' in ip_result.msg
+    when: ip_ssh_result.failed and ip_ssh_result.elapsed >= "{{ timeout_threshold }}"
     become: yes
     docker_container:
       name: ceos_{{ vm_set_name }}_{{ inventory_hostname }}
@@ -39,11 +42,11 @@
     delegate_to: "{{ VM_host[0] }}"
 
   - name: set container_reachable=True for ceos container
-    when: ip_result.failed == false
+    when: not ip_ssh_result.failed
     set_fact: container_reachable=True
 
   - name: set container_reachable=False for ceos container
-    when: ip_result.failed == true
+    when: ip_ssh_result.failed
     set_fact: container_reachable=False
 
   when: not container_reachable

--- a/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
+++ b/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
@@ -18,7 +18,27 @@
     become: yes
     docker_container:
       name: ceos_{{ vm_set_name }}_{{ inventory_hostname }}
+      image: "{{ ceos_image }}"
+      command: /sbin/init systemd.setenv=INTFTYPE=eth systemd.setenv=ETBA=1 systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 systemd.setenv=CEOS=1 systemd.setenv=EOS_PLATFORM=ceoslab systemd.setenv=container=docker systemd.setenv=MGMT_INTF=eth0
+      pull: no
+      state: started
+      tty: yes
+      network_mode: container:net_{{ vm_set_name }}_{{ inventory_hostname }}
+      detach: True
       restart: yes
+      capabilities:
+        - net_admin
+      privileged: yes
+      env:
+        CEOS=1
+        container=docker
+        EOS_PLATFORM=ceoslab
+        SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1
+        ETBA=1
+        INTFTYPE=eth
+        MGMT_INTF=eth0
+      volumes:
+        - /{{ ceos_image_mount_dir }}/ceos_{{ vm_set_name }}_{{ inventory_hostname }}:/mnt/flash
     when: ceos_reachability.failed and ceos_reachability.elapsed >= timeout_threshold
     delegate_to: "{{ VM_host[0] }}"
 

--- a/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
+++ b/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
@@ -7,47 +7,23 @@
     wait_for:
       port: 22
       host: "{{ ansible_host }}"
-      search_regex: OpenSSH
+      state: started
       delay: 0
       timeout: "{{ timeout_threshold }}"
-    register: ip_ssh_result
+    register: ceos_reachability
     ignore_errors: yes
-    delegate_to: "{{ VM_host[0] }}"
+    delegate_to: "localhost"
 
   - name: restart cEOS container
-    when: ip_ssh_result.failed and ip_ssh_result.elapsed >= timeout_threshold
     become: yes
     docker_container:
       name: ceos_{{ vm_set_name }}_{{ inventory_hostname }}
-      image: "{{ ceos_image }}"
-      command: /sbin/init systemd.setenv=INTFTYPE=eth systemd.setenv=ETBA=1 systemd.setenv=SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 systemd.setenv=CEOS=1 systemd.setenv=EOS_PLATFORM=ceoslab systemd.setenv=container=docker systemd.setenv=MGMT_INTF=eth0
-      pull: no
-      state: started
-      tty: yes
-      network_mode: container:net_{{ vm_set_name }}_{{ inventory_hostname }}
-      detach: True
       restart: yes
-      capabilities:
-        - net_admin
-      privileged: yes
-      env:
-        CEOS=1
-        container=docker
-        EOS_PLATFORM=ceoslab
-        SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1
-        ETBA=1
-        INTFTYPE=eth
-        MGMT_INTF=eth0
-      volumes:
-      - /{{ ceos_image_mount_dir }}/ceos_{{ vm_set_name }}_{{ inventory_hostname }}:/mnt/flash
+    when: ceos_reachability.failed and ceos_reachability.elapsed >= timeout_threshold
     delegate_to: "{{ VM_host[0] }}"
 
-  - name: set container_reachable=True for ceos container
-    when: not ip_ssh_result.failed
-    set_fact: container_reachable=True
-
-  - name: set container_reachable=False for ceos container
-    when: ip_ssh_result.failed
-    set_fact: container_reachable=False
+  - name: update container_reachable
+    set_fact:
+      container_reachable: "{{ not ceos_reachability.failed|bool }}"
 
   when: not container_reachable


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the occasional bug of cEOS's mgmt-ip will be unreachable after container started.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Use cEOS instead of vEOS
Fix the occasional bug of cEOS's mgmt-ip will be unreachable after container started.
#### How did you do it?
Wait for mgmt-ip be reachable, if time out, restart it.

#### How did you verify/test it?
Add topology and run testcases on both Ubuntu 18.04(Server27) and Ubuntu 20.04(Server24).

bgp/test_bgp_fact.py:
bgp/test_bgp_fact.py::test_bgp_facts[str2-n3164-acs-3-0] PASSED          [ 16%]
bgp/test_bgp_fact.py::test_bgp_facts[str2-n3164-acs-3-1] PASSED          [ 33%]
bgp/test_bgp_fact.py::test_bgp_facts[str2-n3164-acs-3-2] PASSED          [ 50%]
bgp/test_bgp_fact.py::test_bgp_facts[str2-n3164-acs-3-3] PASSED          [ 66%]
bgp/test_bgp_fact.py::test_bgp_facts[str2-n3164-acs-3-4] PASSED          [ 83%]
bgp/test_bgp_fact.py::test_bgp_facts[str2-n3164-acs-3-5] PASSED          [100%]

decap/test_decap.py:
decap/test_decap.py::test_decap PASSED                                   [100%]

#### Any platform specific information?
Tested on Ubuntu 18.04(Server27) and Ubuntu 20.04(Server24).
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
