### PR TITLE
Remove double definition of skip_release_for_platform

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -61,18 +61,6 @@ def skip_release_for_platform(duthost, release_list, platform_list):
 				", ".join(release_list), 
 				", ".join(platform_list)))
 
-def skip_release_for_platform(duthost, release_list, platform_list):
-    """
-    @summary: Skip current test if any given release keywords are in os_version and any given platform keywords are in platform
-    @param duthost: The DUT
-    @param release_list: A list of incompatible releases
-    @param platform_list: A list of incompatible platforms
-    """
-    if any(release in duthost.os_version for release in release_list) and any(platform in duthost.facts['platform'] for platform in platform_list):
-        pytest.skip("DUT has version {} and platform {} and test does not support {} for {}".format(duthost.os_version, 
-            duthost.facts['platform'], ", ".join(release_list), ", ".join(platform_list)))
-
-
 def wait(seconds, msg=""):
     """
     @summary: Pause specified number of seconds


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Remove double definition of skip_release_for_platform

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Had double definition of skip_release_for_platform from two different PRs
#### How did you do it?
Removed one of them
#### How did you verify/test it?
Run tests which calls the double defined utility
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
