### PR TITLE
Load minigraph after test_add_rack to restore config_db.json

### DIFF
--- a/tests/configlet/test_add_rack.py
+++ b/tests/configlet/test_add_rack.py
@@ -108,6 +108,8 @@ def restore_orig_minigraph(duthost):
     if ret["stat"]["exists"]:
         duthost.shell("cp /etc/sonic/orig/minigraph.xml.addRack.orig /etc/sonic/minigraph.xml")
         duthost.shell("chmod u+w /etc/sonic/minigraph.xml")
+        # Reload original minigraph
+        load_minigraph(duthost, duthost.hostname)
         log_info("restored minigraph")
         return True
     else:


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
```config_db.json``` was modified in ```test_add_rack``` and not restored after test running, and this result in ```PortChannel0001``` was missing.
This PR addressed the issue by issuing a ```config load_minigraph``` after ```minigraph.xml``` was restored on DUT, and ```config_db.json``` will be restored from ```minigraph.xml```.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to restore ```config_db.json``` on DUT to unblock other test cases.
 
#### How did you do it?
Issue a ```config load_minigraph``` after ```minigraph.xml``` was restored.

#### How did you verify/test it?
Verified on a T1 testbed, and confirmed that ```config_db.json``` was restored.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
