### PR TITLE
[snmp] skip snmp default route test for all backend topologies

### DIFF
--- a/tests/snmp/test_snmp_default_route.py
+++ b/tests/snmp/test_snmp_default_route.py
@@ -14,7 +14,7 @@ def test_snmp_default_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     """compare the snmp facts between observed states and target state"""
 
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    pytest_require('t1-backend' not in tbinfo['topo']['name'], "Skip this testcase since this topology {} has no default routes".format(tbinfo['topo']['name']))
+    pytest_require('backend' not in tbinfo['topo']['name'], "Skip this testcase since this topology {} has no default routes".format(tbinfo['topo']['name']))
 
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
     snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
test_snmp_default_route.py is failing on topology t0-backend.

#### How did you do it?
t0-backend and t1-backend doesn't have default route on data plane. t1-backend already skipped this test. this change adds t0-backend to the skip list.

#### How did you verify/test it?
Run snmp test on a t0-backend testbed.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

