### PR TITLE
[qos] Add dot1p to queue mapping test

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -479,6 +479,41 @@ class TestQosSai(QosSaiBase):
             testParams=testParams
         )
 
+    def testQosSaiDot1pQueueMapping(
+        self, ptfhost, dutTestParams, dutConfig
+    ):
+        """
+            Test QoS SAI Dot1p to queue mapping
+
+            Args:
+                ptfhost (AnsibleHost): Packet Test Framework (PTF)
+                dutTestParams (Fixture, dict): DUT host test params
+                dutConfig (Fixture, dict): Map of DUT config containing dut interfaces, test port IDs, test port IPs,
+                    and test ports
+
+            Returns:
+                None
+
+            Raises:
+                RunAnsibleModuleFail if ptf test fails
+        """
+        if "backend" not in dutTestParams["topo"]:
+            pytest.skip("Dot1p-queue mapping is not supported on {}".format(dutTestParams["topo"]))
+
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
+            "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
+            "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
+            "src_port_id": dutConfig["testPorts"]["src_port_id"],
+            "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
+            "vlan_id": dutConfig["testPorts"]["src_port_vlan"]
+        })
+        self.runPtfTest(
+            ptfhost, testCase="sai_qos_tests.Dot1pToQueueMapping",
+            testParams=testParams
+        )
+
     def testQosSaiDwrr(
         self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
     ):

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -354,22 +354,23 @@ class Dot1pToQueueMapping(sai_base_test.ThriftInterfaceDataPlane):
         exp_ttl = 63
 
         # According to SONiC configuration dot1ps are classified as follows:
-        # dot1p 0 -> queue 0
-        # dot1p 1 -> queue 6
-        # dot1p 2 -> queue 5
+        # dot1p 0 -> queue 1
+        # dot1p 1 -> queue 0
+        # dot1p 2 -> queue 2
         # dot1p 3 -> queue 3
         # dot1p 4 -> queue 4
-        # dot1p 5 -> queue 2
-        # dot1p 6 -> queue 1
-        # dot1p 7 -> queue 0
+        # dot1p 5 -> queue 5
+        # dot1p 6 -> queue 6
+        # dot1p 7 -> queue 7
         queue_dot1p_map = {
-            0 : [0, 7],
-            1 : [6],
-            2 : [5],
+            0 : [1],
+            1 : [0],
+            2 : [2],
             3 : [3],
             4 : [4],
-            5 : [2],
-            6 : [1]
+            5 : [5],
+            6 : [6],
+            7 : [7]
         }
         print >> sys.stderr, queue_dot1p_map
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Backend topologies use dot1p instead of dscp. Hence add testcase to check if the dot1p values are mapped to the correct queues.

Summary:
Fixes #3877

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

#### How did you verify/test it?
Test passed on backend topology and is skipped as expected on others
```
nejo@98d1c349dc9f:/var/nejo/sonic-mgmt-int/tests$ ./run_tests.sh -u -t t0,any -i ../ansible/str2,../ansible/veos -n vms18-t0-7050qx-acs-02 -e "--disable_loganalyzer" -c qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping                     
=== Running tests in groups ===
================================================================================================================== test session starts ===================================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/nejo/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collected 1 item                                                                                                                                                                                                                                         

qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping[None] PASSED                                                                                                                                                                          [100%]

--------------------------------------------------------------------------------------------- generated xml file: /var/nejo/sonic-mgmt-int/tests/logs/tr.xml ---------------------------------------------------------------------------------------------=============================================================================================================== 1 passed in 732.60 seconds ==============================================================================================================


nejo@98d1c349dc9f:/var/nejo/sonic-mgmt-int/tests$ ./run_tests.sh -u -t t0,any -i ../ansible/str,../ansible/veos -n vms7-t0-dx010-5 -e "--disable_loganalyzer" -c qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping                       
=== Running tests in groups ===
================================================================================================================== test session starts ===================================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/nejo/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collected 1 item                                                                                                                                                                                                                                         

qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping[None] SKIPPED                                                                                                                                                                         [100%]

--------------------------------------------------------------------------------------------- generated xml file: /var/nejo/sonic-mgmt-int/tests/logs/tr.xml ---------------------------------------------------------------------------------------------
================================================================================================================ short test summary info =================================================================================================================
SKIPPED [1] /var/nejo/sonic-mgmt-int/tests/qos/test_qos_sai.py:502: Dot1p-queue mapping is not supported on t0
============================================================================================================== 1 skipped in 648.45 seconds ===============================================================================================================
```
