### PR TITLE
[Mellanox][drop counters] Added ignore for not supported drop counters test case

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -609,10 +609,13 @@ def test_loopback_filter(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, p
     do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
-def test_ip_pkt_with_expired_ttl(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info, sai_acl_drop_adj_enabled):
+def test_ip_pkt_with_expired_ttl(duthost, do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info, sai_acl_drop_adj_enabled):
     """
     @summary: Create an IP packet with TTL=0.
     """
+    if "x86_64-mlnx_msn" in duthost.facts["platform"]:
+        pytest.skip("Not supported on Mellanox devices")
+
     log_pkt_params(ports_info["dut_iface"], ports_info["dst_mac"], ports_info["src_mac"], pkt_fields["ipv4_dst"],
                     pkt_fields["ipv4_src"])
     


### PR DESCRIPTION
[Mellanox][drop counters] Added ignore for not supported drop counters test case

Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Test case "test_ip_pkt_with_expired_ttl" not supported on Mellanox devices. Added ignore for test case for all Mellanox devices.

Summary: Added ignore on Mellanox devices for not supported test case "test_ip_pkt_with_expired_ttl" 
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Test case "test_ip_pkt_with_expired_ttl" not supported on Mellanox devices.

#### How did you do it?
Added skip in test for all Mellanox devices

#### How did you verify/test it?
Executed test case and checked that it skipped on Mellanox devices

#### Any platform specific information?
Mellanox only

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
