### PR TITLE
[platform_tests] Ensure reboot-cause string for power-off matches the output on all platforms

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -33,7 +33,7 @@ reboot_ctrl_dict = {
     REBOOT_TYPE_POWEROFF: {
         "timeout": 300,
         "wait": 120,
-        "cause": "Power Loss",
+        "cause": "Power",
         "test_reboot_cause_only": True
     },
     REBOOT_TYPE_COLD: {
@@ -206,7 +206,6 @@ def get_reboot_cause(dut):
     logging.info('Getting reboot cause from dut {}'.format(dut.hostname))
     output = dut.shell('show reboot-cause')
     cause  = output['stdout']
-
     for type, ctrl in reboot_ctrl_dict.items():
         if re.search(ctrl['cause'], cause):
             return type
@@ -221,5 +220,5 @@ def check_reboot_cause(dut, reboot_cause_expected):
     @param reboot_cause_expected: The expected reboot cause.
     """
     reboot_cause_got = get_reboot_cause(dut)
-    logging.debug("dut {} last reboot-cause {}".format(dut.hostname, reboot_cause_got))
+    logging.info("dut {} last reboot-cause {} expected-reboot-cause {}".format(dut.hostname, reboot_cause_got, reboot_cause_expected))
     return reboot_cause_got == reboot_cause_expected


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
On Dell platforms, the reboot-cause after power-cycle is returned as  "Hardware - Other (Power on reset)". Changing script to ensure power-cycle reboot cause is identified correctly

Summary:


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix test_power_off_reboot test case on Dell platform

#### How did you do it?
Changed reboot-cause string to match the reboot reason returned on multiple platforms

#### How did you verify/test it?
Validated test_power_off_reboot on 9332

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
