### PR TITLE
Fix the first testbed missing in server recover summary log issue

### DIFF
--- a/ansible/recover_server.py
+++ b/ansible/recover_server.py
@@ -193,13 +193,15 @@ def do_jobs(testbeds, passfile, tbfile=None, vmfile=None, vmtype=None, skip_clea
             if jobs[0].failed_task is not None:
                 output.append('Server %s cleanup failed, skip recovery.' % server)
             jobs = jobs[1:]
-        # start-vms output
-        if jobs[0].failed_task is None:
-            start_vms_result = 'Succeed.'
-        else:
-            start_vms_result = 'Failed.'
-        output.append('Server %s start-vms result: %s ' % (server, start_vms_result))
-        jobs = jobs[1:]
+
+        if vmtype != 'ceos':
+            # start-vms output. If vmtype is ceos, start-vms is not required
+            if jobs[0].failed_task is None:
+                start_vms_result = 'Succeed.'
+            else:
+                start_vms_result = 'Failed.'
+            output.append('Server %s start-vms result: %s ' % (server, start_vms_result))
+            jobs = jobs[1:]
 
         output.append('Server %s recovery result:' % server)
         headers = [server, 'add-topo', 'deploy-mg']
@@ -305,7 +307,7 @@ if __name__ == '__main__':
     parser.add_argument('--testbed-servers', action='append', type=str, required=True, help='testbed server to recover')
     parser.add_argument('--testbed', default='testbed.csv', help='testbed file(default: testbed.csv)')
     parser.add_argument('--vm-file', default='veos', help='vm inventory file(default: veos)')
-    parser.add_argument('--vm-type', default='veos', help='vm type (veos|ceos|vsonic, default: veos)')
+    parser.add_argument('--vm-type', default='veos', choices=['veos', 'ceos', 'vsonic'], help='vm type (veos|ceos|vsonic, default: veos)')
     parser.add_argument('--inventory', help='Deprecated. Inventory info is already in testbed.(csv|yaml), no need to specify in argument')
     parser.add_argument('--passfile', default='password.txt', help='Ansible vault password file(default: password.txt)')
     parser.add_argument('--skip-cleanup', action='store_true', help='Skip cleanup server')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

The recover_server.py tool prints a summary log reporting recovery
results of each testbed. When vm type is "ceos", the first testbed
is missing from the recover summary log. The issue was introduced
after the recover_server.py script was enhanced to support ceos.
The code printing summary needs to skip the job for "start-vms".
When vm type is ceos, the start-vms job is not needed. However,
the code printing summary always assume that a start-vms job
is there and unnecessary skipped a job when vm type is ceos.
Consequently, the job for the first testbed is skipped.

#### How did you do it?
The fix is to only skip log of the "start-vms" job when vm type is
not ceos.

#### How did you verify/test it?
Run the recover_server.py tool and use vm type "ceos".

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
