### PR TITLE
Added new files test_voq_disrupts.py and test_voq_intfs.py. Modified …

### DIFF
--- a/tests/voq/test_voq_disrupts.py
+++ b/tests/voq/test_voq_disrupts.py
@@ -1,0 +1,281 @@
+import pytest
+import logging
+import time
+
+from voq_helpers import sonic_ping
+from voq_helpers import eos_ping
+
+from test_voq_ipfwd import pick_ports
+from test_voq_ipfwd import check_packet
+
+from test_voq_init import check_voq_interfaces
+from voq_helpers import dump_and_verify_neighbors_on_asic
+
+from tests.common import reboot
+from tests.common import config_reload
+from tests.common.utilities import wait_until
+
+from tests.common.helpers.parallel import parallel_run
+from tests.common.helpers.parallel import reset_ansible_local_tmp
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('t2')
+]
+
+
+def check_bgp_neighbors(duthosts):
+    """
+    Validates neighbors are established
+
+    Args:
+        duthosts: Duthosts fixture
+
+    Returns:
+        True if all neighbors are established, False if one or more are down.
+
+    """
+    down_nbrs = 0
+    for node in duthosts.frontend_nodes:
+        for asic in node.asics:
+            bgp_facts = asic.bgp_facts()['ansible_facts']
+
+            for address in bgp_facts['bgp_neighbors']:
+                if bgp_facts['bgp_neighbors'][address]['state'] != "established":
+                    logger.info("BGP neighbor: %s is down: %s." % (
+                        address, bgp_facts['bgp_neighbors'][address]['state']))
+                    down_nbrs += 1
+    if down_nbrs != 0:
+        logger.warning("Neighbors are still down: %d", down_nbrs)
+        return False
+    else:
+        logger.info("All BGP neighbors are restored.")
+        return True
+
+
+def poll_bgp_restored(duthosts, timeout=900, delay=20):
+    """
+    Polls for all neighbors to be established.
+
+    Args:
+        duthosts: The duthosts fixture.
+        timeout: how long to poll
+        delay: time between checks.
+
+    Raises:
+        AssertionError if neighbors did not come up.
+
+    """
+    logger.info("Poll for BGP to recover.")
+    restored = False
+    endtime = time.time() + timeout
+    while not restored and time.time() < endtime:
+        restored = check_bgp_neighbors(duthosts)
+        if restored:
+            break
+        time.sleep(delay)
+    else:
+        raise AssertionError("BGP was never restored.")
+
+
+def check_intfs_and_nbrs(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
+    """
+    Checks interfaces and neighbors are correct on frontend nodes and chassisdb.
+
+    Args:
+        duthosts: duthosts fixture
+        all_cfg_facts: all_cfg_facts fixture
+        nbrhosts: nbrhosts fixture
+        nbr_macs: nbr_macs fixture
+
+    """
+    for host in duthosts.frontend_nodes:
+        for asic in host.asics:
+            cfg_facts = all_cfg_facts[host.hostname][asic.asic_index]['ansible_facts']
+            check_voq_interfaces(duthosts, host, asic, cfg_facts)
+
+            logger.info("Checking local neighbors on host: %s, asic: %s", host.hostname, asic.asic_index)
+            if 'BGP_NEIGHBOR' in cfg_facts:
+                neighs = cfg_facts['BGP_NEIGHBOR']
+            else:
+                logger.info("No local neighbors for host: %s/%s, skipping", host.hostname, asic.asic_index)
+                continue
+
+            dump_and_verify_neighbors_on_asic(duthosts, host, asic, neighs, nbrhosts, all_cfg_facts, nbr_macs)
+
+
+def check_ip_fwd(duthosts, all_cfg_facts, nbrhosts):
+    """
+    Checks basic IP connectivity through the voq system.
+
+    Args:
+        duthosts: duthosts fixture
+        all_cfg_facts: all_cfg_facts fixture
+        nbrhosts: nbrhosts fixture
+    """
+    for porttype in ["ethernet", "portchannel"]:
+        for version in [4, 6]:
+
+            ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, port_type_a=porttype, version=version)
+
+            for ttl, size in [(2, 64), (1, 1450)]:
+                # local interfaces
+                check_packet(sonic_ping, ports, 'portB', 'portA', size=size, ttl=ttl, ttl_change=0)
+
+                # local neighbors
+                check_packet(sonic_ping, ports, 'portA', 'portA', dst_ip_fld='nbr_ip', size=size, ttl=ttl, ttl_change=0)
+
+                vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
+
+                check_packet(eos_ping, ports, 'portD', 'portA', dst_ip_fld='my_lb_ip', src_ip_fld='nbr_lb',
+                             dev=vm_host_to_A, size=size, ttl=ttl)
+
+                # loopbacks
+                check_packet(sonic_ping, ports, 'portA', 'portA', dst_ip_fld='nbr_lb', size=size, ttl=ttl, ttl_change=0)
+
+                # inband
+                check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='inband', size=size, ttl=ttl, ttl_change=0)
+
+                # DUT loopback
+                # these don't decrement ttl
+                check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='my_ip', size=size,
+                             ttl=ttl, ttl_change=0)
+                check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='nbr_ip', size=size,
+                             ttl=ttl, ttl_change=0)
+                check_packet(sonic_ping, ports, 'portA', 'portA', src_ip_fld='my_lb_ip', dst_ip_fld='nbr_lb', size=size,
+                             ttl=ttl, ttl_change=0)
+
+                vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
+                check_packet(eos_ping, ports, 'portA', 'portA', dst_ip_fld='my_lb_ip', src_ip_fld='nbr_lb',
+                             dev=vm_host_to_A, size=size, ttl=ttl, ttl_change=0)
+
+                # end to end
+                vm_host_to_A = nbrhosts[ports['portA']['nbr_vm']]['host']
+                check_packet(eos_ping, ports, 'portB', 'portA', dst_ip_fld='nbr_lb', src_ip_fld='nbr_lb',
+                             dev=vm_host_to_A, size=size, ttl=ttl)
+                check_packet(eos_ping, ports, 'portC', 'portA', dst_ip_fld='nbr_lb', src_ip_fld='nbr_lb',
+                             dev=vm_host_to_A, size=size, ttl=ttl)
+                check_packet(eos_ping, ports, 'portD', 'portA', dst_ip_fld='nbr_lb', src_ip_fld='nbr_lb',
+                             dev=vm_host_to_A, size=size, ttl=ttl)
+
+
+@pytest.mark.skip(reason="Not yet implemented - reboot of supervisor does not reset line cards.")
+def test_reboot_supervisor(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_macs):
+    """
+    Tests the system after supervisor reset, all cards should reboot and interfaces/neighbors should be in sync across
+    the system.
+
+    Args:
+        duthosts: duthosts fixture
+        localhost: localhost fixture
+        all_cfg_facts: all_cfg_facts fixture
+        nbrhosts: nbrhosts fixture
+        nbr_macs: nbr_macs fixture
+    """
+    logger.info("=" * 80)
+    logger.info("Precheck")
+    logger.info("-" * 80)
+
+    check_intfs_and_nbrs(duthosts, all_cfg_facts, nbrhosts, nbr_macs)
+    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts)
+
+    logger.info("=" * 80)
+    logger.info("Coldboot on node: %s", duthosts.supervisor_nodes[0].hostname)
+    logger.info("-" * 80)
+
+    reboot(duthosts.supervisor_nodes[0], localhost, wait=600)
+    assert wait_until(300, 20, duthosts.supervisor_nodes[0].critical_services_fully_started), "Not all critical services are fully started"
+
+    poll_bgp_restored(duthosts)
+
+    logger.info("=" * 80)
+    logger.info("Postcheck")
+    logger.info("-" * 80)
+
+    check_intfs_and_nbrs(duthosts, all_cfg_facts, nbrhosts, nbr_macs)
+    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts)
+
+
+def test_reboot_system(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_macs):
+    """
+    Tests the system after all cards are explicitly reset, interfaces/neighbors should be in sync across the system.
+
+    Args:
+        duthosts: duthosts fixture
+        localhost: localhost fixture
+        all_cfg_facts: all_cfg_facts fixture
+        nbrhosts: nbrhosts fixture
+        nbr_macs: nbr_macs fixture
+    """
+
+    @reset_ansible_local_tmp
+    def reboot_node(lh, node=None, results=None):
+        node_results = []
+        node_results.append(reboot(node, lh, wait=600))
+        results[node.hostname] = node_results
+
+    logger.info("=" * 80)
+    logger.info("Precheck")
+    logger.info("-" * 80)
+
+    check_intfs_and_nbrs(duthosts, all_cfg_facts, nbrhosts, nbr_macs)
+    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts)
+
+    logger.info("=" * 80)
+    logger.info("Coldboot on all nodes")
+    logger.info("-" * 80)
+
+    t0 = time.time()
+
+    parallel_run(reboot_node, [localhost], {}, duthosts.nodes, timeout=1000)
+
+    for node in duthosts.nodes:
+        assert wait_until(300, 20, node.critical_services_fully_started), "Not all critical services are fully started"
+
+    poll_bgp_restored(duthosts)
+
+    t1 = time.time()
+    elapsed = t1 - t0
+
+    logger.info("-" * 80)
+    logger.info("Time to reboot and recover: %s seconds.", str(elapsed))
+    logger.info("-" * 80)
+
+    logger.info("=" * 80)
+    logger.info("Postcheck")
+    logger.info("-" * 80)
+
+    check_intfs_and_nbrs(duthosts, all_cfg_facts, nbrhosts, nbr_macs)
+    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts)
+
+
+def test_config_reload_lc(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
+    """
+    Tests the system after a config reload on a linecard, interfaces/neighbors should be in sync across the system.
+
+    Args:
+        duthosts: duthosts fixture
+        all_cfg_facts: all_cfg_facts fixture
+        nbrhosts: nbrhosts fixture
+        nbr_macs: nbr_macs fixture
+    """
+    logger.info("=" * 80)
+    logger.info("Precheck")
+    logger.info("-" * 80)
+
+    check_intfs_and_nbrs(duthosts, all_cfg_facts, nbrhosts, nbr_macs)
+    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts)
+
+    logger.info("=" * 80)
+    logger.info("Config reload on node: %s", duthosts.frontend_nodes[0].hostname)
+    logger.info("-" * 80)
+
+    config_reload(duthosts.frontend_nodes[0], config_source='config_db', wait=600)
+    poll_bgp_restored(duthosts)
+
+    logger.info("=" * 80)
+    logger.info("Postcheck")
+    logger.info("-" * 80)
+    check_intfs_and_nbrs(duthosts, all_cfg_facts, nbrhosts, nbr_macs)
+    check_ip_fwd(duthosts, all_cfg_facts, nbrhosts)

--- a/tests/voq/test_voq_init.py
+++ b/tests/voq/test_voq_init.py
@@ -307,7 +307,8 @@ def check_voq_interfaces(duthosts, per_host, asic, cfg_facts):
 
     # Verify each RIF in config had a corresponding local port RIF in the asicDB.
     for rif in dev_intfs:
-        pytest_assert(rif in rif_ports_in_asicdb, "Interface %s is in configdb.json but not in asicdb" % rif)
+        if rif not in rif_ports_in_asicdb:
+            raise AssertionError("Interface %s is in configdb.json but not in asicdb" % rif)
 
     logger.info("Interfaces %s are present in configdb.json and asicdb" % str(dev_intfs.keys()))
 

--- a/tests/voq/test_voq_intfs.py
+++ b/tests/voq/test_voq_intfs.py
@@ -1,0 +1,110 @@
+
+import pytest
+import logging
+import ipaddress
+
+from tests.common import config_reload
+
+from test_voq_init import check_voq_interfaces
+
+from tests.common.helpers.redis import VoqDbCli, RedisKeyNotFound
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('t2')
+]
+
+ADDR = ipaddress.IPv4Interface(u"50.1.1.1/24")
+
+
+def test_cycle_voq_intf(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
+    """
+    Delete and recreate VOQ interface through config save/load.  Verify interface
+    is removed after configdb reload and then recreated after loading initial minigraph.
+
+    Args:
+        duthosts: The duthosts fixture
+        all_cfg_facts: all_cfg_facts fixture from voq conftest
+        nbrhosts: nbrhosts fixture
+        nbr_macs: nbr_macs fixture from voq conftest
+
+    """
+
+    duthost = duthosts.frontend_nodes[0]
+    for asic in duthost.asics:
+        cfg_facts = all_cfg_facts[duthost.hostname][asic.asic_index]['ansible_facts']
+        check_voq_interfaces(duthosts, duthost, asic, cfg_facts)
+
+    intf_asic = duthost.asics[0]
+    intf_config_facts = duthost.config_facts(source='persistent',
+                                             asic_index=intf_asic.asic_index)['ansible_facts']
+    portchannel = intf_config_facts['PORTCHANNEL'].keys()[0]
+    portchannel_members = intf_config_facts['PORTCHANNEL'][portchannel].get('members')
+
+    try:
+        logger.info("remove ethernet from a portchannel to use for interface create")
+        intf = portchannel_members[0]
+        logging.info('Deleting lag members {} from lag {} on dut {}'
+                     .format(portchannel_members, portchannel, duthost.hostname))
+        for member in portchannel_members:
+            duthost.shell("config portchannel {} member del {} {}"
+                          .format(intf_asic.cli_ns_option, portchannel, member))
+
+        logger.info("add an IP interface to a former member")
+        cmd = "config interface {} ip add {} {}".format(intf_asic.cli_ns_option, intf, str(ADDR))
+        logger.info("Execute: %s", cmd)
+        duthost.shell(cmd)
+
+        logger.info("Save and reload config")
+
+        duthost.shell_cmds(cmds=["config save -y"])
+        config_reload(duthost, config_source='config_db', wait=600)
+
+        logger.info("Check interfaces after add.")
+        for asic in duthost.asics:
+            new_cfgfacts = duthost.config_facts(source='persistent', asic_index='all')[asic.asic_index]['ansible_facts']
+            check_voq_interfaces(duthosts, duthost, asic, new_cfgfacts)
+
+        logger.info("Check interface on supervisor - should be present from chassis db.")
+        if duthost.is_multi_asic and len(duthosts.supervisor_nodes) == 0:
+            sup = duthost
+        else:
+            sup = duthosts.supervisor_nodes[0]
+        voqdb = VoqDbCli(sup)
+
+        key = "SYSTEM_INTERFACE|{}|{}|{}".format(intf_config_facts['DEVICE_METADATA']['localhost']['hostname'],
+                                                 intf_config_facts['DEVICE_METADATA']['localhost']['asic_name'],
+                                                 intf)
+
+        voqdb.get_keys(key)
+
+        logger.info("Remove an IP interface to a former member.")
+        cmd = "config interface {} ip remove {} {}".format(intf_asic.cli_ns_option, intf, str(ADDR))
+        logger.info("Execute: %s", cmd)
+        duthost.shell(cmd)
+
+        logger.info("Save and reload config")
+
+        duthost.shell_cmds(cmds=["config save -y"])
+        config_reload(duthost, config_source='config_db', wait=600)
+
+        logger.info("check interface is gone after config reload")
+
+        for asic in duthost.asics:
+            new_cfgfacts = duthost.config_facts(source='persistent', asic_index='all')[asic.asic_index]['ansible_facts']
+            check_voq_interfaces(duthosts, duthost, asic, new_cfgfacts)
+
+        with pytest.raises(RedisKeyNotFound):
+            voqdb.get_keys(key)
+        logger.info("-- Interface {} deleted from chassisdb on supervisor card".format(key))
+
+    finally:
+        # restore interface from minigraph
+        logger.info("Restore config from minigraph.")
+        config_reload(duthost, config_source='minigraph', wait=600)
+        duthost.shell_cmds(cmds=["config save -y"])
+
+        for asic in duthost.asics:
+            new_cfgfacts = duthost.config_facts(source='persistent', asic_index='all')[asic.asic_index]['ansible_facts']
+            check_voq_interfaces(duthosts, duthost, asic, new_cfgfacts)


### PR DESCRIPTION

### Description of PR

Summary:
Implement Disruptive Events and IP interface delete/add test cases from VoQ test plan: https://github.com/Azure/sonic-mgmt/blob/master/docs/testplan/Distributed-VoQ-Arch-test-plan.md

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)

### Approach

What is the motivation for this PR?
Adding automated tests to cover the disruptive events and IP interfaces portion of the Distributed VoQ system testplan.

#### How did you do it?
Test validations were reused from existing helpers and functions. Interface and neighbor validation comes from voq_helpers and voq_init scripts. Packet forwarding validation utilizes the pick_ports and check_packet routines from voq_ipfwd.

The tests reuse the reboot and config reload commands from tests.common. A new routine was added to poll for all BGP neighbors to recover before continuing with validation after a reboot.

There are disruptive tests for system reset, supervisor reset, and linecard config reload. There is also a test to cover removing and recreating and interface, and validating chassisdb is updated accordingly.

#### How did you verify/test it?
Ran on t2 voq system

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T
### Documentation 

