### PR TITLE
[dual-tor] Correct the expectation num of pkts in IPinIP tunnel

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -737,8 +737,11 @@ def check_nexthops_balance(rand_selected_dut,
     # expect this packet to be sent to downlinks (active mux) and uplink (stanby mux)
     expected_downlink_ports =  [get_ptf_server_intf_index(rand_selected_dut, tbinfo, iface) for iface in downlink_ints]
     expected_uplink_ports = list()
-    for members in get_t1_ptf_pc_ports(rand_selected_dut, tbinfo).values():
-        for member in members:
+    expected_uplink_portchannels = list()
+    portchannel_ports = get_t1_ptf_pc_ports(rand_selected_dut, tbinfo)
+    for pc, intfs in portchannel_ports.items():
+        expected_uplink_portchannels.append(pc)
+        for member in intfs:
             expected_uplink_ports.append(int(member.strip("eth")))
     logging.info("Expecting packets in downlink ports {}".format(expected_downlink_ports))
     logging.info("Expecting packets in uplink ports {}".format(expected_uplink_ports))
@@ -778,17 +781,22 @@ def check_nexthops_balance(rand_selected_dut,
         # Step 1: Calculate total uplink share.
         total_uplink_share = expect_packet_num * (nexthops_count - len(expected_downlink_ports))
         # Step 2: Divide uplink share among all portchannels
-        expect_packet_num = total_uplink_share // (len(expected_uplink_ports) / 2)
+        expect_packet_num = total_uplink_share // len(expected_uplink_portchannels)
+        pkt_num_lo = expect_packet_num * (1.0 - 0.25)
+        pkt_num_hi = expect_packet_num * (1.0 + 0.25)
         # Step 3: Check if uplink distribution (hierarchical ECMP) is balanced
-        for uplink_int in expected_uplink_ports:
-            pkt_num_lo = expect_packet_num * (1.0 - 0.25)
-            pkt_num_hi = expect_packet_num * (1.0 + 0.25)
-            count = port_packet_count.get(uplink_int, 0)
-            logging.info("Packets received on uplink port {}: {}".format(uplink_int, count))
-            # Within a single portchannel, just one interface could receive the pkts as the outer header is the same
-            if count != 0 and (count < pkt_num_lo or count > pkt_num_hi):
+        for pc, intfs in portchannel_ports.items():
+            count = 0
+            # Collect the packets count within a single portchannel
+            for member in intfs:
+                uplink_int = int(member.strip("eth"))
+                count = count + port_packet_count.get(uplink_int, 0)
+            logging.info("Packets received on portchannel {}: {}".format(pc, count))
+
+            if count < pkt_num_lo or count > pkt_num_hi:
                 balance = False
-                pt_assert(balance, "Hierarchical ECMP failed: packets not evenly distributed on uplink port {}".format(uplink_int))
+                pt_assert(balance, "Hierarchical ECMP failed: packets not evenly distributed on portchannel {}".format(
+                    pc))
 
 
 def verify_upstream_traffic(host, ptfadapter, tbinfo, itfs, server_ip, pkt_num = 100, drop = False):

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -777,15 +777,16 @@ def check_nexthops_balance(rand_selected_dut,
         # Hierarchical ECMP validation (in case of standby MUXs):
         # Step 1: Calculate total uplink share.
         total_uplink_share = expect_packet_num * (nexthops_count - len(expected_downlink_ports))
-        # Step 2: Divide uplink share among all uplinks
-        expect_packet_num = total_uplink_share // len(expected_uplink_ports)
+        # Step 2: Divide uplink share among all portchannels
+        expect_packet_num = total_uplink_share // (len(expected_uplink_ports) / 2)
         # Step 3: Check if uplink distribution (hierarchical ECMP) is balanced
         for uplink_int in expected_uplink_ports:
             pkt_num_lo = expect_packet_num * (1.0 - 0.25)
             pkt_num_hi = expect_packet_num * (1.0 + 0.25)
             count = port_packet_count.get(uplink_int, 0)
             logging.info("Packets received on uplink port {}: {}".format(uplink_int, count))
-            if count < pkt_num_lo or count > pkt_num_hi:
+            # Within a single portchannel, just one interface could receive the pkts as the outer header is the same
+            if count != 0 and (count < pkt_num_lo or count > pkt_num_hi):
                 balance = False
                 pt_assert(balance, "Hierarchical ECMP failed: packets not evenly distributed on uplink port {}".format(uplink_int))
 


### PR DESCRIPTION
What is the motivation for this PR?
As the outer header is the same in IPinIP tunnel between lower tor and upper tor, so within a single port-channel, all the pkts should send to the same interface. The other one should not receive the pkts. But in the current code, it is supposed the pkts will be received by all the interfaces evenly.

How did you do it?
Correct the expectation num of pkts according to the number of port-channels.

How did you verify/test it?
Run dualtor/test_orchagent_active_tor_downstream.py test case.

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
