### PR TITLE
fixed arista 7060 fanout config

### DIFF
--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -29,8 +29,11 @@ vlan {{ device_vlan_range[inventory_hostname] | list | join(',') }}
 vrf definition management
    rd 1:1
 !
-{% for i in range(1,33) %}
+{% for i in range(1, device_port_vlans[inventory_hostname]|length + 1) %}
 {% set intf =  'Ethernet' + i|string + '/1'  %}
+{% if intf not in device_port_vlans[inventory_hostname] %}
+{% set intf =  'Ethernet' + i|string  %}
+{% endif %}
 interface {{ intf }}
 {% if intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] != "Trunk" %}
 {%     if device_conn[inventory_hostname][intf]['speed'] == "100000" %}
@@ -111,7 +114,7 @@ interface {{ intf }}
 !
 interface Management 1
  description TO LAB MGMT SWITCH
- ip address {{ device_info[inventory_hostname]["ManagementIp"] }}
+ ip address {{ device_info[inventory_hostname]["ManagementIp"] }}/{{ hostvars[inventory_hostname].mgmt_subnet_mask_length }}
  no shutdown
 !
 # LACP packets pass through


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fixed arista 7060 fanout config
Fixes # (issue)
- made change to generate config for server interface

Number of interfaces presented in lab_connection_graph is hardcoded in fanout config so fanout is only configured with the first 32 interfaces skipping the rest, including interface for a server when it is out of range. Fixed by taking number of interfaces dynamically
- added IP mask for mgmt address

After applying a mgmt IP address with no mask in startup-config , the mgmt IP address stays unset in running-config so ssh connection is unavailable
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Make Arista fanout autoconfig script up to date
#### How did you do it?
Explored the generated config and fixed it
#### How did you verify/test it?
ansible-playbook fanout.yml -i <inventory_file> --limit <fanout_host> --vault-password-file <pass_file>
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
