### PR TITLE
Limit memory used by PTF and CEOS docker containers

### DIFF
--- a/ansible/roles/eos/tasks/ceos.yml
+++ b/ansible/roles/eos/tasks/ceos.yml
@@ -27,6 +27,7 @@
     capabilities:
       - net_admin
     privileged: yes
+    memory: 2G
     env:
       CEOS=1
       container=docker

--- a/ansible/roles/eos/tasks/ceos.yml
+++ b/ansible/roles/eos/tasks/ceos.yml
@@ -28,6 +28,7 @@
       - net_admin
     privileged: yes
     memory: 2G
+    memory_swap: 2G
     env:
       CEOS=1
       container=docker

--- a/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
+++ b/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
@@ -30,6 +30,7 @@
         - net_admin
       privileged: yes
       memory: 2G
+      memory_swap: 2G
       env:
         CEOS=1
         container=docker

--- a/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
+++ b/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
@@ -29,6 +29,7 @@
       capabilities:
         - net_admin
       privileged: yes
+      memory: 2G
       env:
         CEOS=1
         container=docker

--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -67,6 +67,7 @@
     capabilities:
       - net_admin
     privileged: yes
+    memory: 200M
   async: 300
   poll: 0
   loop: "{{ VM_targets|flatten(levels=1) }}"

--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -68,6 +68,7 @@
       - net_admin
     privileged: yes
     memory: 200M
+    memory_swap: 200M
   async: 300
   poll: 0
   loop: "{{ VM_targets|flatten(levels=1) }}"

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -76,6 +76,7 @@
               - net_admin
             privileged: yes
             memory: 4G
+            memory_swap: 4G
           become: yes
 
         - name: Bind ptf_ip to keysight_api_server
@@ -111,6 +112,7 @@
           - net_admin
         privileged: yes
         memory: 4G
+        memory_swap: 4G
       become: yes
 
     - name: Get dut ports
@@ -163,6 +165,7 @@
         - net_admin
       privileged: yes
       memory: 4G
+      memory_swap: 4G
     become: yes
 
   - name: Enable ipv6 for docker container ptf_{{ vm_set_name }}

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -75,6 +75,7 @@
             capabilities:
               - net_admin
             privileged: yes
+            memory: 4G
           become: yes
 
         - name: Bind ptf_ip to keysight_api_server
@@ -109,6 +110,7 @@
         capabilities:
           - net_admin
         privileged: yes
+        memory: 4G
       become: yes
 
     - name: Get dut ports
@@ -160,6 +162,7 @@
       capabilities:
         - net_admin
       privileged: yes
+      memory: 4G
     become: yes
 
   - name: Enable ipv6 for docker container ptf_{{ vm_set_name }}

--- a/ansible/roles/vm_set/tasks/remove_dut_port.yml
+++ b/ansible/roles/vm_set/tasks/remove_dut_port.yml
@@ -4,5 +4,3 @@
     vlan_ids: "{{ device_vlan_map_list[dut_name] }}"
     cmd: "remove"
   become: yes
-
-

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -42,6 +42,7 @@
         - net_admin
       privileged: yes
       memory: 4G
+      memory_swap: 4G
     become: yes
 
   - name: Enable ipv6 for docker container ptf_{{ vm_set_name }}

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -41,6 +41,7 @@
       capabilities:
         - net_admin
       privileged: yes
+      memory: 4G
     become: yes
 
   - name: Enable ipv6 for docker container ptf_{{ vm_set_name }}

--- a/ansible/roles/vm_set/tasks/start_sid.yml
+++ b/ansible/roles/vm_set/tasks/start_sid.yml
@@ -58,6 +58,7 @@
       - net_admin
     privileged: yes
     memory: 8G
+    memory_swap: 8G
     env: "{{ sid_env }}"
     command: /usr/sbin/init
   become: yes

--- a/ansible/roles/vm_set/tasks/start_sid.yml
+++ b/ansible/roles/vm_set/tasks/start_sid.yml
@@ -15,7 +15,7 @@
 
 - fail: msg="mellanox_spc3_hwskus is not defined"
   when: "mellanox_spc3_hwskus is not defined"
-  
+
 - set_fact:
     chip: "spectrum"
   when: hostvars[dut_name]['hwsku'] in mellanox_spc1_hwskus
@@ -57,6 +57,7 @@
     capabilities:
       - net_admin
     privileged: yes
+    memory: 8G
     env: "{{ sid_env }}"
     command: /usr/sbin/init
   become: yes


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
In case there is memory leak in the PTF or CEOS docker, the whole test server health
could be affected. 

#### How did you do it?
This change added limit to memory that can be used by different docker containers.
* PTF - 4G
* CEOS - 2G
* net for CEOS - 200M
* SID - 8G

With this change, the docker service is able to control the blast radius.

#### How did you verify/test it?
Deploy T0 and T1-lag testbeds using CEOS. Run some test scripts.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
