### PR TITLE
Fix ansible variable VM_targets undefined issue for ptf topology

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -175,7 +175,7 @@
         home_path: "{{ getent_passwd[ansible_user][4] }}"
       when: home_path is not defined
 
-    # root_path is supposed to be absolute path. 
+    # root_path is supposed to be absolute path.
     - set_fact:
         root_path: "{{ home_path + '/' + root_path }}"
       when: "not '{{ root_path }}'.startswith('/')"
@@ -264,6 +264,10 @@
     - name: Generate vm list of target VMs
       set_fact: VM_targets={{ VM_hosts | filter_vm_targets(topology['VMs'], VM_base) | sort }}
       when: topology['VMs'] is defined
+
+    - name: Set fallback default value for VM_targets
+      set_fact: VM_targets={{ [] }}
+      when: VM_targets is not defined
 
     - name: Set vm configuration properties when configuration is defined
       set_fact: vm_properties="{{ configuration | expand_properties(configuration_properties) }}"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
PR #4156 replaced variable `VM_hosts` with `VM_targets` when call the
vm_topology module. With this change, the `vm_topology` module will 
create bridges for VMs used by current testbed instead of create bridges
for all VMs available on the test server.

However, the change missed the ptf topology scenario. In case of
ptf topology, the `VM_targets` ansible variable is not defined. Calling
the `vm_topology` module will fail.

#### How did you do it?
The fix is to assign default value `[]` to `VM_targets` when it is not defined.

#### How did you verify/test it?
Test add-topo/remove-topo for ptf and t0 topologies.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
