### PR TITLE
kill zombie process before running test

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -103,6 +103,12 @@ function setup_environment()
     export ANSIBLE_LIBRARY=${BASE_PATH}/ansible/library/
     export ANSIBLE_CONNECTION_PLUGINS=${BASE_PATH}/ansible/plugins/connection
 
+    # Kill pytest and ansible-playbook process
+    pkill --signal 9 pytest
+    pkill --signal 9 ansible-playbook
+    # Kill ssh initiated by ansible, try to match full command begins with 'ssh' and contains path '/.ansible'
+    pkill --signal 9 -f "^ssh.*/\.ansible"
+
     rm -fr ${BASE_PATH}/tests/_cache
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

In case something went wrong, previous test run may result in zombie processes running in the container even after the testing is completed. The zombie process could have negative impact to subsequent test runs. It would be more robust to start new
tests if we try to kill any possible zombie process before test runs.

#### How did you do it?

Use `pkill` to kill pytest/ansible-playbook process and ssh process initiated by ansible

#### How did you verify/test it?

Run first test to simulate the zombie process:

`./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c bgp/test_bgp_fact.py -f vtestbed.csv -i veos_vtb`

When first test is running, run test command again and check whether the previous process was killed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
