### PR TITLE
added docs for how to use the pytest results storing and history plugin

### DIFF
--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -10,6 +10,7 @@ Plugins:
 - [ptfadapter](/tests/common/ptfadapter/README.md)
 - [DUT monitor](/tests/common/dut_monitor/README.md)
 - [Log Analyzer](/tests/common/loganalyzer/README.md)
+- [Results reports and history (argus)](/tests/common/pytest_argus/README.md)
 - [PSU Controller](/tests/common/pdu_controller/README.md)
 - [Sanity Check](/tests/common/sanity_check/README.md)
 - [Test Completeness](/tests/common/test_completeness/README.md)

--- a/tests/common/pytest_argus/README.md
+++ b/tests/common/pytest_argus/README.md
@@ -1,0 +1,31 @@
+To start with pytest argus plugin for storing regression results there are 2 options, either have the python module as part of sonic-mgmt container by copying the code in .\sonic-mgmt\tests\common\pytest_argus (not prefered) or the recomended way is to have 1 folder where sonic-mgmt is and also create an 'extra' folder along side sonic-mgmt folder
+
+install using pip pytest-argus in extra folder
+```
+mkdir ./extra
+pip install --target=./extra pytest_argus
+```
+
+configure your mysql server IP, user, password, etc.
+```
+# /extra/pytest_argus/settings.yaml
+database:
+   host: 127.0.0.1
+   port: 3306
+   dbname: ARGUS
+   user: root
+   password: argus
+   client_encoding: utf-8
+   connect_timeout: 60
+   sslmode: none
+   test_type: sonic
+```
+
+
+when doing step 5 from [Test Bed Setup](./docs/testbed/README.testbed.Setup.md) add the ./extra folder to the python path
+```
+docker run -v $PWD:/data --env PYTHONPATH=/data/extra -it docker-sonic-mgmt bash
+```
+
+https://pypi.org/project/pytest-argus/
+https://github.com/keysight/argus

--- a/tests/common/pytest_argus/README.md
+++ b/tests/common/pytest_argus/README.md
@@ -1,12 +1,12 @@
 To start with pytest argus plugin for storing regression results there are 2 options, either have the python module as part of sonic-mgmt container by copying the code in .\sonic-mgmt\tests\common\pytest_argus (not prefered) or the recomended way is to have 1 folder where sonic-mgmt is and also create an 'extra' folder along side sonic-mgmt folder
 
-install using pip pytest-argus in extra folder
+Install using pip pytest-argus in extra folder
 ```
 mkdir ./extra
 pip install --target=./extra pytest_argus
 ```
 
-configure your mysql server IP, user, password, etc.
+Configure your mysql server IP, user, password, etc.
 ```
 # /extra/pytest_argus/settings.yaml
 database:
@@ -22,10 +22,13 @@ database:
 ```
 
 
-when doing step 5 from [Test Bed Setup](./docs/testbed/README.testbed.Setup.md) add the ./extra folder to the python path
+When doing step 5 from [Test Bed Setup](./docs/testbed/README.testbed.Setup.md) add the ./extra folder to the python path
 ```
 docker run -v $PWD:/data --env PYTHONPATH=/data/extra -it docker-sonic-mgmt bash
 ```
 
-https://pypi.org/project/pytest-argus/
-https://github.com/keysight/argus
+For bringing database up as well as the result viewer please refer to https://github.com/Keysight/argus/tree/main/docs
+
+Other resources:
+ * https://pypi.org/project/pytest-argus/
+ * https://github.com/keysight/argus


### PR DESCRIPTION
### Description of PR
currently it is very hard to have a history of past regression runs, build over build graphs,
this plugin is meant o store all the results in a database and provides a nice web interface for looking at few reports like build over build  pass rate, test case history, test case history per island ....

Summary:
enhancement

### Type of change
Docs

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
currently it is very hard to have a history of past regression runs

#### How did you do it?
created 3 components
 * a pytest plugin that captures live the progress of the tests
 * a database schema meant to store the test results
 * a web app ment to generate reports from the database results
created a docker compose file that will bring up the webapp container and the database container for easy installation and deployment (few commands to get started)

#### How did you verify/test it?
ran sonic regression 20+ times and store results and ran teh reports

#### Any platform specific information?
docker and docker compose are needed to run the containers

#### Supported testbed topology if it's a new test case?

### Documentation 
this commit is pure docs.
