### PR TITLE
[snmp] address random shared memory check failure

### DIFF
--- a/tests/snmp/test_snmp_memory.py
+++ b/tests/snmp/test_snmp_memory.py
@@ -5,11 +5,14 @@ Parameters:
 """
 
 import pytest
+import logging
 from tests.common.helpers.assertions import pytest_assert # pylint: disable=import-error
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 pytestmark = [
     pytest.mark.topology('any')
 ]
+
+logger = logging.getLogger(__name__)
 
 CALC_DIFF = lambda snmp, sys_data: float(abs(snmp - int(sys_data)) * 100) / float(snmp)
 
@@ -50,21 +53,36 @@ def test_snmp_memory(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     host_ip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    snmp_facts = get_snmp_facts(localhost, host=host_ip, version="v2c",
-                                community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
-    facts = collect_memory(duthost)
     compare = (('ansible_sysTotalFreeMemery', 'MemFree'), ('ansible_sysTotalBuffMemory', 'Buffers'),
                ('ansible_sysCachedMemory', 'Cached'), ('ansible_sysTotalSharedMemory', 'Shmem'))
 
-    # Verify correct behaviour of sysTotalMemery, sysTotalSharedMemory
-    pytest_assert(not abs(snmp_facts['ansible_sysTotalMemery'] - int(facts['MemTotal'])),
-                  "Unexpected res sysTotalMemery {} v.s. {}".format(snmp_facts['ansible_sysTotalMemery'], facts['MemTotal']))
+    # Checking memory attributes within a certain percentage is not guarantee to
+    # work 100% of the time. There could always be a big memory change between the
+    # test read from snmp and read from system.
+    # Allow the test to retry a few times before claiming failure.
+    for _ in range(3):
+        snmp_facts = get_snmp_facts(localhost, host=host_ip, version="v2c",
+                                    community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+        facts = collect_memory(duthost)
+        # Verify correct behaviour of sysTotalMemery
+        pytest_assert(not abs(snmp_facts['ansible_sysTotalMemery'] - int(facts['MemTotal'])),
+                      "Unexpected res sysTotalMemery {} v.s. {}".format(snmp_facts['ansible_sysTotalMemery'], facts['MemTotal']))
 
-    # Verify correct behaviour of sysTotalFreeMemery, sysTotalBuffMemory, sysCachedMemory
-    snmp_diff = [snmp for snmp, sys_data in compare if CALC_DIFF(snmp_facts[snmp],
-                                                                 facts[sys_data]) > percent]
-    pytest_assert(not snmp_diff,
-                  "Snmp memory MIBs: {} differs more than {} %".format(snmp_diff, percent))
+        # Verify correct behaviour of sysTotalFreeMemery, sysTotalBuffMemory, sysCachedMemory, sysTotalSharedMemory
+        new_comp = set()
+        snmp_diff = []
+        for snmp, sys_data in compare:
+            if CALC_DIFF(snmp_facts[snmp], facts[sys_data]) > percent:
+                snmp_diff.append(snmp)
+                new_comp.add((snmp, sys_data))
+
+        compare = new_comp
+        if not snmp_diff:
+            return
+
+        logging.info("Snmp memory MIBs: {} differs more than {} %".format(snmp_diff, percent))
+
+    pytest.fail("Snmp memory MIBs: {} differs more than {} %".format(snmp_diff, percent))
 
 
 def test_snmp_memory_load(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_all_duts, load_memory):

--- a/tests/snmp/test_snmp_memory.py
+++ b/tests/snmp/test_snmp_memory.py
@@ -54,13 +54,11 @@ def test_snmp_memory(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
                                 community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
     facts = collect_memory(duthost)
     compare = (('ansible_sysTotalFreeMemery', 'MemFree'), ('ansible_sysTotalBuffMemory', 'Buffers'),
-               ('ansible_sysCachedMemory', 'Cached'))
+               ('ansible_sysCachedMemory', 'Cached'), ('ansible_sysTotalSharedMemory', 'Shmem'))
 
     # Verify correct behaviour of sysTotalMemery, sysTotalSharedMemory
     pytest_assert(not abs(snmp_facts['ansible_sysTotalMemery'] - int(facts['MemTotal'])),
-                  "Unexpected res sysTotalMemery {}".format(snmp_facts['ansible_sysTotalMemery']))
-    pytest_assert(not abs(snmp_facts['ansible_sysTotalSharedMemory'] - int(facts['Shmem'])),
-                  "Unexpected res sysTotalSharedMemory {}".format(snmp_facts['ansible_sysTotalSharedMemory']))
+                  "Unexpected res sysTotalMemery {} v.s. {}".format(snmp_facts['ansible_sysTotalMemery'], facts['MemTotal']))
 
     # Verify correct behaviour of sysTotalFreeMemery, sysTotalBuffMemory, sysCachedMemory
     snmp_diff = [snmp for snmp, sys_data in compare if CALC_DIFF(snmp_facts[snmp],


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
test_snmp_memory.py is randomly failing.

#### How did you do it?
Shared memory is a changing number on target device, therefore there is a chance that the snmp and system read took different readings by timing.

This is an enhancement but I don't think this change addresses the issue fully. The reason for these random failures was mainly because the time we collected the snmp facts and the time we read these information from the dut would be different, So memory allocation / usage changes over time. Anything dynamic could see a jump of more than 4%. 4% is too artificial to work on all cases.

#### How did you verify/test it?
Run snmp test.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
