### PR TITLE
[dualtor_io]: Loosen requirements for asymmetric cases

### DIFF
--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -117,10 +117,9 @@ def validate_traffic_results(tor_IO, allowed_disruption, delay):
 
     pytest_assert(len(failures) == 0, '\n' + '\n'.join(failures))
 
-def verify_and_report(tor_IO, verify, delay):
+def verify_and_report(tor_IO, verify, delay, allowed_disruption):
     # Wait for the IO to complete before doing checks
     if verify:
-        allowed_disruption = 0 if delay == 0 else 1
         validate_traffic_results(tor_IO, allowed_disruption=allowed_disruption,
             delay=delay)
     return tor_IO.get_test_results()
@@ -196,7 +195,7 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo):
     
     duthosts_list = []
     def t1_to_server_io_test(activehost, tor_vlan_port=None,
-                            delay=0, action=None, verify=False, send_interval=None,
+                            delay=0, allowed_disruption=0, action=None, verify=False, send_interval=None,
                             stop_after=None):
         """
         Helper method for `send_t1_to_server_with_action`.
@@ -227,7 +226,12 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo):
                         action, tbinfo, tor_vlan_port, send_interval,
                         traffic_direction="t1_to_server", stop_after=stop_after)
 
-        return verify_and_report(tor_IO, verify, delay)
+        # If a delay is allowed but no numebr of allowed disruptions
+        # is specified, default to 1 allowed disruption
+        if delay and not allowed_disruption:
+            allowed_disruption = 1
+
+        return verify_and_report(tor_IO, verify, delay, allowed_disruption)
 
     yield t1_to_server_io_test
 
@@ -258,7 +262,7 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo):
 
     duthosts_list = []
     def server_to_t1_io_test(activehost, tor_vlan_port=None,
-                            delay=0, action=None, verify=False, send_interval=None,
+                            delay=0, allowed_disruption=0, action=None, verify=False, send_interval=None,
                             stop_after=None):
         """
         Helper method for `send_server_to_t1_with_action`.
@@ -288,7 +292,12 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo):
                         action, tbinfo, tor_vlan_port, send_interval,
                         traffic_direction="server_to_t1", stop_after=stop_after)
 
-        return verify_and_report(tor_IO, verify, delay)
+        # If a delay is allowed but no numebr of allowed disruptions
+        # is specified, default to 1 allowed disruption
+        if delay and not allowed_disruption:
+            allowed_disruption = 1
+
+        return verify_and_report(tor_IO, verify, delay, allowed_disruption)
 
     yield server_to_t1_io_test
 

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -129,6 +129,7 @@ def set_drop(url, recover_all_directions):
         drop_intfs.add(interface_name)
         server_url = url(interface_name, DROP)
         data = {"out_sides": directions}
+        logger.info("Dropping packets to {} on {}".format(directions, interface_name))
         pytest_assert(_post(server_url, data), "Failed to set drop on {}".format(directions))
 
     yield _set_drop

--- a/tests/dualtor_io/test_link_drop.py
+++ b/tests/dualtor_io/test_link_drop.py
@@ -5,17 +5,16 @@ import tabulate
 import time
 
 from tests.common.dualtor.control_plane_utils import verify_tor_states
-from tests.common.dualtor.dual_tor_utils import upper_tor_host
-from tests.common.dualtor.dual_tor_utils import lower_tor_host
-from tests.common.dualtor.data_plane_utils import send_server_to_t1_with_action
-from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action
-from tests.common.dualtor.mux_simulator_control import set_drop
-from tests.common.dualtor.mux_simulator_control import set_output
-from tests.common.dualtor.mux_simulator_control import simulator_flap_counter
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
-from tests.common.fixtures.ptfhost_utils import run_icmp_responder
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host # lgtm[py/unused-import]
+from tests.common.dualtor.data_plane_utils import send_server_to_t1_with_action # lgtm[py/unused-import]
+from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import set_drop # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import set_output # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import simulator_flap_counter # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses             # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory         # lgtm[py/unused-import]
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 
 pytestmark = [
@@ -95,6 +94,7 @@ def test_active_link_drop_upstream(
         upper_tor_host,
         verify=True,
         delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        allowed_disruption=3,
         action=drop_flow_upper_tor
     )
     verify_tor_states(
@@ -120,6 +120,7 @@ def test_active_link_drop_downstream_active(
         upper_tor_host,
         verify=True,
         delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        allowed_disruption=3,
         action=drop_flow_upper_tor
     )
     verify_tor_states(
@@ -145,6 +146,7 @@ def test_active_link_drop_downstream_standby(
         lower_tor_host,
         verify=True,
         delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        allowed_disruption=3,
         action=drop_flow_upper_tor
     )
     verify_tor_states(
@@ -168,7 +170,8 @@ def test_standby_link_drop_upstream(
     send_server_to_t1_with_action(
         upper_tor_host,
         verify=True,
-        delay=0,
+        delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        allowed_disruption=2,
         action=drop_flow_lower_tor
     )
     verify_tor_states(
@@ -176,7 +179,7 @@ def test_standby_link_drop_upstream(
         expected_standby_host=lower_tor_host,
         expected_standby_health="unhealthy"
     )
-    check_simulator_flap_counter(0)
+    check_simulator_flap_counter(2)
 
 
 def test_standby_link_drop_downstream_active(
@@ -194,7 +197,8 @@ def test_standby_link_drop_downstream_active(
     send_t1_to_server_with_action(
         upper_tor_host,
         verify=True,
-        delay=0,
+        delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        allowed_disruption=2,
         action=drop_flow_lower_tor
     )
     verify_tor_states(
@@ -202,7 +206,7 @@ def test_standby_link_drop_downstream_active(
         expected_standby_host=lower_tor_host,
         expected_standby_health="unhealthy"
     )
-    check_simulator_flap_counter(0)
+    check_simulator_flap_counter(2)
 
 
 def test_standby_link_drop_downstream_standby(
@@ -220,7 +224,8 @@ def test_standby_link_drop_downstream_standby(
     send_t1_to_server_with_action(
         lower_tor_host,
         verify=True,
-        delay=0,
+        delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        allowed_disruption=2,
         action=drop_flow_lower_tor
     )
     verify_tor_states(
@@ -228,4 +233,4 @@ def test_standby_link_drop_downstream_standby(
         expected_standby_host=lower_tor_host,
         expected_standby_health="unhealthy"
     )
-    check_simulator_flap_counter(0)
+    check_simulator_flap_counter(2)

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -24,7 +24,7 @@ def test_active_link_down_upstream(
     """
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=shutdown_fanout_upper_tor_intfs
+        allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -44,7 +44,7 @@ def test_active_link_down_downstream_active(
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=shutdown_fanout_upper_tor_intfs
+        allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -64,7 +64,7 @@ def test_active_link_down_downstream_standby(
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=shutdown_fanout_upper_tor_intfs
+        allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -84,7 +84,7 @@ def test_standby_link_down_upstream(
     """
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=shutdown_fanout_lower_tor_intfs
+        allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -104,7 +104,7 @@ def test_standby_link_down_downstream_active(
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=shutdown_fanout_lower_tor_intfs
+        allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -124,7 +124,7 @@ def test_standby_link_down_downstream_standby(
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=shutdown_fanout_lower_tor_intfs
+        allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Flaky/failing test cases for dualtor_io link_drop and link_failure tests

#### How did you do it?
- Loosen requirements for successful test run. For cases involving asymmetric link failures/drops:
    - When affecting the active ToR link, allow up to 3 switchovers
        - When the heartbeat is lost, the standby ToR takes over. The original active eventually switches itself to standby as a result of probing the mux state. After some time, the original active is still receiving no heartbeat, and has mux state of standby which will cause it to switch itself to active once again. At this point, the heartbeat will again be lost because of the asymmetric drop, which will cause the standby to switch itself over again.
    - When affecting the standby ToR link, allow up to 2 switchovers
        - The original standby ToR will lose the heartbeat, and try to switch itself to active as a result. However, because of the asymmetric drop it will not receive replies to its own heartbeat. Then, the original active detects that no heartbeat is coming from the peer, and switches itself back to active.
- Run GARP service during tests to ensure neighbors are added on ToRs

#### How did you verify/test it?
Run test_link_drop.py and test_link_failure.py several times, verify all pass
```
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now
deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
=================================================================================== test session starts ====================================================================================platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, profiling-1.7.0, ansible-2.2.2
collected 12 items

dualtor_io/test_link_drop.py::test_active_link_drop_upstream PASSED                                                                                                                  [  8%]
dualtor_io/test_link_drop.py::test_active_link_drop_downstream_active PASSED                                                                                                         [ 16%]
dualtor_io/test_link_drop.py::test_active_link_drop_downstream_standby PASSED                                                                                                        [ 25%]
dualtor_io/test_link_drop.py::test_standby_link_drop_upstream PASSED                                                                                                                 [ 33%]
dualtor_io/test_link_drop.py::test_standby_link_drop_downstream_active PASSED                                                                                                        [ 41%]
dualtor_io/test_link_drop.py::test_standby_link_drop_downstream_standby PASSED                                                                                                       [ 50%]
dualtor_io/test_link_failure.py::test_active_link_down_upstream PASSED                                                                                                               [ 58%]
dualtor_io/test_link_failure.py::test_active_link_down_downstream_active PASSED                                                                                                      [ 66%]
dualtor_io/test_link_failure.py::test_active_link_down_downstream_standby PASSED                                                                                                     [ 75%]
dualtor_io/test_link_failure.py::test_standby_link_down_upstream PASSED                                                                                                              [ 83%]
dualtor_io/test_link_failure.py::test_standby_link_down_downstream_active PASSED                                                                                                     [ 91%]
dualtor_io/test_link_failure.py::test_standby_link_down_downstream_standby PASSED                                                                                                    [100%]

---------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt/tests/logs/tr.xml -----------------------------------------------------------------=============================================================================== 12 passed in 6719.51 seconds ===============================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
