### PR TITLE
[platform_tests/api]: Add watchdog config for Nokia ixs7215 device

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -76,3 +76,10 @@ x86_64-cel_e1031-r0:
     valid_timeout: 30
     greater_timeout: 180
     too_big_timeout: 200
+
+# Nokia IXS-7215 watchdog
+armhf-nokia_ixs7215_52x-r0:
+  default:
+    valid_timeout: 30
+    greater_timeout: 170
+    too_big_timeout: 200


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add watchdog config for the Nokia ixs7215 device

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fixes watchdog failed test case on the Nokia ixs7215 platform

#### How did you do it?
Add the definition of too_big_timeout value in watchdog.yml which will be used to compare to the ixs7215 watchdog max time setting.

#### How did you verify/test it?
Run the pytest platform watchdog test case.

#### Any platform specific information?
Nokia ixs7215 platform

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
