### PR TITLE
Implement test case for everflow per interface

### DIFF
--- a/tests/everflow/templates/acl-erspan.json.j2
+++ b/tests/everflow/templates/acl-erspan.json.j2
@@ -17,11 +17,19 @@
                                 },
                                 {% for qset in rule["qualifiers"].keys() %}
                                 "{{ qset }}": {
+                                {% if qset == "input_interface" %}
+                                    "interface_ref": {
+                                        "config": {
+                                            "interface": "{{ rule["qualifiers"]["input_interface"] }}"
+                                            }
+                                        }
+                                {% else %}
                                     "config": {
                                         {% for qualifier, value in rule["qualifiers"][qset].items() %}
                                         "{{ qualifier }}": {{ value|to_nice_json }}{% if not loop.last %},{% endif %}
                                         {% endfor %}
                                     }
+                                {% endif %}
                                 }{% if not loop.last %},{% endif %}
                                 {% endfor %}
                             }{% if not loop.last %},{% endif %}

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -1,0 +1,180 @@
+"""Test cases to support the Everflow Mirroring feature in SONiC."""
+import logging
+import time
+import pytest
+
+import ptf.testutils as testutils
+import everflow_test_utilities as everflow_utils
+
+from everflow_test_utilities import BaseEverflowTest
+from everflow_test_utilities import TEMPLATE_DIR, EVERFLOW_RULE_CREATE_TEMPLATE, DUT_RUN_DIR, EVERFLOW_RULE_CREATE_FILE
+from tests.common.helpers.assertions import pytest_require, pytest_assert
+
+from everflow_test_utilities import setup_info, EVERFLOW_DSCP_RULES       # noqa: F401, E501 lgtm[py/unused-import] pylint: disable=import-error
+
+pytestmark = [
+    pytest.mark.topology("any")
+]
+
+EVERFLOW_TABLE_NAME = {
+    "ipv4": "EVERFLOW",
+    "ipv6": "EVERFLOWV6"
+}
+
+EVERFLOW_SESSION_NAME = "everflow_session_per_interface"
+
+logger = logging.getLogger(__file__)
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_on_dualtor_testbed(tbinfo):
+    if 'dualtor' in tbinfo['topo']['name']:
+        pytest.skip("Skip running on dualtor testbed")
+
+
+def build_candidate_ports(duthost, tbinfo):
+    """
+    Build candidate ports for testing
+    """
+    candidate_ports = {}
+    unselected_ports = {}
+    if tbinfo['topo']['type'] == 't0':
+        candidate_neigh_name = 'Server'
+    else:
+        candidate_neigh_name = 'T0'
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+
+    for dut_port, neigh in mg_facts["minigraph_neighbors"].items():
+        ptf_idx = mg_facts["minigraph_ptf_indices"][dut_port]
+        if candidate_neigh_name in neigh['name'] and len(candidate_ports) < 4:
+            candidate_ports.update({dut_port: ptf_idx})
+        if len(unselected_ports) < 4 and dut_port not in candidate_ports:
+            unselected_ports.update({dut_port: ptf_idx})
+    
+    logger.info("Candidate testing ports are {}".format(candidate_ports))
+    return candidate_ports, unselected_ports
+    
+
+def build_acl_rule_vars(candidate_ports, ip_ver):
+    """
+    Build vars for generating ACL rule
+    """
+    config_vars = {}
+    config_vars['acl_table_name'] = EVERFLOW_TABLE_NAME[ip_ver]
+    config_vars['rules'] = [{'qualifiers': {'input_interface': ','.join(candidate_ports.keys())}}]
+    return config_vars
+
+
+@pytest.fixture(scope='module')
+def apply_mirror_session(rand_selected_dut):
+    mirror_session_info = BaseEverflowTest.mirror_session_info(EVERFLOW_SESSION_NAME, rand_selected_dut.facts["asic_type"])
+    logger.info("Applying mirror session to DUT")
+    BaseEverflowTest.apply_mirror_config(rand_selected_dut, mirror_session_info)
+    time.sleep(10)
+    cmd = 'sonic-db-cli STATE_DB hget \"MIRROR_SESSION_TABLE|{}\" \"monitor_port\"'.format(EVERFLOW_SESSION_NAME)
+    monitor_port = rand_selected_dut.shell(cmd=cmd)['stdout']
+    pytest_assert(monitor_port != "", "Failed to retrieve monitor_port")
+
+    yield mirror_session_info, monitor_port
+
+    logger.info("Removing mirror session from DUT")
+    BaseEverflowTest.remove_mirror_config(rand_selected_dut, EVERFLOW_SESSION_NAME)
+
+
+@pytest.fixture(scope='module', params=['ipv4', 'ipv6'], autouse=True)
+def apply_acl_rule(request, rand_selected_dut, tbinfo, apply_mirror_session):
+    """
+    Apply ACL rule for matching input_ports
+    """
+    # Skip ipv6 test on Mellanox platform
+    ip_ver = request.param
+    if "mellanox" == rand_selected_dut.facts["asic_type"] and ip_ver == "ipv6":
+        pytest.skip("Match 'IN_PORTS' in EVERFLOWV6 is not supported on Mellanox platform")
+    # Check existence of EVERFLOW
+    table_name = EVERFLOW_TABLE_NAME[ip_ver]
+    output = rand_selected_dut.shell('show acl table {}'.format(table_name))['stdout_lines']
+    # Skip if EVERFLOW table doesn't exist
+    pytest_require(len(output) > 2, "Skip test since {} dosen't exist".format(table_name))
+    mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
+    mirror_session_info, monitor_port = apply_mirror_session    
+    # Build testing port list
+    candidate_ports, unselected_ports = build_candidate_ports(rand_selected_dut, tbinfo)
+    pytest_require(len(candidate_ports) >= 1, "Not sufficient ports for testing")
+
+    # Copy and apply ACL rule
+    config_vars = build_acl_rule_vars(candidate_ports, ip_ver)
+    rand_selected_dut.host.options["variable_manager"].extra_vars.update(config_vars)
+    rand_selected_dut.command("mkdir -p {}".format(DUT_RUN_DIR))
+    rand_selected_dut.template(src=os.path.join(TEMPLATE_DIR, EVERFLOW_RULE_CREATE_TEMPLATE),
+                                dest=os.path.join(DUT_RUN_DIR, EVERFLOW_RULE_CREATE_FILE))
+    logger.info("Applying acl rule config to DUT")
+    command = "acl-loader update full {} --table_name {} --session_name {}" \
+                      .format(os.path.join(DUT_RUN_DIR, EVERFLOW_RULE_CREATE_FILE), table_name, EVERFLOW_SESSION_NAME)
+    rand_selected_dut.shell(cmd=command)
+    ret = {
+        "candidate_ports": candidate_ports,
+        "unselected_ports": unselected_ports,
+        "mirror_session_info": mirror_session_info,
+        "monitor_port": {monitor_port: mg_facts["minigraph_ptf_indices"][monitor_port]}
+    }
+    
+    yield ret
+
+    logger.info("Removing acl rule config from DUT")
+    BaseEverflowTest.remove_acl_rule_config(rand_selected_dut, table_name)
+
+
+def generate_testing_packet(ptfadapter, duthost, mirror_session_info, router_mac):
+    packet = testutils.simple_tcp_packet(
+            eth_src=ptfadapter.dataplane.get_mac(0, 0),
+            eth_dst=router_mac
+        )
+    setup = {}
+    setup["router_mac"] = router_mac
+    exp_packet = BaseEverflowTest.get_expected_mirror_packet(mirror_session_info, setup, duthost, packet, False)
+    return packet, exp_packet
+
+
+def get_uplink_ports(duthost, tbinfo):
+    """The collector IP is a destination reachable by default. 
+    So we need to collect the uplink ports to do a packet capture
+    """
+    uplink_ports = []
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    if 't0' == tbinfo['topo']['type']:
+        neigh_name = 'T1'
+    else:
+        neigh_name = 'T2'
+    for dut_port, neigh in mg_facts["minigraph_neighbors"].items():
+        ptf_idx = mg_facts["minigraph_ptf_indices"][dut_port]
+        if neigh_name in neigh['name']:
+            uplink_ports.append(ptf_idx)
+    return uplink_ports
+
+
+def send_and_verify_packet(ptfadapter, packet, expected_packet, tx_port, rx_ports, exp_recv):
+    ptfadapter.dataplane.flush()
+    testutils.send(ptfadapter, pkt=packet, port_id=tx_port)
+    if exp_recv:
+        testutils.verify_packet_any_port(ptfadapter, pkt=expected_packet, ports=rx_ports, timeout=5)
+    else:
+        testutils.verify_no_packet_any(ptfadapter, pkt=expected_packet, ports=rx_ports)
+
+
+def test_everflow_per_interface(ptfadapter, rand_selected_dut, apply_acl_rule, tbinfo):
+    """Verify packet ingress from candidate ports are captured by EVERFLOW, while packets
+    ingress from unselected ports are not captured
+    """
+    everflow_config = apply_acl_rule
+    packet, exp_packet = generate_testing_packet(ptfadapter, rand_selected_dut, everflow_config['mirror_session_info'], rand_selected_dut.facts["router_mac"])
+    uplink_ports = get_uplink_ports(rand_selected_dut, tbinfo)
+    # Verify that packet ingressed from INPUT_PORTS (candidate ports) are mirrored
+    for port, ptf_idx in everflow_config['candidate_ports'].items():
+        logger.info("Verifying packet ingress from {} is mirrored".format(port))
+        send_and_verify_packet(ptfadapter, packet, exp_packet, ptf_idx, uplink_ports, True)
+    
+    # Verify that packet ingressed from unselected ports are not mirrored
+    for port, ptf_idx in everflow_config['unselected_ports'].items():
+        logger.info("Verifying packet ingress from {} is not mirrored".format(port))
+        send_and_verify_packet(ptfadapter, packet, exp_packet, ptf_idx, uplink_ports, False)
+   
+    

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -474,7 +474,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                tolerance="10")
         finally:
             # Clean up ACL rules and routes
-            self.remove_acl_rule_config(duthost, table_name, config_method)
+            BaseEverflowTest.remove_acl_rule_config(duthost, table_name, config_method)
             self.remove_acl_table_config(duthost, table_name, config_method)
             if bind_interface_namespace:
                 self.remove_acl_table_config(duthost, table_name, config_method, bind_interface_namespace)


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to add new test cases to verify everflow per interface feature.
The feature is implemented by matching ```IN_PORTS``` in ACL rule, and implemted in PR https://github.com/Azure/sonic-swss/pull/598. We leverage this feature to do packet capture on certain ports.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to add new test cases to verify everflow per interface feature.

#### How did you do it?
1. Setup ACL rule matching ```IN_PORTS``` and mirror sessions to mirror packets
2. Selected some ports for testing
3. Verify packet ingressed from selected ports are mirrored, while packets ingressed from other ports are not mirrored.

#### How did you verify/test it?
Verified on both ```Mellanox``` and ```Broadcom``` platforms, T0 and T1 topo.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
```T0``` and ```T1```

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
