### PR TITLE
[fast-reboot] Fix downtime check and prevent false negatives

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -969,19 +969,17 @@ class ReloadTest(BaseTest):
         if self.no_routing_stop - self.reboot_start > datetime.timedelta(seconds=self.test_params['graceful_limit']):
             self.fails['dut'].add("%s cycle must be less than graceful limit %s seconds" % (self.reboot_type, self.test_params['graceful_limit']))
 
-        if 'warm-reboot' in self.reboot_type:
-            if self.total_disrupt_time > self.limit.total_seconds():
-                self.fails['dut'].add("Total downtime period must be less then %s seconds. It was %s" \
-                    % (str(self.limit), str(self.total_disrupt_time)))
+        if self.total_disrupt_time > self.limit.total_seconds():
+            self.fails['dut'].add("Total downtime period must be less then %s seconds. It was %s" \
+                % (str(self.limit), str(self.total_disrupt_time)))
 
+        if 'warm-reboot' in self.reboot_type:
             # after the data plane is up, check for routing changes
             if self.test_params['inboot_oper'] and self.sad_handle:
                 self.check_inboot_sad_status()
-
             # postboot check for all preboot operations
             if self.test_params['preboot_oper'] and self.sad_handle:
                 self.check_postboot_sad_status()
-
             else:
                 # verify there are no interface flaps after warm boot
                 self.neigh_lag_status_check()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix fast-reboot dataplane downtime check logic
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
After PR https://github.com/Azure/sonic-mgmt/pull/4076, fast-reboot downtime calculation is same as warm-reboot's.
However, the verification of the downtime is still used only for warm-reboot.

This is leading to false-negatives for fast-reboot. The test passes even if the downtime is > 30s.

#### How did you do it?
Enable common verification logic for fast and warm-reboot.

#### How did you verify/test it?
Reproduced the issue locally, and verified that with fix, the test fails (as expected), if the downtime is > 30s.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
