### PR TITLE
[wait_until] Improve error logging

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -10,6 +10,7 @@ import six
 import sys
 import threading
 import time
+import traceback
 from io import BytesIO
 
 import pytest
@@ -92,8 +93,10 @@ def wait_until(timeout, interval, condition, *args, **kwargs):
 
         try:
             check_result = condition(*args, **kwargs)
-        except Exception as e:
-            logger.error("Exception caught while checking %s: %s" % (condition.__name__, repr(e)))
+        except Exception:
+            exc_info = sys.exc_info()
+            details = traceback.format_exception(*exc_info)
+            logger.error("Exception caught while checking %s:\n%s" % (condition.__name__, "".join(details)))
             check_result = False
 
         if check_result:


### PR DESCRIPTION
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
For errors occured in the retried function in `wait_until`, it would be better to have the traceback in the log.

#### How did you do it?
Log traceback when error is caught by `wait_until`

#### How did you verify/test it?
* current log with this PR
```
08/09/2021 08:24:19 utilities.wait_until                     L0098 ERROR  | Exception caught while checking check_dut: 
Traceback (most recent call last): 
  File "/data/repo/master_image_qualification/sonic-mgmt/tests/common/utilities.py", line 94, in wait_until 
    check_result = condition(*args, **kwargs) 
  File "/data/repo/master_image_qualification/sonic-mgmt/tests/bgp/test_bgp_bbr.py", line 235, in check_dut 
    advertised_to = set([bgp_neighbors[_]['name'] for _ in dut_route['advertisedTo']]) 
KeyError: 'advertisedTo' 
```
* previously
```
08/09/2021 08:24:19 utilities.wait_until                     L0098 ERROR  | Exception caught while checking check_dut: KeyError: 'advertisedTo' 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
