### PR TITLE
Add object ID to platform objects serialized by JSON serializer

### DIFF
--- a/tests/common/helpers/platform_api/scripts/platform_api_server.py
+++ b/tests/common/helpers/platform_api/scripts/platform_api_server.py
@@ -22,11 +22,14 @@ def obj_serialize(obj):
     ''' JSON serializer for objects not serializable by default json library code
         We simply return a dictionary containing the object's class and module
     '''
-    syslog.syslog(syslog.LOG_WARNING, 'Unserializable object: {}.{}'.format(obj.__module__, obj.__class__.__name__))
+    syslog.syslog(syslog.LOG_WARNING,
+            'Unserializable object: {}.{} at {}'.format(
+                obj.__module__, obj.__class__.__name__, hex(id(obj))))
 
     data = {
         '__class__': obj.__class__.__name__,
-        '__module__': obj.__module__
+        '__module__': obj.__module__,
+        'object_id' : hex(id(obj))
     }
     return data
 


### PR DESCRIPTION
Signed-off-by: Prince George <prgeor@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The test_sfps() test case in test_chassis.py is going through a list of SFP objects but in reality, chassis.get_all_sfps() and chassis.get_sfp() is actually not returning objects, rather json serialized string, see the test logs below:

05:49:35 chassis.chassis_api L0016 INFO | Executing chassis API: "get_sfp", arguments: "[0]", result: "{u'module': u'arista.utils.sonic_platform.sfp', u'class': u'Sfp'}"
05:49:35 test_chassis.test_sfps L0136 INFO | name=
05:49:35 chassis.chassis_api L0016 INFO | Executing chassis API: "get_sfp", arguments: "[1]", result: "{u'module': u'arista.utils.sonic_platform.sfp', u'class': u'Sfp'}"
05:49:35 test_chassis.test_sfps L0136 INFO | name=
05:49:35 chassis.chassis_api L0016 INFO | Executing chassis API: "get_sfp", arguments: "[2]", result: "{u'module': u'arista.utils.sonic_platform.sfp', u'class': u'Sfp'}"
05:49:35 test_chassis.test_sfps L0136 INFO | name=
05:49:35 chassis.chassis_api L0016 INFO | Executing chassis API: "get_sfp", arguments: "[3]", result: "{u'module': u'arista.utils.sonic_platform.sfp', u'class': u'Sfp'}"
05:49:35 test_chassis.test_sfps L0136 INFO | name=
05:49:35 chassis.chassis_api L0016 INFO | Executing chassis API: "get_sfp", arguments: "[4]", result: "{u'module': u'arista.utils.sonic_platform.sfp', u'class': u'Sfp'}"
05:49:35 test_chassis.test_sfps L0136 INFO | name=
05:49:35 chassis.chassis_api L0016 INFO | Executing chassis API: "get_sfp", arguments: "[5]", result: "{u'module': u'arista.utils.sonic_platform.sfp', u'class': u'Sfp'}"
05:49:35 test_chassis.test_sfps L0136 INFO | name=
05:49:35 chassis.chassis_api L0016 INFO | Executing chassis API: "get_sfp", arguments: "[6]", result: "{u'module': u'arista.utils.sonic_platform.sfp', u'class': u'Sfp'}"

So, all the sfp_list[] are same here:- [https://github.com/Azure/sonic-mgmt/blob/master/tests/platform_tests/api/test_chassis.py#L390](https://github.com/Azure/sonic-mgmt/blob/master/tests/platform_tests/api/test_chassis.py#L390)

As part of JSON serialization added object address so that each SFP instance can be uniquely identified and verified.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tested all the following tests which uses JSON serialization are passing:-

test_fans(), test_modules(), test_psus(), test_thermals(), test_sfps(), test_fan_drawers(), test_components()



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
