### PR TITLE
[span] Skip span tests on broadcom platform

### DIFF
--- a/tests/span/conftest.py
+++ b/tests/span/conftest.py
@@ -54,6 +54,13 @@ def ports_for_test(cfg_facts):
     }
 
 @pytest.fixture(scope='module', autouse=True)
+def skip_unsupported_asic_type(duthost):
+    SPAN_UNSUPPORTED_ASIC_TYPE = ["broadcom"]
+    if duthost.facts["asic_type"] in SPAN_UNSUPPORTED_ASIC_TYPE:
+        pytest.skip(
+            "Skipping span test on {} platform".format(duthost.facts["asic_type"]))
+
+@pytest.fixture(scope='module', autouse=True)
 def setup_monitor_port(duthosts, rand_one_dut_hostname, ports_for_test):
     '''
     Used to prepare monitor port for test


### PR DESCRIPTION
What is the motivation for this PR?
Span is not required, so skip it on the broadcom platform.

How did you verify/test it?
Run span tests, it should be skipped on broadcom platform. No impact on other platforms.

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
