### PR TITLE
Add fanout template to generate config for 10g interface

### DIFF
--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -69,6 +69,29 @@ interface {{ intf }}
 {%         else %}
    shutdown
 {%         endif %}
+{%     elif device_conn[inventory_hostname][intf]['speed'] == "10000" %}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
+   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
+   switchport mode dot1q-tunnel
+   spanning-tree portfast
+   speed forced 10gfull
+   no error-correction encoding
+   no shutdown
+{%         for j in range(2,5) %}
+{% set intf =  'Ethernet' + i|string + '/' + j|string %}
+interface {{ intf }}
+{%             if intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] != "Trunk" %}
+   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
+   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
+   switchport mode dot1q-tunnel
+   spanning-tree portfast
+   speed forced 10gfull
+   no error-correction encoding
+   no shutdown
+{%             else %}
+   shutdown
+{%             endif %}
+{%         endfor %}
 {%     else %}
 {#        Not valid speed value #}
    shutdown


### PR DESCRIPTION
### Description of PR
Add fanout template to generate config for 10g interface

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To prepare connection to DUT of Mellanox-SN2700-D40C8S8.

#### How did you do it?
How to apply config to fanout switch:
```
ansible-playbook fanout.yml -i <inventary> --limit <fanout> -b --vault-password-file ~/password.txt
```

#### How did you verify/test it?
Verify on DUT that all the ports are oper up.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
