### PR TITLE
Remove duplicate indices for breakout ports

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -2,8 +2,6 @@ import ast
 import logging
 import pytest
 
-from natsort import natsorted
-
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import sfp
 from tests.common.utilities import skip_version
@@ -33,9 +31,9 @@ pytestmark = [
 
 @pytest.fixture(scope="class")
 def setup(request, duthosts, enum_rand_one_per_hwsku_hostname, xcvr_skip_list, conn_graph_facts):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     sfp_setup = {}
-    sfp_port_indices = []
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    
     if duthost.is_supervisor_node():
         pytest.skip("skipping for supervisor node")
 
@@ -44,15 +42,17 @@ def setup(request, duthosts, enum_rand_one_per_hwsku_hostname, xcvr_skip_list, c
 
     physical_port_index_map = get_physical_port_indices(duthost, physical_intfs)
   
-    sfp_setup["sfp_port_indices"] = [physical_port_index_map[intf] \
-        for intf in natsorted(physical_port_index_map.keys())]
+    sfp_port_indices = set([physical_port_index_map[intf] \
+        for intf in physical_port_index_map.keys()])
+    sfp_setup["sfp_port_indices"] = sorted(sfp_port_indices)
 
     if len(xcvr_skip_list[duthost.hostname]):
         logging.info("Skipping tests on {}".format(xcvr_skip_list[duthost.hostname]))
 
-    sfp_setup["sfp_test_port_indices"] = [physical_port_index_map[intf] for intf in \
-                                                natsorted(physical_port_index_map.keys()) \
-                                                if intf not in xcvr_skip_list[duthost.hostname]]
+    sfp_port_indices = set([physical_port_index_map[intf] for intf in \
+                                                physical_port_index_map.keys() \
+                                                if intf not in xcvr_skip_list[duthost.hostname]])
+    sfp_setup["sfp_test_port_indices"] = sorted(sfp_port_indices)
     if request.cls is not None:
         request.cls.sfp_setup = sfp_setup
 


### PR DESCRIPTION
Signed-off-by: Prince George <prgeor@microsoft.com>


### Description of PR
Remove duplicate indices for breakout ports. 


### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911


#### What is the motivation for this PR?
This PR# [https://github.com/Azure/sonic-mgmt/pull/4157/](https://github.com/Azure/sonic-mgmt/pull/4157/) introduced duplicate indices for breakout ports resulting in test_sfp.py failures when breakout configuration is running.

#### How did you verify/test it?
Run test_sfp.py on 7050cx3 with 50G breakout ports
Run test_sfp.py on 7050cx3 without breakout
