### PR TITLE
Ignoring ip protocol 253 in IPv6 packets in the fib hash test.

### DIFF
--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -171,7 +171,7 @@ class HashTest(BaseTest):
         # ip_proto 2 is IGMP, should not be forwarded by router
         # ip_proto 254 is experimental
         # MLNX ASIC can't forward ip_proto 254, BRCM is OK, skip for all for simplicity
-        skip_ports = [2, 254]
+        skip_ports = [2, 253, 254]
         if ipv6:
             # Skip ip_proto 0 for IPv6
             skip_ports.append(0)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
When a DNX chipset gets an IPv6 packet with ip protocol 253, it strips out 4 bytes from its payload
before forwarding the packet out. This issue was raised against BCM

   https://github.com/Broadcom-Switch-Collab/Zeus_SAI/issues/100

#### How did you do it?
Recommendation of BCM and MSFT is to avoid ip protocol 253 (similar to protocol 2 and 254) in the fib hash test


#### How did you verify/test it?
Ran fib_hash test against linecards in a VoQ Chassis with DNX chipset.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
