### PR TITLE
[Mellanox] Modify AbnormalFanMocker check_result return value

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -1003,14 +1003,16 @@ class AbnormalFanMocker(SingleFanMocker):
             if fan['fan'] == self.fan_data.name:
                 try:
                     actual_color = self.fan_drawer_data.get_status_led()
-                    assert actual_color == self.expect_led_color, 'FAN {} color is {}, expect: {}'.format(fan['fan'],
-                                                                                                          actual_color,
-                                                                                                          self.expect_led_color)
+                    if actual_color != self.expect_led_color:
+                        logging.error('FAN {} color is {}, expect: {}'.format(fan['fan'], actual_color,
+                                                                              self.expect_led_color))
+                        return False
                 except SysfsNotExistError as e:
                     logging.info('LED check only support on SPC2 and SPC3: {}'.format(e))
-                return
+                return True
 
-        assert 0, 'Expected data not found'
+        logging.error('Expected data not found')
+        return False
 
     def is_fan_removable(self):
         """


### PR DESCRIPTION
Return True if the actual fan data is same with the mock data, else return False.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Modify AbnormalFanMocker check_result return value
Fixes # (issue) Modify AbnormalFanMocker check_result return value to make test case "test_thermal_control_fan_status" pass

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The test case "test_thermal_control_fan_status" will failed after the PR #3684 is merged
#### How did you do it?
Change the return value of the check_result in AbnormalFanMocker, before the #3684 is merged, it dose not care about the return value of the check_result in AbnormalFanMocker, after the PR is merged, it will check the return value of the check_result
#### How did you verify/test it?
Run test cases in test_platform_info.py and all the test cases pass
#### Any platform specific information?
No, it happens on any kind of platform
