### PR TITLE
Fix the issue of "ptf_portchannel_action" undefined in restart-ptf

### DIFF
--- a/ansible/roles/vm_set/tasks/ptf_portchannel.yml
+++ b/ansible/roles/vm_set/tasks/ptf_portchannel.yml
@@ -27,4 +27,3 @@
     cmd: "{{ ptf_portchannel_action }}"
     portchannel_config: "{{ portchannel_config }}"
   delegate_to: "{{ ptf_host }}"
-

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -15,6 +15,11 @@
       mux_simulator_action: stop
     when: "'dualtor' in topo"
 
+  - name: Stop PTF portchannel service
+    include_tasks: ptf_portchannel.yml
+    vars:
+      ptf_portchannel_action: stop
+
   - name: Remove ptf container ptf_{{ vm_set_name }}
     docker_container:
       name: ptf_{{ vm_set_name }}
@@ -102,6 +107,8 @@
 
   - name: Start PTF portchannel service
     include_tasks: ptf_portchannel.yml
+    vars:
+      ptf_portchannel_action: start
 
   - name: Announce routes
     include_tasks: announce_routes.yml


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
PR #4248 updated the playbook ptf_portchannel.yml to accept variable
"ptf_portchannel_action". Another playbook renumber_topo.yml calling
the ptf_portchannel.yml was not updated to pass down the variable.
This cause issue variable "ptf_portchannel_action" undefined while
run "testbed-cli.sh restart-ptf".

#### How did you do it?
The change is to update the renumber_topo.yml to include the
ptf_portchannel.yml with variable. Also added a step to stop
portchannel in PTF before removing PTF docker.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
