### PR TITLE
Skip unimplemented SFP platform APIs

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -46,6 +46,21 @@ def skip_release(duthost, release_list):
     if any(release == duthost.sonic_release for release in release_list):
         pytest.skip("DUT is release {} and test does not support {}".format(duthost.sonic_release, ", ".join(release_list)))
 
+def skip_release_for_platform(duthost, release_list, platform_list):
+    """
+    @summary: Skip current test if any given release keywords are in os_version and any given platform keywords are in platform
+    @param duthost: The DUT
+    @param release_list: A list of incompatible releases
+    @param platform_list: A list of incompatible platforms
+    """
+    if any(release in duthost.os_version for release in release_list) and \
+		any(platform in duthost.facts['platform'] for platform in platform_list):
+        pytest.skip("DUT has version {} and platform {} and \
+			test does not support {} for {}".format(duthost.os_version,
+            			duthost.facts['platform'], 
+				", ".join(release_list), 
+				", ".join(platform_list)))
+
 def wait(seconds, msg=""):
     """
     @summary: Pause specified number of seconds

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -110,7 +110,7 @@ class TestSfpApi(PlatformApiTestBase):
 
     @pytest.fixture(scope="module")
     def is_platform_api_implemented(self, duthost):
-        if "202012" in duthost.os_version:
+        if "202012" == duthost.sonic_release:
             platform = duthost.facts['platform']
             if 'arista' in platform or 'mlnx' in platform:
                 return False
@@ -132,7 +132,7 @@ class TestSfpApi(PlatformApiTestBase):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         if duthost.is_supervisor_node():
             pytest.skip("skipping for supervisor node")
-        self.skip_absent_sfp = True #request.config.getoption("--skip-absent-sfp")
+        self.skip_absent_sfp = request.config.getoption("--skip-absent-sfp")
         self.list_sfps = physical_port_indices
         #logging.info("physical_port_indices {}".format(physical_port_indices))
         self.candidate_sfp = []

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -1,6 +1,5 @@
 import ast
 import logging
-import inspect
 
 import pytest
 

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -7,6 +7,7 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import sfp
 from tests.common.utilities import skip_version
+from tests.common.utilities import skip_release_for_platform
 from tests.common.platform.interface_utils import get_physical_port_indices
 from tests.common.utilities import wait_until
 
@@ -107,14 +108,6 @@ class TestSfpApi(PlatformApiTestBase):
     duthost_vars = None
     num_sfps = None
     candidate_sfp = None
-
-    @pytest.fixture(scope="module")
-    def is_platform_api_implemented(self, duthost):
-        if "202012" == duthost.sonic_release:
-            platform = duthost.facts['platform']
-            if 'arista' in platform or 'mlnx' in platform:
-                return False
-        return True
 
     # get_physical_port_indices() is wrapped around pytest fixture with module
     # scope because this function can be quite time consuming based upon the
@@ -217,12 +210,9 @@ class TestSfpApi(PlatformApiTestBase):
                     self.expect(presence is True, "Transceiver {} is not present".format(i))
         self.assert_expectations()
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
-            is_platform_api_implemented):
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
 
         for i in self.candidate_sfp:
             model = sfp.get_model(platform_api_conn, i)
@@ -230,48 +220,40 @@ class TestSfpApi(PlatformApiTestBase):
                 self.expect(isinstance(model, STRING_TYPE), "Transceiver {} model appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
-            is_platform_api_implemented):
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         for i in self.candidate_sfp:
             serial = sfp.get_serial(platform_api_conn, i)
             if self.expect(serial is not None, "Unable to retrieve transceiver {} serial number".format(i)):
                 self.expect(isinstance(serial, STRING_TYPE), "Transceiver {} serial number appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn, 
-            is_platform_api_implemented):
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         for i in self.candidate_sfp:
             status = sfp.get_status(platform_api_conn, i)
             if self.expect(status is not None, "Unable to retrieve transceiver {} status".format(i)):
                 self.expect(isinstance(status, bool), "Transceiver {} status appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_position_in_parent(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn,
-            is_platform_api_implemented):
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+    def test_get_position_in_parent(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         for i in self.candidate_sfp:
             position = sfp.get_position_in_parent(platform_api_conn, i)
             if self.expect(position is not None, "Failed to perform get_position_in_parent for sfp {}".format(i)):
                 self.expect(isinstance(position, int), "Position value must be an integer value for sfp {}".format(i))
         self.assert_expectations()
 
-    def test_is_replaceable(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn,
-            is_platform_api_implemented):
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+    def test_is_replaceable(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         for sfp_id in self.candidate_sfp:
             replaceable = sfp.is_replaceable(platform_api_conn, sfp_id)
             if self.expect(replaceable is not None, "Failed to perform is_replaceable for sfp {}".format(sfp_id)):
@@ -306,12 +288,11 @@ class TestSfpApi(PlatformApiTestBase):
                         self.expect(False, "Transceiver {} info contains unexpected field '{}'".format(i, key))
         self.assert_expectations()
 
-    def test_get_transceiver_bulk_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
-            is_platform_api_implemented):
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+    def test_get_transceiver_bulk_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+            platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         for i in self.candidate_sfp:
             bulk_status_dict = sfp.get_transceiver_bulk_status(platform_api_conn, i)
             if self.expect(bulk_status_dict is not None, "Unable to retrieve transceiver {} bulk status".format(i)):
@@ -325,13 +306,12 @@ class TestSfpApi(PlatformApiTestBase):
                         self.expect(False, "Transceiver {} bulk status does not contain field: '{}'".format(i, key))
         self.assert_expectations()
 
-    def test_get_transceiver_threshold_info(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-            platform_api_conn, is_platform_api_implemented):
+    def test_get_transceiver_threshold_info(self, duthosts, enum_rand_one_per_hwsku_hostname,
+                                                localhost, platform_api_conn):
         # TODO: Do more sanity checking on transceiver threshold info values
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         for i in self.candidate_sfp:
             thold_info_dict = sfp.get_transceiver_threshold_info(platform_api_conn, i)
             if self.expect(thold_info_dict is not None, "Unable to retrieve transceiver {} threshold info".format(i)):
@@ -347,12 +327,10 @@ class TestSfpApi(PlatformApiTestBase):
                         self.expect(False, "Transceiver {} threshold info contains unexpected field '{}'".format(i, key))
         self.assert_expectations()
 
-    def test_get_reset_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
-            is_platform_api_implemented):
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+    def test_get_reset_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         # TODO: Do more sanity checking on the data we retrieve
         for i in self.candidate_sfp:
             reset_status = sfp.get_reset_status(platform_api_conn, i)
@@ -360,13 +338,11 @@ class TestSfpApi(PlatformApiTestBase):
                 self.expect(isinstance(reset_status, bool), "Transceiver {} reset status appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_rx_los(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
-            is_platform_api_implemented):
+    def test_get_rx_los(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         # TODO: Do more sanity checking on the data we retrieve
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         for i in self.candidate_sfp:
             rx_los = sfp.get_rx_los(platform_api_conn, i)
             if self.expect(rx_los is not None, "Unable to retrieve transceiver {} RX loss-of-signal data".format(i)):
@@ -374,13 +350,11 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} RX loss-of-signal data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_tx_fault(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn, 
-            is_platform_api_implemented):
+    def test_get_tx_fault(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         # TODO: Do more sanity checking on the data we retrieve
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         for i in self.candidate_sfp:
             tx_fault = sfp.get_tx_fault(platform_api_conn, i)
             if self.expect(tx_fault is not None, "Unable to retrieve transceiver {} TX fault data".format(i)):
@@ -388,38 +362,32 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} TX fault data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
-            is_platform_api_implemented):
+    def test_get_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         # TODO: Do more sanity checking on the data we retrieve
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         for i in self.candidate_sfp:
             temp = sfp.get_temperature(platform_api_conn, i)
             if self.expect(temp is not None, "Unable to retrieve transceiver {} temperatue".format(i)):
                 self.expect(isinstance(temp, float), "Transceiver {} temperature appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_voltage(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
-            is_platform_api_implemented):
+    def test_get_voltage(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         # TODO: Do more sanity checking on the data we retrieve
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         for i in self.candidate_sfp:
             voltage = sfp.get_voltage(platform_api_conn, i)
             if self.expect(voltage is not None, "Unable to retrieve transceiver {} voltage".format(i)):
                 self.expect(isinstance(voltage, float), "Transceiver {} voltage appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_tx_bias(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
-            is_platform_api_implemented):
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+    def test_get_tx_bias(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         # TODO: Do more sanity checking on the data we retrieve
         for i in self.candidate_sfp:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
@@ -433,12 +401,10 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} TX bias data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_rx_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
-            is_platform_api_implemented):
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+    def test_get_rx_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         # TODO: Do more sanity checking on the data we retrieve
         # TODO: Should we should expect get_rx_power() to return None or a list of "N/A" strings
         # if the transceiver is non-optical, e.g., DAC
@@ -458,13 +424,11 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} RX power data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_tx_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
-            is_platform_api_implemented):
+    def test_get_tx_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         # TODO: Do more sanity checking on the data we retrieve
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         for i in self.candidate_sfp:
             tx_power = sfp.get_tx_power(platform_api_conn, i)
             if self.expect(tx_power is not None, "Unable to retrieve transceiver {} TX power data".format(i)):
@@ -484,13 +448,11 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} TX power data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_reset(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
-            is_platform_api_implemented):
+    def test_reset(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         # TODO: Verify that the transceiver was actually reset
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         for i in self.candidate_sfp:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
             if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
@@ -503,13 +465,11 @@ class TestSfpApi(PlatformApiTestBase):
                self.expect(ret is False, "Resetting transceiver {} succeeded but should have failed".format(i))
         self.assert_expectations()
 
-    def test_tx_disable(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
-            is_platform_api_implemented):
+    def test_tx_disable(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         """This function tests both the get_tx_disable() and tx_disable() APIs"""
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         for i in self.candidate_sfp:
             # First ensure that the transceiver type supports setting TX disable
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
@@ -529,13 +489,11 @@ class TestSfpApi(PlatformApiTestBase):
                                     "Transceiver {} TX disable data is incorrect".format(i))
         self.assert_expectations()
 
-    def test_tx_disable_channel(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
-            is_platform_api_implemented):
+    def test_tx_disable_channel(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         """This function tests both the get_tx_disable_channel() and tx_disable_channel() APIs"""
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         for i in self.candidate_sfp:
             # First ensure that the transceiver type supports setting TX disable on individual channels
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
@@ -587,13 +545,11 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} expected low-power state {} is not aligned with the real state".format(i, "enable" if state is True else "disable"))
         self.assert_expectations()
 
-    def test_power_override(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
-            is_platform_api_implemented):
+    def test_power_override(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         """This function tests both the get_power_override() and set_power_override() APIs"""
-        if not is_platform_api_implemented:
-             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-             pytest.skip("Skipping {} on {} running {} version".format(
-                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+
         for i in self.candidate_sfp:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
             if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -1,5 +1,6 @@
 import ast
 import logging
+import inspect
 
 import pytest
 
@@ -107,6 +108,14 @@ class TestSfpApi(PlatformApiTestBase):
     num_sfps = None
     candidate_sfp = None
 
+    @pytest.fixture(scope="module")
+    def is_platform_api_implemented(self, duthost):
+        if "202012" in duthost.os_version:
+            platform = duthost.facts['platform']
+            if 'arista' in platform or 'mlnx' in platform:
+                return False
+        return True
+
     # get_physical_port_indices() is wrapped around pytest fixture with module
     # scope because this function can be quite time consuming based upon the
     # number of ports on the DUT
@@ -123,7 +132,7 @@ class TestSfpApi(PlatformApiTestBase):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         if duthost.is_supervisor_node():
             pytest.skip("skipping for supervisor node")
-        self.skip_absent_sfp = request.config.getoption("--skip-absent-sfp")
+        self.skip_absent_sfp = True #request.config.getoption("--skip-absent-sfp")
         self.list_sfps = physical_port_indices
         #logging.info("physical_port_indices {}".format(physical_port_indices))
         self.candidate_sfp = []
@@ -208,35 +217,61 @@ class TestSfpApi(PlatformApiTestBase):
                     self.expect(presence is True, "Transceiver {} is not present".format(i))
         self.assert_expectations()
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
+            is_platform_api_implemented):
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
+
         for i in self.candidate_sfp:
             model = sfp.get_model(platform_api_conn, i)
             if self.expect(model is not None, "Unable to retrieve transceiver {} model".format(i)):
                 self.expect(isinstance(model, STRING_TYPE), "Transceiver {} model appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
+            is_platform_api_implemented):
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         for i in self.candidate_sfp:
             serial = sfp.get_serial(platform_api_conn, i)
             if self.expect(serial is not None, "Unable to retrieve transceiver {} serial number".format(i)):
                 self.expect(isinstance(serial, STRING_TYPE), "Transceiver {} serial number appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn, 
+            is_platform_api_implemented):
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         for i in self.candidate_sfp:
             status = sfp.get_status(platform_api_conn, i)
             if self.expect(status is not None, "Unable to retrieve transceiver {} status".format(i)):
                 self.expect(isinstance(status, bool), "Transceiver {} status appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_position_in_parent(self, platform_api_conn):
+    def test_get_position_in_parent(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn,
+            is_platform_api_implemented):
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         for i in self.candidate_sfp:
             position = sfp.get_position_in_parent(platform_api_conn, i)
             if self.expect(position is not None, "Failed to perform get_position_in_parent for sfp {}".format(i)):
                 self.expect(isinstance(position, int), "Position value must be an integer value for sfp {}".format(i))
         self.assert_expectations()
 
-    def test_is_replaceable(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn):
+    def test_is_replaceable(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn,
+            is_platform_api_implemented):
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         for sfp_id in self.candidate_sfp:
             replaceable = sfp.is_replaceable(platform_api_conn, sfp_id)
             if self.expect(replaceable is not None, "Failed to perform is_replaceable for sfp {}".format(sfp_id)):
@@ -271,7 +306,12 @@ class TestSfpApi(PlatformApiTestBase):
                         self.expect(False, "Transceiver {} info contains unexpected field '{}'".format(i, key))
         self.assert_expectations()
 
-    def test_get_transceiver_bulk_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_transceiver_bulk_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
+            is_platform_api_implemented):
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         for i in self.candidate_sfp:
             bulk_status_dict = sfp.get_transceiver_bulk_status(platform_api_conn, i)
             if self.expect(bulk_status_dict is not None, "Unable to retrieve transceiver {} bulk status".format(i)):
@@ -285,8 +325,13 @@ class TestSfpApi(PlatformApiTestBase):
                         self.expect(False, "Transceiver {} bulk status does not contain field: '{}'".format(i, key))
         self.assert_expectations()
 
-    def test_get_transceiver_threshold_info(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_transceiver_threshold_info(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+            platform_api_conn, is_platform_api_implemented):
         # TODO: Do more sanity checking on transceiver threshold info values
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         for i in self.candidate_sfp:
             thold_info_dict = sfp.get_transceiver_threshold_info(platform_api_conn, i)
             if self.expect(thold_info_dict is not None, "Unable to retrieve transceiver {} threshold info".format(i)):
@@ -302,7 +347,12 @@ class TestSfpApi(PlatformApiTestBase):
                         self.expect(False, "Transceiver {} threshold info contains unexpected field '{}'".format(i, key))
         self.assert_expectations()
 
-    def test_get_reset_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_reset_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
+            is_platform_api_implemented):
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         # TODO: Do more sanity checking on the data we retrieve
         for i in self.candidate_sfp:
             reset_status = sfp.get_reset_status(platform_api_conn, i)
@@ -310,8 +360,13 @@ class TestSfpApi(PlatformApiTestBase):
                 self.expect(isinstance(reset_status, bool), "Transceiver {} reset status appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_rx_los(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_rx_los(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
+            is_platform_api_implemented):
         # TODO: Do more sanity checking on the data we retrieve
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         for i in self.candidate_sfp:
             rx_los = sfp.get_rx_los(platform_api_conn, i)
             if self.expect(rx_los is not None, "Unable to retrieve transceiver {} RX loss-of-signal data".format(i)):
@@ -319,8 +374,13 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} RX loss-of-signal data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_tx_fault(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_tx_fault(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn, 
+            is_platform_api_implemented):
         # TODO: Do more sanity checking on the data we retrieve
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         for i in self.candidate_sfp:
             tx_fault = sfp.get_tx_fault(platform_api_conn, i)
             if self.expect(tx_fault is not None, "Unable to retrieve transceiver {} TX fault data".format(i)):
@@ -328,23 +388,38 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} TX fault data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
+            is_platform_api_implemented):
         # TODO: Do more sanity checking on the data we retrieve
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         for i in self.candidate_sfp:
             temp = sfp.get_temperature(platform_api_conn, i)
             if self.expect(temp is not None, "Unable to retrieve transceiver {} temperatue".format(i)):
                 self.expect(isinstance(temp, float), "Transceiver {} temperature appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_voltage(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_voltage(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
+            is_platform_api_implemented):
         # TODO: Do more sanity checking on the data we retrieve
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         for i in self.candidate_sfp:
             voltage = sfp.get_voltage(platform_api_conn, i)
             if self.expect(voltage is not None, "Unable to retrieve transceiver {} voltage".format(i)):
                 self.expect(isinstance(voltage, float), "Transceiver {} voltage appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_tx_bias(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_tx_bias(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
+            is_platform_api_implemented):
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         # TODO: Do more sanity checking on the data we retrieve
         for i in self.candidate_sfp:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
@@ -358,7 +433,12 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} TX bias data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_rx_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_rx_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
+            is_platform_api_implemented):
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         # TODO: Do more sanity checking on the data we retrieve
         # TODO: Should we should expect get_rx_power() to return None or a list of "N/A" strings
         # if the transceiver is non-optical, e.g., DAC
@@ -378,8 +458,13 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} RX power data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_tx_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_tx_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
+            is_platform_api_implemented):
         # TODO: Do more sanity checking on the data we retrieve
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         for i in self.candidate_sfp:
             tx_power = sfp.get_tx_power(platform_api_conn, i)
             if self.expect(tx_power is not None, "Unable to retrieve transceiver {} TX power data".format(i)):
@@ -399,8 +484,13 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} TX power data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_reset(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_reset(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
+            is_platform_api_implemented):
         # TODO: Verify that the transceiver was actually reset
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         for i in self.candidate_sfp:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
             if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
@@ -413,8 +503,13 @@ class TestSfpApi(PlatformApiTestBase):
                self.expect(ret is False, "Resetting transceiver {} succeeded but should have failed".format(i))
         self.assert_expectations()
 
-    def test_tx_disable(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_tx_disable(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
+            is_platform_api_implemented):
         """This function tests both the get_tx_disable() and tx_disable() APIs"""
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         for i in self.candidate_sfp:
             # First ensure that the transceiver type supports setting TX disable
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
@@ -434,8 +529,13 @@ class TestSfpApi(PlatformApiTestBase):
                                     "Transceiver {} TX disable data is incorrect".format(i))
         self.assert_expectations()
 
-    def test_tx_disable_channel(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_tx_disable_channel(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
+            is_platform_api_implemented):
         """This function tests both the get_tx_disable_channel() and tx_disable_channel() APIs"""
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         for i in self.candidate_sfp:
             # First ensure that the transceiver type supports setting TX disable on individual channels
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
@@ -487,8 +587,13 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} expected low-power state {} is not aligned with the real state".format(i, "enable" if state is True else "disable"))
         self.assert_expectations()
 
-    def test_power_override(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_power_override(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
+            is_platform_api_implemented):
         """This function tests both the get_power_override() and set_power_override() APIs"""
+        if not is_platform_api_implemented:
+             duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+             pytest.skip("Skipping {} on {} running {} version".format(
+                               inspect.currentframe().f_code.co_name, duthost.facts['platform'], duthost.os_version))
         for i in self.candidate_sfp:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
             if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):


### PR DESCRIPTION
Signed-off-by: Prince George <prgeor@microsoft.com>

### Description of PR
Arista and Mellanox platforms haven't implemented many APIs:- [https://github.com/aristanetworks/sonic/blob/202012/arista/utils/sonic_platform/sfp.py#L18](https://github.com/aristanetworks/sonic/blob/202012/arista/utils/sonic_platform/sfp.py#L18)
Hence, the tests are failing.

Current SFP implementation is heavily platform dependent even though almost all APIs should ideally be platform independent. For 202012, skipping many of the SFP platform API tests.  Once SFP refactor changes are in, all these APIs needs to be enabled back.

Summary:


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

#### What is the motivation for this PR?
Fix https://github.com/Azure/sonic-buildimage/issues/8437

#### How did you do it?
Skip the unimplemented platform APIs for Arista and Mellanox platforms running 202012

#### How did you verify/test it?
Run all tests in test_sfp.py, ensure unimplemented API tests are skipped and others pass.

