### PR TITLE
test_pcied: complemented DB data checks according the test plan

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -451,3 +451,12 @@ def dump_scapy_packet_show_output(packet):
         return sys.stdout.getvalue()
     finally:
         sys.stdout = _stdout
+
+
+def compose_dict_from_cli(fields_list):
+    """Convert the output of hgetall command to a dict object containing the field, key pairs of the database table content
+
+    Args:
+        fields_list: A list of lines, the output of redis-cli hgetall command
+    """
+    return dict(zip(fields_list[0::2], fields_list[1::2]))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: test_pcied - complemented DB data checks according the test plan
Fixes # (issue)
- added missing data checks for test_pcied 
Among other checks [the test plan](https://github.com/Azure/sonic-mgmt/blob/master/docs/testplan/PMON-Services-Daemons-test-plan.md#test-case--2-verify-each-daemon-status-if-all-expected-db-data-is-populated) mentions DB data checks on daemon stop/restart to make sure data is cleared (on stop) and updated (on restart), steps 5 and 8. These checks were missing so the PR brings them
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Make test scenarios consistent with the test plan
#### How did you do it?
Complemented the tests with missing checks
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t1,any platform_tests/daemon/test_pcied.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
