### PR TITLE
Skip dualtor test on unsupported platform

### DIFF
--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -4,8 +4,10 @@ import time
 
 from tests.common.dualtor.dual_tor_utils import get_crm_nexthop_counter # lgtm[py/unused-import]
 from tests.common.helpers.assertions import pytest_assert as py_assert
+from tests.common.helpers.assertions import pytest_require as py_require
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses, run_garp_service
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr
+from tests.common.utilities import get_host_visible_vars
 
 CRM_POLL_INTERVAL = 1
 CRM_DEFAULT_POLL_INTERVAL = 300
@@ -57,6 +59,18 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def common_setup_teardown(request, tbinfo, vmhost):
+def common_setup_teardown(rand_selected_dut, request, tbinfo, vmhost):
+    # Skip dualtor test cases on unsupported platform
+    supported_platforms = ['broadcom_td3_hwskus', 'broadcom_th2_hwskus']
+    hostvars = get_host_visible_vars(rand_selected_dut.host.options['inventory'], rand_selected_dut.hostname)
+    hwsku = rand_selected_dut.facts['hwsku']
+    skip = True
+    for platform in supported_platforms:
+        supported_skus = hostvars.get(platform, [])
+        if hwsku in supported_skus:
+            skip = False
+            break
+    py_require(not skip, "Skip on unsupported platform")
+
     if 'dualtor' in tbinfo['topo']['name']:
         request.getfixturevalue('run_garp_service')


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip dualtor test cases on unsupported platform.
Currently, dualtor test cases, including mocked dualtor test cases are supposed to run on ```broadcom_td3_hwskus``` and  ```broadcom_th2_hwskus```.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to skip dualtor test cases on unsupported platform.

#### How did you do it?
Check hwsku of current DUT, and skip the case if not supported.

#### How did you verify/test it?
Verified on both supported and unsupported platforms, the feature works as expected.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
