### PR TITLE
Skip SFP tests on Arista 7050qx-32s

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -2,8 +2,6 @@ import ast
 import logging
 import pytest
 
-from natsort import natsorted
-
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import sfp
 from tests.common.utilities import skip_version
@@ -34,7 +32,6 @@ pytestmark = [
 @pytest.fixture(scope="class")
 def setup(request, duthosts, enum_rand_one_per_hwsku_hostname, xcvr_skip_list, conn_graph_facts):
     sfp_setup = {}
-    sfp_port_indices = set()
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     skip_release_for_platform(duthost, ["202012"], ["arista_7050_qx32s"])
     
@@ -47,16 +44,16 @@ def setup(request, duthosts, enum_rand_one_per_hwsku_hostname, xcvr_skip_list, c
     physical_port_index_map = get_physical_port_indices(duthost, physical_intfs)
   
     sfp_port_indices = set([physical_port_index_map[intf] \
-        for intf in natsorted(physical_port_index_map.keys())])
-    sfp_setup["sfp_port_indices"] = list(sfp_port_indices)
+        for intf in physical_port_index_map.keys()])
+    sfp_setup["sfp_port_indices"] = sorted(sfp_port_indices)
 
     if len(xcvr_skip_list[duthost.hostname]):
         logging.info("Skipping tests on {}".format(xcvr_skip_list[duthost.hostname]))
 
     sfp_port_indices = set([physical_port_index_map[intf] for intf in \
-                                                natsorted(physical_port_index_map.keys()) \
+                                                physical_port_index_map.keys() \
                                                 if intf not in xcvr_skip_list[duthost.hostname]])
-    sfp_setup["sfp_test_port_indices"] = list(sfp_port_indices)
+    sfp_setup["sfp_test_port_indices"] = sorted(sfp_port_indices)
     if request.cls is not None:
         request.cls.sfp_setup = sfp_setup
 


### PR DESCRIPTION
Signed-off-by: Prince George <prgeor@microsoft.com>


### Description of PR
Skip SFP test on Arista 7050qx-32s for 202012 release

In 7050qx platform the SFP ports 1 to 4 when operational,  QSFP port 5 is not available for use. The SFP test currently don't have any means to know ports that are operational mutually exclusive in a platform. To fix this later on platform.json will be enhanced to capture this information. 

Also, ensure sfp_port_indices[] list is a unique set of indices (i.e no duplicate indices) for breakout case as well .


### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
1. SFP test failure on Arista due to 7050qx-32s incorrect SFP index being tested
2. SFP test failure when breakout is enabled

#### How did you verify/test it?
Ran test_sfp.py successfully on 7050qx  and str2-7050cx3-acs-11(has breakout enabled)

#### Any platform specific information?

SFP test won't run on Arista 7050qx-32s for 202012 release