### PR TITLE
Fix "AttributeError: 'InterruptableThread' object has no attribute '_e'"

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -56,11 +56,11 @@ def skip_release_for_platform(duthost, release_list, platform_list):
     """
     if any(release in duthost.os_version for release in release_list) and \
 		any(platform in duthost.facts['platform'] for platform in platform_list):
-        pytest.skip("DUT has version {} and platform {} and \
-			test does not support {} for {}".format(duthost.os_version,
-            			duthost.facts['platform'], 
-				", ".join(release_list), 
-				", ".join(platform_list)))
+        pytest.skip("DUT has version {} and platform {} and test does not support {} for {}".format(
+            duthost.os_version,
+            duthost.facts['platform'],
+			", ".join(release_list),
+			", ".join(platform_list)))
 
 def wait(seconds, msg=""):
     """
@@ -131,6 +131,10 @@ def wait_tcp_connection(client, server_hostname, listening_port, timeout_s = 30)
 class InterruptableThread(threading.Thread):
     """Thread class that can be interrupted by Exception raised."""
 
+    def __init__(self, **kwargs):
+        super(InterruptableThread, self).__init__(**kwargs)
+        self._e = None
+
     def set_error_handler(self, error_handler):
         """Add error handler callback that will be called when the thread exits with error."""
         self.error_handler = error_handler
@@ -140,7 +144,6 @@ class InterruptableThread(threading.Thread):
         @summary: Run the target function, call `start()` to start the thread
                   instead of directly calling this one.
         """
-        self._e = None
         try:
             threading.Thread.run(self)
         except Exception:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The recover_server.py script ocassionally gives error like below:

+ python recover_server.py --testbed-servers server_2 --vm-file veos --vm-type veos --skip-cleanup
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
INFO - LOG PATH: /tmp/recover_server_2021-09-08_02-52-23
Traceback (most recent call last):
  File "recover_server.py", line 328, in <module>
INFO - Start running task server_2_start_vms
    do_jobs(testbeds, passfile, tbfile=tbfile, vmfile=vmfile, vmtype=vmtype, skip_cleanup=skip_cleanup, dry_run=dry_run)
  File "recover_server.py", line 300, in do_jobs
    _join_all(threads)
  File "recover_server.py", line 238, in _join_all
    alive_thread.join(timeout=0)
  File "/azp/agent/_work/40/s/tests/common/utilities.py", line 160, in join
    if self._e:
AttributeError: 'InterruptableThread' object has no attribute '_e'

The reason is that attribute "_e" is initialized in method "run" of "InterruptableThread". When thread.start() is called,
the run method is scheduled, not executed immediately. If we try to access the "_e" attribute immediate after
thread.start(), there is chance that the "run" method is not executed yet and the "_e" attribute is not available.

#### How did you do it?
The fix is to initialize "_e" attribute in "__init__" method of class "InterruptableThread", then the "_e" attribute will always
be available.

#### How did you verify/test it?
Test run the recover_server.py script.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
