### PR TITLE
[test_sub_port_interfaces] Skip subport test on unsupported platform

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -46,6 +46,18 @@ def pytest_addoption(parser):
     )
 
 
+@pytest.fixture(scope='module', autouse=True)
+def skip_unsupported_asic_type(duthost):
+    SUBPORT_UNSUPPORTED_ASIC_LIST = ["th2"]
+    vendor = duthost.facts["asic_type"]
+    hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
+    for asic in SUBPORT_UNSUPPORTED_ASIC_LIST:
+        vendorAsic = "{0}_{1}_hwskus".format(vendor, asic)
+        if vendorAsic in hostvars.keys() and duthost.facts['hwsku'] in hostvars[vendorAsic]:
+            pytest.skip(
+                "Skipping test since subport is not supported on {0} {1} platforms".format(vendor, asic))
+
+
 @pytest.fixture(params=['port', 'port_in_lag'])
 def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter):
     """

--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert as py_assert
+from tests.common.utilities import get_host_visible_vars
 from tests.common.utilities import wait_until
 from sub_ports_helpers import DUT_TMP_DIR
 from sub_ports_helpers import TEMPLATE_DIR
@@ -50,7 +51,7 @@ def pytest_addoption(parser):
 def skip_unsupported_asic_type(duthost):
     SUBPORT_UNSUPPORTED_ASIC_LIST = ["th2"]
     vendor = duthost.facts["asic_type"]
-    hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
+    hostvars = get_host_visible_vars(duthost.host.options['inventory'], duthost.hostname)
     for asic in SUBPORT_UNSUPPORTED_ASIC_LIST:
         vendorAsic = "{0}_{1}_hwskus".format(vendor, asic)
         if vendorAsic in hostvars.keys() and duthost.facts['hwsku'] in hostvars[vendorAsic]:


### PR DESCRIPTION
What is the motivation for this PR?
SAI reports SAI_STATUS_NOT_SUPPORTED error while config the subport interface on some platforms. Need to mark it to skip on  those platforms.

How did you do it?
Use a fixture to check if need to skip or not.

How did you verify/test it?
Run test_sub_port_interfaces.py, it should be skipped on those platforms.

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
