### PR TITLE
[platform_tests]Skip test for the platforms which doesn't support some platform apis

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -34,16 +34,16 @@ def skip_version(duthost, version_list):
         pytest.skip("DUT has version {} and test does not support {}".format(duthost.os_version, ", ".join(version_list)))
 
 
-def skip_version_for_platform(duthost, version_list, platform_list):
+def skip_release_for_platform(duthost, release_list, platform_list):
     """
-    @summary: Skip current test if any given version keywords are in os_version and any given platform keywords are in platform
+    @summary: Skip current test if any given release keywords are in os_version and any given platform keywords are in platform
     @param duthost: The DUT
-    @param version_list: A list of incompatible versions
+    @param release_list: A list of incompatible releases
     @param platform_list: A list of incompatible platforms
     """
-    if any(version in duthost.os_version for version in version_list) and any(platform in duthost.facts['platform'] for platform in platform_list):
+    if any(release in duthost.os_version for release in release_list) and any(platform in duthost.facts['platform'] for platform in platform_list):
         pytest.skip("DUT has version {} and platform {} and test does not support {} for {}".format(duthost.os_version, 
-            duthost.facts['platform'], ", ".join(version_list), ", ".join(platform_list)))
+            duthost.facts['platform'], ", ".join(release_list), ", ".join(platform_list)))
 
 
 def wait(seconds, msg=""):

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -34,6 +34,18 @@ def skip_version(duthost, version_list):
         pytest.skip("DUT has version {} and test does not support {}".format(duthost.os_version, ", ".join(version_list)))
 
 
+def skip_version_for_platform(duthost, version_list, platform_list):
+    """
+    @summary: Skip current test if any given version keywords are in os_version and any given platform keywords are in platform
+    @param duthost: The DUT
+    @param version_list: A list of incompatible versions
+    @param platform_list: A list of incompatible platforms
+    """
+    if any(version in duthost.os_version for version in version_list) and any(platform in duthost.facts['platform'] for platform in platform_list):
+        pytest.skip("DUT has version {} and platform {} and test does not support {} for {}".format(duthost.os_version, 
+            duthost.facts['platform'], ", ".join(version_list), ", ".join(platform_list)))
+
+
 def wait(seconds, msg=""):
     """
     @summary: Pause specified number of seconds

--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -201,6 +201,11 @@ class TestThermalApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_set_low_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        platform = duthost.facts['platform']
+        if platform in ('x86_64-arista_7050_qx32', 'x86_64-arista_7050_qx32s'):
+            pytest.skip('skip {} test for {}'.format(funcName, platform))
+
         # Ensure the thermal temperature is sane
         for i in range(self.num_thermals):
             low_temperature = 20
@@ -217,6 +222,11 @@ class TestThermalApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_set_high_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        platform = duthost.facts['platform']
+        if platform in ('x86_64-arista_7050_qx32', 'x86_64-arista_7050_qx32s'):
+            pytest.skip('skip {} test for {}'.format(funcName, platform))
+
         # Ensure the thermal temperature is sane
         for i in range(self.num_thermals):
             high_temperature = 80

--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -204,7 +204,7 @@ class TestThermalApi(PlatformApiTestBase):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         platform = duthost.facts['platform']
         if platform in ('x86_64-arista_7050_qx32', 'x86_64-arista_7050_qx32s'):
-            pytest.skip('skip {} test for {}'.format(funcName, platform))
+            pytest.skip('skip test_set_low_threshold for {}'.format(platform))
 
         # Ensure the thermal temperature is sane
         for i in range(self.num_thermals):
@@ -225,7 +225,7 @@ class TestThermalApi(PlatformApiTestBase):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         platform = duthost.facts['platform']
         if platform in ('x86_64-arista_7050_qx32', 'x86_64-arista_7050_qx32s'):
-            pytest.skip('skip {} test for {}'.format(funcName, platform))
+            pytest.skip('skip test_set_high_threshold for {}'.format(platform))
 
         # Ensure the thermal temperature is sane
         for i in range(self.num_thermals):

--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -8,6 +8,7 @@ import yaml
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import chassis, thermal
+from tests.common.utilities import skip_version_for_platform
 
 from platform_api_test_base import PlatformApiTestBase
 
@@ -202,9 +203,7 @@ class TestThermalApi(PlatformApiTestBase):
 
     def test_set_low_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        platform = duthost.facts['platform']
-        if platform in ('x86_64-arista_7050_qx32', 'x86_64-arista_7050_qx32s'):
-            pytest.skip('skip test_set_low_threshold for {}'.format(platform))
+        skip_version_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
 
         # Ensure the thermal temperature is sane
         for i in range(self.num_thermals):
@@ -223,9 +222,7 @@ class TestThermalApi(PlatformApiTestBase):
 
     def test_set_high_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        platform = duthost.facts['platform']
-        if platform in ('x86_64-arista_7050_qx32', 'x86_64-arista_7050_qx32s'):
-            pytest.skip('skip test_set_high_threshold for {}'.format(platform))
+        skip_version_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
 
         # Ensure the thermal temperature is sane
         for i in range(self.num_thermals):

--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -8,7 +8,7 @@ import yaml
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import chassis, thermal
-from tests.common.utilities import skip_version_for_platform
+from tests.common.utilities import skip_release_for_platform
 
 from platform_api_test_base import PlatformApiTestBase
 
@@ -203,7 +203,7 @@ class TestThermalApi(PlatformApiTestBase):
 
     def test_set_low_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        skip_version_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
+        skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
 
         # Ensure the thermal temperature is sane
         for i in range(self.num_thermals):
@@ -222,7 +222,7 @@ class TestThermalApi(PlatformApiTestBase):
 
     def test_set_high_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        skip_version_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
+        skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
 
         # Ensure the thermal temperature is sane
         for i in range(self.num_thermals):

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -344,6 +344,10 @@ def test_show_platform_firmware_status(duthosts, enum_rand_one_per_hwsku_hostnam
     @summary: Verify output of `show platform firmware status`
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    platform = duthost.facts['platform']
+    if platform in ('x86_64-arista_7050_qx32', 'x86_64-arista_7050_qx32s'):
+            pytest.skip('skip {} test for {}'.format(funcName, platform))
+
     cmd = " ".join([CMD_SHOW_PLATFORM, "firmware", "status"])
 
     logging.info("Verifying output of '{}' on '{}' ...".format(cmd, duthost.hostname))

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -21,7 +21,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.daemon_utils import check_pmon_daemon_status
 from tests.common.platform.device_utils import get_dut_psu_line_pattern
 from tests.common.utilities import get_inventory_files, get_host_visible_vars
-from tests.common.utilities import skip_version_for_platform
+from tests.common.utilities import skip_release_for_platform
 
 pytestmark = [
     pytest.mark.sanity_check(skip_sanity=True),
@@ -345,7 +345,7 @@ def test_show_platform_firmware_status(duthosts, enum_rand_one_per_hwsku_hostnam
     @summary: Verify output of `show platform firmware status`
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    skip_version_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
+    skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
 
 
     cmd = " ".join([CMD_SHOW_PLATFORM, "firmware", "status"])

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -346,7 +346,7 @@ def test_show_platform_firmware_status(duthosts, enum_rand_one_per_hwsku_hostnam
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     platform = duthost.facts['platform']
     if platform in ('x86_64-arista_7050_qx32', 'x86_64-arista_7050_qx32s'):
-            pytest.skip('skip {} test for {}'.format(funcName, platform))
+            pytest.skip('skip test_show_platform_firmware_status for {}'.format(platform))
 
     cmd = " ".join([CMD_SHOW_PLATFORM, "firmware", "status"])
 

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -21,6 +21,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.daemon_utils import check_pmon_daemon_status
 from tests.common.platform.device_utils import get_dut_psu_line_pattern
 from tests.common.utilities import get_inventory_files, get_host_visible_vars
+from tests.common.utilities import skip_version_for_platform
 
 pytestmark = [
     pytest.mark.sanity_check(skip_sanity=True),
@@ -344,9 +345,8 @@ def test_show_platform_firmware_status(duthosts, enum_rand_one_per_hwsku_hostnam
     @summary: Verify output of `show platform firmware status`
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    platform = duthost.facts['platform']
-    if platform in ('x86_64-arista_7050_qx32', 'x86_64-arista_7050_qx32s'):
-            pytest.skip('skip test_show_platform_firmware_status for {}'.format(platform))
+    skip_version_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
+
 
     cmd = " ".join([CMD_SHOW_PLATFORM, "firmware", "status"])
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (https://github.com/Azure/sonic-buildimage/issues/8438, https://github.com/Azure/sonic-buildimage/issues/8442)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix issues of  https://github.com/Azure/sonic-buildimage/issues/8438 
 and https://github.com/Azure/sonic-buildimage/issues/8442

#### How did you do it?
Add a condition to check the dut platform(arista-7050) before running 
- TestThermalApi::test_set_<low/high>_threshold
- cli/test_show_platform.py::test_show_platform_firmware_status
#### How did you verify/test it?
Run the tests and verify if the tests are skipped on the specific platform
#### Any platform specific information?
The change is only applicable for Arista-7050

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
