### PR TITLE
[Sensor] Modify the coretemp data format of 7260

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -2395,7 +2395,7 @@ sensors_checks:
       - pmbus-i2c-4-58/vout1/in2_lcrit_alarm
       - pmbus-i2c-4-58/vout1/in2_crit_alarm
       temp:
-      - coretemp-isa-0000/Physical id 0/temp1_crit_alarm
+      - coretemp-isa-0000/Package id 0/temp1_crit_alarm
       - coretemp-isa-0000/Core 0/temp2_crit_alarm
       - coretemp-isa-0000/Core 1/temp3_crit_alarm
       - lm73-i2c-88-48/Front panel temp sensor/temp1_min_alarm
@@ -2429,8 +2429,8 @@ sensors_checks:
       - - pmbus-i2c-4-58/iout1/curr2_input
         - pmbus-i2c-4-58/iout1/curr2_max
       temp:
-      - - coretemp-isa-0000/Physical id 0/temp1_input
-        - coretemp-isa-0000/Physical id 0/temp1_max
+      - - coretemp-isa-0000/Package id 0/temp1_input
+        - coretemp-isa-0000/Package id 0/temp1_max
       - - coretemp-isa-0000/Core 0/temp2_input
         - coretemp-isa-0000/Core 0/temp2_max
       - - coretemp-isa-0000/Core 1/temp3_input


### PR DESCRIPTION
What is the motivation for this PR?
The coretemp data format of 7260 has been changed to "Package id" since 202012 image.

How did you do it?
Modify the coretemp data format of 7260 from "Physical id" to "Package id".

How did you verify/test it?
Run the sensor test.

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
