### PR TITLE
[container_checker] Parameterize with DuT and container name.

### DIFF
--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -30,48 +30,58 @@ CONTAINER_STOP_THRESHOLD_SECS = 30
 CONTAINER_RESTART_THRESHOLD_SECS = 180
 
 
-@pytest.fixture(autouse=True, scope='module')
-def config_reload_after_tests(duthost):
+@pytest.fixture(autouse=True, scope="module")
+def config_reload_after_tests(rand_selected_dut):
+    """Restores the DuT.
+
+    Args:
+      rand_selected_dut: The fixture returns a randomly selected DuT.
+
+    Returns:
+      None.
+    """
+    duthost = rand_selected_dut
+
     bgp_neighbors = duthost.get_bgp_neighbors()
     up_bgp_neighbors = [ k.lower() for k, v in bgp_neighbors.items() if v["state"] == "established" ]
+
     yield
+
     config_reload(duthost)
     postcheck_critical_processes_status(duthost, up_bgp_neighbors)
 
 
 @pytest.fixture(autouse=True, scope="module")
-def check_image_version(duthost):
+def check_image_version(rand_selected_dut):
     """Skips this test if the SONiC image installed on DUT was 201911 or old version.
 
     Args:
-        duthost: Host DUT.
+      rand_selected_dut: The fixture returns a randomly selected DuT.
 
-    Return:
-        None.
+    Returns:
+      None.
     """
+    duthost = rand_selected_dut
+
     pytest_require(parse_version(duthost.kernel_version) > parse_version("4.9.0"),
                    "Test was not supported for 201911 and older image version!")
 
 
 @pytest.fixture(autouse=True, scope="module")
-def update_monit_service(duthosts, enum_dut_feature_container, enum_rand_one_per_hwsku_frontend_hostname):
+def update_monit_service(rand_selected_dut):
     """Update Monit configuration and restart it.
 
     This function will first reduce the monitoring interval of container checker
-    from 5 minutes to 2 minutes, then restart Monit service without delaying. After
-    testing, these two changes will be rolled back.
+    from 5 minutes to 1 minute, then restart Monit service with delaying 10 seconds.
+    After testing, these two changes will be rolled back.
 
     Args:
-        duthost: name of Host DUT.
+      rand_selected_dut: The fixture returns a randomly selected DuT.
 
-    Return:
-        None.
+    Returns:
+      None.
     """
-    dut_name, container_name = decode_dut_and_container_name(enum_dut_feature_container)
-    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname and container_name != "unknown",
-                   "Skips testing container_checker of container '{}' on the DuT '{}' since another DuT '{}' was chosen."
-                   .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))
-    duthost = duthosts[dut_name]
+    duthost = rand_selected_dut
 
     logger.info("Back up Monit configuration files on DuT '{}' ...".format(duthost.hostname))
     duthost.shell("sudo cp -f /etc/monit/monitrc /tmp/")
@@ -85,8 +95,10 @@ def update_monit_service(duthosts, enum_dut_feature_container, enum_rand_one_per
     duthost.shell("sudo sed -i 's/set daemon 60/set daemon 10/' /etc/monit/monitrc")
     logger.info("Restart the Monit service without delaying to monitor.")
     duthost.shell("sudo systemctl restart monit")
+
     yield
-    logger.info("Roll back the Monit configuration of container checker on DuT '[]' ..."
+
+    logger.info("Roll back the Monit configuration of container checker on DuT '{}' ..."
                 .format(duthost.hostname))
     duthost.shell("sudo mv -f /tmp/monitrc /etc/monit/")
     duthost.shell("sudo mv -f /tmp/sonic-host /etc/monit/conf.d/")
@@ -98,11 +110,11 @@ def check_all_critical_processes_status(duthost):
     """Post-checks the status of critical processes.
 
     Args:
-        duthost: Host DUT.
+      duthost: Host DUT.
 
-    Return:
-        This function will return True if all critical processes are running.
-        Otherwise it will return False.
+    Returns:
+      This function will return True if all critical processes are running.
+      Otherwise it will return False.
     """
     processes_status = duthost.all_critical_process_status()
     for container_name, processes in processes_status.items():
@@ -116,12 +128,12 @@ def post_test_check(duthost, up_bgp_neighbors):
     """Post-checks the status of critical processes and state of BGP sessions.
 
     Args:
-        duthost: Host DUT.
-        skip_containers: A list contains the container names which should be skipped.
+      duthost: Host DUT.
+      skip_containers: A list contains the container names which should be skipped.
 
-    Return:
-        This function will return True if all critical processes are running and
-        all BGP sessions are established. Otherwise it will return False.
+    Returns:
+      This function will return True if all critical processes are running and
+      all BGP sessions are established. Otherwise it will return False.
     """
     return check_all_critical_processes_status(duthost) and duthost.check_bgp_session_state(up_bgp_neighbors, "established")
 
@@ -131,68 +143,59 @@ def postcheck_critical_processes_status(duthost, up_bgp_neighbors):
        state of BGP sessions.
 
     Args:
-        duthost: Host DUT.
-        skip_containers: A list contains the container names which should be skipped.
+      duthost: Host DUT.
+      skip_containers: A list contains the container names which should be skipped.
 
-    Return:
-        If all critical processes are running and all BGP sessions are established, it
-        returns True. Otherwise it will call the function to do post-check every 30 seconds
-        for 3 minutes. It will return False after timeout
+    Returns:
+      If all critical processes are running and all BGP sessions are established, it
+      returns True. Otherwise it will call the function to do post-check every 30 seconds
+      for 3 minutes. It will return False after timeout
     """
     logger.info("Post-checking status of critical processes and BGP sessions...")
     return wait_until(CONTAINER_RESTART_THRESHOLD_SECS, CONTAINER_CHECK_INTERVAL_SECS,
                       post_test_check, duthost, up_bgp_neighbors)
 
 
-def stop_containers(duthost, container_autorestart_states, skip_containers):
-    """Stops the running containers and returns their names as a list.
+def stop_container(duthost, container_name):
+    """Stops the running container.
 
     Args:
-        duthost: Host DUT.
-        container_autorestart_states: A dictionary which key is container name and
-        value is the state of autorestart feature.
-        skip_containers: A list contains the container names which should be skipped.
+      duthost: Host DUT.
+      container_name: A string represents the container which will be stopped.
 
-    Return:
-        A list contains the container names which are stopped.
+    Returns:
+      None
     """
-    stopped_container_list = []
 
-    for container_name in container_autorestart_states.keys():
-        if container_name not in skip_containers:
-            logger.info("Stopping the container '{}' on DuT '{}' ...".format(container_name, duthost.hostname))
-            duthost.shell("sudo systemctl stop {}.service".format(container_name))
-            logger.info("Waiting until container '{}' is stopped...".format(container_name))
-            stopped = wait_until(CONTAINER_STOP_THRESHOLD_SECS,
-                                 CONTAINER_CHECK_INTERVAL_SECS,
-                                 check_container_state, duthost, container_name, False)
-            pytest_assert(stopped, "Failed to stop container '{}'".format(container_name))
-            logger.info("Container '{}' on DuT '{}' was stopped".format(container_name, duthost.hostname))
-            stopped_container_list.append(container_name)
-
-    return stopped_container_list
+    logger.info("Stopping the container '{}' on DuT '{}' ...".format(container_name, duthost.hostname))
+    duthost.shell("sudo systemctl stop {}.service".format(container_name))
+    logger.info("Waiting until container '{}' is stopped...".format(container_name))
+    stopped = wait_until(CONTAINER_STOP_THRESHOLD_SECS,
+                         CONTAINER_CHECK_INTERVAL_SECS,
+                         check_container_state, duthost, container_name, False)
+    pytest_assert(stopped, "Failed to stop container '{}'".format(container_name))
+    logger.info("Container '{}' on DuT '{}' was stopped".format(container_name, duthost.hostname))
 
 
-def get_expected_alerting_messages(stopped_container_list):
-    """Generates the expected alerting messages from the stopped containers.
+def get_expected_alerting_message(container_name):
+    """Generates the expected alerting message from the stopped container.
 
     Args:
-        stopped_container_list: A list contains container names.
+      container_name: A string represents the container name.
 
     Return:
-        A list contains the expected alerting messages.
+      A list contains the expected alerting message.
     """
-    logger.info("Generating the expected alerting messages...")
+    logger.info("Generating the expected alerting message for container '{}' ...".format(container_name))
     expected_alerting_messages = []
 
-    for container_name in stopped_container_list:
-        expected_alerting_messages.append(".*Expected containers not running.*{}.*".format(container_name))
+    expected_alerting_messages.append(".*Expected containers not running.*{}.*".format(container_name))
 
-    logger.info("Generating the expected alerting messages was done!")
+    logger.info("Generating the expected alerting message was done!")
     return expected_alerting_messages
 
 
-def test_container_checker(duthosts, enum_dut_feature_container, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
+def test_container_checker(duthosts, enum_dut_feature, rand_selected_dut, tbinfo):
     """Tests the feature of container checker.
 
     This function will check whether the container names will appear in the Monit
@@ -200,40 +203,42 @@ def test_container_checker(duthosts, enum_dut_feature_container, enum_rand_one_p
 
     Args:
         duthosts: list of DUTs.
-        rand_one_dut_hostname: hostname of DUT.
+        enum_dut_feature: A list contains strings ("<dut_name>|<container_name>").
+        rand_selected_dut: The fixture returns a randomly selected DuT.
         tbinfo: Testbed information.
 
     Returns:
         None.
     """
-    dut_name, container_name = decode_dut_and_container_name(enum_dut_feature_container)
-    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname and container_name != "unknown",
+    dut_name, container_name = decode_dut_and_container_name(enum_dut_feature)
+    pytest_require(dut_name == rand_selected_dut.hostname and container_name != "unknown",
                    "Skips testing container_checker of container '{}' on the DuT '{}' since another DuT '{}' was chosen."
-                   .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))
+                   .format(container_name, dut_name, rand_selected_dut.hostname))
     duthost = duthosts[dut_name]
 
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="container_checker")
     loganalyzer.expect_regex = []
 
-    container_autorestart_states = duthost.get_container_autorestart_states()
     disabled_containers = get_disabled_container_list(duthost)
 
     skip_containers = disabled_containers[:]
     skip_containers.append("gbsyncd")
+    skip_containers.append("database")
     # Skip 'radv' container on devices whose role is not T0.
     if tbinfo["topo"]["type"] != "t0":
         skip_containers.append("radv")
 
-    stopped_container_list = stop_containers(duthost, container_autorestart_states, skip_containers)
-    pytest_assert(len(stopped_container_list) > 0, "None of containers was stopped!")
+    pytest_require(container_name not in skip_containers,
+                   "Container '{}' is skipped for testing.".format(container_name))
+    stop_container(duthost, container_name)
 
-    expected_alerting_messages = get_expected_alerting_messages(stopped_container_list)
-    loganalyzer.expect_regex.extend(expected_alerting_messages)
+    expected_alerting_message = get_expected_alerting_message(container_name)
+    loganalyzer.expect_regex.extend(expected_alerting_message)
     marker = loganalyzer.init()
 
-    # Wait for 2 minutes such that Monit has a chance to write alerting message into syslog.
-    logger.info("Sleep 2 minutes to wait for the alerting message...")
-    time.sleep(130)
+    # Wait for 1 minutes such that Monit has a chance to write alerting message into syslog.
+    logger.info("Sleep 1 minutes to wait for the alerting message...")
+    time.sleep(70)
 
     logger.info("Checking the alerting messages from syslog...")
     loganalyzer.analyze(marker)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR aims to parameterize the `test_contianer_checker.py` with combination of DuT and container names such that this test case will run against each container separately. Another benefit is we can clearly catch the failure reason.

#### How did you do it?
I followed the method used in `test_container_autorestart.py`.

#### How did you verify/test it?
I tested this on single ToR `str-msn2700-20` and Dual ToR (`str2-7050cx3-acs-06 and str2-7050cx3-acs-07`).

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
