### PR TITLE
[Platform API][pytest] fix test_platform_info.py::test_thermal_control_load_invalid_value_json

### DIFF
--- a/tests/platform_tests/files/invalid_value_policy.json
+++ b/tests/platform_tests/files/invalid_value_policy.json
@@ -22,6 +22,10 @@
                 {
                     "type": "fan.all.set_speed",
                     "speed": "-1"
+                },
+                {
+                    "type": "fan.all.set_speed",
+                    "speed": "-1"
                 }
             ]
         }


### PR DESCRIPTION

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:

-->
### Description of PR
Currently Arista Platforms do not support speed setting of fans in the thermalctl script, so in order to apply an invalid value policy what we would do is apply a duplicate policy, in order to raise an exception and hence loganalyzer issue would be fixed.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Ran the changes on Arista7050cx3 testbed

#### How did you verify/test it?
Verified that the test case works fine. 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
