### PR TITLE
[platform test][202012] Skip unsupported platform api test on all arista platform

### DIFF
--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -161,7 +161,7 @@ class TestPsuApi(PlatformApiTestBase):
     def test_power(self, duthost, localhost, platform_api_conn):
         ''' PSU power test '''
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
+        skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
 
         for psu_id in range(self.num_psus):
             name = psu.get_name(platform_api_conn, psu_id)
@@ -207,7 +207,7 @@ class TestPsuApi(PlatformApiTestBase):
     def test_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         ''' PSU temperature test '''
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
+        skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
 
         for psu_id in range(self.num_psus):
             name = psu.get_name(platform_api_conn, psu_id)

--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -203,7 +203,7 @@ class TestThermalApi(PlatformApiTestBase):
 
     def test_set_low_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
+        skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
 
         # Ensure the thermal temperature is sane
         for i in range(self.num_thermals):
@@ -222,7 +222,7 @@ class TestThermalApi(PlatformApiTestBase):
 
     def test_set_high_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
+        skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
 
         # Ensure the thermal temperature is sane
         for i in range(self.num_thermals):

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -346,7 +346,7 @@ def test_show_platform_firmware_status(duthosts, enum_rand_one_per_hwsku_hostnam
     @summary: Verify output of `show platform firmware status`
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista_7050"])
+    skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
 
 
     cmd = " ".join([CMD_SHOW_PLATFORM, "firmware", "status"])

--- a/tests/platform_tests/daemon/test_ledd.py
+++ b/tests/platform_tests/daemon/test_ledd.py
@@ -127,7 +127,7 @@ def test_pmon_ledd_term_and_start_status(check_daemon_status, duthosts, rand_one
 
     duthost.stop_pmon_daemon(daemon_name, SIG_TERM, pre_daemon_pid)
 
-    wait_until(30, 10, check_expected_daemon_status, duthost, expected_running_status)
+    wait_until(50, 10, check_expected_daemon_status, duthost, expected_running_status)
 
     post_daemon_status, post_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     pytest_assert(post_daemon_status == expected_running_status,

--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -19,7 +19,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.daemon_utils import check_pmon_daemon_enable_status
 from tests.common.platform.processes_utils import wait_critical_processes, check_critical_processes
 from tests.common.utilities import compose_dict_from_cli
-from tests.common.utilities import wait_until
+from tests.common.utilities import wait_until, skip_release
 
 logger = logging.getLogger(__name__)
 
@@ -170,8 +170,7 @@ def test_pmon_pcied_term_and_start_status(check_daemon_status, duthosts, rand_on
     """
     duthost = duthosts[rand_one_dut_hostname]
 
-    if "201811" in duthost.os_version or "201911" in duthost.os_version:
-        pytest.skip("Skip: SIG_TERM behaves differnetly in {} on {}".format(daemon_name, duthost.os_version))
+    skip_release(duthost, ["201811", "201911"])
 
     pre_daemon_status, pre_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     logger.info("{} daemon is {} with pid {}".format(daemon_name, pre_daemon_status, pre_daemon_pid))

--- a/tests/platform_tests/daemon/test_syseepromd.py
+++ b/tests/platform_tests/daemon/test_syseepromd.py
@@ -157,7 +157,7 @@ def test_pmon_syseepromd_term_and_start_status(check_daemon_status, duthosts, ra
     """
     duthost = duthosts[rand_one_dut_hostname]
 
-    skip_release(duthost, ["201811", "201911", "202012"])
+    skip_release(duthost, ["201811", "201911"])
 
     pre_daemon_status, pre_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     logger.info("{} daemon is {} with pid {}".format(daemon_name, pre_daemon_status, pre_daemon_pid))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
As arista 7050, skip unsupported test for other arista platforms

#### How did you do it?
Use skip_release_for_platform() to skip the unsupported tests for all arista platform

#### How did you verify/test it?
Run platform api test under tests/platform_tests/api/

#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
