### PR TITLE
[acl] Run garp service just for dual_tor

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -149,7 +149,7 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
             upstream_port_id_to_router_mac_map[port_id] = rand_selected_dut.facts["router_mac"]
 
     # stop garp service for single tor
-    if 'dualtor' not in tbinfo['topo']['name'] and rand_unselected_dut is None:
+    if 'dualtor' not in tbinfo['topo']['name']:
         logging.info("Stopping GARP service on single tor")
         ptfhost.shell("supervisorctl stop garp_service")
 

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -96,7 +96,7 @@ BYTES_COUNT = "bytes_count"
 
 
 @pytest.fixture(scope="module")
-def setup(duthosts, rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter):
+def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter):
     """Gather all required test information from DUT and tbinfo.
 
     Args:
@@ -147,6 +147,11 @@ def setup(duthosts, rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter):
             upstream_ports[neighbor['namespace']].append(interface)
             upstream_port_ids.append(port_id)
             upstream_port_id_to_router_mac_map[port_id] = rand_selected_dut.facts["router_mac"]
+
+    # stop garp service for single tor
+    if 'dualtor' not in tbinfo['topo']['name'] and rand_unselected_dut is None:
+        logging.info("Stopping GARP service on single tor")
+        ptfhost.shell("supervisorctl stop garp_service")
 
     # If running on a dual ToR testbed, any uplink for either ToR is an acceptable
     # source or destination port
@@ -859,7 +864,7 @@ class BaseAclTest(object):
         if dropped:
             testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=self.get_dst_ports(setup, direction))
         else:
-            testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=self.get_dst_ports(setup, direction))
+            testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=self.get_dst_ports(setup, direction), timeout=20)
 
 
 class TestBasicAcl(BaseAclTest):


### PR DESCRIPTION
What is the motivation for this PR?
After running garp service, DUT will flood the arp packets to all the other ports under the same vlan interface, which means ptf needs to poll N x N packets in one second to do the verification. (N is the number of ports in the vlan interfaces on DUT). So even ptf has already received the expected packet, ptf may miss doing the verification on the DUT which has lots of ports. As this garp service is just required on dual-tor, so we can skip it on single-tor.

How did you do it?
Check the typo name, just import garp service for dual-tor. For the next
step improvement, we may need to consider to increase the interval of
garp service.

How did you verify/test it?
Run test_acl.py on 7260 which has 112 ports in the same vlan interface.

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
