### PR TITLE
[drop_packets]: Skip counter check for some tests

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -28,6 +28,20 @@ LOG_EXPECT_PORT_OPER_UP_RE = ".*Port {} oper state set from down to up.*"
 
 logger = logging.getLogger(__name__)
 
+@pytest.fixture(scope='module')
+def sai_acl_drop_adj_enabled(rand_selected_dut):
+    """
+    Determines if the `sai_adjust_acl_drop_in_rx_drop` property is enabled
+
+    Since this leads to an undpredictable number of packets getting
+    counted as RX_DRP (in certain test cases), if it is enabled we need to
+    skip checking the drop counters for certain test cases
+    """
+    check_cmd = "bcmcmd 'config show' | grep 'sai_adjust_acl_drop_in_rx_drop=1'"
+    res = rand_selected_dut.shell(check_cmd)
+
+    return res["rc"] == 0
+
 
 @pytest.fixture
 def fanouthost(request, duthosts, rand_one_dut_hostname, localhost):
@@ -586,13 +600,13 @@ def test_loopback_filter(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, p
     do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
-def test_ip_pkt_with_expired_ttl(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info):
+def test_ip_pkt_with_expired_ttl(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info, sai_acl_drop_adj_enabled):
     """
     @summary: Create an IP packet with TTL=0.
     """
     log_pkt_params(ports_info["dut_iface"], ports_info["dst_mac"], ports_info["src_mac"], pkt_fields["ipv4_dst"],
                     pkt_fields["ipv4_src"])
-
+    
     pkt = testutils.simple_tcp_packet(
         eth_dst=ports_info["dst_mac"],  # DUT port
         eth_src=ports_info["src_mac"],  # PTF port
@@ -602,11 +616,11 @@ def test_ip_pkt_with_expired_ttl(do_test, ptfadapter, setup, tx_dut_ports, pkt_f
         tcp_dport=pkt_fields["tcp_dport"],
         ip_ttl=0)
 
-    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
 
 
 @pytest.mark.parametrize("pkt_field, value", [("version", 1), ("chksum", 10), ("ihl", 1)])
-def test_broken_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, pkt_field, value, ports_info):
+def test_broken_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, pkt_field, value, ports_info, sai_acl_drop_adj_enabled):
     """
     @summary: Create a packet with broken IP header.
     """
@@ -622,10 +636,10 @@ def test_broken_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, 
         )
     setattr(pkt[testutils.scapy.scapy.all.IP], pkt_field, value)
 
-    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
 
 
-def test_absent_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info):
+def test_absent_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info, sai_acl_drop_adj_enabled):
     """
     @summary: Create packets with absent IP header.
     """
@@ -645,7 +659,7 @@ def test_absent_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, 
     pkt.type = 0x800
     pkt = pkt/tcp
 
-    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
 
 
 @pytest.mark.parametrize("eth_dst", ["01:00:5e:00:01:02", "ff:ff:ff:ff:ff:ff"])


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/Azure/sonic-buildimage/issues/8100

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Recent SAI changes on some platforms cause some dropped packets to not be added to the RX_DRP counter

#### How did you do it?
If the DUT used for the test has the SAI change applied (`sai_adjust_acl_drop_in_rx_drop`), do not check the RX_DRP counter for the following test cases:

- IP packet with TTL=0
- IP packet with broken header
- IP packet with missing header

Instead, for these cases only look at traffic forwarding behavior to determine if the test passes (packets generated by these tests should all be dropped and not forwarded by the DUT). 

#### How did you verify/test it?
Run the tests on platforms with the new SAI change and verify they pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
