### PR TITLE
Fix the OVS bridges not removed issue in cleanup.sh

### DIFF
--- a/ansible/roles/vm_set/templates/cleanup.sh.j2
+++ b/ansible/roles/vm_set/templates/cleanup.sh.j2
@@ -15,7 +15,7 @@ test -z "$(virsh list --all --name)" || virsh list --all --name | xargs -I % vir
 rm -f {{ root_path }}/disks/*
 
 # remove all ovs bridges
-test -z "$(ovs-vsctl list-br)" || ovs-vsctl list-br | sed -e 's/^/-- del-br /' | xargs ovs-vsctl
+test -z "$(ovs-vsctl list-br)" || ovs-vsctl list-br | xargs -I % ovs-vsctl del-br %
 
 # stop all running docker containers
 test -z "$(docker ps -q)" || docker stop $(docker ps -q)
@@ -25,4 +25,3 @@ test -z "$(docker ps -a -q)" || docker rm -f $(docker ps -a -q)
 
 # remove all docker images
 test -z "$(docker images -q)" || docker rmi -f $(docker images -q|uniq)
-


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
During 'testbed-cli.sh add-topo', a tool 'cleanup.sh' is generated to test server.
This script is for cleaning up  all the VMs, bridges and dockers created during
add-topo. However, the script can't really remove all the OVS bridges as it
intended to. 

#### How did you do it?
This change fixed the command for removing OVS bridges.
With this fix, this script is able to cleanup all the OVS bridges as well.

#### How did you verify/test it?
Run this script on a test server. Then check OVS bridges.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
