### PR TITLE
Split mux-simulator server for multiple dualtor testbeds

### DIFF
--- a/ansible/group_vars/all/mux_simulator_http_port_map.yml
+++ b/ansible/group_vars/all/mux_simulator_http_port_map.yml
@@ -1,0 +1,28 @@
+---
+
+# This file contains the mapping from dualtor testbed name to mux-simulator server TCP port
+# A same test server could serve multiple dualtor testbeds. Each dualtor testbed need to have its own
+# instance of mux-simulator server. Different mux-simulator server instances need to listen on different
+# TCP ports. This file maintains the mapping between dualtor testbeds and TCP port of its mux-simulator server.
+
+# This information will be used during deployment of a topology. Mux-simulator server will be started for
+# testbeds on TCP port specified here.
+
+# This information will be used by tests too. Test scripts need to know the TCP port to construct URL for accessing
+# the HTTP API of mux-simulator server.
+
+mux_simulator_http_port:
+    # Format requirement:
+    #   <testbed_name>: <port>
+
+    ### Examples:
+
+    # On server1
+    dualtor-testbed-1: 8080
+    dualtor-testbed-1: 8082
+
+    # On server2
+    dualtor-testbed-3: 8080
+    dualtor-testbed-4: 8082
+
+    #### Add your own port assignment after here ###

--- a/ansible/group_vars/all/variables
+++ b/ansible/group_vars/all/variables
@@ -1,2 +1,0 @@
-mux_simulator_port: 8080
-

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -218,7 +218,7 @@
     include_tasks: ptf_change_mac.yml
     when: topo != 'fullmesh'
 
-  - name: Send arp ping packet to gw for flusing the ARP table
+  - name: Send arp ping packet to gw for flushing the ARP table
     command: docker exec -i ptf_{{ vm_set_name }} python -c "from scapy.all import *; arping('{{ mgmt_gw }}')"
     become: yes
 

--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -6,6 +6,7 @@
 - name: Set variable abs_root_path
   set_fact:
     abs_root_path: "{{ real_root_path.stdout }}"
+    mux_simulator_port: "{{ mux_simulator_http_port[testbed_name] }}"
 
 - name: Start mux simulator
   block:
@@ -21,50 +22,27 @@
       dest: "{{ abs_root_path }}"
       mode: 0755
 
-  - name: Set default mux_simulator_port
-    set_fact:
-      mux_simulator_port: 8080
-    when: mux_simulator_port is not defined
-
   - name: Generate mux-simulator systemd service file
     template:
       src: mux-simulator.service.j2
-      dest: /etc/systemd/system/mux-simulator.service
+      dest: /etc/systemd/system/mux-simulator-{{ mux_simulator_port }}.service
     become: yes
 
-  - name: Start the mux-simulator service
+  - name: Start the mux-simulator service for testbed {{ testbed_name }}
     systemd:
-      name: mux-simulator
+      name: mux-simulator-{{ mux_simulator_port }}
       state: started
       daemon_reload: yes
     become: yes
-
-  - name: Record vm_set of testbed using mux-simulator
-    lineinfile:
-      path: "{{ abs_root_path }}/mux_simulator.setups.txt"
-      line: "{{ vm_set_name }}"
-      state: present
-      create: yes
 
   when: mux_simulator_action == "start"
 
 - name: Stop mux simulator
   block:
 
-  - name: Remove the record of testbed using mux-simulator
-    lineinfile:
-      path: "{{ abs_root_path }}/mux_simulator.setups.txt"
-      line: "{{ vm_set_name }}"
-      state: absent
-
-  - name: Check if the record file is empty
-    command: "grep -P '\\S' {{ abs_root_path }}/mux_simulator.setups.txt"
-    register: record_file_content
-    ignore_errors: yes
-
-  - name: Stop the mux-simulator service if no setup is using it
+  - name: Stop the mux-simulator service for testbed {{ testbed_name }}
     systemd:
-      name: mux-simulator
+      name: mux-simulator-{{ mux_simulator_port }}
       state: stopped
     become: yes
     ignore_errors: yes

--- a/ansible/roles/vm_set/templates/mux-simulator.service.j2
+++ b/ansible/roles/vm_set/templates/mux-simulator.service.j2
@@ -3,4 +3,4 @@ Description=mux simulator
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/env python {{ abs_root_path }}/mux_simulator.py {{ mux_simulator_port }}
+ExecStart=/usr/bin/env python {{ abs_root_path }}/mux_simulator.py {{ mux_simulator_port }} {{ vm_set_name }} -v

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -7,15 +7,15 @@ function usage
   echo "testbed-cli. Interface to testbeds"
   echo "Usage:"
   echo "    $0 [options] (start-vms | stop-vms) <server-name> <vault-password-file>"
-  echo "    $0 [options] (start-topo-vms | stop-topo-vms) <topo-name> <vault-password-file>"
-  echo "    $0 [options] (add-topo | remove-topo | renumber-topo | connect-topo) <topo-name> <vault-password-file>"
-  echo "    $0 [options] refresh-dut <topo-name> <vault-password-file>"
-  echo "    $0 [options] (connect-vms | disconnect-vms) <topo-name> <vault-password-file>"
-  echo "    $0 [options] config-vm <topo-name> <vm-name> <vault-password-file>"
-  echo "    $0 [options] announce-routes <topo-name> <vault-password-file>"
-  echo "    $0 [options] (gen-mg | deploy-mg | test-mg) <topo-name> <inventory> <vault-password-file>"
+  echo "    $0 [options] (start-topo-vms | stop-topo-vms) <testbed-name> <vault-password-file>"
+  echo "    $0 [options] (add-topo | remove-topo | renumber-topo | connect-topo) <testbed-name> <vault-password-file>"
+  echo "    $0 [options] refresh-dut <testbed-name> <vault-password-file>"
+  echo "    $0 [options] (connect-vms | disconnect-vms) <testbed-name> <vault-password-file>"
+  echo "    $0 [options] config-vm <testbed-name> <vm-name> <vault-password-file>"
+  echo "    $0 [options] announce-routes <testbed-name> <vault-password-file>"
+  echo "    $0 [options] (gen-mg | deploy-mg | test-mg) <testbed-name> <inventory> <vault-password-file>"
   echo "    $0 [options] (create-master | destroy-master) <k8s-server-name> <vault-password-file>"
-  echo "    $0 [options] restart-ptf <topo-name> <vault-password-file>"
+  echo "    $0 [options] restart-ptf <testbed-name> <vault-password-file>"
   echo
   echo "Options:"
   echo "    -t <tbfile>     : testbed CSV file name (default: 'testbed.csv')"
@@ -28,7 +28,7 @@ function usage
   echo "Positional Arguments:"
   echo "    <server-name>         : Hostname of server on which to start VMs"
   echo "    <vault-password-file> : Path to file containing Ansible Vault password"
-  echo "    <topo-name>           : Name of the target topology"
+  echo "    <testbed-name>        : Name of the target testbed"
   echo "    <inventory>           : Name of the Ansible inventory containing the DUT"
   echo "    <k8s-server-name>     : Server identifier in form k8s_server_{id}, corresponds to k8s_ubuntu inventory group name"
   echo
@@ -41,31 +41,32 @@ function usage
   echo "        $0 start-vms server-name vault-password-file -e batch_size=2 -e interval=60"
   echo "To enable autostart of VMs:"
   echo "        $0 start-vms server-name vault-password-file -e autostart=yes"
-  echo "To start VMs for specified topology on server: $0 start-topo-vms 'topo-name' ~/.password"
+  echo "To start VMs for specified testbed on server: $0 start-topo-vms 'testbed-name' ~/.password"
   echo "To stop all VMs on a server:  $0 stop-vms 'server-name' ~/.password"
-  echo "To stop VMs for specified topology on server: $0 stop-topo-vms 'topo-name' ~/.password"
+  echo "To stop VMs for specified testbed on server: $0 stop-topo-vms 'testbed-name' ~/.password"
   echo "To cleanup *all* vms and docker: $0 cleanup-vmhost 'server-name' ~/.password"
-  echo "To deploy a topology on a server: $0 add-topo 'topo-name' ~/.password"
+  echo "To deploy topology for specified testbed on a server: $0 add-topo 'testbed-name' ~/.password"
   echo "    Optional argument for add-topo:"
   echo "        -e ptf_imagetag=<tag>    # Use PTF image with specified tag for creating PTF container"
-  echo "To remove a topology on a server: $0 remove-topo 'topo-name' ~/.password"
-  echo "To remove a topology and keysight-api-server container on a server: $0 remove-topo 'topo-name' ~/.password remove_keysight_api_server"
-  echo "To renumber a topology on a server: $0 renumber-topo 'topo-name' ~/.password"
-  echo "To connect a topology: $0 connect-topo 'topo-name' ~/.password"
-  echo "To refresh DUT in a topology: $0 refresh-dut 'topo-name' ~/.password"
-  echo "To configure a VM on a server: $0 config-vm 'topo-name' 'vm-name' ~/.password"
-  echo "To announce routes to DUT: $0 announce-routes 'topo-name' ~/.password"
-  echo "To generate minigraph for DUT in a topology: $0 gen-mg 'topo-name' 'inventory' ~/.password"
-  echo "To deploy minigraph to DUT in a topology: $0 deploy-mg 'topo-name' 'inventory' ~/.password"
+  echo "To remove topology for specified testbed on a server: $0 remove-topo 'testbed-name' ~/.password"
+  echo "To remove topology and keysight-api-server container for specified testbedon a server:"
+  echo "        $0 remove-topo 'testbed-name' ~/.password remove_keysight_api_server"
+  echo "To renumber topology for specified testbed on a server: $0 renumber-topo 'testbed-name' ~/.password"
+  echo "To connect topology for specified testbed: $0 connect-topo 'testbed-name' ~/.password"
+  echo "To refresh DUT of specified testbed: $0 refresh-dut 'testbed-name' ~/.password"
+  echo "To configure VMs for specified testbed on a server: $0 config-vm 'testbed-name' 'vm-name' ~/.password"
+  echo "To announce routes to DUT for specified testbed: $0 announce-routes 'testbed-name' ~/.password"
+  echo "To generate minigraph for DUT in specified testbed: $0 gen-mg 'testbed-name' 'inventory' ~/.password"
+  echo "To deploy minigraph to DUT in specified testbed: $0 deploy-mg 'testbed-name' 'inventory' ~/.password"
   echo "    gen-mg, deploy-mg, test-mg supports enabling/disabling data ACL with parameter"
   echo "        -e enable_data_plane_acl=true"
   echo "        -e enable_data_plane_acl=false"
   echo "        by default, data acl is enabled"
   echo "To create Kubernetes master on a server: $0 -m k8s_ubuntu create-master 'k8s-server-name'  ~/.password"
   echo "To destroy Kubernetes master on a server: $0 -m k8s_ubuntu destroy-master 'k8s-server-name' ~/.password"
-  echo "To restart ptf defined in testbed: $0 restart-ptf 'topo-name' ~/.password"
+  echo "To restart ptf of specified testbed: $0 restart-ptf 'testbed-name' ~/.password"
   echo
-  echo "You should define your topology in testbed CSV file"
+  echo "You should define your testbed in testbed CSV file"
   echo
   exit
 }
@@ -77,17 +78,17 @@ function read_csv
 
   if [ $? -ne 0 ]
   then
-   echo "Couldn't find topology name '$1'"
+   echo "Couldn't find testbed name '$1'"
    exit
   fi
 
   NL='
 '
   case $line in
-    *"$NL"*) echo "Find more than one topology names in $tbfile"
+    *"$NL"*) echo "Find more than one testbed names in $tbfile"
              exit
              ;;
-          *) echo Found topology $1
+          *) echo "Found testbed $1"
              ;;
   esac
 
@@ -115,14 +116,14 @@ function read_yaml
 
   if [ $linecount == 0 ]
   then
-    echo "Couldn't find topology name '$1'"
+    echo "Couldn't find testbed name '$1'"
     exit
   elif [ $linecount -gt 1 ]
   then
-    echo "Find more than one topology name in $tbfile"
+    echo "Find more than one testbed name in $tbfile"
     exit
   else
-    echo found topology $1
+    echo found testbed $1
   fi
 
   tb_line=${tb_lines[0]}
@@ -153,10 +154,10 @@ function read_file
 
   if [[ $tbfile == *.csv ]]
   then
-    read_csv ${topology}
+    read_csv ${testbed_name}
   elif [[ $tbfile == *.yaml ]]
   then
-    read_yaml ${topology}
+    read_yaml ${testbed_name}
   fi
 }
 
@@ -185,39 +186,39 @@ function stop_vms
 
 function start_topo_vms
 {
-  topology=$1
+  testbed_name=$1
   passwd=$2
   shift
   shift
-  read_file ${topology}
+  read_file ${testbed_name}
 
-  echo "Starting VMs for topology '${topology}' on server '${server}'"
+  echo "Starting VMs for testbed '${testbed_name}' on server '${server}'"
 
   ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_start_VMs.yml --vault-password-file="${passwd}" -l "${server}" -e VM_base="$vm_base" -e topo="$topo" $@
 }
 
 function stop_topo_vms
 {
-  topology=$1
+  testbed_name=$1
   passwd=$2
   shift
   shift
-  read_file ${topology}
+  read_file ${testbed_name}
 
-  echo "Stopping VMs for topology '${topology}' on server '${server}'"
+  echo "Stopping VMs for testbed '${testbed_name}' on server '${server}'"
 
   ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_stop_VMs.yml --vault-password-file="${passwd}" -l "${server}" -e VM_base="$vm_base" -e topo="$topo" $@
 }
 
 function add_topo
 {
-  topology=$1
+  testbed_name=$1
   passwd=$2
   shift
   shift
-  echo "Deploying topology '${topology}'"
+  echo "Deploying topology for testbed '${testbed_name}'"
 
-  read_file ${topology}
+  read_file ${testbed_name}
 
   echo "$dut" "$duts"
 
@@ -226,7 +227,7 @@ function add_topo
   fi
 
   ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_add_vm_topology.yml --vault-password-file="${passwd}" -l "$server" \
-        -e topo_name="$topo_name" -e duts_name="$duts" -e VM_base="$vm_base" \
+        -e testbed_name="$testbed_name" -e duts_name="$duts" -e VM_base="$vm_base" \
         -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" \
         -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" \
         $ansible_options $@
@@ -243,13 +244,13 @@ function add_topo
 
 function remove_topo
 {
-  topology=$1
+  testbed_name=$1
   passwd=$2
   shift
   shift
-  echo "Removing topology '${topology}'"
+  echo "Removing topology for testbed '${testbed_name}'"
 
-  read_file ${topology}
+  read_file ${testbed_name}
 
   remove_keysight_api_server=0
   for i in "$@"
@@ -265,7 +266,7 @@ function remove_topo
   fi
 
   ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_remove_vm_topology.yml --vault-password-file="${passwd}" -l "$server" \
-      -e topo_name="$topo_name" -e duts_name="$duts" -e VM_base="$vm_base" \
+      -e testbed_name="$testbed_name" -e duts_name="$duts" -e VM_base="$vm_base" \
       -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" \
       -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" \
       -e remove_keysight_api_server="$remove_keysight_api_server" \
@@ -276,18 +277,18 @@ function remove_topo
 
 function connect_topo
 {
-  topology=$1
+  testbed_name=$1
   passwd=$2
   shift
   shift
 
-  echo "Connect to Topology '${topology}'"
+  echo "Connect topology for testbed '${testbed_name}'"
 
-  read_file ${topology}
+  read_file ${testbed_name}
 
   ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_connect_topo.yml \
                      --vault-password-file="${passwd}" --limit "$server" \
-                     -e topo_name="$topo_name" -e duts_name="$duts" \
+                     -e duts_name="$duts" \
                      -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" \
                      -e topo="$topo" -e vm_set_name="$vm_set_name" \
                      -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" $@
@@ -299,15 +300,15 @@ function connect_topo
 
 function renumber_topo
 {
-  topology=$1
+  testbed_name=$1
   passwd=$2
   shift
   shift
-  echo "Renumbering topology '${topology}'"
+  echo "Renumbering topology for testbed '${testbed_name}'"
 
-  read_file ${topology}
+  read_file ${testbed_name}
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_renumber_vm_topology.yml --vault-password-file="${passwd}" -l "$server" -e topo_name="$topo_name" -e duts_name="$duts" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" -e ptf_imagename="$ptf_imagename" -e ptf_ipv6="$ptf_ipv6" $@
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_renumber_vm_topology.yml --vault-password-file="${passwd}" -l "$server" -e duts_name="$duts" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" -e ptf_imagename="$ptf_imagename" -e ptf_ipv6="$ptf_ipv6" $@
 
   ansible-playbook fanout_connect.yml -i $vmfile --limit "$server" --vault-password-file="${passwd}" -e "dut=$duts" $@
 
@@ -316,36 +317,36 @@ function renumber_topo
 
 function restart_ptf
 {
-  topology=$1
+  testbed_name=$1
   passwd=$2
   shift
   shift
 
-  read_file ${topology}
+  read_file ${testbed_name}
 
-  echo "Restart ptf for testbed '${vm_set_name}'"
+  echo "Restart ptf ptf_${vm_set_name} for testbed '${testbed_name}'"
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_renumber_vm_topology.yml --vault-password-file="${passwd}" -l "$server" -e topo_name="$topo_name" -e duts_name="$duts" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" -e ptf_imagename="$ptf_imagename" -e ptf_ipv6="$ptf_ipv6" $@
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_renumber_vm_topology.yml --vault-password-file="${passwd}" -l "$server" -e duts_name="$duts" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" -e ptf_imagename="$ptf_imagename" -e ptf_ipv6="$ptf_ipv6" $@
 
   echo Done
 }
 
 function refresh_dut
 {
-  topology=$1
+  testbed_name=$1
   passwd=$2
   shift
   shift
-  echo "Refresh $duts in  '${topology}'"
+  echo "Refresh $duts in testbed '${testbed_name}'"
 
-  read_file ${topology}
+  read_file ${testbed_name}
 
   if [ -n "$sonic_vm_dir" ]; then
       ansible_options="-e sonic_vm_storage_location=$sonic_vm_dir"
   fi
 
   ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_add_vm_topology.yml --vault-password-file="${passwd}" -l "$server" \
-        -e topo_name="$topo_name" -e duts_name="$duts" -e VM_base="$vm_base" \
+        -e testbed_name="$testbed_name" -e duts_name="$duts" -e VM_base="$vm_base" \
         -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" \
         -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" \
         -e force_stop_sonic_vm="yes" \
@@ -360,7 +361,7 @@ function connect_vms
 
   read_file $1
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_connect_vms.yml --vault-password-file="$2" -l "$server" -e topo_name="$topo_name" -e duts_name="$duts" -e VM_base="$vm_base" -e topo="$topo" -e vm_set_name="$vm_set_name"
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_connect_vms.yml --vault-password-file="$2" -l "$server" -e duts_name="$duts" -e VM_base="$vm_base" -e topo="$topo" -e vm_set_name="$vm_set_name"
 
   echo Done
 }
@@ -371,21 +372,21 @@ function disconnect_vms
 
   read_file $1
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_disconnect_vms.yml --vault-password-file="$2" -l "$server" -e topo_name="$topo_name" -e duts_name="$duts" -e VM_base="$vm_base" -e topo="$topo" -e vm_set_name="$vm_set_name"
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_disconnect_vms.yml --vault-password-file="$2" -l "$server" -e duts_name="$duts" -e VM_base="$vm_base" -e topo="$topo" -e vm_set_name="$vm_set_name"
 
   echo Done
 }
 
 function announce_routes
 {
-  topology=$1
+  testbed_name=$1
   passfile=$2
   shift
   shift
 
-  echo "Announce routes '$topology'"
+  echo "Announce routes to DUTs of testbed '$testbed_name'"
 
-  read_file $topology
+  read_file $testbed_name
 
   ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_announce_routes.yml --vault-password-file="$passfile" \
       -l "$server" -e vm_set_name="$vm_set_name" -e topo="$topo" -e ptf_ip="$ptf_ip" $@
@@ -395,54 +396,54 @@ function announce_routes
 
 function generate_minigraph
 {
-  topology=$1
+  testbed_name=$1
   inventory=$2
   passfile=$3
   shift
   shift
   shift
 
-  echo "Generating minigraph '$topology'"
+  echo "Generating minigraph for testbed '$testbed_name'"
 
-  read_file $topology
+  read_file $testbed_name
 
-  ansible-playbook -i "$inventory" config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$duts" -e testbed_name="$topology" -e testbed_file=$tbfile -e vm_file=$vmfile -e local_minigraph=true $@
+  ansible-playbook -i "$inventory" config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$duts" -e testbed_name="$testbed_name" -e testbed_file=$tbfile -e vm_file=$vmfile -e local_minigraph=true $@
 
   echo Done
 }
 
 function deploy_minigraph
 {
-  topology=$1
+  testbed_name=$1
   inventory=$2
   passfile=$3
   shift
   shift
   shift
 
-  echo "Deploying minigraph '$topology'"
+  echo "Deploying minigraph to testbed '$testbed_name'"
 
-  read_file $topology
+  read_file $testbed_name
 
-  ansible-playbook -i "$inventory" config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$duts" -e testbed_name="$topology" -e testbed_file=$tbfile -e vm_file=$vmfile -e deploy=true -e save=true $@
+  ansible-playbook -i "$inventory" config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$duts" -e testbed_name="$testbed_name" -e testbed_file=$tbfile -e vm_file=$vmfile -e deploy=true -e save=true $@
 
   echo Done
 }
 
 function test_minigraph
 {
-  topology=$1
+  testbed_name=$1
   inventory=$2
   passfile=$3
   shift
   shift
   shift
 
-  echo "Test minigraph generation '$topology'"
+  echo "Test minigraph generation for testbed '$testbed_name'"
 
-  read_file $topology
+  read_file $testbed_name
 
-  ansible-playbook -i "$inventory" --diff --connection=local --check config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$duts" -e testbed_name="$topology" -e testbed_file=$tbfile -e vm_file=$vmfile -e local_minigraph=true $@
+  ansible-playbook -i "$inventory" --diff --connection=local --check config_sonic_basedon_testbed.yml --vault-password-file="$passfile" -l "$duts" -e testbed_name="$testbed_name" -e testbed_file=$tbfile -e vm_file=$vmfile -e local_minigraph=true $@
 
   echo Done
 }

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -38,6 +38,10 @@
     fail: msg="Please use -l server_X to limit this playbook to one host"
     when: "{{ play_hosts|length }} != 1"
 
+  - name: Check that variable testbed_name is defined
+    fail: msg="Define testbed_name variable with -e testbed_name=something"
+    when: testbed_name is not defined
+
   - name: Check that variable vm_set_name is defined
     fail: msg="Define vm_set_name variable with -e vm_set_name=something"
     when: vm_set_name is not defined

--- a/ansible/testbed_remove_vm_topology.yml
+++ b/ansible/testbed_remove_vm_topology.yml
@@ -23,6 +23,10 @@
     fail: msg="Please use -l server_X to limit this playbook to one host"
     when: "{{ play_hosts|length }} != 1"
 
+  - name: Check that variable testbed_name is defined
+    fail: msg="Define testbed_name variable with -e testbed_name=something"
+    when: testbed_name is not defined
+
   - name: Check that variable vm_set_name is defined
     fail: msg="Define vm_set_name variable with -e vm_set_name=something"
     when: vm_set_name is not defined

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -107,12 +107,12 @@ def _post(server_url, data):
     """
     try:
         server_url = '{}?reqId={}'.format(server_url, uuid.uuid4())  # Add query string param reqId for debugging
-        logger.debug('POST {} with {}'.format(server_url, data))
+        logger.debug('POST {} with {}'.format(server_url, data))     # lgtm [py/clear-text-logging-sensitive-data]
         headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
         resp = requests.post(server_url, json=data, headers=headers)
         return resp.status_code == 200
     except Exception as e:
-        logger.warn("POST {} with data {} failed, err: {}".format(server_url, data, repr(e)))
+        logger.warn("POST {} with data {} failed, err: {}".format(server_url, data, repr(e)))  # lgtm [py/clear-text-logging-sensitive-data]
 
     return False
 

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import time
 import json
+import uuid
 
 import requests
 
@@ -31,9 +32,11 @@ def mux_server_url(request, tbinfo):
     if 'dualtor' in tbinfo['topo']['name']:
         server = tbinfo['server']
         vmset_name = tbinfo['group-name']
+
         inv_files = request.config.option.ansible_inventory
         ip = utilities.get_test_server_vars(inv_files, server).get('ansible_host')
-        port = utilities.get_group_visible_vars(inv_files, server).get('mux_simulator_port')
+        _port_map = utilities.get_group_visible_vars(inv_files, server).get('mux_simulator_http_port')
+        port = _port_map[tbinfo['conf-name']]
         return "http://{}:{}/mux/{}".format(ip, port, vmset_name)
     return ""
 
@@ -103,6 +106,7 @@ def _post(server_url, data):
         True if succeed. False otherwise
     """
     try:
+        server_url = '{}?reqId={}'.format(server_url, uuid.uuid4())  # Add query string param reqId for debugging
         logger.debug('POST {} with {}'.format(server_url, data))
         headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
         resp = requests.post(server_url, json=data, headers=headers)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -491,7 +491,7 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds):
 @pytest.fixture(scope="session")
 def vmhost(ansible_adhoc, request, tbinfo):
     server = tbinfo["server"]
-    inv_files = request.config.option.ansible_inventory
+    inv_files = get_inventory_files(request)
     vmhost = get_test_server_host(inv_files, server)
     return VMHost(ansible_adhoc, vmhost.name)
 

--- a/tests/templates/y_cable_simulator_client.j2
+++ b/tests/templates/y_cable_simulator_client.j2
@@ -2,6 +2,7 @@ from urllib import request, error
 import json
 import os
 import re
+import uuid
 from sonic_py_common import logger, device_info
 from portconfig import get_port_config
 from natsort import natsorted
@@ -147,7 +148,7 @@ def _url(physical_port, action=None):
     """
     host_intf_index = _physical_port_to_host_port(physical_port)
     url = BASE_URL + "/mux/{}/{}".format(VM_SET, host_intf_index)
-    
+
     if action:
         url += "/{}".format(action)
 
@@ -165,7 +166,9 @@ def _post(physical_port, data):
     """
     data = json.dumps(data).encode(encoding='utf-8')
     header = {'Accept': 'application/json', 'Content-Type': 'application/json'}
-    req = request.Request(url=_url(physical_port), data=data, headers=header)
+    url = '{}?reqId={}'.format(_url(physical_port), uuid.uuid4())
+    req = request.Request(url=url, data=data, headers=header)
+    helper_logger.log_info('POST {} with {}'.format(url, data))
     try:
         _ = request.urlopen(req)
     except error.HTTPError as e:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
A test server may serve multiple dualtor testbeds. The original design is to start
a single `mux-simulator` systemd service for all the dualtor testbeds using the
server. It turns out that this approach is not flexible enough. Sometimes we may
need to restart the mux-simulator server for one testbed. If the other testbeds
are running tests, they could be negatively affected.

#### How did you do it?
The new design is to have a mux simulator service running for each testbed. Each
of the mux simulator server listens on different TCP port. A dedicate mux simulator
systemd service is created for each testbed. Each of them has its own listening port
and log files.

Related mux simulator control lib, y_cable driver and code for injecting y_cable
driver have been updated accordingly.

Other improvements:
* Remove unused variable "-e topo_name" in testbed-cli.sh calling ansibe playbook
* In testbed-cli.sh help message, rename topo-name to testbed-name which is easier
  to understand
* Enhance mux-simulator to support new API `/mux/<vm_set>/reload` for reloading
  mux status
* Enhance mux-simulator to support new API `/mux/<vm_set>/log` for logging a message
  to log of mux simulator server
* Enhance mux simulator control lib and y_cable driver to append an UUID as query
  parameter to URL of POST request for debugging purpose. The UUID can be used to
  correlate mux simulator server logs and client side logs.
* Updated the mux simulator document.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
