### PR TITLE
[loganalyzer]: add option to wait for end marker to appear /var/log/syslog

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -21,7 +21,9 @@ import sys
 import getopt
 import re
 import os
+import os.path
 import csv
+import time
 import pprint
 import logging
 import logging.handlers
@@ -180,7 +182,48 @@ class AnsibleLogAnalyzer:
         syslogger.info('\n')
         self.flush_rsyslogd()
 
-    def place_marker(self, log_file_list, marker):
+    def wait_for_marker(self, marker, timeout=60, polling_interval=10):
+        '''
+        @summary: Wait the marker to appear in the /var/log/syslog file
+        @param marker:         Marker to be placed into log files.
+        @param timeout:        Maximum time in seconds to wait till Marker in /var/log/syslog
+        @param polling_interval:  Polling interval during the wait
+        '''
+
+        wait_time = 0
+        last_check_pos = 0
+        syslog_file = "/var/log/syslog"
+        prev_syslog_file = "/var/log/syslog.1"
+        last_dt = os.path.getctime(syslog_file)
+        while wait_time <= timeout:
+            with open(syslog_file, 'r') as fp:
+                dt = os.path.getctime(syslog_file)
+                if last_dt != dt:
+                    try:
+                        with open(prev_syslog_file, 'r') as pfp:
+                            pfp.seek(last_check_pos)
+                            for l in fp:
+                                if marker in l:
+                                    return True
+                    except FileNotFoundError:
+                        print("cannot find file {}".format(prev_syslog_file))
+                    last_check_pos = 0
+                    last_dt = dt
+                # resume from last search position
+                if last_check_pos:
+                    fp.seek(last_check_pos)
+                # check if marker in the file
+                for l in fp:
+                    if marker in l:
+                        return True
+                # record last search position
+                last_check_pos = fp.tell()
+            time.sleep(polling_interval)
+            wait_time += polling_interval
+
+        return False
+
+    def place_marker(self, log_file_list, marker, wait_for_marker=False):
         '''
         @summary: Place marker into '/dev/log' and each log file specified.
         @param log_file_list : List of file paths, to be applied with marker.
@@ -191,6 +234,9 @@ class AnsibleLogAnalyzer:
             self.place_marker_to_file(log_file, marker)
 
         self.place_marker_to_syslog(marker)
+        if wait_for_marker:
+            if self.wait_for_marker(marker) is False:
+                raise RuntimeError("cannot find marker {} in /var/log/syslog".format(marker))
 
         return
     #---------------------------------------------------------------------
@@ -697,7 +743,7 @@ def main(argv):
         ignore_file_list = ignore_files_in.split(tokenizer)
         expect_file_list = expect_files_in.split(tokenizer)
 
-        analyzer.place_marker(log_file_list, analyzer.create_end_marker())
+        analyzer.place_marker(log_file_list, analyzer.create_end_marker(), wait_for_marker=True)
 
         match_messages_regex, messages_regex_m = analyzer.create_msg_regex(match_file_list)
         ignore_messages_regex, messages_regex_i = analyzer.create_msg_regex(ignore_file_list)
@@ -713,7 +759,7 @@ def main(argv):
         write_result_file(run_id, out_dir, result, messages_regex_e, unused_regex_messages)
         write_summary_file(run_id, out_dir, result, unused_regex_messages)
     elif (action == "add_end_marker"):
-        analyzer.place_marker(log_file_list, analyzer.create_end_marker())
+        analyzer.place_marker(log_file_list, analyzer.create_end_marker(), wait_for_marker=True)
         return 0
 
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

    [loganalyzer]: add option to wait for end marker to appear /var/log/syslog
    
    Due to various reason (disk sync, os scheduling), log analyzer end marker
    cannot be sync to disk (/var/log/syslog) immediately. Lack of end marker
    can cause log analyzer to fail.
    
    this pr add option to wait for end marker to appear in /var/log/syslog
    before return to address above issue.
    
    The implementation uses polling to check if marker appears or not, and set
    maximum wait time to be 60 seconds

#### How did you do it?

    this pr add option to wait for end marker to appear in /var/log/syslog
    before return to address above issue.
    
    The implementation uses polling to check if marker appears or not, and set
    maximum wait time to be 60 seconds

#### How did you verify/test it?

pr test on 202012 image passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
