### PR TITLE
Fix AttributeError exception seen when testing 201911 image.

### DIFF
--- a/ansible/module_utils/multi_asic_utils.py
+++ b/ansible/module_utils/multi_asic_utils.py
@@ -20,3 +20,5 @@ def load_db_config():
         pass
     except NameError:
         pass
+    except AttributeError:
+        pass


### PR DESCRIPTION
201911 does not require loading of database config.
Add the right exception so that the exception of load db
config can be ignored for 201911 image.

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
After https://github.com/Azure/sonic-mgmt/pull/4112 fix to load database config, testing 201911 image causes an AttributeError:
line 68, in get_po_names\r\n  File \"/tmp/ansible_lag_facts_payload_eqDCQY/ansible_lag_facts_payload.zip/ansible/module_utils/multi_asic_utils.py\", line 15, in load_db_config\r\nAttributeError: type object 'SonicDBConfig' has no attribute 'load_sonic_global_db_config'\r\n"
#### How did you do it?
Add exception handler.
#### How did you verify/test it?
Run tests in multi-asic VS 20911 image and ensure the error is not seen.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
