### PR TITLE
[test_drop_counters] Relax expected Interface RX_DRP count check by up to 2 packets exceeding expected drop count

### DIFF
--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -95,7 +95,12 @@ def verify_drop_counters(duthosts, asic_index, dut_iface, get_cnt_cli_cmd, colum
         return drop_list
     check_drops_on_dut = lambda: packets_count in get_drops_across_all_duthosts()
     if not wait_until(25, 1, check_drops_on_dut):
-        fail_msg = "'{}' drop counter was not incremented on iface {}. DUT {} == {}; Sent == {}".format(
-            column_key, dut_iface, column_key, get_drops_across_all_duthosts(), packets_count
-        )
-        pytest.fail(fail_msg)
+        # The actual Drop count should always be equal or 1 or 2 packets more than what is expected due to some other drop may occur
+        # over the interface being examined. When that happens if looking onlyu for exact count it will be a false positive failure.
+        # So do one more check to allow up to 2 packets more dropped than what was expected as an allowed case.
+        if ((packets_count+2) in get_drops_across_all_duthosts()) or ((packets_count+1) in get_drops_across_all_duthosts()):
+            logger.warning("Actual drops {} exceeded expected drops {} on iface {}\n".format(actual_drop, packets_count, dut_iface))
+        else:
+            fail_msg = "'{}' drop counter was not incremented on iface {}. DUT {} == {}; Sent == {}".format(
+                column_key, dut_iface, column_key, get_drops_across_all_duthosts(), packets_count)
+            pytest.fail(fail_msg)

--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -98,9 +98,10 @@ def verify_drop_counters(duthosts, asic_index, dut_iface, get_cnt_cli_cmd, colum
         # The actual Drop count should always be equal or 1 or 2 packets more than what is expected due to some other drop may occur
         # over the interface being examined. When that happens if looking onlyu for exact count it will be a false positive failure.
         # So do one more check to allow up to 2 packets more dropped than what was expected as an allowed case.
-        if ((packets_count+2) in get_drops_across_all_duthosts()) or ((packets_count+1) in get_drops_across_all_duthosts()):
+        actual_drop = get_drops_across_all_duthosts()
+        if ((packets_count+2) in actual_drop) or ((packets_count+1) in actual_drop):
             logger.warning("Actual drops {} exceeded expected drops {} on iface {}\n".format(actual_drop, packets_count, dut_iface))
         else:
             fail_msg = "'{}' drop counter was not incremented on iface {}. DUT {} == {}; Sent == {}".format(
-                column_key, dut_iface, column_key, get_drops_across_all_duthosts(), packets_count)
+                column_key, dut_iface, column_key, actual_drop, packets_count)
             pytest.fail(fail_msg)


### PR DESCRIPTION

### Description of PR
Overtime there are natural (expected) drops occurring on interfaces. When that happens during the course of the testcase run the exact match check can cause unnecessary false-positive failures.  Since this should not happen frequently, we should relax the drop count check by up to 2 packets before declaring it as a failure.  For the case where the actual drop count being less than the expected drop count case it will continue to be flagged as failure case just as before.
This false-positive failure condition was found when investigating a nightly test case failure.

Summary:
Fixes # (https://github.com/Azure/sonic-mgmt/issues/4231)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To eliminate false-positive failures that may occur from time to time when the testcase only check for interface RX_DRP counters.

#### How did you verify/test it?
Manually inserted condition to force the false-positive scenario and then with the code fix to observe it triggered the warming logging while allowed the testcase to pass. Here is the example of a test run with fix in place:
```
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /home/gechiang/workspace/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: forked-1.3.0, xdist-1.28.0, html-1.22.1, metadata-1.10.0, repeat-0.9.1, ansible-2.2.2
collected 1 item

drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-ipv4-src]
--------------------------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------------------------
20:58:02 drop_counters.verify_drop_counters       L0103 WARNING| Actual drops [1002] exceeded expected drops 1000 on iface Ethernet120

PASSED                                                                                                                                                                                                                                [100%]

------------------------------------------------------------------------------- generated xml file: /home/gechiang/workspace/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------------------
========================================================================================================= 1 passed in 82.53 seconds =========================================================================================================
INFO:root:Can not get Allure report URL. Please check logs
Exception AttributeError: "'NoneType' object has no attribute 'close'" in <bound method EventDescriptor.__del__ of <ptf.ptfutils.EventDescriptor instance at 0x7f4607c81a00>> ignored
gechiang@f8554d546fef:~/workspace/sonic-mgmt-int/tests$
```

Before the fix:
```
"StartTimeUTC": 2021-09-09T20:38:29.498491Z,
"OSVersion": 20201231.23,
"TestbedName": SONIC_Testbed_xxx,
"Feature": drop_packets,
"FilePath": drop_packets/drop_packets.py,
"TestCase": test_ip_is_zero_addr[port_channel_members-ipv4-src],
"Result": failure,
"Error": false,
"ReportId": 4d69207b-72f4-4c01-b15c-dd9da83fb0cb,
"Summary": Failed: 'RX_DRP' drop counter was not incremented on iface Ethernet112. DUT RX_DRP == [1001]; Sent == 1000,
```