### PR TITLE
[202012 platform_tests/daemon] test_pmon_ledd_term_and_start_status test is flaky

### DIFF
--- a/tests/platform_tests/daemon/test_ledd.py
+++ b/tests/platform_tests/daemon/test_ledd.py
@@ -18,6 +18,7 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.daemon_utils import check_pmon_daemon_enable_status
 from tests.common.platform.processes_utils import wait_critical_processes, check_critical_processes
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,10 @@ def check_daemon_status(duthosts, rand_one_dut_hostname):
     if daemon_status is not "RUNNING":
         duthost.start_pmon_daemon(daemon_name)
         time.sleep(10)
+
+def check_expected_daemon_status(duthost, expected_daemon_status):
+    daemon_status, _ = duthost.get_pmon_daemon_status(daemon_name)
+    return daemon_status == expected_daemon_status
 
 def test_pmon_ledd_running_status(duthosts, rand_one_dut_hostname):
     """
@@ -122,7 +127,7 @@ def test_pmon_ledd_term_and_start_status(check_daemon_status, duthosts, rand_one
 
     duthost.stop_pmon_daemon(daemon_name, SIG_TERM, pre_daemon_pid)
 
-    time.sleep(15)
+    wait_until(30, 10, check_expected_daemon_status, duthost, expected_running_status)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,

--- a/tests/platform_tests/daemon/test_ledd.py
+++ b/tests/platform_tests/daemon/test_ledd.py
@@ -122,10 +122,6 @@ def test_pmon_ledd_term_and_start_status(check_daemon_status, duthosts, rand_one
 
     duthost.stop_pmon_daemon(daemon_name, SIG_TERM, pre_daemon_pid)
 
-    daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
-    pytest_assert(daemon_status != expected_running_status and pre_daemon_pid != daemon_pid,
-                          "{} status for SIG_TERM should not be {} with pid:{}!".format(daemon_name, daemon_status, daemon_pid))
-
     time.sleep(10)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)

--- a/tests/platform_tests/daemon/test_ledd.py
+++ b/tests/platform_tests/daemon/test_ledd.py
@@ -122,7 +122,7 @@ def test_pmon_ledd_term_and_start_status(check_daemon_status, duthosts, rand_one
 
     duthost.stop_pmon_daemon(daemon_name, SIG_TERM, pre_daemon_pid)
 
-    time.sleep(10)
+    time.sleep(15)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,


### PR DESCRIPTION
ledd daemon exit delays some time after recieving SIG_TERM.
Hence manual test run passed but most of nightly test run failed

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (https://github.com/Azure/sonic-buildimage/issues/8700)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
We see the test_pmon_ledd_term_and_start_status test failed during nightly test but pass on manual test run.

#### How did you do it?
1. Remove the daemon status right after sending the SIG_TERM to the daemon.
2. Instead, check the daemon status after waiting until the expected daemon restart time.
#### How did you verify/test it?
3. Manual test pass.
#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
