### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/spytest/containers/keysight-ubuntu18/Dockerfile
+++ b/spytest/containers/keysight-ubuntu18/Dockerfile
@@ -28,12 +28,12 @@ RUN apt -y install snmptrapd
 COPY . /keysight
 WORKDIR /keysight
 
-RUN pip install -r ./spytest.txt
+RUN pip install --no-cache-dir -r ./spytest.txt
 
 # https://downloads.ixiacom.com/support/downloads_and_updates/public/ixnetwork/9.10/IxNetworkAPI9.10.2007.7Linux64.bin.tgz
 RUN bash ./IxNetworkAPI9.10.2007.7Linux64.bin -i silent
 
-RUN pip install -r /opt/ixia/ixnetwork/9.10.2007.7/lib/PythonApi/requirements.txt
+RUN pip install --no-cache-dir -r /opt/ixia/ixnetwork/9.10.2007.7/lib/PythonApi/requirements.txt
 
 ENV SCID_TGEN_PATH=/opt
 ENV SCID_TCL85_BIN=/opt


### PR DESCRIPTION
### Description of PR

using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6
