### PR TITLE
[dualtor_io]: Fix BGP tests

### DIFF
--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -31,17 +31,17 @@ def test_active_tor_kill_bgpd_upstream(
     Action: Shutdown all BGP sessions on the active ToR
     Expectation:
         Verify packet flow after the active ToR (A) loses BGP sessions
-        ToR A DBs indicate active, ToR B DBs indicate standby
-        T1 switch receives packet from the initial active ToR (A) and not the standby ToR (B)
-        Verify traffic interruption < 1 second
+        ToR A DBs indicate standby, ToR B DBs indicate active
+        T1 switch receives packet from the initial standby ToR (B) and not the active ToR (A)
+        Verify traffic interruption < threshold
     '''
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         action=lambda: kill_bgpd(upper_tor_host)
     )
     verify_tor_states(
-        expected_active_host=upper_tor_host,
-        expected_standby_host=lower_tor_host
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host
     )
 
 
@@ -97,16 +97,14 @@ def test_active_tor_kill_bgpd_downstream_standby(
     Action: Shutdown all BGP sessions on the active ToR
     Expectation:
         Verify packet flow after the active ToR (A) loses BGP sessions
-        T1 switch continues to receive IP-in-IP traffic, from lower to upper ToR
-        No switchover occurs
-        verify traffic interruption is < 1 second
+        Verify ToR A standby, ToR B active
+        Verify traffic interruption is < 1 second
     '''
-    with tunnel_traffic_monitor(lower_tor_host, existing=True):
-        send_t1_to_server_with_action(
-            lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            action=lambda: kill_bgpd(upper_tor_host)
-        )
+    send_t1_to_server_with_action(
+        lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        action=lambda: kill_bgpd(upper_tor_host)
+    )
     verify_tor_states(
-        expected_active_host=upper_tor_host,
-        expected_standby_host=lower_tor_host
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host
     )


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Test expectations did not align with new image behavior

#### How did you do it?
- Change the expected active and standby ToRs for some scenarios
- Remove tunnel traffic check for some scenarios

#### How did you verify/test it?
Run BGP tests, verify they pass 
```
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now
deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
=================================================================================== test session starts ====================================================================================platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 4 items

dualtor_io/test_tor_bgp_failure.py::test_active_tor_kill_bgpd_upstream PASSED                                                                                                        [ 25%]
dualtor_io/test_tor_bgp_failure.py::test_standby_tor_kill_bgpd_upstream PASSED                                                                                                       [ 50%]
dualtor_io/test_tor_bgp_failure.py::test_standby_tor_kill_bgpd_downstream_active PASSED                                                                                              [ 75%]
dualtor_io/test_tor_bgp_failure.py::test_active_tor_kill_bgpd_downstream_standby PASSED                                                                                              [100%]

---------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt/tests/logs/tr.xml -----------------------------------------------------------------=============================================================================== 4 passed in 2254.30 seconds ================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
