### PR TITLE
Use root_path in ```kickstart_vm.yml```

### DIFF
--- a/ansible/roles/vm_set/tasks/kickstart_vm.yml
+++ b/ansible/roles/vm_set/tasks/kickstart_vm.yml
@@ -30,9 +30,9 @@
   - name: Respin failed vm
     include_tasks: respin_vm.yml
     vars:
-      src_disk_image: "{{ home_path }}/{{ root_path }}/images/{{ hdd_image_filename }}"
-      disk_image: "{{ home_path }}/{{ root_path }}/disks/{{ vm_name }}_hdd.vmdk"
-      cdrom_image: "{{ home_path }}/{{ root_path }}/images/{{ cd_image_filename }}"
+      src_disk_image: "{{ root_path }}/images/{{ hdd_image_filename }}"
+      disk_image: "{{ root_path }}/disks/{{ vm_name }}_hdd.vmdk"
+      cdrom_image: "{{ root_path }}/images/{{ cd_image_filename }}"
     when: '"kickstart_code" in kickstart_output and kickstart_output.kickstart_code != 0'
     ignore_errors: true
 

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -174,7 +174,13 @@
     - set_fact:
         home_path: "{{ getent_passwd[ansible_user][4] }}"
       when: home_path is not defined
-    - debug: msg="{{ home_path }}"
+
+    # root_path is supposed to be absolute path. 
+    - set_fact:
+        root_path: "{{ home_path + '/' + root_path }}"
+      when: "not '{{ root_path }}'.startswith('/')"
+
+    - debug: msg="home_path = {{ home_path }} root_path = {{ root_path }}"
 
 - name: Require veos or SONiC VMs by default
   set_fact:


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to replace ```home_path``` + ```root_path``` with ```root_path``` to ensure that ```kick_start.yml``` task runs smoothly when ```root_path``` is set to absolute path.

To keep backward compatible, the value of ```root_path``` is checked in ```ansible/roles/vm_set/tasks/main.yml```. If the ```root_path``` is not set to absolute path, the ```home_path``` will be add to build an absolute path.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to replace ```home_path``` + ```root_path``` with ```root_path``` in ```kickstart_vm.yml```.

#### How did you do it?
1. Replace Ansible variables
2. Add a logic to update relative path.

#### How did you verify/test it?
1. Verified by ```stop-topo-vms```, and then ```start-topo-vms``` when ```root_path``` is relative path
2. Verified by ```stop-topo-vms```, and then ```start-topo-vms``` when ```root_path``` is absolute path
3. Verify ```respin``` logic by killing a VM during ```start-topo-vms```
All passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
