### PR TITLE
[Platform API][pytest] Fix test_chassis.py::test_get_system_eeprom_info; skip platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -223,14 +223,22 @@ class TestChassisApi(PlatformApiTestBase):
         # Ensure the base MAC address is sane
         base_mac = syseeprom_info_dict[ONIE_TLVINFO_TYPE_CODE_BASE_MAC_ADDR]
         pytest_assert(base_mac is not None, "Failed to retrieve base MAC address")
-        pytest_assert(re.match(REGEX_MAC_ADDRESS, base_mac), "Base MAC address appears to be incorrect")
+        #pytest_assert(re.match(REGEX_MAC_ADDRESS, base_mac), "Base MAC address appears to be incorrect")
 
         # Ensure the serial number is sane
         serial = syseeprom_info_dict[ONIE_TLVINFO_TYPE_CODE_SERIAL_NUMBER]
         pytest_assert(serial is not None, "Failed to retrieve serial number")
         pytest_assert(re.match(REGEX_SERIAL_NUMBER, serial), "Serial number appears to be incorrect")
+        host_vars = get_host_visible_vars(self.inv_files, duthost.hostname)
+        expected_syseeprom_info_dict = host_vars.get('syseeprom_info')
 
-        self.compare_value_with_device_facts(duthost, 'syseeprom_info', syseeprom_info_dict)
+        for field in expected_syseeprom_info_dict:
+            pytest_assert(field in syseeprom_info_dict, "Expected field '{}' not present in syseeprom on '{}'".format(field, duthost.hostname))
+            pytest_assert(syseeprom_info_dict[field] == expected_syseeprom_info_dict[field],
+                          "System EEPROM info is incorrect - for '{}', rcvd '{}', expected '{}' on '{}'".
+                          format(field, syseeprom_info_dict[field], expected_syseeprom_info_dict[field], duthost.hostname))
+
+        #self.compare_value_with_device_facts(duthost, 'syseeprom_info', syseeprom_info_dict)
 
     def test_get_reboot_cause(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         # TODO: Compare return values to potential combinations

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -223,7 +223,7 @@ class TestChassisApi(PlatformApiTestBase):
         # Ensure the base MAC address is sane
         base_mac = syseeprom_info_dict[ONIE_TLVINFO_TYPE_CODE_BASE_MAC_ADDR]
         pytest_assert(base_mac is not None, "Failed to retrieve base MAC address")
-        #pytest_assert(re.match(REGEX_MAC_ADDRESS, base_mac), "Base MAC address appears to be incorrect")
+        pytest_assert(re.match(REGEX_MAC_ADDRESS, base_mac), "Base MAC address appears to be incorrect")
 
         # Ensure the serial number is sane
         serial = syseeprom_info_dict[ONIE_TLVINFO_TYPE_CODE_SERIAL_NUMBER]
@@ -238,7 +238,6 @@ class TestChassisApi(PlatformApiTestBase):
                           "System EEPROM info is incorrect - for '{}', rcvd '{}', expected '{}' on '{}'".
                           format(field, syseeprom_info_dict[field], expected_syseeprom_info_dict[field], duthost.hostname))
 
-        #self.compare_value_with_device_facts(duthost, 'syseeprom_info', syseeprom_info_dict)
 
     def test_get_reboot_cause(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         # TODO: Compare return values to potential combinations

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -89,10 +89,12 @@ def test_show_platform_summary(duthosts, enum_rand_one_per_hwsku_hostname, dut_v
 
 
 def test_show_platform_syseeprom(duthosts, enum_rand_one_per_hwsku_hostname, dut_vars):
+
     """
     @summary: Verify output of `show platform syseeprom`
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
     cmd = " ".join([CMD_SHOW_PLATFORM, "syseeprom"])
 
     logging.info("Verifying output of '{}' on '{}' ...".format(cmd, duthost.hostname))

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -89,7 +89,6 @@ def test_show_platform_summary(duthosts, enum_rand_one_per_hwsku_hostname, dut_v
 
 
 def test_show_platform_syseeprom(duthosts, enum_rand_one_per_hwsku_hostname, dut_vars):
-
     """
     @summary: Verify output of `show platform syseeprom`
     """


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
change the logic inside get_system_eeprom_info by changing the way dictionary values are compared, 
skip the test platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom since for this Arista does not abide by the ONIE output format because our eeprom uses a different format and stores other information. 

#### How did you do it?
made the changes
#### How did you verify/test it?
ran the test on few platforms
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
