### PR TITLE
Move test_acl_drop to drop_packets.py common test file and add ACL egress case

### DIFF
--- a/tests/drop_packets/acl_templates/acltb_test_rule_egress.json
+++ b/tests/drop_packets/acl_templates/acltb_test_rule_egress.json
@@ -1,0 +1,29 @@
+{
+    "acl": {
+        "acl-sets": {
+            "acl-set": {
+                "OUTDATAACL": {
+                    "acl-entries": {
+                        "acl-entry": {
+                            "1": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 1
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "192.168.144.0/24"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -24,6 +24,9 @@ L3_COL_KEY = RX_ERR
 pytest.SKIP_COUNTERS_FOR_MLNX = False
 MELLANOX_MAC_UPDATE_SCRIPT = os.path.join(os.path.dirname(__file__), "fanout/mellanox/mlnx_update_mac.j2")
 
+ACL_COUNTERS_UPDATE_INTERVAL = 10
+LOG_EXPECT_ACL_RULE_CREATE_RE = ".*Successfully created ACL rule.*"
+LOG_EXPECT_ACL_RULE_REMOVE_RE = ".*Successfully deleted ACL rule.*"
 LOG_EXPECT_PORT_OPER_DOWN_RE = ".*Port {} oper state set from up to down.*"
 LOG_EXPECT_PORT_OPER_UP_RE = ".*Port {} oper state set from down to up.*"
 
@@ -256,6 +259,55 @@ def ports_info(ptfadapter, duthosts, rand_one_dut_hostname, setup, tx_dut_ports)
         data["dst_mac"] = setup['intf_per_namespace'][ns][data["dut_iface"]]['macaddress']
     data["src_mac"] = ptfadapter.dataplane.ports[(0, data["ptf_tx_port_id"])].mac()
     return data
+
+
+def acl_setup(duthosts, loganalyzer, template_dir, acl_rules_template, del_acl_rules_template, dut_tmp_dir,
+              dut_clear_conf_file_path):
+    for duthost in duthosts:
+        acl_facts = duthost.acl_facts()["ansible_facts"]["ansible_acl_facts"]
+        if 'DATAACL' not in acl_facts.keys():
+            pytest.skip("Skipping test since DATAACL table is not present on DUT")
+
+        duthost.command("mkdir -p {}".format(dut_tmp_dir))
+        dut_conf_file_path = os.path.join(dut_tmp_dir, acl_rules_template)
+
+        logger.info("Generating config for ACL rule, ACL table - DATAACL")
+        duthost.template(src=os.path.join(template_dir, acl_rules_template), dest=dut_conf_file_path)
+        logger.info("Generating clear config for ACL rule, ACL table - DATAACL")
+        duthost.template(src=os.path.join(template_dir, del_acl_rules_template), dest=dut_clear_conf_file_path)
+
+        logger.info("Applying {}".format(dut_conf_file_path))
+
+        loganalyzer[duthost.hostname].expect_regex = [LOG_EXPECT_ACL_RULE_CREATE_RE]
+        with loganalyzer[duthost.hostname]:
+            duthost.command("config acl update full {}".format(dut_conf_file_path))
+
+
+def acl_teardown(duthosts, loganalyzer, dut_tmp_dir, dut_clear_conf_file_path):
+    for duthost in duthosts:
+        loganalyzer[duthost.hostname].expect_regex = [LOG_EXPECT_ACL_RULE_REMOVE_RE]
+        with loganalyzer[duthost.hostname]:
+            logger.info("Applying {}".format(dut_clear_conf_file_path))
+            duthost.command("config acl update full {}".format(dut_clear_conf_file_path))
+            logger.info("Removing {}".format(dut_tmp_dir))
+            duthost.command("rm -rf {}".format(dut_tmp_dir))
+            time.sleep(ACL_COUNTERS_UPDATE_INTERVAL)
+
+
+@pytest.fixture
+def acl_ingress(duthosts, loganalyzer):
+    """ Create acl rule defined in config file. Delete rule after test case finished """
+    base_dir = os.path.dirname(os.path.realpath(__file__))
+    template_dir = os.path.join(base_dir, 'acl_templates')
+    acl_rules_template = "acltb_test_rule.json"
+    del_acl_rules_template = "acl_rule_del.json"
+    dut_tmp_dir = os.path.join("tmp", os.path.basename(base_dir))
+    dut_clear_conf_file_path = os.path.join(dut_tmp_dir, del_acl_rules_template)
+
+    acl_setup(duthosts, loganalyzer, template_dir, acl_rules_template, del_acl_rules_template, dut_tmp_dir,
+              dut_clear_conf_file_path)
+    yield
+    acl_teardown(duthosts, loganalyzer, dut_tmp_dir, dut_clear_conf_file_path)
 
 
 def log_pkt_params(dut_iface, mac_dst, mac_src, ip_dst, ip_src):
@@ -772,3 +824,30 @@ def test_non_routable_igmp_pkts(do_test, ptfadapter, setup, fanouthost, tx_dut_p
 
     log_pkt_params(ports_info["dut_iface"], ethernet_dst, ports_info["src_mac"], pkt.getlayer("IP").dst, pkt_fields["ipv4_src"])
     do_test("L3", pkt, ptfadapter, ports_info, setup["dut_to_ptf_port_map"].values(), tx_dut_ports)
+
+
+def test_acl_drop(do_test, ptfadapter, duthosts, rand_one_dut_hostname, setup, tx_dut_ports, pkt_fields, acl_ingress,
+                  ports_info):
+    """
+        @summary: Verify that DUT drops packet with SRC IP 20.0.0.0/24 matched by ingress ACL
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    if tx_dut_ports[ports_info["dut_iface"]] not in \
+            duthost.acl_facts()["ansible_facts"]["ansible_acl_facts"]["DATAACL"]["ports"]:
+        pytest.skip("RX DUT port absent in 'DATAACL' table")
+
+    ip_src = "20.0.0.5"
+
+    log_pkt_params(ports_info["dut_iface"], ports_info["dst_mac"], ports_info["src_mac"], pkt_fields["ipv4_dst"],
+                   ip_src)
+
+    pkt = testutils.simple_tcp_packet(
+        eth_dst=ports_info["dst_mac"],  # DUT port
+        eth_src=ports_info["src_mac"],  # PTF port
+        ip_src=ip_src,
+        ip_dst=pkt_fields["ipv4_dst"],
+        tcp_sport=pkt_fields["tcp_sport"],
+        tcp_dport=pkt_fields["tcp_dport"]
+    )
+
+    do_test("ACL", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -5,7 +5,6 @@ import pytest
 import yaml
 import re
 
-import ptf.packet as packet
 import ptf.testutils as testutils
 
 from collections import defaultdict
@@ -28,9 +27,6 @@ NAMESPACE_PREFIX = "sudo ip netns exec {} "
 NAMESPACE_SUFFIX = "-n {} "
 GET_L2_COUNTERS = "portstat -j "
 GET_L3_COUNTERS = "intfstat -j "
-ACL_COUNTERS_UPDATE_INTERVAL = 10
-LOG_EXPECT_ACL_RULE_CREATE_RE = ".*Successfully created ACL rule.*"
-LOG_EXPECT_ACL_RULE_REMOVE_RE = ".*Successfully deleted ACL rule.*"
 LOG_EXPECT_PORT_ADMIN_DOWN_RE = ".*Configure {} admin status to down.*"
 LOG_EXPECT_PORT_ADMIN_UP_RE = ".*Port {} oper state set from down to up.*"
 
@@ -90,47 +86,6 @@ def parse_combined_counters(duthosts, rand_one_dut_hostname):
                 if re.match(item, duthost.facts["platform"]):
                     COMBINED_ACL_DROP_COUNTER = True
                     break
-
-
-@pytest.fixture
-def acl_setup(duthosts, loganalyzer):
-    """ Create acl rule defined in config file. Delete rule after test case finished """
-    for duthost in duthosts:
-        acl_facts = duthost.acl_facts()["ansible_facts"]["ansible_acl_facts"]
-        if 'DATAACL' not in acl_facts.keys():
-            pytest.skip("Skipping test since DATAACL table is not supported on this platform")
-
-        base_dir = os.path.dirname(os.path.realpath(__file__))
-        template_dir = os.path.join(base_dir, 'acl_templates')
-        acl_rules_template = "acltb_test_rule.json"
-        del_acl_rules_template = "acl_rule_del.json"
-        dut_tmp_dir = os.path.join("tmp", os.path.basename(base_dir))
-
-        duthost.command("mkdir -p {}".format(dut_tmp_dir))
-        dut_conf_file_path = os.path.join(dut_tmp_dir, acl_rules_template)
-        dut_clear_conf_file_path = os.path.join(dut_tmp_dir, del_acl_rules_template)
-
-        logger.info("Generating config for ACL rule, ACL table - DATAACL")
-        duthost.template(src=os.path.join(template_dir, acl_rules_template), dest=dut_conf_file_path)
-        logger.info("Generating clear config for ACL rule, ACL table - DATAACL")
-        duthost.template(src=os.path.join(template_dir, del_acl_rules_template), dest=dut_clear_conf_file_path)
-
-        logger.info("Applying {}".format(dut_conf_file_path))
-
-        loganalyzer[duthost.hostname].expect_regex = [LOG_EXPECT_ACL_RULE_CREATE_RE]
-        with loganalyzer[duthost.hostname]:
-            duthost.command("config acl update full {}".format(dut_conf_file_path))
-
-    yield
-
-    for duthost in duthosts:
-        loganalyzer[duthost.hostname].expect_regex = [LOG_EXPECT_ACL_RULE_REMOVE_RE]
-        with loganalyzer[duthost.hostname]:
-            logger.info("Applying {}".format(dut_clear_conf_file_path))
-            duthost.command("config acl update full {}".format(dut_clear_conf_file_path))
-            logger.info("Removing {}".format(dut_tmp_dir))
-            duthost.command("rm -rf {}".format(dut_tmp_dir))
-            time.sleep(ACL_COUNTERS_UPDATE_INTERVAL)
 
 
 def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info, tx_dut_ports=None, skip_counter_check=False):
@@ -308,39 +263,6 @@ def test_reserved_dmac_drop(do_test, ptfadapter, duthosts, rand_one_dut_hostname
         )
 
         do_test("L2", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"])
-
-
-def test_acl_drop(do_test, ptfadapter, duthosts, rand_one_dut_hostname, setup, tx_dut_ports, pkt_fields, acl_setup, ports_info):
-    """
-    @summary: Verify that DUT drops packet with SRC IP 20.0.0.0/24 matched by ingress ACL and ACL drop counter incremented
-    """
-    duthost = duthosts[rand_one_dut_hostname]
-    acl_facts = duthost.acl_facts()["ansible_facts"]["ansible_acl_facts"]
-    if 'DATAACL' not in acl_facts.keys():
-        pytest.skip("Skipping test since DATAACL table is not supported on this platform")
-
-    if tx_dut_ports[ports_info["dut_iface"]] not in acl_facts["DATAACL"]["ports"]:
-        pytest.skip("RX DUT port absent in 'DATAACL' table")
-
-    ip_src = "20.0.0.5"
-
-    log_pkt_params(ports_info["dut_iface"], ports_info["dst_mac"], ports_info["src_mac"], pkt_fields["ipv4_dst"], ip_src)
-
-    pkt = testutils.simple_tcp_packet(
-        eth_dst=ports_info["dst_mac"], # DUT port
-        eth_src=ports_info["src_mac"], # PTF port
-        ip_src=ip_src,
-        ip_dst=pkt_fields["ipv4_dst"],
-        tcp_sport=pkt_fields["tcp_sport"],
-        tcp_dport=pkt_fields["tcp_dport"]
-        )
-    asic_index = ports_info["asic_index"]
-    base_verification("ACL", pkt, ptfadapter, duthosts, asic_index, ports_info, tx_dut_ports)
-
-    # Verify packets were not egresed the DUT
-    exp_pkt = expected_packet_mask(pkt)
-    exp_pkt.set_do_not_care_scapy(packet.IP, 'ip_src')
-    testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=setup["neighbor_sniff_ports"])
 
 
 def test_no_egress_drop_on_down_link(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, rif_port_down, ports_info):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
- Move test_acl_drop to the common drop file 
- Split the acl_setup fixture into two functions
- Create test case for ACL egress drops

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To have the ability to use the acl test in more test files
To test that ACL counters on egress are working as should

#### How did you do it?

#### How did you verify/test it?
Execute drop_packets/test_drop_counters.py -k test_acl_drop

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
