### PR TITLE
[t0-56] adapt vrf tests to topology t0-56

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -310,8 +310,9 @@ def cleanup_vlan_peer(ptfhost, vlan_peer_vrf2ns_map):
     for vrf, ns in vlan_peer_vrf2ns_map.iteritems():
         ptfhost.shell("ip netns del {}".format(ns))
 
-def gen_vrf_fib_file(vrf, tbinfo, ptfhost, dst_intfs, \
-                     render_file, limited_podset_number=10, limited_tor_number=10):
+def gen_vrf_fib_file(vrf, tbinfo, ptfhost, render_file, dst_intfs=None, \
+                     limited_podset_number=10, limited_tor_number=10):
+    dst_intfs = dst_intfs if dst_intfs else get_default_vrf_fib_dst_intfs(vrf, tbinfo)
     extra_vars = {
         'testbed_type': tbinfo['topo']['name'],
         'props': g_vars['props'],
@@ -324,6 +325,18 @@ def gen_vrf_fib_file(vrf, tbinfo, ptfhost, dst_intfs, \
     ptfhost.host.options['variable_manager'].extra_vars.update(extra_vars)
 
     ptfhost.template(src="vrf/vrf_fib.j2", dest=render_file)
+
+def get_default_vrf_fib_dst_intfs(vrf, tbinfo):
+    dst_intfs = []
+    vms_num = len(tbinfo['topo']['properties']['topology']['VMs'])
+    if vrf == 'Vrf1':
+        dst_intfs_range = list(range(1, int(vms_num / 2) + 1))
+    else:
+        dst_intfs_range = list(range(int(vms_num / 2) + 1, vms_num + 1))
+    for intfs_num in dst_intfs_range:
+        dst_intfs.append('PortChannel000{}'.format(intfs_num))
+
+    return dst_intfs
 
 def gen_vrf_neigh_file(vrf, ptfhost, render_file):
     extra_vars = {
@@ -582,11 +595,9 @@ class TestVrfFib():
     @pytest.fixture(scope="class", autouse=True)
     def setup_fib_test(self, ptfhost, tbinfo):
         gen_vrf_fib_file('Vrf1', tbinfo, ptfhost,
-                    dst_intfs=['PortChannel0001', 'PortChannel0002'],
                     render_file='/tmp/vrf1_fib.txt')
 
         gen_vrf_fib_file('Vrf2', tbinfo, ptfhost,
-                    dst_intfs=['PortChannel0003', 'PortChannel0004'],
                     render_file='/tmp/vrf2_fib.txt')
 
     def test_show_bgp_summary(self, duthosts, rand_one_dut_hostname, cfg_facts):
@@ -628,11 +639,9 @@ class TestVrfIsolation():
     @pytest.fixture(scope="class", autouse=True)
     def setup_vrf_isolation(self, ptfhost, tbinfo):
         gen_vrf_fib_file('Vrf1', tbinfo, ptfhost,
-                    dst_intfs=['PortChannel0001', 'PortChannel0002'],
                     render_file='/tmp/vrf1_fib.txt')
 
         gen_vrf_fib_file('Vrf2', tbinfo, ptfhost,
-                    dst_intfs=['PortChannel0003', 'PortChannel0004'],
                     render_file='/tmp/vrf2_fib.txt')
 
         gen_vrf_neigh_file('Vrf1', ptfhost, render_file="/tmp/vrf1_neigh.txt")
@@ -691,7 +700,7 @@ class TestVrfAclRedirect():
             pytest.skip("Switch does not support ACL REDIRECT_ACTION")
 
     @pytest.fixture(scope="class", autouse=True)
-    def setup_acl_redirect(self, duthosts, rand_one_dut_hostname, cfg_facts):
+    def setup_acl_redirect(self, duthosts, rand_one_dut_hostname, cfg_facts, tbinfo):
         duthost = duthosts[rand_one_dut_hostname]
         # -------- Setup ----------
 
@@ -713,16 +722,16 @@ class TestVrfAclRedirect():
         pc2_v4_neigh_ips = [ (pc2_if_name, str(ip.ip+1)) for ip in pc2_if_ips['ipv4'] ]
         pc2_v6_neigh_ips = [ (pc2_if_name, str(ip.ip+1)) for ip in pc2_if_ips['ipv6'] ]
 
-        pc4_if_name = 'PortChannel0004'
-        pc4_if_ips = get_intf_ips(pc4_if_name, cfg_facts)
-        pc4_v4_neigh_ips = [ (pc4_if_name, str(ip.ip+1)) for ip in pc4_if_ips['ipv4'] ]
-        pc4_v6_neigh_ips = [ (pc4_if_name, str(ip.ip+1)) for ip in pc4_if_ips['ipv6'] ]
+        pc_vrf2_if_name = 'PortChannel000{}'.format(len(tbinfo['topo']['properties']['topology']['VMs']))
+        pc_vrf2_if_ips = get_intf_ips(pc_vrf2_if_name, cfg_facts)
+        pc_vrf2_v4_neigh_ips = [ (pc_vrf2_if_name, str(ip.ip+1)) for ip in pc_vrf2_if_ips['ipv4'] ]
+        pc_vrf2_v6_neigh_ips = [ (pc_vrf2_if_name, str(ip.ip+1)) for ip in pc_vrf2_if_ips['ipv6'] ]
 
-        redirect_dst_ips = pc2_v4_neigh_ips + pc4_v4_neigh_ips
-        redirect_dst_ipv6s = pc2_v6_neigh_ips + pc4_v6_neigh_ips
+        redirect_dst_ips = pc2_v4_neigh_ips + pc_vrf2_v4_neigh_ips
+        redirect_dst_ipv6s = pc2_v6_neigh_ips + pc_vrf2_v6_neigh_ips
         redirect_dst_ports = []
         redirect_dst_ports.append(vrf_intf_ports['Vrf1'][pc2_if_name])
-        redirect_dst_ports.append(vrf_intf_ports['Vrf2'][pc4_if_name])
+        redirect_dst_ports.append(vrf_intf_ports['Vrf2'][pc_vrf2_if_name])
 
         self.c_vars['src_ports'] = src_ports
         self.c_vars['dst_ports'] = dst_ports
@@ -980,7 +989,6 @@ class TestVrfWarmReboot():
     def setup_vrf_warm_reboot(self, ptfhost, tbinfo):
         # -------- Setup ----------
         gen_vrf_fib_file('Vrf1', tbinfo, ptfhost,
-                         dst_intfs=['PortChannel0001', 'PortChannel0002'],
                          render_file='/tmp/vrf1_fib.txt',
                          limited_podset_number=50,
                          limited_tor_number=16)
@@ -1426,7 +1434,6 @@ class TestVrfUnbindIntf():
     @pytest.mark.usefixtures('setup_vrf_rebind_intf')
     def test_vrf1_fib_after_rebind(self, ptfhost, tbinfo, partial_ptf_runner):
         gen_vrf_fib_file('Vrf1', tbinfo, ptfhost,
-                         dst_intfs=['PortChannel0001', 'PortChannel0002'],
                          render_file='/tmp/rebindvrf_vrf1_fib.txt')
 
         partial_ptf_runner(
@@ -1453,11 +1460,9 @@ class TestVrfDeletion():
         duthost = duthosts[rand_one_dut_hostname]
         # -------- Setup ----------
         gen_vrf_fib_file('Vrf1', tbinfo, ptfhost,
-                    dst_intfs=['PortChannel0001', 'PortChannel0002'],
                     render_file="/tmp/vrf1_fib.txt")
 
         gen_vrf_fib_file('Vrf2', tbinfo, ptfhost,
-                    dst_intfs=['PortChannel0003', 'PortChannel0004'],
                     render_file="/tmp/vrf2_fib.txt")
 
         gen_vrf_neigh_file('Vrf1', ptfhost, render_file="/tmp/vrf1_neigh.txt")

--- a/tests/vrf/vrf_config_db.j2
+++ b/tests/vrf/vrf_config_db.j2
@@ -3,10 +3,19 @@
 {%     if k == 'BGP_NEIGHBOR' %}
     "BGP_NEIGHBOR": {
 {%         for neigh in cfg_t0['BGP_NEIGHBOR'] | sort %}
-{%             if cfg_t0['BGP_NEIGHBOR'][neigh]['name'] in ['ARISTA01T1', 'ARISTA02T1'] %}
+{#     to detect number of pcs, used multiplier 2, because each neigh have ipv4 and ipv6 key #}
+{%             if cfg_t0['BGP_NEIGHBOR'] | length == 8  %}
+{%                 if cfg_t0['BGP_NEIGHBOR'][neigh]['name'] in ['ARISTA01T1', 'ARISTA02T1'] %}
         "Vrf1|{{ neigh }}": {{ cfg_t0['BGP_NEIGHBOR'][neigh] | to_nice_json | indent(width=8) }}
-{%-            else %}
+{%-                else %}
         "Vrf2|{{ neigh }}": {{ cfg_t0['BGP_NEIGHBOR'][neigh] | to_nice_json | indent(width=8) }}
+{%-                endif %}
+{%-            else %}
+{%                 if cfg_t0['BGP_NEIGHBOR'][neigh]['name'] in ['ARISTA01T1', 'ARISTA02T1', 'ARISTA03T1', 'ARISTA04T1'] %}
+        "Vrf1|{{ neigh }}": {{ cfg_t0['BGP_NEIGHBOR'][neigh] | to_nice_json | indent(width=8) }}
+{%-                else %}
+        "Vrf2|{{ neigh }}": {{ cfg_t0['BGP_NEIGHBOR'][neigh] | to_nice_json | indent(width=8) }}
+{%-                endif %}
 {%-            endif %}
 {%-            if not loop.last %},{%endif %}
 
@@ -55,12 +64,23 @@
 {%     elif k == 'PORTCHANNEL_INTERFACE' %}
     "PORTCHANNEL_INTERFACE": {
 {%        for pc in cfg_t0['PORTCHANNEL_INTERFACE'] | sort %}
-{%             if pc in ['PortChannel0001', 'PortChannel0002'] %}
+{#     each pc have 3 keys: pc, pc|ipv4 and pc|ipv6 #}
+{%             if cfg_t0['PORTCHANNEL_INTERFACE'] | length == 12  %}
+{%                 if pc in ['PortChannel0001', 'PortChannel0002'] %}
         "{{ pc }}": {"vrf_name": "Vrf1"}
-{%-            elif pc in ['PortChannel0003', 'PortChannel0004'] %}
+{%-                elif pc in ['PortChannel0003', 'PortChannel0004'] %}
         "{{ pc }}": {"vrf_name": "Vrf2"}
-{%-            else %}
+{%-                else %}
         "{{ pc }}": {{ cfg_t0['PORTCHANNEL_INTERFACE'][pc] }}
+{%-                endif %}
+{%-            else %}
+{%                 if pc in ['PortChannel0001', 'PortChannel0002', 'PortChannel0003', 'PortChannel0004'] %}
+        "{{ pc }}": {"vrf_name": "Vrf1"}
+{%-                elif pc in ['PortChannel0005', 'PortChannel0006', 'PortChannel0007', 'PortChannel0008'] %}
+        "{{ pc }}": {"vrf_name": "Vrf2"}
+{%-                else %}
+        "{{ pc }}": {{ cfg_t0['PORTCHANNEL_INTERFACE'][pc] }}
+{%-                endif %}
 {%-            endif %}
 {%-            if not loop.last %},{% endif %}
 

--- a/tests/vrf/vrf_fib.j2
+++ b/tests/vrf/vrf_fib.j2
@@ -5,7 +5,7 @@
 {%- endmacro %}
 
 {# defualt route#}
-{% if testbed_type == 't0' or testbed_type == 't0-64' %}
+{% if testbed_type == 't0' or testbed_type == 't0-64' or testbed_type == 't0-56'%}
 0.0.0.0/0 {{ gen_dst_ports(dst_intfs) }}
 ::/0 {{ gen_dst_ports(dst_intfs) }}
 


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Unlike topology t0 and t0-64, topology t0-56 has 8 PortChannels. Files were changed to use a dynamic number of PortChannels.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
part of the tests adaptation plan

#### How did you do it?

#### How did you verify/test it?
executed on t0 & t0-56 D48C8 setup

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
