### PR TITLE
Make "ip neigh flush $ptf_ip" best effort in testbed-cli.sh add-topo

### DIFF
--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -236,7 +236,7 @@ function add_topo
   fi
 
   # Delete the obsoleted arp entry for the PTF IP
-  ip neighbor flush $ptf_ip
+  ip neighbor flush $ptf_ip || true
 
   echo Done
 }


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The add_topo function in testbed-cli.sh runs "ip neighbor flush $ptf_ip" to delete
obsoleted arp entry for the PTF IP to ensure that the newly created PTF IP is
reachable immediately. However, this command may fail with error message
`Failed to send flush request: Operation not permitted` ocassionally. This would
cause none-zero RC for the 'testbed-cli.sh add-topo' task. Since this command
is a best effort operation, so it would be better for it to always return RC 0.

#### How did you do it?
Change `ip neighbor flush $ptf_ip` to `ip neighbor flush $ptf_ip || true`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
