### PR TITLE
[PG] add checking for increasing ingress PG drop packet counters

### DIFF
--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -25,6 +25,7 @@ from switch import (switch_init,
                     port_list,
                     sai_thrift_read_port_watermarks,
                     sai_thrift_read_pg_counters,
+                    sai_thrift_read_pg_drop_counters,
                     sai_thrift_read_pg_shared_watermark,
                     sai_thrift_read_buffer_pool_watermark,
                     sai_thrift_read_headroom_pool_watermark,
@@ -672,6 +673,9 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
         # get counter names to query
         ingress_counters, egress_counters = get_counter_names(sonic_version)
 
+        # Clear all counters for all ports
+        sai_thrift_clear_all_counters(self.client)
+
         # Prepare IP packet data
         ttl = 64
         default_packet_length = 64
@@ -780,6 +784,14 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # xmit port no egress drop
             for cntr in egress_counters:
                 assert(xmit_counters[cntr] == xmit_counters_base[cntr])
+
+            # According to SONiC configuration lossless dscps are classified as follows:
+            # dscp  3 -> pg 3
+            # dscp  4 -> pg 4
+            pg_dropped_cntrs = sai_thrift_read_pg_drop_counters(self.client, port_list[src_port_id])
+            logging.info("Dropped packet counters on port #{} :{} packets, current dscp: {}".format(src_port_id, pg_dropped_cntrs[dscp], dscp))
+            # Check that counters per lossless PG increased
+            assert pg_dropped_cntrs[dscp] > 0
 
         finally:
             sai_thrift_port_tx_enable(self.client, asic_type, [dst_port_id])

--- a/tests/saitests/switch.py
+++ b/tests/saitests/switch.py
@@ -747,6 +747,28 @@ def sai_thrift_read_pg_counters(client, port_id):
 
     return pg_cntrs
 
+def sai_thrift_read_pg_drop_counters(client, port_id):
+    pg_cntr_ids = [
+        SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS
+    ]
+
+    # fetch pg ids under port id
+    pg_ids = []
+    port_attrs = client.sai_thrift_get_port_attribute(port_id)
+    attrs = port_attrs.attr_list
+    for attr in attrs:
+        if attr.id == SAI_PORT_ATTR_INGRESS_PRIORITY_GROUP_LIST:
+            for pg_id in attr.value.objlist.object_id_list:
+                pg_ids.append(pg_id)
+
+    # get counter values of counter ids of interest under each pg
+    pg_cntrs = []
+    for pg_id in pg_ids:
+        cntr_vals = client.sai_thrift_get_pg_stats(pg_id, pg_cntr_ids, len(pg_cntr_ids))
+        pg_cntrs.append(cntr_vals[0])
+
+    return pg_cntrs
+
 def sai_thrift_read_pg_shared_watermark(client, port_id):
     pg_cntr_ids=[
         SAI_INGRESS_PRIORITY_GROUP_STAT_SHARED_WATERMARK_BYTES


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Add ability to check PG dropped packet counters

#### How did you do it?
Use existing QoS infrastructure to check dropped packets per PG per Interface

#### How did you verify/test it?
run test: 

 `py.test qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit  --inventory "../ansible/inventory, ../ansible/veos" --host-pattern (dut)-ptf32 --module-path                ../ansible/library/ --testbed (dut)-ptf32 --testbed_file ../ansible/testbed.csv`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
ptf32

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
