### PR TITLE
[Ansible][vm_topology] Get all interfaces with `ifconfig -a`

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -842,9 +842,9 @@ class VMTopology(object):
             bool: True if the interface exists. Otherwise False.
         """
         if pid:
-            cmdline = 'nsenter -t %s -n ifconfig %s' % (pid, intf)
+            cmdline = 'nsenter -t %s -n ifconfig -a %s' % (pid, intf)
         else:
-            cmdline = 'ifconfig %s' % intf
+            cmdline = 'ifconfig -a %s' % intf
 
         try:
             VMTopology.cmd(cmdline)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4222

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
`VMTopology.intf_exists` could not retrieve existing down ports with `ifconfig`.

#### How did you do it?
Use `ifconfig -a`

#### How did you verify/test it?
Run `restart-ptf`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
