### PR TITLE
Add scp copy test

### DIFF
--- a/ansible/group_vars/all/creds.yml
+++ b/ansible/group_vars/all/creds.yml
@@ -13,3 +13,6 @@ sonic_password: "password"
 
 k8s_master_login: "ubuntu"
 k8s_master_password: "use_own_value"
+
+ptf_host_user: root
+ptf_host_pass: root

--- a/docs/testplan/SCP_copy-test-plan.md
+++ b/docs/testplan/SCP_copy-test-plan.md
@@ -10,7 +10,7 @@ This test was verified on a t0 topology, but should work on any other topology s
 
 ## Test Procedure
 
-1. The PTF container generates a 1 GB file with random bytes.
+1. The PTF container generates a 0.5 GB file with random bytes.
 2. AN MD5 checksum is generated for the generated file.
 3. The DUT requests this file from the PTF via scp started from the DUT.
 4. An MD5 checksum is generated for the file on the DUT.

--- a/docs/testplan/SCP_copy-test-plan.md
+++ b/docs/testplan/SCP_copy-test-plan.md
@@ -1,0 +1,22 @@
+ - [Overview](#overview)
+     - [Scope](#scope)
+ - [Test Procedure](#test-procedure)
+
+## Overview
+The purpose of this test is to ensure that the DUT is able to fetch from an external SCP server without loss of file integrity. The file used by the test exceeds a gigabyte in order to ensure integrity even for large file sizes.
+
+### Scope
+This test was verified on a t0 topology, but should work on any other topology since the only interaction is between the host computer running the SCP server and the DUT.
+
+## Test Procedure
+
+1. The PTF container generates a 1 GB file with random bytes.
+2. AN MD5 checksum is generated for the generated file.
+3. The DUT requests this file from the PTF via scp started from the DUT.
+4. An MD5 checksum is generated for the file on the DUT.
+5. The checksums are compared, failing if they differ.
+6. The DUT copies over a copy of the same file back to the PTF via SCP initiated from the PTF.
+7. An MD5 checksum is generated for the copy sent to the PTF.
+8. The checksums are compared again, failing if they differ.
+9. Both systems are cleaned of the large file.
+

--- a/docs/testplan/SCP_copy-test-plan.md
+++ b/docs/testplan/SCP_copy-test-plan.md
@@ -3,10 +3,10 @@
  - [Test Procedure](#test-procedure)
 
 ## Overview
-The purpose of this test is to ensure that the DUT is able to fetch from an external SCP server without loss of file integrity. The file used by the test exceeds a gigabyte in order to ensure integrity even for large file sizes.
+The purpose of this test is to ensure that the DUT is able to fetch from an external SCP server without loss of file integrity. The file used by the test is close to half a gigabyte in order to ensure integrity even for large file sizes.
 
 ### Scope
-This test was verified on a t0 topology, but should work on any other topology since the only interaction is between the host computer running the SCP server and the DUT.
+This test was verified on a t0 topology, but should work on any other topology since the only interaction is between the host computer, DUT and the PTF.
 
 ## Test Procedure
 

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -187,7 +187,8 @@ test_t1_lag() {
     platform_tests/test_cpu_memory_usage.py \
     bgp/test_bgpmon.py \
     container_checker/test_container_checker.py \
-    process_monitoring/test_critical_process_monitoring.py"
+    process_monitoring/test_critical_process_monitoring.py \
+    scp/test_scp_copy.py"
 
     pushd $SONIC_MGMT_DIR/tests
     ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname

--- a/tests/scp/perform_scp.py
+++ b/tests/scp/perform_scp.py
@@ -1,0 +1,35 @@
+import pexpect
+import sys
+
+is_source_ip = sys.argv[1] 
+ip = sys.argv[2]
+source_path = sys.argv[3]
+dest_path = sys.argv[4]
+user = sys.argv[5]
+
+command = ""
+if is_source_ip == "y":
+    command = "scp {}@{}:{} {}".format(user, ip, source_path, dest_path)
+else:
+    command = "scp {} {}@{}:{}".format(source_path, user, ip, dest_path)
+
+
+try:
+    #child = pexpect.spawn("scp root@10.250.0.102:/root/test_file.bin /home/admin")
+    child = pexpect.spawn(command)
+    prompt = child.expect(["Are you sure you want to continue connecting (yes/no)?", "password:"])
+
+    if prompt == 0:
+        child.sendline("yes")
+        child.expect("password")
+
+    child.sendline("root")
+    while True:
+        pxres = child.expect(['scp_progress_output_that_changes', pexpect.EOF, pexpect.TIMEOUT], timeout=2000)
+        if pxres==0:
+            continue
+        else:
+            break
+except Exception as e:
+    print("scp potentially failed with message: " + str(e))
+

--- a/tests/scp/perform_scp.py
+++ b/tests/scp/perform_scp.py
@@ -1,31 +1,26 @@
 import pexpect
 import sys
 
-is_source_ip = sys.argv[1] 
+copy_direction = sys.argv[1] 
 ip = sys.argv[2]
 source_path = sys.argv[3]
 dest_path = sys.argv[4]
 user = sys.argv[5]
 
 command = ""
-if is_source_ip == "y":
-    command = "scp {}@{}:{} {}".format(user, ip, source_path, dest_path)
+if copy_direction == "in":
+    command = "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {}@{}:{} {}".format(user, ip, source_path, dest_path)
 else:
-    command = "scp {} {}@{}:{}".format(source_path, user, ip, dest_path)
+    command = "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {} {}@{}:{}".format(source_path, user, ip, dest_path)
 
 
 try:
-    #child = pexpect.spawn("scp root@10.250.0.102:/root/test_file.bin /home/admin")
     child = pexpect.spawn(command)
-    prompt = child.expect(["Are you sure you want to continue connecting (yes/no)?", "password:"])
-
-    if prompt == 0:
-        child.sendline("yes")
-        child.expect("password")
+    prompt = child.expect(["password:"])
 
     child.sendline("root")
     while True:
-        pxres = child.expect(['scp_progress_output_that_changes', pexpect.EOF, pexpect.TIMEOUT], timeout=2000)
+        pxres = child.expect(['scp_progress_output_that_changes', pexpect.EOF, pexpect.TIMEOUT], timeout=4000)
         if pxres==0:
             continue
         else:

--- a/tests/scp/perform_scp.py
+++ b/tests/scp/perform_scp.py
@@ -6,6 +6,7 @@ ip = sys.argv[2]
 source_path = sys.argv[3]
 dest_path = sys.argv[4]
 user = sys.argv[5]
+password = sys.argv[6]
 
 command = ""
 if copy_direction == "in":
@@ -18,7 +19,7 @@ try:
     child = pexpect.spawn(command)
     prompt = child.expect(["password:"])
 
-    child.sendline("root")
+    child.sendline(password)
     while True:
         pxres = child.expect(['scp_progress_output_that_changes', pexpect.EOF, pexpect.TIMEOUT], timeout=4000)
         if pxres==0:

--- a/tests/scp/test_scp_copy.py
+++ b/tests/scp/test_scp_copy.py
@@ -1,0 +1,78 @@
+import os
+import pytest
+import time
+from tests.common.helpers.assertions import pytest_assert
+import logging
+import pwd
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology("any"),
+    pytest.mark.device_type("vs"),
+]
+
+SCP_PORT = 22
+TEST_FILE_NAME = "test_file.bin"
+TEST_FILE_2_NAME = "test_file_2.bin"
+
+@pytest.fixture
+def setup_teardown(duthosts, rand_one_dut_hostname, ptfhost):
+    duthost = duthosts[rand_one_dut_hostname]
+
+    # Copies script to DUT
+    duthost.copy(src="scp/perform_scp.py", dest="/home/admin/perform_scp.py")
+
+    yield
+
+    files_to_remove = ["./{}".format(TEST_FILE_NAME), "/home/admin/perform_scp.py"]
+    for file in files_to_remove:
+        duthost.file(path=file, state="absent")
+
+    files_to_remove_2 = ["./{}".format(TEST_FILE_NAME),"./{}".format(TEST_FILE_2_NAME)]
+    for file in files_to_remove_2:
+        ptfhost.file(path=file, state="absent")
+
+def test_scp_copy(duthosts, rand_one_dut_hostname, ptfhost, setup_teardown):
+    duthost = duthosts[rand_one_dut_hostname]
+    ptf_ip = ptfhost.mgmt_ip
+
+    duthost.copy(src="scp/perform_scp.py", dest="/home/admin/perform_scp.py")
+
+    # Generate the file from /dev/urandom
+    ptfhost.command(("dd if=/dev/urandom of=./{} count=1 bs=1000000000 iflag=fullblock".format(TEST_FILE_NAME)))
+
+    # Ensure that file was downloaded
+    res = ptfhost.command("ls -ltr ./{}".format(TEST_FILE_NAME), module_ignore_errors=True)["rc"]
+    pytest_assert(res==0, "Test file was not downloaded on the DUT")
+
+    # Generate MD5 checksum to compare with the sent file
+    output = ptfhost.command("md5sum ./{}".format(TEST_FILE_NAME))["stdout"]
+    #output = os.system("md5sum ./{}".format(TEST_FILE_NAME))["stdout"]
+    orig_checksum = output.split()[0]
+
+    duthost.command("python3 perform_scp.py y {} /root/{} /home/admin root".format(ptf_ip, TEST_FILE_NAME))
+
+    # Validate file was received
+    res = duthost.command("ls -ltr ./{}".format(TEST_FILE_NAME), module_ignore_errors=True)["rc"]
+
+    pytest_assert(res==0, "Test file was not found on DUT after attempted scp get")
+
+    # Get MD5 checksum of received file
+    output = duthost.command("md5sum ./{}".format(TEST_FILE_NAME))["stdout"]
+    new_checksum = output.split()[0]
+
+    # Confirm that the received file is identical to the original file
+    pytest_assert(orig_checksum == new_checksum, "Original file differs from file sent to the DUT")
+
+    # Use scp to copy the file into the PTF
+    duthost.command("python3 perform_scp.py n {} /home/admin/{} /root/{} root".format(ptf_ip, TEST_FILE_NAME, TEST_FILE_2_NAME))
+
+    # Validate that the file copied is now present in the PTF
+    res = ptfhost.command("ls -ltr ./{}".format(TEST_FILE_2_NAME), module_ignore_errors=True)["rc"]
+    pytest_assert(res==0, "Test file was not found on PTF after attempted scp put")
+
+    # Get MD5 checksum of copied file
+    output = ptfhost.command("md5sum ./{}".format(TEST_FILE_2_NAME))["stdout"]
+    fin_checksum = output.split()[0]
+
+    pytest_assert(new_checksum == fin_checksum, "Copied file on PTF differs from copied DUT file")

--- a/tests/scp/test_scp_copy.py
+++ b/tests/scp/test_scp_copy.py
@@ -44,8 +44,8 @@ def test_scp_copy(duthosts, rand_one_dut_hostname, ptfhost, setup_teardown, cred
     output = ptfhost.command("md5sum ./{}".format(TEST_FILE_NAME))["stdout"]
     orig_checksum = output.split()[0]
 
-    duthost.command("python3 perform_scp.py in {} /root/{} /home/admin root {}"\
-        .format(ptf_ip, TEST_FILE_NAME, creds["ptf_host_pass"]))
+    duthost.command("python3 perform_scp.py in {} /root/{} /home/admin {} {}"\
+        .format(ptf_ip, TEST_FILE_NAME, creds["ptf_host_user"], creds["ptf_host_pass"]))
 
     # Validate file was received
     res = duthost.command("ls -ltr ./{}".format(TEST_FILE_NAME), module_ignore_errors=True)["rc"]
@@ -62,8 +62,8 @@ def test_scp_copy(duthosts, rand_one_dut_hostname, ptfhost, setup_teardown, cred
             .format(TEST_FILE_NAME, orig_checksum, TEST_FILE_NAME, new_checksum))
 
     # Use scp to copy the file into the PTF
-    duthost.command("python3 perform_scp.py out {} /home/admin/{} /root/{} root {}"\
-            .format(ptf_ip, TEST_FILE_NAME, TEST_FILE_2_NAME, creds["ptf_host_pass"]))
+    duthost.command("python3 perform_scp.py out {} /home/admin/{} /root/{} {} {}"\
+            .format(ptf_ip, TEST_FILE_NAME, TEST_FILE_2_NAME, creds["ptf_host_user"], creds["ptf_host_pass"]))
 
     # Validate that the file copied is now present in the PTF
     res = ptfhost.command("ls -ltr ./{}".format(TEST_FILE_2_NAME), module_ignore_errors=True)["rc"]

--- a/tests/scp/test_scp_copy.py
+++ b/tests/scp/test_scp_copy.py
@@ -28,8 +28,7 @@ def setup_teardown(duthosts, rand_one_dut_hostname, ptfhost):
     for file in files_to_remove_2:
         ptfhost.file(path=file, state="absent")
 
-def test_scp_copy(duthosts, rand_one_dut_hostname, ptfhost, setup_teardown):
-
+def test_scp_copy(duthosts, rand_one_dut_hostname, ptfhost, setup_teardown, creds):
     duthost = duthosts[rand_one_dut_hostname]
     ptf_ip = ptfhost.mgmt_ip
 
@@ -45,7 +44,8 @@ def test_scp_copy(duthosts, rand_one_dut_hostname, ptfhost, setup_teardown):
     output = ptfhost.command("md5sum ./{}".format(TEST_FILE_NAME))["stdout"]
     orig_checksum = output.split()[0]
 
-    duthost.command("python3 perform_scp.py in {} /root/{} /home/admin root".format(ptf_ip, TEST_FILE_NAME))
+    duthost.command("python3 perform_scp.py in {} /root/{} /home/admin root {}"\
+        .format(ptf_ip, TEST_FILE_NAME, creds["ptf_host_pass"]))
 
     # Validate file was received
     res = duthost.command("ls -ltr ./{}".format(TEST_FILE_NAME), module_ignore_errors=True)["rc"]
@@ -62,8 +62,8 @@ def test_scp_copy(duthosts, rand_one_dut_hostname, ptfhost, setup_teardown):
             .format(TEST_FILE_NAME, orig_checksum, TEST_FILE_NAME, new_checksum))
 
     # Use scp to copy the file into the PTF
-    duthost.command("python3 perform_scp.py out {} /home/admin/{} /root/{} root"\
-            .format(ptf_ip, TEST_FILE_NAME, TEST_FILE_2_NAME))
+    duthost.command("python3 perform_scp.py out {} /home/admin/{} /root/{} root {}"\
+            .format(ptf_ip, TEST_FILE_NAME, TEST_FILE_2_NAME, creds["ptf_host_pass"]))
 
     # Validate that the file copied is now present in the PTF
     res = ptfhost.command("ls -ltr ./{}".format(TEST_FILE_2_NAME), module_ignore_errors=True)["rc"]


### PR DESCRIPTION

### Description of PR


Summary:
Adds a test that checks that the DUT is able to access external objects via SCP

### Type of change


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This test existed in the Arista testplan but was not present for SONiC.

#### How did you do it?
Generate a file on the PTF. The DUT uses scp to fetch the file from the PTF. File integrity is checked by comparing checksums for the file before and after transport. 
The same file is then transferred back to the ptf via scp initiated from the DUT. File integrity is checked by again comparing checksums.


#### How did you verify/test it?
The test passed on my platform and confirmed that the file was copied to the host and the dut manually.
Also made sure that the cleanup function works as expected.

#### Any platform specific information?
Ran this test with sonic based VMs. The interactions here are between the host, DUT and PTF. Assumptions are : There is enough memory on the DUT and PTF. Also assuming that the DUT has scp working since it is linux based.

#### Supported testbed topology if it's a new test case?
Tested on t0.

But should work on any topology since this test is only using direct communication between the host, DUT and PTF.

### Documentation 
Wrote a short testplan included.
