### PR TITLE
Add file check to enable fixture/testcases on platforms with no thermal_policy file support

### DIFF
--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -303,9 +303,10 @@ class ThermalPolicyFileContext:
         thermal control daemon to make it effect.
         :return:
         """
-        self.dut.command('mv -f {} {}'.format(self.thermal_policy_file_path, self.thermal_policy_file_backup_path))
-        self.dut.copy(src=os.path.join(FILES_DIR, self.src), dest=self.thermal_policy_file_path)
-        restart_thermal_control_daemon(self.dut)
+        if os.path.exists(self.thermal_policy_file_path):
+            self.dut.command('mv -f {} {}'.format(self.thermal_policy_file_path, self.thermal_policy_file_backup_path))
+            self.dut.copy(src=os.path.join(FILES_DIR, self.src), dest=self.thermal_policy_file_path)
+            restart_thermal_control_daemon(self.dut)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """
@@ -315,8 +316,10 @@ class ThermalPolicyFileContext:
         :param exc_tb: Not used.
         :return:
         """
-        self.dut.command('mv -f {} {}'.format(self.thermal_policy_file_backup_path, self.thermal_policy_file_path))
-        restart_thermal_control_daemon(self.dut)
+
+        if os.path.exists(self.thermal_policy_file_backup_path):
+            self.dut.command('mv -f {} {}'.format(self.thermal_policy_file_backup_path, self.thermal_policy_file_path))
+            restart_thermal_control_daemon(self.dut)
 
 
 @pytest.fixture

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -305,8 +305,8 @@ class ThermalPolicyFileContext:
         """
         if os.path.exists(self.thermal_policy_file_path):
             self.dut.command('mv -f {} {}'.format(self.thermal_policy_file_path, self.thermal_policy_file_backup_path))
-            self.dut.copy(src=os.path.join(FILES_DIR, self.src), dest=self.thermal_policy_file_path)
-            restart_thermal_control_daemon(self.dut)
+        self.dut.copy(src=os.path.join(FILES_DIR, self.src), dest=self.thermal_policy_file_path)
+        restart_thermal_control_daemon(self.dut)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -305,6 +305,8 @@ class ThermalPolicyFileContext:
         """
         if os.path.exists(self.thermal_policy_file_path):
             self.dut.command('mv -f {} {}'.format(self.thermal_policy_file_path, self.thermal_policy_file_backup_path))
+        else:
+            logging.warning("Thermal Policy file {} not found".format(self.thermal_policy_file_path))
         self.dut.copy(src=os.path.join(FILES_DIR, self.src), dest=self.thermal_policy_file_path)
         restart_thermal_control_daemon(self.dut)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Testcases and fixtures that use ThermalPolicyFileContext class fail on platforms that do not use thermal_policy.json. This causes system_health and other platform_info tests to fail

Summary:
Fixes https://github.com/Azure/sonic-buildimage/issues/8446

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Certain Dell platforms do not support thermal_policy.json. A few testcases like test_system_health.py::test_device_checker and multiple cases in test_platform_info.py fail while trying to load a new thermal_policy as part of the fixture. 

#### How did you do it?
Added a file check before the thermal policy file is accessed

#### How did you verify/test it?
Validated by running test_system_health.py and test_platform_info.py on Dell 9332 (no thermal_policy file) and on DX010 which supports thermal_policy to ensure the testcases continue to work

#### Any platform specific information?
Check added for Dell platforms which do not support thermal_policy

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
