### PR TITLE
[test_fdb] Only check dummy_mac when checking fdb clear

### DIFF
--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -163,7 +163,7 @@ def get_fdb_dynamic_mac_count(duthost):
     logger.info('"show mac" output on DUT:\n{}'.format(pprint.pformat(res['stdout_lines'])))
     total_mac_count = 0
     for l in res['stdout_lines']:
-        if "dynamic" in l.lower():
+        if "dynamic" in l.lower() and DUMMY_MAC_PREFIX in l.lower():
             total_mac_count += 1
     return total_mac_count
 


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/Azure/sonic-mgmt/issues/3934

This PR is to focus on only dummy mac when checking if FDB table is cleared completely.

When SONiC is configured to L2 mode, VMs will keep sending packets to L2 interfaces, which will populate FDB on DUT and result in test failure. This PR is to address the issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix #3934

#### How did you do it?
Focus on dummy mac when checking if FDB table is cleared completely.

#### How did you verify/test it?
Verified on SN4600
1. Config device to L2 switch
2. Run ```test_fdb```, and confirm test can pass now.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
