### PR TITLE
Add wait after loading minigraph config in mock-dualtor tests

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -1,6 +1,5 @@
 import time
 import logging
-from common.plugins.sanity_check.constants import RECOVER_METHODS
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +64,7 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
         else:
             is_buffer_model_dynamic = False
         duthost.shell('config load_minigraph -y &>/dev/null', executable="/bin/bash")
-        time.sleep(RECOVER_METHODS.get("load_minigraph", {}).get("recover_wait", 60))
+        time.sleep(60)
         if start_bgp:
             duthost.shell('config bgp startup all')
         if is_buffer_model_dynamic:

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -1,5 +1,6 @@
 import time
 import logging
+from common.plugins.sanity_check.constants import RECOVER_METHODS
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +65,7 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
         else:
             is_buffer_model_dynamic = False
         duthost.shell('config load_minigraph -y &>/dev/null', executable="/bin/bash")
+        time.sleep(RECOVER_METHODS.get("load_minigraph", {}).get("recover_wait", 60))
         if start_bgp:
             duthost.shell('config bgp startup all')
         if is_buffer_model_dynamic:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add wait after loading minigraph config in mock-dualtor tests
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To fix flay errors seen in dualtor tests running on mocked-dualtor testbeds.

```
duthost = <MultiAsicSonicHost> str2-7050cx3-acs-01
tbinfo = {'auto_recover': 'True', 'comment': 'lawlee', 'conf-name': 'vms20-t0-7050cx3-1', 'duts': ['str2-7050cx3-acs-01'], ...}

    @pytest.fixture(scope="module")
    def cleanup_mocked_configs(duthost, tbinfo):
        """Config reload to reset the mocked configs applied to DUT."""
    
        yield
    
        if is_t0_mocked_dualtor(tbinfo):
            logger.info("Load minigraph to reset the DUT %s", duthost.hostname)
>           config_reload(duthost, config_source="minigraph")

duthost    = <MultiAsicSonicHost> str2-7050cx3-acs-01
tbinfo     = {'auto_recover': 'True', 'comment': 'lawlee', 'conf-name': 'vms20-t0-7050cx3-1', 'duts': ['str2-7050cx3-acs-01'], ...}

common/dualtor/dual_tor_mock.py:427: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
common/config_reload.py:68: in config_reload
    duthost.shell('config bgp startup all')
common/devices/multi_asic.py:89: in _run_on_asics
    return getattr(self.sonichost, self.multi_asic_attr)(*module_args, **complex_args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <SonicHost> str2-7050cx3-acs-01
module_args = ('config bgp startup all',), complex_args = {}
previous_frame = <frame object at 0x55f923814490>
filename = '/azp/agent/_work/25/s/tests/common/devices/multi_asic.py'
line_number = 89, function_name = '_run_on_asics'
lines = ['            return getattr(self.sonichost, self.multi_asic_attr)(*module_args, **complex_args)\n']
index = 0, verbose = True, module_ignore_errors = False, module_async = False

    def _run(self, *module_args, **complex_args):
    
        previous_frame = inspect.currentframe().f_back
        filename, line_number, function_name, lines, index = inspect.getframeinfo(previous_frame)
    
        verbose = complex_args.pop('verbose', True)
    
        if verbose:
            logging.debug("{}::{}#{}: [{}] AnsibleModule::{}, args={}, kwargs={}"\
                .format(filename, function_name, line_number, self.hostname,
                        self.module_name, json.dumps(module_args), json.dumps(complex_args)))
        else:
            logging.debug("{}::{}#{}: [{}] AnsibleModule::{} executing..."\
                .format(filename, function_name, line_number, self.hostname, self.module_name))
    
        module_ignore_errors = complex_args.pop('module_ignore_errors', False)
        module_async = complex_args.pop('module_async', False)
    
        if module_async:
            def run_module(module_args, complex_args):
                return self.module(*module_args, **complex_args)[self.hostname]
            pool = ThreadPool()
            result = pool.apply_async(run_module, (module_args, complex_args))
            return pool, result
    
        res = self.module(*module_args, **complex_args)[self.hostname]
    
        if verbose:
            logging.debug("{}::{}#{}: [{}] AnsibleModule::{} Result => {}"\
                .format(filename, function_name, line_number, self.hostname, self.module_name, json.dumps(res)))
        else:
            logging.debug("{}::{}#{}: [{}] AnsibleModule::{} done, is_failed={}, rc={}"\
                .format(filename, function_name, line_number, self.hostname, self.module_name, \
                        res.is_failed, res.get('rc', None)))
    
        if (res.is_failed or 'exception' in res) and not module_ignore_errors:
>           raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
E           RunAnsibleModuleFail: run module shell failed, Ansible Results =>
E           {
E               "failed": true, 
E               "msg": "Timeout (32s) waiting for privilege escalation prompt: "
E           }

complex_args = {}
filename   = '/azp/agent/_work/25/s/tests/common/devices/multi_asic.py'
function_name = '_run_on_asics'
index      = 0
line_number = 89
lines      = ['            return getattr(self.sonichost, self.multi_asic_attr)(*module_args, *
```

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
