### PR TITLE
upgrade ceos to version 4.25.5.1M, fix the issue of arista endless loop

### DIFF
--- a/ansible/group_vars/all/ceos.yml
+++ b/ansible/group_vars/all/ceos.yml
@@ -1,4 +1,4 @@
-ceos_image_filename: cEOS64-lab-4.23.2F.tar.xz
-ceos_image_orig: ceosimage:4.23.2F
-ceos_image: ceosimage:4.23.2F-1
+ceos_image_filename: cEOS64-lab-4.25.5.1M.tar
+ceos_image_orig: ceosimage:4.25.5.1M
+ceos_image: ceosimage:4.25.5.1M-1
 skip_ceos_image_downloading: false

--- a/ansible/group_vars/all/ceos.yml
+++ b/ansible/group_vars/all/ceos.yml
@@ -1,3 +1,7 @@
+# upgrade cEOS to 4.25.5.1M from 4.23.2F at 2021/09/15
+#ceos_image_filename: cEOS64-lab-4.23.2F.tar.xz
+#ceos_image_orig: ceosimage:4.23.2F
+#ceos_image: ceosimage:4.23.2F-1
 ceos_image_filename: cEOS64-lab-4.25.5.1M.tar
 ceos_image_orig: ceosimage:4.25.5.1M
 ceos_image: ceosimage:4.25.5.1M-1

--- a/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
+++ b/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
@@ -1,7 +1,7 @@
 - block:
   - name: set time out threshold
     set_fact:
-      timeout_threshold: 120
+      timeout_threshold: 240
 
   - name: wait until container's mgmt-ip is reachable
     wait_for:

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -91,8 +91,15 @@ class Arista(object):
             self.shell.send(cmd + '\n')
 
         input_buffer = ''
+        loop_times = 0
         while re.search(prompt, input_buffer) is None:
             input_buffer += self.shell.recv(16384)
+            loop_times += 1
+            # cEOS will not return a arista_prompt if you send lots of 'exit' to close the ssh connect(vEOS do will),
+            # then an endless loop emerges,
+            # so if input_buffer is merely an 'exit', we can break the loop immediately
+            if loop_times > 10 and input_buffer.replace('\n', '').replace('\r', '').strip().lower() == 'exit':
+                break
 
         return input_buffer
 

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -92,8 +92,11 @@ class Arista(object):
             int: command execution status code
             str: command return value
         """
-        stdin, stdout, stderr = self.conn.exec_command(cmd)
-        return stdout.channel.recv_exit_status(), stdout.read()
+        self.log('exec_command is: %s' % (cmd))
+        stdin, stdout, stderr = self.single_conn.exec_command(cmd)
+        (status_code, res) = (stdout.channel.recv_exit_status(), stdout.read())
+        self.log('exec_command return is, status: %d, value: |%s|' % (status_code, res))
+        return status_code, res
 
     def exec_command_compatible(self, *cmds):
         """
@@ -171,6 +174,7 @@ class Arista(object):
             # but wait for v4_routing_ok and v6_routing_ok
             if not quit_enabled:
                 cmd = self.queue.get()
+                self.log('self.queue.get() finish: %s'%(cmd))
                 if cmd == 'quit':
                     quit_enabled = True
                     continue

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -93,7 +93,7 @@ class Arista(object):
             str: command return value
         """
         self.log('exec_command is: %s' % (cmd))
-        stdin, stdout, stderr = self.single_conn.exec_command(cmd)
+        stdin, stdout, stderr = self.conn.exec_command(cmd)
         (status_code, res) = (stdout.channel.recv_exit_status(), stdout.read())
         self.log('exec_command return is, status: %d, value: |%s|' % (status_code, res))
         return status_code, res

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -142,7 +142,8 @@ class Arista(object):
             cur_time = time.time()
             info = {}
             debug_info = {}
-            lacp_output = self.do_cmd('show lacp neighbor')
+            # 'show lacp neighbor' command is deprecated by 'show lacp peer'
+            lacp_output = self.do_cmd('show lacp peer')
             info['lacp'] = self.parse_lacp(lacp_output)
             bgp_neig_output = self.do_cmd('show ip bgp neighbors')
             info['bgp_neig'] = self.parse_bgp_neighbor(bgp_neig_output)
@@ -177,7 +178,7 @@ class Arista(object):
             samples[cur_time] = sample
             if self.DEBUG:
                 debug_data[cur_time] = {
-                    'show lacp neighbor' : lacp_output,
+                    'show lacp peer' : lacp_output,
                     'show ip bgp neighbors' : bgp_neig_output,
                     'show ip route bgp' : bgp_route_v4_output,
                     'show ipv6 route bgp' : bgp_route_v6_output,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
1. cEOS containers' mgmt-ip occasionally unavaillable, upgrade cEOS image version will fix that
2. cEOS terminal behavior slightly different from vEOS, enhance arista.py to avoid endless loop 
#### How did you do it?
1. upgrade cEOS image version
2. break loop if ssh connect returns merely an 'exit', as for other commands who relies on the return  e.g. 'show interfaces po1 | json', 'exit' won't appear in input_buffer, so the change won't influence it.
#### How did you verify/test it?
1. Run platform_tests/test_advanced_reboot.py test on physical testbed and it didn't stuck again.
2. Tried run command 'show interfaces po1 | json', it's not influenced.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
