### PR TITLE
[test_vlan] Enable storage backend topology

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -25,6 +25,9 @@ pytestmark = [
     pytest.mark.topology('t0')
 ]
 
+# Use original ports intead of sub interfaces for ptfadapter if it's t0-backend
+PTF_PORT_MAPPING_MODE = "use_orig_interface"
+
 
 @pytest.fixture(scope="module")
 def cfg_facts(duthosts, rand_one_dut_hostname):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4030

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Let `test_vlan` use ptf original interfaces to do IO for ptfadapter if
the topo is `t0-backend`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Define per-module port mapping mode for `test_vlan` to let `ptfadapter` choose the original interface to test for `t0-backend` topology.

#### How did you verify/test it?
Run over `t0` and `t0-backend`
```
vlan/test_vlan.py::test_vlan_tc1_send_untagged PASSED                                                                                                                                                                                                                  [ 16%]
vlan/test_vlan.py::test_vlan_tc2_send_tagged PASSED                                                                                                                                                                                                                    [ 33%]
vlan/test_vlan.py::test_vlan_tc3_send_invalid_vid PASSED                                                                                                                                                                                                               [ 50%]
vlan/test_vlan.py::test_vlan_tc4_tagged_non_broadcast PASSED                                                                                                                                                                                                           [ 66%]
vlan/test_vlan.py::test_vlan_tc5_untagged_non_broadcast PASSED                                                                                                                                                                                                         [ 83%]
vlan/test_vlan.py::test_vlan_tc6_tagged_qinq_switch_on_outer_tag SKIPPED                                                                                                                                                                                               [100%]

=================================================================================================================== 5 passed, 1 skipped in 286.66 seconds ====================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
