### PR TITLE
Added changes for updating TestbedProcessing module

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -388,7 +388,13 @@ def makeLab(data, devices, testbed, outfile):
                 toWrite.write("[" + key + "]\n")
                 for host in value.get("host"):
                     entry = host
-                    dev = devices.get(host.lower())
+
+                    if host.lower() in devices:
+                        dev = devices.get(host.lower())
+                    elif host.lower() in testbed:
+                        dev = testbed.get(host.lower())
+                    else:
+                        dev = None
 
                     if "ptf" in key:
                         try: #get ansible host
@@ -458,8 +464,8 @@ def makeLab(data, devices, testbed, outfile):
 
                         if card_type != 'supervisor':
                            entry += "\tstart_switchid=" + str( start_switchid )
-                           if num_asic is not None:
-                              start_switchid += int( num_asic )
+                           if num_asics is not None:
+                              start_switchid += int( num_asics )
                            else:
                               start_switchid += 1
 
@@ -525,6 +531,13 @@ def makeLab(data, devices, testbed, outfile):
                                entry += "\tmax_cores=" + str( max_cores )
                         except AttributeError:
                             print("\t\t" + host + " max_cores not found")
+
+                        try: #get os
+                            os = dev.get("os")
+                            if os is not None:
+                               entry += "\tos=" + str( os )
+                        except AttributeError:
+                            print("\t\t" + host + " os not found")
 
                     toWrite.write(entry + "\n")
                 toWrite.write("\n")


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
- Fixed incorrect name of `num_asics` value.
- Added extra approach for getting `os` value from `testbed-new.yaml`.
- Added extra approach for getting `dev` value from `testbed ` dictionary.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Sometimes the device configuration is located in `testbed` dictionary of `testbed-new.yaml` module.
The `fanouthosts` fixture gets 'os' type from `host_vars`. 
#### How did you do it?
Added the possibility for getting `dev` value from `testbed ` dictionary.
Added the possibility for defining os type by the extra parameter `os` in `testbed-new.yaml`.
Example:
_testbed-new.yaml_:
```
devices:
    str-msn2700-01:
        os: sonic               
        device_type: DevSonic                       # source: sonic-mgmt/ansible/files/sonic_lab_devices-github.csv      
```
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
