### PR TITLE
fixed test_dhcpv6_relay: set src MAC address for DHCP reply packets

### DIFF
--- a/ansible/roles/test/files/ptftests/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcpv6_relay_test.py
@@ -230,6 +230,7 @@ class DHCPTest(DataplaneBaseTest):
     def server_send_advertise_relay_reply(self):
         # Form and send DHCPv6 RELAY-REPLY encapsulating ADVERTISE packet
         advertise_relay_reply_packet = self.create_dhcp_advertise_relay_reply_packet()
+        advertise_relay_reply_packet.src = self.dataplane.get_mac(0, self.server_port_indices[0])
         testutils.send_packet(self, self.server_port_indices[0], advertise_relay_reply_packet)
 
     # Verify that the DHCPv6 ADVERTISE would be received by our simulated client
@@ -279,6 +280,7 @@ class DHCPTest(DataplaneBaseTest):
     def server_send_reply_relay_reply(self):
         # Form and send DHCPv6 RELAY-REPLY encapsulating REPLY packet
         reply_relay_reply_packet = self.create_dhcp_reply_relay_reply_packet()
+        reply_relay_reply_packet.src = self.dataplane.get_mac(0, self.server_port_indices[0])
         testutils.send_packet(self, self.server_port_indices[0], reply_relay_reply_packet)
 
     # Verify that the DHCPv6 REPLY would be received by our simulated client


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fixed test_dhcpv6_relay - set src MAC address for DHCP reply packets
Fixes # (issue)
- fixed DHCP server forged packets

Reply packets sent from DHCP server's name don't have MACs set and they don't come to DHCP client. Added src MACs for the packets and the packets now come to the client
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix the test
#### How did you do it?
Identified missing src MACS for DHCP server packets, set MACs
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t0,any dhcp_relay/test_dhcpv6_relay.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
