### PR TITLE
[test_psu] 'skip_release_for_platform' is used without imported

### DIFF
--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -9,6 +9,8 @@ from tests.common.helpers.platform_api import chassis, psu
 from tests.common.utilities import skip_version
 from tests.platform_tests.cli.util import get_skip_mod_list
 from platform_api_test_base import PlatformApiTestBase
+from tests.common.utilities import skip_release_for_platform
+
 
 ###################################################
 # TODO: Remove this after we transition to Python 3


### PR DESCRIPTION
The skip_release_for_platform is used but not imported

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 'skip_release_for_platform' is used without imported in test_psu.py
Fixes # (issue) Add import 'skip_release_for_platform' in test_psu.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Add import 'skip_release_for_platform' in test_psu.py
#### How did you do it?
Add import 'skip_release_for_platform' in test_psu.py
#### How did you verify/test it?
Run the test_psu.py file and it will pass with no err.
#### Any platform specific information?
No, the issue happens on all platform
