### PR TITLE
[decap] Fix issue where the decap test setup fail

### DIFF
--- a/tests/decap/conftest.py
+++ b/tests/decap/conftest.py
@@ -72,4 +72,5 @@ def pytest_generate_tests(metafunc):
   dscp = metafunc.config.getoption("dscp_uniform")
   if "supported_ttl_dscp_params" in metafunc.fixturenames:
       params = build_ttl_dscp_params({'ttl': ttl, 'dscp': dscp})
-      metafunc.parametrize("supported_ttl_dscp_params", params, ids=lambda p: "ttl=%s, dscp=%s" % (p['ttl'], p['dscp']))
+      metafunc.parametrize("supported_ttl_dscp_params", params, ids=lambda p: "ttl=%s, dscp=%s" % (p['ttl'], p['dscp']), scope="module")
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix issue where the decap test setup failed due to metafunc parametrize scope mismatched 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix issue where the decap test setup failed due to metafunc parametrize scope mismatched 

#### How did you do it?
Update the scope for `support_ttl_dscp_params`

#### How did you verify/test it?
Run test on physical DUT and got success
```
decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe] PASSED              [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
