### PR TITLE
Remove pretest label from test_nbr_health

### DIFF
--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
-    pytest.mark.pretest,
     pytest.mark.topology('util') #special marker
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  Remove pretest label, and run test_nbr_health as a standalone testcase.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

In nightly regression the test `test_nbr_health` runs as part of pretest list of cases. However, there is no sanity check in this test. This leads to pretest failure if testbed is unhealthy.
Additionally, sanity can't be enabled for this test as it is also run in public KVM testbed deployment, where deploy-mg is done after this testcase is executed:
https://github.com/Azure/sonic-jenkins/blob/master/azure-pipeline/provkvmtest.sh#L367


#### How did you do it?
Remove pretest label, and run test_nbr_health as a standalone testcase.

#### How did you verify/test it?
If this case is not executed as part of pretest list, other pretest cases (with sanity check enabled) recover the testbed. After recovery, this case successfully passes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
