### PR TITLE
Increase timeout for ```verify_packet``` in ```test_null_route_helper```

### DIFF
--- a/tests/acl/null_route/test_null_route_helper.py
+++ b/tests/acl/null_route/test_null_route_helper.py
@@ -208,9 +208,9 @@ def send_and_verify_packet(ptfadapter, pkt, exp_pkt, tx_port, rx_port, expected_
     ptfadapter.dataplane.flush()
     testutils.send(ptfadapter, pkt=pkt, port_id=tx_port)
     if expected_action == FORWARD:
-        testutils.verify_packet(ptfadapter, pkt=exp_pkt, port_id=rx_port, timeout=2)
+        testutils.verify_packet(ptfadapter, pkt=exp_pkt, port_id=rx_port, timeout=5)
     else:
-        testutils.verify_no_packet(ptfadapter, pkt=exp_pkt, port_id=rx_port, timeout=2)
+        testutils.verify_no_packet(ptfadapter, pkt=exp_pkt, port_id=rx_port, timeout=5)
 
 
 def test_null_route_helper(rand_selected_dut, tbinfo, ptfadapter, apply_pre_defined_rules, setup_ptf):


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Test case ```test_null_route_helper``` is flaky on Arista platform because the time cost for populating IPv6 neighbor and forwarding packets is a little larger than 2 seconds. 
To address this issue, the timeout value is increased to 5 seconds. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to increase timeout for ```verify_packet``` in ```test_null_route_helper```.

#### How did you do it?
The timeout value is increased to 5 seconds. 

#### How did you verify/test it?
Verified on Arista 7050 box. Run the test case after rebooting, test case was consistently passing.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
