### PR TITLE
[Mellanox] Read PSU fan max/min speed per PSU

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -88,7 +88,7 @@ FAN_NAMING_RULE = {
         "name": "psu{}_fan1",
         "speed": "psu{}_fan1_speed_get",
         "power_status": "psu{}_pwr_status",
-        "max_speed": "psu_fan_max",
+        "max_speed": "psu{}_fan_max",
     }
 }
 
@@ -551,10 +551,7 @@ class FanData:
         :return: Max speed of this FAN or -1 if max speed is not available.
         """
         if self.max_speed_file:
-            if 'psu' not in self.max_speed_file:
-                max_speed = self.helper.read_thermal_value(self.max_speed_file)
-            else:
-                max_speed = self.helper.read_value(os.path.join('/run/hw-management/config', self.max_speed_file))
+            max_speed = self.helper.read_thermal_value(self.max_speed_file)
             return int(max_speed)
         else:
             return -1


### PR DESCRIPTION
Change-Id: I6dc3980965fdfc377053a23fd6c721b301fc9a01

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Align with PR https://github.com/Azure/sonic-buildimage/pull/8563

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911

### Approach
#### What is the motivation for this PR?

Align with PR https://github.com/Azure/sonic-buildimage/pull/8563

#### How did you do it?

Read PSU fan max/min speed per PSU

#### How did you verify/test it?

Manually run test case test_platform_info::test_show_platform_fanstatus_mocked

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
