### PR TITLE
upgrade cEOS to version 4.25.5.1M, fix the issue of arista endless loop

### DIFF
--- a/ansible/group_vars/all/ceos.yml
+++ b/ansible/group_vars/all/ceos.yml
@@ -1,4 +1,4 @@
-ceos_image_filename: cEOS64-lab-4.23.2F.tar.xz
-ceos_image_orig: ceosimage:4.23.2F
-ceos_image: ceosimage:4.23.2F-1
+ceos_image_filename: cEOS64-lab-4.25.5.1M.tar
+ceos_image_orig: ceosimage:4.25.5.1M
+ceos_image: ceosimage:4.25.5.1M-1
 skip_ceos_image_downloading: false

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -91,8 +91,15 @@ class Arista(object):
             self.shell.send(cmd + '\n')
 
         input_buffer = ''
+        loop_times = 0
         while re.search(prompt, input_buffer) is None:
             input_buffer += self.shell.recv(16384)
+            loop_times += 1
+            # cEOS will not return a arista_prompt if you send lots of 'exit' to close the ssh connect(vEOS do will),
+            # then an endless loop emerges,
+            # so if input_buffer is merely an 'exit', we can break the loop immediately
+            if loop_times > 10 and input_buffer.replace('\n', '').replace('\r', '').strip().lower() == 'exit':
+                break
 
         return input_buffer
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
1. cEOS containers' mgmt-ip occasionally unavaillable, upgrade cEOS image version will fix that
2. cEOS terminal behavior slightly different from vEOS, enhance arista.py to avoid endless loop 
#### How did you do it?
1. upgrade cEOS image version
2. break loop if ssh connect returns merely an 'exit', as for other commands who relies on the return  e.g. 'show interfaces po1 | json', 'exit' won't appear in input_buffer, so the change won't influence it.
#### How did you verify/test it?
1. Run platform_tests/test_advanced_reboot.py test on physical testbed and it didn't stuck again.
2. Tried run command 'show interfaces po1 | json', it's not influenced.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
