### PR TITLE
[loganalyzer]: flush end marker to disk 

### DIFF
--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -216,8 +216,7 @@ def test_container_checker(duthosts, enum_dut_feature_container, rand_selected_d
                    .format(container_name, dut_name, rand_selected_dut.hostname))
     duthost = duthosts[dut_name]
 
-    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="container_checker")
-    loganalyzer.expect_regex = []
+    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="container_checker_{}".format(container_name))
 
     disabled_containers = get_disabled_container_list(duthost)
 
@@ -232,14 +231,8 @@ def test_container_checker(duthosts, enum_dut_feature_container, rand_selected_d
                    "Container '{}' is skipped for testing.".format(container_name))
     stop_container(duthost, container_name)
 
-    expected_alerting_message = get_expected_alerting_message(container_name)
-    loganalyzer.expect_regex.extend(expected_alerting_message)
-    marker = loganalyzer.init()
-
-    # Wait for 1 minutes such that Monit has a chance to write alerting message into syslog.
-    logger.info("Sleep 1 minutes to wait for the alerting message...")
-    time.sleep(70)
-
-    logger.info("Checking the alerting messages from syslog...")
-    loganalyzer.analyze(marker)
-    logger.info("Found all the expected alerting messages from syslog!")
+    loganalyzer.expect_regex = get_expected_alerting_message(container_name)
+    with loganalyzer:
+        # Wait for 1 minutes such that Monit has a chance to write alerting message into syslog.
+        logger.info("Sleep 1 minutes to wait for the alerting message...")
+        time.sleep(70)


### PR DESCRIPTION
sometime, test fails because it cannot find end marker. the fix here
is to kill -HUP rsyslogd to ensure the end marker log line is flushed
to disk.

Also refactor the test_container_checker to use simplified loganalyzer syntax

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
sometime, test fails because it cannot find end marker. the fix here
is to kill -HUP rsyslogd to ensure the end marker log line is flushed
to disk.

Also refactor the test_container_checker to use simplified loganalyzer syntax

Signed-off-by: Guohan Lu <lguohan@gmail.com>
#### How did you do it?

kill -HUP to rsyslogd

#### How did you verify/test it?
locally 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
