### PR TITLE
[Mellanox] Adjust some sensor labels for SN4410 sensor data

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -3690,110 +3690,106 @@ sensors_checks:
       - mlxreg_fan-isa-0000/Chassis Fan Drawer-6 Tach 1/fan11_fault
       - mlxreg_fan-isa-0000/Chassis Fan Drawer-6 Tach 2/fan12_fault
       power:
-      - xdpe12284-i2c-5-62/PMIC-1 ASIC 0.85V VCORE_T6_7 Rail Curr (in)/curr1_max_alarm
-      - xdpe12284-i2c-5-62/PMIC-1 ASIC 1.8V T6_7 Rail Curr (in)/curr2_max_alarm
-      - xdpe12284-i2c-5-62/PMIC-1 ASIC 0.85V VCORE_T6_7 Rail Curr (out)/curr3_max_alarm
-      - xdpe12284-i2c-5-62/PMIC-1 ASIC 0.85V VCORE_T6_7 Rail Curr (out)/curr3_crit_alarm
-      - xdpe12284-i2c-5-62/PMIC-1 ASIC 1.8V T6_7 Rail Curr (out)/curr4_max_alarm
-      - xdpe12284-i2c-5-62/PMIC-1 ASIC 1.8V T6_7 Rail Curr (out)/curr4_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail Curr (in2)/curr2_max_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 ASIC 0.8V VCORE MAIN Rail Curr (out)/curr3_max_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 ASIC 0.8V VCORE MAIN Rail Curr (out)/curr3_crit_alarm
       - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail (in1)/in1_lcrit_alarm
       - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail (in1)/in1_crit_alarm
       - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail (in2)/in2_lcrit_alarm
       - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail (in2)/in2_crit_alarm
-      - xdpe12284-i2c-5-62/PMIC-1 ASIC 0.85V VCORE_T6_7 Rail (out)/in3_crit_alarm
-      - xdpe12284-i2c-5-62/PMIC-1 ASIC 0.85V VCORE_T6_7 Rail (out)/in3_lcrit_alarm
-      - xdpe12284-i2c-5-62/PMIC-1 ASIC 1.8V T6_7 Rail (out)/in4_crit_alarm
-      - xdpe12284-i2c-5-62/PMIC-1 ASIC 1.8V T6_7 Rail (out)/in4_lcrit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 ASIC 0.8V VCORE MAIN Rail (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 ASIC 0.8V VCORE MAIN Rail (out)/in3_lcrit_alarm
 
-      - xdpe12284-i2c-5-64/PMIC-2 ASIC 0.85V VCORE_T6_7 Rail Curr (in)/curr1_max_alarm
-      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V T6_7 Rail Curr (in)/curr2_max_alarm
-      - xdpe12284-i2c-5-64/PMIC-2 ASIC 0.85V VCORE_T6_7 Rail Curr (out)/curr3_max_alarm
-      - xdpe12284-i2c-5-64/PMIC-2 ASIC 0.85V VCORE_T6_7 Rail Curr (out)/curr3_crit_alarm
-      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V T6_7 Rail Curr (out)/curr4_max_alarm
-      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V T6_7 Rail Curr (out)/curr4_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail Curr (in2)/curr2_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V VCORE MAIN Rail Curr (out)/curr3_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V VCORE MAIN Rail Curr (out)/curr3_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.2V VCORE MAIN Rail Curr (out)/curr4_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.2V VCORE MAIN Rail Curr (out)/curr4_crit_alarm
       - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail (in1)/in1_lcrit_alarm
       - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail (in1)/in1_crit_alarm
       - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail (in2)/in2_lcrit_alarm
       - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail (in2)/in2_crit_alarm
-      - xdpe12284-i2c-5-64/PMIC-2 ASIC 0.85V VCORE_T6_7 Rail (out)/in3_crit_alarm
-      - xdpe12284-i2c-5-64/PMIC-2 ASIC 0.85V VCORE_T6_7 Rail (out)/in3_lcrit_alarm
-      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V T6_7 Rail (out)/in4_crit_alarm
-      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V T6_7 Rail (out)/in4_lcrit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V VCORE MAIN Rail (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V VCORE MAIN Rail (out)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.2V VCORE MAIN Rail (out)/in4_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.2V VCORE MAIN Rail (out)/in4_lcrit_alarm
 
-      - xdpe12284-i2c-5-66/PMIC-3 ASIC 0.85V VCORE_T6_7 Rail Curr (in)/curr1_max_alarm
-      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V T6_7 Rail Curr (in)/curr2_max_alarm
-      - xdpe12284-i2c-5-66/PMIC-3 ASIC 0.85V VCORE_T6_7 Rail Curr (out)/curr3_max_alarm
-      - xdpe12284-i2c-5-66/PMIC-3 ASIC 0.85V VCORE_T6_7 Rail Curr (out)/curr3_crit_alarm
-      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V T6_7 Rail Curr (out)/curr4_max_alarm
-      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V T6_7 Rail Curr (out)/curr4_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 PSU 12V Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 PSU 12V Rail Curr (in2)/curr2_max_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 0.85V T0_1 Rail Curr (out)/curr3_max_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 0.85V T0_1 Rail Curr (out)/curr3_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V T0_1 Rail Curr (out)/curr4_max_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V T0_1 Rail Curr (out)/curr4_crit_alarm
       - xdpe12284-i2c-5-66/PMIC-3 PSU 12V Rail (in1)/in1_lcrit_alarm
       - xdpe12284-i2c-5-66/PMIC-3 PSU 12V Rail (in1)/in1_crit_alarm
       - xdpe12284-i2c-5-66/PMIC-3 PSU 12V Rail (in2)/in2_lcrit_alarm
       - xdpe12284-i2c-5-66/PMIC-3 PSU 12V Rail (in2)/in2_crit_alarm
-      - xdpe12284-i2c-5-66/PMIC-3 ASIC 0.85V VCORE_T6_7 Rail (out)/in3_crit_alarm
-      - xdpe12284-i2c-5-66/PMIC-3 ASIC 0.85V VCORE_T6_7 Rail (out)/in3_lcrit_alarm
-      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V T6_7 Rail (out)/in4_crit_alarm
-      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V T6_7 Rail (out)/in4_lcrit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 0.85V T0_1 Rail (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 0.85V T0_1 Rail (out)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V T0_1 Rail (out)/in4_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V T0_1 Rail (out)/in4_lcrit_alarm
 
-      - xdpe12284-i2c-5-68/PMIC-4 ASIC 0.85V VCORE_T6_7 Rail Curr (in)/curr1_max_alarm
-      - xdpe12284-i2c-5-68/PMIC-4 ASIC 1.8V T6_7 Rail Curr (in)/curr2_max_alarm
-      - xdpe12284-i2c-5-68/PMIC-4 ASIC 0.85V VCORE_T6_7 Rail Curr (out)/curr3_max_alarm
-      - xdpe12284-i2c-5-68/PMIC-4 ASIC 0.85V VCORE_T6_7 Rail Curr (out)/curr3_crit_alarm
-      - xdpe12284-i2c-5-68/PMIC-4 ASIC 1.8V T6_7 Rail Curr (out)/curr4_max_alarm
-      - xdpe12284-i2c-5-68/PMIC-4 ASIC 1.8V T6_7 Rail Curr (out)/curr4_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 PSU 12V Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 PSU 12V Rail Curr (in2)/curr2_max_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 0.85V T2_3 Rail Curr (out)/curr3_max_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 0.85V T2_3 Rail Curr (out)/curr3_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 1.8V T2_3 Rail Curr (out)/curr4_max_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 1.8V T2_3 Rail Curr (out)/curr4_crit_alarm
       - xdpe12284-i2c-5-68/PMIC-4 PSU 12V Rail (in1)/in1_lcrit_alarm
       - xdpe12284-i2c-5-68/PMIC-4 PSU 12V Rail (in1)/in1_crit_alarm
       - xdpe12284-i2c-5-68/PMIC-4 PSU 12V Rail (in2)/in2_lcrit_alarm
       - xdpe12284-i2c-5-68/PMIC-4 PSU 12V Rail (in2)/in2_crit_alarm
-      - xdpe12284-i2c-5-68/PMIC-4 ASIC 0.85V VCORE_T6_7 Rail (out)/in3_crit_alarm
-      - xdpe12284-i2c-5-68/PMIC-4 ASIC 0.85V VCORE_T6_7 Rail (out)/in3_lcrit_alarm
-      - xdpe12284-i2c-5-68/PMIC-4 ASIC 1.8V T6_7 Rail (out)/in4_crit_alarm
-      - xdpe12284-i2c-5-68/PMIC-4 ASIC 1.8V T6_7 Rail (out)/in4_lcrit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 0.85V T2_3 Rail (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 0.85V T2_3 Rail (out)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 1.8V T2_3 Rail (out)/in4_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-4 ASIC 1.8V T2_3 Rail (out)/in4_lcrit_alarm
 
-      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 0.85V VCORE_T6_7 Rail Curr (in)/curr1_max_alarm
-      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 1.8V T6_7 Rail Curr (in)/curr2_max_alarm
-      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 0.85V VCORE_T6_7 Rail Curr (out)/curr3_max_alarm
-      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 0.85V VCORE_T6_7 Rail Curr (out)/curr3_crit_alarm
-      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 1.8V T6_7 Rail Curr (out)/curr4_max_alarm
-      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 1.8V T6_7 Rail Curr (out)/curr4_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 PSU 12V Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 PSU 12V Rail Curr (in2)/curr2_max_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 0.85V T4_5 Rail Curr (out)/curr3_max_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 0.85V T4_5 Rail Curr (out)/curr3_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 1.8V T4_5 Rail Curr (out)/curr4_max_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 1.8V T4_5 Rail Curr (out)/curr4_crit_alarm
       - xdpe12284-i2c-5-6a/PMIC-5 PSU 12V Rail (in1)/in1_lcrit_alarm
       - xdpe12284-i2c-5-6a/PMIC-5 PSU 12V Rail (in1)/in1_crit_alarm
       - xdpe12284-i2c-5-6a/PMIC-5 PSU 12V Rail (in2)/in2_lcrit_alarm
       - xdpe12284-i2c-5-6a/PMIC-5 PSU 12V Rail (in2)/in2_crit_alarm
-      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 0.85V VCORE_T6_7 Rail (out)/in3_crit_alarm
-      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 0.85V VCORE_T6_7 Rail (out)/in3_lcrit_alarm
-      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 1.8V T6_7 Rail (out)/in4_crit_alarm
-      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 1.8V T6_7 Rail (out)/in4_lcrit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 0.85V T4_5 Rail (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 0.85V T4_5 Rail (out)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 1.8V T4_5 Rail (out)/in4_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-5 ASIC 1.8V T4_5 Rail (out)/in4_lcrit_alarm
 
-      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 0.85V VCORE_T6_7 Rail Curr (in)/curr1_max_alarm
-      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 1.8V T6_7 Rail Curr (in)/curr2_max_alarm
-      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 0.85V VCORE_T6_7 Rail Curr (out)/curr3_max_alarm
-      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 0.85V VCORE_T6_7 Rail Curr (out)/curr3_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 PSU 12V Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 PSU 12V Rail Curr (in2)/curr2_max_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 0.85V T6_7 Rail Curr (out)/curr3_max_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 0.85V T6_7 Rail Curr (out)/curr3_crit_alarm
       - xdpe12284-i2c-5-6c/PMIC-6 ASIC 1.8V T6_7 Rail Curr (out)/curr4_max_alarm
       - xdpe12284-i2c-5-6c/PMIC-6 ASIC 1.8V T6_7 Rail Curr (out)/curr4_crit_alarm
       - xdpe12284-i2c-5-6c/PMIC-6 PSU 12V Rail (in1)/in1_lcrit_alarm
       - xdpe12284-i2c-5-6c/PMIC-6 PSU 12V Rail (in1)/in1_crit_alarm
       - xdpe12284-i2c-5-6c/PMIC-6 PSU 12V Rail (in2)/in2_lcrit_alarm
       - xdpe12284-i2c-5-6c/PMIC-6 PSU 12V Rail (in2)/in2_crit_alarm
-      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 0.85V VCORE_T6_7 Rail (out)/in3_crit_alarm
-      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 0.85V VCORE_T6_7 Rail (out)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 0.85V T6_7 Rail (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-6 ASIC 0.85V T6_7 Rail (out)/in3_lcrit_alarm
       - xdpe12284-i2c-5-6c/PMIC-6 ASIC 1.8V T6_7 Rail (out)/in4_crit_alarm
       - xdpe12284-i2c-5-6c/PMIC-6 ASIC 1.8V T6_7 Rail (out)/in4_lcrit_alarm
 
-      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 0.85V VCORE_T6_7 Rail Curr (in)/curr1_max_alarm
-      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.8V T6_7 Rail Curr (in)/curr2_max_alarm
-      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 0.85V VCORE_T6_7 Rail Curr (out)/curr3_max_alarm
-      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 0.85V VCORE_T6_7 Rail Curr (out)/curr3_crit_alarm
-      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.8V T6_7 Rail Curr (out)/curr4_max_alarm
-      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.8V T6_7 Rail Curr (out)/curr4_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 PSU 12V Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 PSU 12V Rail Curr (in2)/curr2_max_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V T0_3 Rail_1 Curr (out)/curr3_max_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V T0_3 Rail_1 Curr (out)/curr3_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V T4_7 Rail_2 Curr (out)/curr4_max_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V T4_7 Rail_2 Curr (out)/curr4_crit_alarm
       - xdpe12284-i2c-5-6e/PMIC-7 PSU 12V Rail (in1)/in1_lcrit_alarm
       - xdpe12284-i2c-5-6e/PMIC-7 PSU 12V Rail (in1)/in1_crit_alarm
       - xdpe12284-i2c-5-6e/PMIC-7 PSU 12V Rail (in2)/in2_lcrit_alarm
       - xdpe12284-i2c-5-6e/PMIC-7 PSU 12V Rail (in2)/in2_crit_alarm
-      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 0.85V VCORE_T6_7 Rail (out)/in3_crit_alarm
-      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 0.85V VCORE_T6_7 Rail (out)/in3_lcrit_alarm
-      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.8V T6_7 Rail (out)/in4_crit_alarm
-      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.8V T6_7 Rail (out)/in4_lcrit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V T0_3 Rail_1 (out)/in3_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V T0_3 Rail_1 (out)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V T4_7 Rail_2 (out)/in4_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-7 ASIC 1.2V T4_7 Rail_2 (out)/in4_lcrit_alarm
 
       - tps53679-i2c-15-58/PMIC-8 COMEX 1.8V Rail Curr (out)/curr1_crit_alarm
       - tps53679-i2c-15-58/PMIC-8 COMEX 1.8V Rail Curr (out)/curr1_max_alarm
@@ -3933,12 +3929,13 @@ sensors_checks:
       - dps460-i2c-4-58/PSU-1(L) Temp 1/temp1_max_alarm
       - dps460-i2c-4-58/PSU-1(L) Temp 2/temp2_crit_alarm
       - dps460-i2c-4-58/PSU-1(L) Temp 2/temp2_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 3/temp3_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 3/temp3_max_alarm
 
       - dps460-i2c-4-59/PSU-2(R) Temp 1/temp1_crit_alarm
       - dps460-i2c-4-59/PSU-2(R) Temp 1/temp1_max_alarm
       - dps460-i2c-4-59/PSU-2(R) Temp 2/temp2_crit_alarm
-      # Temporary commented the line beyond in order to test_sensors.py passing for SN4410 (Redmine bug - 2327108)
-      #- dps460-i2c-4-59/PSU-2(R) Temp 2/temp2_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 2/temp2_max_alarm
       - dps460-i2c-4-59/PSU-2(R) Temp 3/temp3_crit_alarm
       - dps460-i2c-4-59/PSU-2(R) Temp 3/temp3_max_alarm
     compares:


### PR DESCRIPTION
Change-Id: I4b79767fb32d8d9e13f799ddb9e5567a418713ca

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adjust some sensor labels for SN4410 sensor data

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Some of the sensor labels in SN4410 is incorrect, this PR is to fix them.

#### How did you do it?

Adjust MSN4410 sensor data in ansible/group_vars/sonic/sku-sensors-data.yml

#### How did you verify/test it?

Run the test on SN4410 

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
