### PR TITLE
[storage_backend] Skip wr_arp on backend topologies

### DIFF
--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -3,10 +3,12 @@ import logging
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                             # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses                                # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses                                 # lgtm[py/unused-import]
+from tests.common.storage_backend.backend_utils import skip_test_module_over_backend_topologies     # lgtm[py/unused-import]
 from tests.ptf_runner import ptf_runner
+
 
 logger = logging.getLogger(__name__)
 

--- a/tests/common/storage_backend/backend_utils.py
+++ b/tests/common/storage_backend/backend_utils.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_test_module_over_backend_topologies(request, tbinfo):
+    """Skip testcases in the test module if the topo is storage backend."""
+    if "backend" in tbinfo["topo"]["name"]:
+        module_filename = request.module.__name__.split(".")[-1]
+        pytest.skip("Skip %s. Unsupported topology %s." % (module_filename, tbinfo["topo"]["name"]))


### PR DESCRIPTION
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4022

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Skip`test_wr_arp` over storage backend topologies

#### How did you do it?
1. add a common library `tests/common/storage_backend` to keep storage backend related utilities
2. add fixture `skip_test_module_over_backend_topologies` to skip test module if the testbed is storage backend topo
3. use the fixture for  `test_wr_arp`.

#### How did you verify/test it?
* run over storage backend topology
```
arp/test_arp_dualtor.py::test_arp_garp_enabled[str2-7050qx-32s-acs-02-None] SKIPPED                                                                                                                                                                                    [ 25%]
arp/test_arp_dualtor.py::test_proxy_arp[v4-str2-7050qx-32s-acs-02-None] SKIPPED                                                                                                                                                                                        [ 50%]
arp/test_arp_dualtor.py::test_proxy_arp[v6-str2-7050qx-32s-acs-02-None] SKIPPED                                                                                                                                                                                        [ 75%]
arp/test_wr_arp.py::TestWrArp::testWrArp SKIPPED                                                                                                                                                                                                                       [100%]

--------------------------------------------------------------------------------------------- generated xml file: /data/repo/storage_backend/bugfix/sonic-mgmt/tests/output.xml ----------------------------------------------------------------------------------------------
========================================================================================================================= 4 skipped in 56.44 seconds =========================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
