### PR TITLE
[advance-reboot] Restore fast-reboot script inside DUT after negative test

### DIFF
--- a/tests/platform_tests/verify_dut_health.py
+++ b/tests/platform_tests/verify_dut_health.py
@@ -1,6 +1,7 @@
 import copy
 import pytest
 import logging
+import time
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.transceiver_utils import parse_transceiver_info
 from tests.common.reboot import reboot, REBOOT_TYPE_COLD
@@ -160,8 +161,8 @@ def verify_dut_health(request, duthosts, rand_one_dut_hostname, tbinfo):
 def add_fail_step_to_reboot(localhost, duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
 
-    params = tuple()
     def add_exit_to_script(reboot_type):
+        add_exit_to_script.params = tuple()
         if "warm" in reboot_type:
             reboot_script = "warm-reboot"
         elif "fast" in reboot_type:
@@ -174,12 +175,13 @@ def add_fail_step_to_reboot(localhost, duthosts, rand_one_dut_hostname):
         replace_cmd = cmd_format.format(original_line, replaced_line, reboot_script_path)
         logging.info("Modify {} to exit before set +e".format(reboot_script_path))
         duthost.shell(replace_cmd)
-        params = (cmd_format, replaced_line, original_line, reboot_script_path, reboot_script_path)
+        add_exit_to_script.params = (cmd_format, replaced_line, original_line, reboot_script_path, reboot_script_path)
+
 
     yield add_exit_to_script
 
-    if params:
-        cmd_format, replaced_line, original_line, reboot_script_path, reboot_script_path = params
+    if add_exit_to_script.params:
+        cmd_format, replaced_line, original_line, reboot_script_path, reboot_script_path = add_exit_to_script.params
         replace_cmd = cmd_format.format(replaced_line, original_line, reboot_script_path)
         logging.info("Revert {} script to original".format(reboot_script_path))
         duthost.shell(replace_cmd)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix the restoration logic for fastboot and warmboot scripts after the negative cases modify them. Negative testcases are `test_cancelled_fast_reboot` and `test_cancelled_warm_reboot`.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Warmboot SAD cases are failing in the nightly regression testing but not locally. This is caused by tests that precede the sad cases - `test_cancelled_warm_reboot` has incorrect restoration of reboot scripts inside DUT after negative cases modify the scripts.

The error in SAD cases:
```\nFAIL: advanced-reboot.ReloadTest\n----------------------------------------------------------------------\n
Traceback (most recent call last):\n  File "ptftests/advanced-reboot.py", line 1193, in runTest\n
self.handle_post_reboot_test_reports()\n
File "ptftests/advanced-reboot.py", line 1143, in handle_post_reboot_test_reports\n
self.assertTrue(is_good, errors)\nAssertionError: 
Something went wrong. Please check output below:
FAILED:dut:DUT hasn't shutdown in 300 seconds\n`
```
#### How did you do it?
Since the variable inside the inner function is not visible to the outer function, use function attribute for the shared variables. With this approach, the outer function can access the variable using inner function's name.

#### How did you verify/test it?
Executed a negative test (`test_cancelled_warm_reboot`), and script was modified during the test, and restored successfully after the test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
