### PR TITLE
[test_heartbeat_failure] skip the heartbeat test

### DIFF
--- a/tests/dualtor/test_heartbeat_failure.py
+++ b/tests/dualtor/test_heartbeat_failure.py
@@ -11,7 +11,8 @@ from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_ser
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 
 pytestmark = [
-    pytest.mark.topology("dualtor")
+    pytest.mark.topology("dualtor"),
+    pytest.mark.skip(reason="skipping until the mux toggle issue is addressed")
 ]
 
 


### PR DESCRIPTION
What is the motivation for this PR?
After this test is failed, then the subsequent dual-tor test cases will mostly fail as well. Need to figure out the reason why can't gurantee all interfaces to be toggled to active state. See detail on issue#8423.

How did you do it?
just skip this test before issue is addressed.

Signed-off-by: Kevin Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
