### PR TITLE
[test][nhop resources] Ignore NHOP resource count check on Mellanox

### DIFF
--- a/tests/ipfwd/test_nhop_count.py
+++ b/tests/ipfwd/test_nhop_count.py
@@ -7,6 +7,7 @@ import time
 from collections import namedtuple
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.mellanox_data import is_mellanox_device
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import skip_release
 
@@ -241,6 +242,10 @@ def test_nhop(request, duthost):
     - Verify no erros and crash
     """
     skip_release(duthost, ["201811", "201911"])
+
+    if is_mellanox_device(duthost):
+        pytest.skip("Skipping on Mellanox platform")
+
     default_max_nhop_paths = 32
     nhop_group_limit = 1024
     # program more than the advertised limit

--- a/tests/ipfwd/test_nhop_count.py
+++ b/tests/ipfwd/test_nhop_count.py
@@ -243,9 +243,6 @@ def test_nhop(request, duthost):
     """
     skip_release(duthost, ["201811", "201911"])
 
-    if is_mellanox_device(duthost):
-        pytest.skip("Skipping on Mellanox platform")
-
     default_max_nhop_paths = 32
     nhop_group_limit = 1024
     # program more than the advertised limit
@@ -325,9 +322,11 @@ def test_nhop(request, duthost):
     loganalyzer.analyze(marker)
 
     # verify the test used up all the NHOP group resources
-    pytest_assert(
-        crm_after["available"] == 0,
-        "Unused NHOP group resource: {}, used:{}".format(
-            crm_after["available"], crm_after["used"]
+    # skip this check on Mellanox as ASIC resources are shared
+    if not is_mellanox_device(duthost):
+        pytest_assert(
+            crm_after["available"] == 0,
+            "Unused NHOP group resource: {}, used:{}".format(
+                crm_after["available"], crm_after["used"]
+            )
         )
-    )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
 Ignore NHOP resource count check on Mellanox

Fix https://github.com/Azure/sonic-buildimage/issues/8727

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
 Skip NHOP resource count check on Mellanox as resources are shared on this Mellanox platform.

#### How did you do it?
check if DUT is mellanox and skip check

#### How did you verify/test it?
```
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ pytest ipfwd/test_nhop_count.py --testbed=vms11-2-t0 --inventory=../ansible/veos,../ansible/str,../ansible/str2 --testbed_file=../ansible/testbed.csv --host-pattern=str-msn2700-03 --module-path=../ansible/library --disable_
loganalyzer --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================================= test session starts =============================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 1 item

ipfwd/test_nhop_count.py .                                                                                                      [100%]

========================================================== warnings summary ===========================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannotbe rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============================================== 1 passed, 1 warnings in 222.16 seconds ================================================

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
