### PR TITLE
[advanced_reboot] Add regexes for mellanox and 201911 image

### DIFF
--- a/tests/platform_tests/reboot_timing_constants.py
+++ b/tests/platform_tests/reboot_timing_constants.py
@@ -1,26 +1,51 @@
 SERVICE_PATTERNS = {
-    "Stopping": re.compile(r'.*Stopping.*(service|container).*'),
-    "Stopped": re.compile(r'.*Stopped.*(service|container).*'),
-    "Starting": re.compile(r'.*Starting.*(service|container).*'),
-    "Started": re.compile(r'.*Started.*(service|container).*')
+    "LATEST": {
+        "Stopping": re.compile(r'.*Stopping.*(service|container).*'),
+        "Stopped": re.compile(r'.*Stopped.*(service|container).*'),
+        "Starting": re.compile(r'.*Starting.*(service|container).*'),
+        "Started": re.compile(r'.*Started.*(service|container).*')
+    },
+    "201911": {
+        "Stopping": re.compile(r'.*Stopping.*', re.IGNORECASE),
+        "Stopped": re.compile(r'.*Stopped.*', re.IGNORECASE),
+        "Starting": re.compile(r'.*Starting.*', re.IGNORECASE),
+        "Started": re.compile(r'.*Started.*', re.IGNORECASE)
+    }
 }
 
 OTHER_PATTERNS = {
-    "INIT_VIEW|Start": re.compile(r'.*swss#orchagent.*notifySyncd.*sending syncd.*INIT_VIEW.*'),
-    "INIT_VIEW|End": re.compile(r'.*swss#orchagent.*sai_redis_notify_syncd.*switched ASIC to INIT VIEW.*'),
-    "APPLY_VIEW|Start": re.compile(r'.*swss#orchagent.*notifySyncd.*sending syncd.*APPLY_VIEW.*'),
-    "APPLY_VIEW|End": re.compile(r'.*swss#orchagent.*sai_redis_notify_syncd.*switched ASIC to APPLY VIEW.*'),
-    "PORT_INIT|Start": re.compile(r'.*NOTICE swss#orchagent.*initPort: Initialized port.*'),
-    "PORT_READY|Start": re.compile(r'.*swss#orchagent.*updatePortOperStatus.*Port Eth.*oper state set.* to up.*'),
-    "LAG_READY|Start": re.compile(r'.*teamd#tlm_teamd.*try_add_lag.*The LAG \'PortChannel.*\' has been added.*'),
-    "FINALIZER|Start": re.compile(r'.*WARMBOOT_FINALIZER.*Wait for database to become ready.*'),
-    "FINALIZER|End": re.compile(r"(.*WARMBOOT_FINALIZER.*Finalizing warmboot.*)|(.*WARMBOOT_FINALIZER.*warmboot is not enabled.*)"),
-    "SYNCD_CREATE_SWITCH|Start": re.compile(r'.*syncd#syncd.*performWarmRestart: switches defined in warm restart.*'),
-    "SYNCD_CREATE_SWITCH|End": re.compile(r'.*syncd#syncd.*performWarmRestartSingleSwitch: Warm boot: create switch VID.*'),
-    "FPMSYNCD_RECONCILIATION|Start": re.compile(r'.*NOTICE bgp#fpmsyncd: :- main: Warm-Restart timer started.*'),
-    "FPMSYNCD_RECONCILIATION|End": re.compile(r'.*NOTICE bgp#fpmsyncd: :- main: Warm-Restart reconciliation processed.*'),
-    "ROUTE_DEFERRAL_TIMER|Start": re.compile(r'.*ADJCHANGE: neighbor .* in vrf default Up.*'),
-    "ROUTE_DEFERRAL_TIMER|End": re.compile(r'.*rcvd End-of-RIB for IPv4 Unicast from.*')
+    "COMMON": {
+        "PORT_INIT|Start": re.compile(r'.*NOTICE swss#orchagent.*initPort: Initialized port.*'),
+        "PORT_READY|Start": re.compile(r'.*swss#orchagent.*updatePortOperStatus.*Port Eth.*oper state set.* to up.*'),
+        "FINALIZER|Start": re.compile(r'.*WARMBOOT_FINALIZER.*Wait for database to become ready.*'),
+        "FINALIZER|End": re.compile(r"(.*WARMBOOT_FINALIZER.*Finalizing warmboot.*)|(.*WARMBOOT_FINALIZER.*warmboot is not enabled.*)"),
+        "FPMSYNCD_RECONCILIATION|Start": re.compile(r'.*NOTICE bgp#fpmsyncd: :- main: Warm-Restart timer started.*'),
+        "FPMSYNCD_RECONCILIATION|End": re.compile(r'.*NOTICE bgp#fpmsyncd: :- main: Warm-Restart reconciliation processed.*'),
+        "ROUTE_DEFERRAL_TIMER|Start": re.compile(r'.*ADJCHANGE: neighbor .* in vrf default Up.*'),
+        "ROUTE_DEFERRAL_TIMER|End": re.compile(r'.*rcvd End-of-RIB for IPv4 Unicast from.*')
+    },
+    "LATEST": {
+        "INIT_VIEW|Start": re.compile(r'.*swss#orchagent.*notifySyncd.*sending syncd.*INIT_VIEW.*'),
+        "INIT_VIEW|End": re.compile(r'.*swss#orchagent.*sai_redis_notify_syncd.*switched ASIC to INIT VIEW.*'),
+        "APPLY_VIEW|Start": re.compile(r'.*swss#orchagent.*notifySyncd.*sending syncd.*APPLY_VIEW.*'),
+        "APPLY_VIEW|End": re.compile(r'.*swss#orchagent.*sai_redis_notify_syncd.*switched ASIC to APPLY VIEW.*'),
+        "LAG_READY|Start": re.compile(r'.*teamd#tlm_teamd.*try_add_lag.*The LAG \'PortChannel.*\' has been added.*'),
+    },
+    "201911": {
+        "INIT_VIEW|Start": re.compile(r'.*swss#orchagent.*sai_redis_notify_syncd.*sending syncd.*INIT view.*'),
+        "INIT_VIEW|End": re.compile(r'.*swss#orchagent.*initSaiRedis.*Notify syncd INIT_VIEW.*'),
+        "APPLY_VIEW|Start": re.compile(r'.*swss#orchagent.*sai_redis_notify_syncd.*sending syncd.*APPLY view.*'),
+        "APPLY_VIEW|End": re.compile(r'.*syncd#SDK.*notifySyncd.*setting very first run to FALSE, op = APPLY_VIEW.*'),
+        "LAG_READY|Start": re.compile(r'.*teamd#teammgrd.*setLagAdminStatus.*Set port channel PortChannel.*admin status to up')
+    },
+    "BRCM": {
+        "SYNCD_CREATE_SWITCH|Start": re.compile(r'.*syncd#syncd.*performWarmRestart: switches defined in warm restart.*'),
+        "SYNCD_CREATE_SWITCH|End": re.compile(r'.*syncd#syncd.*performWarmRestartSingleSwitch: Warm boot: create switch VID.*'),
+    },
+    "MLNX": {
+        "SYNCD_CREATE_SWITCH|Start": re.compile(r'.*syncd.*mlnx_sai_switch.*mlnx_create_switch: Create switch.*INIT_SWITCH=true.*'),
+        "SYNCD_CREATE_SWITCH|End": re.compile(r'.*syncd#SDK.*mlnx_sai_switch.*mlnx_create_switch.*Created switch Switch ID.*')
+    }
 }
 
 SAIREDIS_PATTERNS = {
@@ -34,9 +59,9 @@ SAIREDIS_PATTERNS = {
 OFFSET_ITEMS = ['DATABASE', 'FINALIZER', 'INIT_VIEW', 'SYNCD_CREATE_SWITCH',
     'FPMSYNCD_RECONCILIATION', 'PORT_INIT', 'PORT_READY', 'SAI_CREATE_SWITCH',
     'NEIGHBOR_ENTRY', 'DEFAULT_ROUTE_SET', 'APPLY_VIEW', 'LAG_READY',
-    'ROUTE_DEFERRAL_TIMER']
+    'FDB_RESTORE', 'ROUTE_DEFERRAL_TIMER']
 
 TIME_SPAN_ITEMS = ['RADV', 'BGP', 'SYNCD', 'SWSS', 'TEAMD', 'DATABASE',
     'SYNCD_CREATE_SWITCH', 'SAI_CREATE_SWITCH', 'APPLY_VIEW', 'INIT_VIEW',
     'NEIGHBOR_ENTRY', 'PORT_INIT', 'PORT_READY', 'FINALIZER', 'LAG_READY',
-    'FPMSYNCD_RECONCILIATION', 'ROUTE_DEFERRAL_TIMER']
+    'FPMSYNCD_RECONCILIATION', 'ROUTE_DEFERRAL_TIMER', 'FDB_RESTORE']

--- a/tests/platform_tests/reboot_timing_constants.py
+++ b/tests/platform_tests/reboot_timing_constants.py
@@ -6,10 +6,10 @@ SERVICE_PATTERNS = {
         "Started": re.compile(r'.*Started.*(service|container).*')
     },
     "201911": {
-        "Stopping": re.compile(r'.*Stopping.*', re.IGNORECASE),
-        "Stopped": re.compile(r'.*Stopped.*', re.IGNORECASE),
-        "Starting": re.compile(r'.*Starting.*', re.IGNORECASE),
-        "Started": re.compile(r'.*Started.*', re.IGNORECASE)
+        "Stopping": re.compile(r'.*Stopping.*'),
+        "Stopped": re.compile(r'.*Stopped.*'),
+        "Starting": re.compile(r'.*Starting.*'),
+        "Started": re.compile(r'.*Started.*')
     }
 }
 

--- a/tests/platform_tests/templates/expect_boot_messages
+++ b/tests/platform_tests/templates/expect_boot_messages
@@ -1,7 +1,6 @@
 r, ".* NOTICE admin: Rebooting with /sbin/kexec -e to.*..."
 
 r, ".* systemd.* (Stopping|Stopped|Starting|Started).* Database container.*"
-
 r, ".* NOTICE admin: (Stopping|Stopped|Starting|Started).* (?!syncd|swss|gbsyncd).* service.*"
 r, ".* NOTICE admin: Stopped.* swss.* service.*"
 r, ".* NOTICE root: (Stopping|Stopped|Starting|Started).* (swss|syncd|gbsyncd).* service.*"
@@ -31,3 +30,25 @@ r, ".*\|c\|SAI_OBJECT_TYPE_FDB_ENTRY.*"
 # bgpd.log messages
 r, ".*ADJCHANGE: neighbor .* in vrf default Up.*"
 r, ".*rcvd End-of-RIB for IPv4 Unicast from.*"
+
+# mlnx specific regexes
+r, ".* syncd.*mlnx_sai_switch.*mlnx_create_switch: Create switch.*INIT_SWITCH=true.*"
+r, ".* syncd#SDK.*mlnx_sai_switch.*mlnx_create_switch.*Created switch Switch ID.*"
+
+# 201911 specific regexes
+r, ".* NOTICE admin: Stopping radv ....*"
+r, ".* INFO systemd.*Stopped Router advertiser container.*"
+r, ".* INFO systemd.*Starting Router advertiser container.*"
+r, ".* INFO systemd.*Started Router advertiser container.*"
+r, ".* NOTICE admin: Stopping bgp.*"
+r, ".* NOTICE admin: Stopped  bgp.*"
+r, ".* INFO systemd.*Started BGP container.*"
+r, ".* NOTICE admin: Stopping teamd.*"
+r, ".* NOTICE admin: Stopped teamd.*"
+r, ".* INFO systemd.*Starting TEAMD container.*"
+r, ".* INFO systemd.*Started TEAMD container.*"
+r, ".* swss#orchagent.*sai_redis_notify_syncd.*sending syncd.*INIT view.*"
+r, ".* swss#orchagent.*initSaiRedis.*Notify syncd INIT_VIEW.*"
+r, ".* swss#orchagent.*sai_redis_notify_syncd.*sending syncd.*APPLY view.*"
+r, ".* syncd#SDK.*notifySyncd.*setting very first run to FALSE, op = APPLY_VIEW.*"
+r, ".* teamd#teammgrd.*setLagAdminStatus.*Set port channel PortChannel.*admin status to up.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add new regexes to support reboot-timing data collection in 201911 images, and MLNX platforms.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To enable reboot time-data collection for older images and other platforms.

#### How did you do it?
Added new regexes.
Separated regexes for 201911 and platform specific.

#### How did you verify/test it?
Tested on a mlnx physical device. Before vs after change:

```
{                                                             {                                                                        
    "offset_from_kexec",                                         "offset_from_kexec": {                                                                                                                                                                      
        "database": "21.012874",                                     "database": "21.427221",                                                                                             
        "finalizer": "21.036351",                                    "finalizer": "21.447488",                                                                                              
        "init_view": "",                                             "init_view": "46.509043",                                                                                     
        "syncd_create_switch": "",                                   "syncd_create_switch": "49.337527",                                                                                               
        "fpmsyncd_reconciliation": "",                               "fpmsyncd_reconciliation": "",                                                                                                   
        "port_init": "58.880123",                                    "port_init": "59.167985",                                                                                              
        "port_ready": "62.84905",                                    "port_ready": "62.912655",                                                                                              
        "sai_create_switch": "48.825303",                            "sai_create_switch": "49.327259",                                                                                                      
        "neighbor_entry": "61.175479",                               "neighbor_entry": "61.430641",                                                                                                   
        "default_route_set": "67.222025",                            "default_route_set": "67.481119",                                                                                                      
        "apply_view": "",                                            "apply_view": "59.057024",                                                                                      
        "lag_ready": "",                                             "lag_ready": "40.283083",                                                                                     
        "route_deferral_timer": "67.164084"                          "route_deferral_timer": "67.48787"              
    },                                                           },                                                                                                                                   
    "controlplane",                                              "controlplane": {                                                                                                                                                                 
        "arp_ping": "",                                              "arp_ping": "",                                                                                    
        "downtime": ""                                               "downtime": ""                                                 
    },                                                           },                                                                                                                                   
    "time_span",                                                 "time_span": {                                                                                                                                                              
        "radv": "",                                                 "radv": "61.153805",                                                                             
        "bgp": "",                                                   "bgp": "57.400839",                                                                               
        "syncd": "50.718939",                                        "syncd": "50.779206",                                                                                          
        "swss": "61.197574",                                         "swss": "62.382224",                                                                                         
        "teamd": "",                                                 "teamd": "64.466507",                                                                                 
        "database": "24.636165",                                     "database": "24.39774",                                                                                             
        "syncd_create_switch": "",                                   "syncd_create_switch": "8.104346",                                                                                               
        "sai_create_switch": "9.488553",                             "sai_create_switch": "9.39597",                                                                                                     
        "apply_view": "",                                            "apply_view": "0.000845",                                                                                      
        "init_view": "",                                             "init_view": "2.809217",                                                                                     
        "neighbor_entry": "9.580305",                                "neighbor_entry": "8.709648",                                                                                                  
        "port_init": "1.691768",                                     "port_init": "1.642174",                                                                                             
        "port_ready": "3.655658",                                    "port_ready": "3.665978",                                                                                              
        "finalizer": "1.53254",                                      "finalizer": "1.671363",                                                                                            
        "lag_ready": "",                                             "lag_ready": "2.163789",                                                                                     
        "fpmsyncd_reconciliation": "",                               "fpmsyncd_reconciliation": "",                                                                                                   
        "route_deferral_timer": "9.561832"                           "route_deferral_timer": "4.79191",                                                           
    },                                                           },                                                                   
    "reboot_type": "fast",                                       "reboot_type": "fast",                                                                                       
    "dataplane",                                                 "dataplane": {                                                                                                                                                              
        "lost_packets": "2976",                                      "lost_packets": "2965",                                                                                            
        "downtime": "17.8233749866"                                  "downtime": "17.8347830772"                                         
    }                                                            }                                                                           
}                                                            }                                                                       
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
