### PR TITLE
Optimize vm_topology to reduce time required for add-topo

### DIFF
--- a/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
+++ b/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
@@ -2,8 +2,8 @@
   - name: set time out threshold
     set_fact:
       timeout_threshold: 120
-    
-  - name: wait for container's mgmt-ip reachable
+
+  - name: wait until container's mgmt-ip is reachable
     wait_for:
       port: 22
       host: "{{ ansible_host }}"
@@ -42,7 +42,7 @@
     when: ceos_reachability.failed and ceos_reachability.elapsed >= timeout_threshold
     delegate_to: "{{ VM_host[0] }}"
 
-  - name: update container_reachable
+  - name: update variable container_reachable
     set_fact:
       container_reachable: "{{ not ceos_reachability.failed|bool }}"
 

--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -2,7 +2,7 @@
   become: yes
   vm_topology:
     cmd:          'create'
-    vm_names:     "{{ VM_hosts }}"
+    vm_names:     "{{ VM_targets }}"
     fp_mtu:       "{{ fp_mtu_size }}"
     max_fp_num:   "{{ max_fp_num }}"
     topo: "{{ topology }}"
@@ -86,7 +86,14 @@
   retries: 10
   delay: 30
 
-- include_tasks: add_ceos_network.yml
+- name: Create network for ceos container net_{{ vm_set_name }}_{{ vm_name }}
+  become: yes
+  ceos_network:
+    name: net_{{ vm_set_name }}_{{ vm_name }}
+    vm_name:    "{{ vm_name }}"
+    fp_mtu:     "{{ fp_mtu_size }}"
+    max_fp_num: "{{ max_fp_num }}"
+    mgmt_bridge: "{{ mgmt_bridge }}"
   loop: "{{ VM_targets|flatten(levels=1) }}"
   loop_control:
     loop_var: vm_name

--- a/ansible/roles/vm_set/tasks/add_ceos_network.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_network.yml
@@ -1,8 +1,0 @@
-- name: Create network for ceos container net_{{ vm_set_name }}_{{ vm_name }}
-  become: yes
-  ceos_network:
-    name: net_{{ vm_set_name }}_{{ vm_name }}
-    vm_name:    "{{ vm_name }}"
-    fp_mtu:     "{{ fp_mtu_size }}"
-    max_fp_num: "{{ max_fp_num }}"
-    mgmt_bridge: "{{ mgmt_bridge }}"

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -190,7 +190,7 @@
       cmd: "bind"
       vm_set_name: "{{ vm_set_name }}"
       topo: "{{ topology }}"
-      vm_names: "{{ VM_hosts }}"
+      vm_names: "{{ VM_targets }}"
       vm_base: "{{ VM_base }}"
       vm_type: "{{ vm_type }}"
       vm_properties: "{{ vm_properties if vm_properties is defined else omit }}"
@@ -244,3 +244,4 @@
   - fetch: src=docker-ptf.tar dest=docker-ptf.tar flat=yes
   - shell: rm -f docker-ptf.tar
   run_once: yes
+  when: vm_type is defined and vm_type == "vsonic"

--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -114,3 +114,10 @@
     become: yes
 
   when: container_type == "IxANVL-CONF-TESTER"
+
+- name: Destroy VMs network
+  vm_topology:
+    cmd: 'destroy'
+    vm_names: "{{ VM_targets }}"
+  become: yes
+  when: vm_type is defined and vm_type=="ceos"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Currently, to add a topology using tool 'testbed-cli.sh add-topo', most of the time is spent
in calling the customized vm_topology module to bind interfaces and bridges for PTF docker
and neighbor VMs. Before apply any operation on an interface, usually we need to firstly
check existence of the interface in host or in docker. The vm_topology module runs command
"ifocnfig -a" and parse the output to find out all the interfaces. Then based on this
information to check existence of interface. On a test server with multiple testbeds, there
could be hundereds of interfaces and bridges in the output of "ifconfig -a". Even worse,
checking existence of interface is a frequent operation. So, it could take more than 20
minutes to run the vm_topology module.

#### How did you do it?
This change mainly improved the way of checking existence of interface in the vm_topology
module. Instead of run "ifconfig -a" every time, the new way is to run "ifconfig <intf_name>"
which is much quicker. With this change, the vm_topology needs around 100 seconds for
t1-lag topo and around 40 seconds for t0 topology.

Other improvements made in this PR:
* Add timestamp to log generated by vm_topology.
* The ceos_network module is also improved in similar way.
* Skip exporting the PTF docker if vm_type is not "vsonic".
* Remove the bridges for CEOS during 'testbed-cli.sh remove-topo' if vm_type is "ceos".

#### How did you verify/test it?
Tested add-topo/remove-topo for VS setup and physical setup. Covered:
* t0 and t1-lag topology
* VEOS and CEOS neighbor

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
