### PR TITLE
[test_sub_port_interfaces] Improve tests

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -271,7 +271,6 @@ def apply_route_config_for_port(request, duthost, ptfhost, define_sub_ports_conf
 
     sub_ports = define_sub_ports_configuration['sub_ports']
     dut_ports = define_sub_ports_configuration['dut_ports']
-    ptf_ports = define_sub_ports_configuration['ptf_ports']
     port_type = define_sub_ports_configuration['port_type']
     subnet = define_sub_ports_configuration['subnet']
 

--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -94,17 +94,17 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter):
         vlan_ranges_ptf = range(21, 41, 10)
 
     if 'max_numbers' in request.node.name:
-        vlan_ranges_dut = range(20, max_numbers_of_sub_ports + 20)
-        vlan_ranges_ptf = range(20, max_numbers_of_sub_ports + 20)
+        vlan_ranges_dut = range(11, max_numbers_of_sub_ports + 11)
+        vlan_ranges_ptf = range(11, max_numbers_of_sub_ports + 11)
 
         # Linux has the limitation of 15 characters on an interface name,
         # but name of LAG port should have prefix 'PortChannel' and suffix
         # '<0-9999>' on SONiC. So max length of LAG port suffix have be 3 characters
         # For example: 'PortChannel1.99'
         if 'port_in_lag' in request.param:
-            max_numbers_of_sub_ports = max_numbers_of_sub_ports if max_numbers_of_sub_ports <= 99 else 99
-            vlan_ranges_dut = range(20, max_numbers_of_sub_ports + 20)
-            vlan_ranges_ptf = range(20, max_numbers_of_sub_ports + 20)
+            vlan_range_end = min(100, max_numbers_of_sub_ports + 11)
+            vlan_ranges_dut = range(11, vlan_range_end)
+            vlan_ranges_ptf = range(11, vlan_range_end)
 
     interface_num = 2
     ip_subnet = u'172.16.0.0/16'

--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -87,15 +87,15 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter):
     """
     sub_ports_config = {}
     max_numbers_of_sub_ports = request.config.getoption("--max_numbers_of_sub_ports")
-    vlan_ranges_dut = range(10, 50, 10)
-    vlan_ranges_ptf = range(10, 50, 10)
+    vlan_ranges_dut = range(20, 60, 10)
+    vlan_ranges_ptf = range(20, 60, 10)
 
     if 'invalid' in request.node.name:
-        vlan_ranges_ptf = range(11, 31, 10)
+        vlan_ranges_ptf = range(21, 41, 10)
 
     if 'max_numbers' in request.node.name:
-        vlan_ranges_dut = range(1, max_numbers_of_sub_ports + 1)
-        vlan_ranges_ptf = range(1, max_numbers_of_sub_ports + 1)
+        vlan_ranges_dut = range(20, max_numbers_of_sub_ports + 20)
+        vlan_ranges_ptf = range(20, max_numbers_of_sub_ports + 20)
 
         # Linux has the limitation of 15 characters on an interface name,
         # but name of LAG port should have prefix 'PortChannel' and suffix
@@ -103,8 +103,8 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter):
         # For example: 'PortChannel1.99'
         if 'port_in_lag' in request.param:
             max_numbers_of_sub_ports = max_numbers_of_sub_ports if max_numbers_of_sub_ports <= 99 else 99
-            vlan_ranges_dut = range(1, max_numbers_of_sub_ports + 1)
-            vlan_ranges_ptf = range(1, max_numbers_of_sub_ports + 1)
+            vlan_ranges_dut = range(20, max_numbers_of_sub_ports + 20)
+            vlan_ranges_ptf = range(20, max_numbers_of_sub_ports + 20)
 
     interface_num = 2
     ip_subnet = u'172.16.0.0/16'
@@ -275,9 +275,12 @@ def apply_route_config_for_port(request, duthost, ptfhost, define_sub_ports_conf
     port_type = define_sub_ports_configuration['port_type']
     subnet = define_sub_ports_configuration['subnet']
 
-    # Get additional port for configuration of SVI port
+    # Get additional port for configuration of SVI port or L3 RIF
     if 'svi' in request.param:
-        dut_ports, ptf_ports = get_port(duthost, ptfhost, 1, port_type, dut_ports.values())
+        interface_num = 1
+    else:
+        interface_num = 2
+    dut_ports, ptf_ports = get_port(duthost, ptfhost, interface_num, port_type, dut_ports.values(), exclude_sub_interface_ports=True)
 
     # Get additional IP addresses for configuration of RIF on the DUT and PTF
     subnet = ipaddress.ip_network(str(subnet.broadcast_address + 1) + u'/24')
@@ -299,6 +302,8 @@ def apply_route_config_for_port(request, duthost, ptfhost, define_sub_ports_conf
             # Configure additional sub-port for connection between SVI port of the DUT and PTF
             create_sub_port_on_ptf(ptfhost, ptf_port, ptf_port_ip)
         else:
+            # should remove port from Vlan1000 first to configure L3 RIF
+            remove_member_from_vlan(duthost, '1000', dut_port)
             # Configure L3 RIF on the DUT
             add_ip_to_dut_port(duthost, dut_port, dut_port_ip)
             # Configure L3 RIF on the PTF
@@ -350,7 +355,6 @@ def apply_route_config_for_port(request, duthost, ptfhost, define_sub_ports_conf
             remove_static_route(ptfhost, dst_port_network, next_hop_sub_ports['neighbor_ip'])
             remove_namespace(ptfhost, name_of_namespace)
 
-
         if 'svi' in request.param:
             # Remove SVI port from the DUT
             remove_member_from_vlan(duthost, vlan_id, next_hop_sub_ports['dut_port'])
@@ -368,6 +372,12 @@ def apply_route_config_for_port(request, duthost, ptfhost, define_sub_ports_conf
             remove_ip_from_port(duthost, next_hop_sub_ports['dut_port'], ip=next_hop_sub_ports['neighbor_ip'])
             # Remove L3 RIF from the PTF
             remove_ip_from_ptf_port(ptfhost, src_port, next_hop_sub_ports['ip'])
+
+            if 'port_in_lag' in port_type:
+                bond_port = src_port
+                cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+                remove_lag_port(duthost, cfg_facts, next_hop_sub_ports['dut_port'])
+                remove_bond_port(ptfhost, bond_port, ptf_ports[bond_port])
 
     if 'svi' in request.param:
         remove_vlan(duthost, vlan_id)

--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -19,6 +19,9 @@ pytestmark = [
     pytest.mark.topology('t0', 't1')
 ]
 
+PTF_PORT_MAPPING_MODE = 'use_orig_interface'
+
+
 class TestSubPorts(object):
     """
     TestSubPorts class for testing sub-port interfaces


### PR DESCRIPTION
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3832 
Fixes #3833 
Fixes #3874 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Improve `test_port_sub_interfaces`:
1. add support to let it run on storage backend topologies
2. fix existing test issue of `test_routing_between_sub_ports_and_port` that it setups rif on ports that has sub interfaces, such rif doesn't work that it doesn't respond to ARP reply.
3. improve cleanup procedures

#### How did you do it?
1. let the testcase uses vlan ids starting from `20`
2. if the port type is port channel, let the testcase setup port channel from ports that has no sub interfaces(for `t1-backend` testbeds, testcases with port type as port channel will be skipped).
3. for testcase `test_routing_between_sub_ports_and_port`, let the testcase configure rif port from ports that has no sub interfaces(for `t1-backend` testbeds, it will be skipped).
4. for testcase `test_routing_between_sub_ports_and_port`, add steps to cleanup those bond ports on ptf

#### How did you verify/test it?
run on `t0`, `t1`, `t0-backend` and `t1-backend` topologies

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
