### PR TITLE
[202012 : Platform_tests] Skip TestPsuApi::test_temperature and TestPsuApi::test_power for Arista-7050

### DIFF
--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -158,6 +158,9 @@ class TestPsuApi(PlatformApiTestBase):
 
     def test_power(self, duthost, localhost, platform_api_conn):
         ''' PSU power test '''
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
+
         for psu_id in range(self.num_psus):
             name = psu.get_name(platform_api_conn, psu_id)
             if name in self.psu_skip_list:
@@ -201,6 +204,9 @@ class TestPsuApi(PlatformApiTestBase):
 
     def test_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         ''' PSU temperature test '''
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
+
         for psu_id in range(self.num_psus):
             name = psu.get_name(platform_api_conn, psu_id)
             if name in self.psu_skip_list:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (https://github.com/Azure/sonic-buildimage/issues/8661)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Skip TestPsuApi::test_temperature and TestPsuApi::test_power for Arista-7050 since it's not supported on 202012
#### How did you do it?
Add skip_release_for_platform into those tests
#### How did you verify/test it?
Run tests/platform_tests/api/test_psu.py
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
