### PR TITLE
Add back retry for running commands in the vm_topology module

### DIFF
--- a/ansible/roles/vm_set/library/ceos_network.py
+++ b/ansible/roles/vm_set/library/ceos_network.py
@@ -293,9 +293,8 @@ class CeosNetwork(object):
                 else:
                     # Result is unexpected, need to retry
                     continue
-        else:
-            # Reached max retry, fail with exception
-            raise Exception('ret_code=%d, error message="%s". cmd="%s"' % (ret_code, err, cmdline))
+        # Reached max retry, fail with exception
+        raise Exception('ret_code=%d, error message="%s". cmd="%s"' % (ret_code, err, cmdline))
 
     @staticmethod
     def get_ovs_br_ports(bridge):

--- a/ansible/roles/vm_set/library/ceos_network.py
+++ b/ansible/roles/vm_set/library/ceos_network.py
@@ -108,11 +108,11 @@ class CeosNetwork(object):
         logging.info("=== Create veth pair %s and %s. Add %s to docker with Pid %s ===" %
             (ext_if, int_if, int_if, self.pid))
 
-        if CeosNetwork.intf_exists(ext_if) and not CeosNetwork.intf_exists(int_if, self.pid):
+        if CeosNetwork.intf_exists(ext_if) and CeosNetwork.intf_not_exists(int_if, self.pid):
             CeosNetwork.cmd("ip link del %s" % ext_if)
 
         t_int_if = int_if + '_t'
-        if not CeosNetwork.intf_exists(ext_if):
+        if CeosNetwork.intf_not_exists(ext_if):
             CeosNetwork.cmd("ip link add %s type veth peer name %s" % (ext_if, t_int_if))
 
         if self.fp_mtu != DEFAULT_MTU:
@@ -127,11 +127,11 @@ class CeosNetwork(object):
         CeosNetwork.iface_up(ext_if)
 
         if CeosNetwork.intf_exists(t_int_if) \
-            and not CeosNetwork.intf_exists(t_int_if, self.pid) \
-            and not CeosNetwork.intf_exists(int_if, self.pid):
+            and CeosNetwork.intf_not_exists(t_int_if, self.pid) \
+            and CeosNetwork.intf_not_exists(int_if, self.pid):
             CeosNetwork.cmd("ip link set netns %s dev %s" % (self.pid, t_int_if))
 
-        if CeosNetwork.intf_exists(t_int_if, self.pid) and not CeosNetwork.intf_exists(int_if, self.pid):
+        if CeosNetwork.intf_exists(t_int_if, self.pid) and CeosNetwork.intf_not_exists(int_if, self.pid):
             CeosNetwork.cmd("nsenter -t %s -n ip link set dev %s name %s" % (self.pid, t_int_if, int_if))
 
         CeosNetwork.iface_up(int_if, self.pid)
@@ -164,6 +164,14 @@ class CeosNetwork(object):
             CeosNetwork.cmd("brctl addif %s %s" % (bridge, intf))
 
     @staticmethod
+    def _intf_cmd(intf, pid=None):
+        if pid:
+            cmdline = 'nsenter -t %s -n ifconfig -a %s' % (pid, intf)
+        else:
+            cmdline = 'ifconfig -a %s' % intf
+        return cmdline
+
+    @staticmethod
     def intf_exists(intf, pid=None):
         """Check if the specified interface exists.
 
@@ -178,13 +186,33 @@ class CeosNetwork(object):
         Returns:
             bool: True if the interface exists. Otherwise False.
         """
-        if pid:
-            cmdline = 'nsenter -t %s -n ifconfig %s' % (pid, intf)
-        else:
-            cmdline = 'ifconfig %s' % intf
+        cmdline = CeosNetwork._intf_cmd(intf, pid=pid)
 
         try:
-            CeosNetwork.cmd(cmdline)
+            CeosNetwork.cmd(cmdline, retry=3)
+            return True
+        except:
+            return False
+
+    @staticmethod
+    def intf_not_exists(intf, pid=None):
+        """Check if the specified interface does not exist.
+
+        This function uses command "ifconfig <intf name>" to check the existence of the specified interface. By default
+        the command is executed on host. If a pid is specified, this command is executed in the network namespace
+        of the specified pid. The meaning is to check if the interface exists in a specific docker.
+
+        Args:
+            intf (str): Name of the interface.
+            pid (str), optional): Pid of docker. Defaults to None.
+
+        Returns:
+            bool: True if the interface does not exist. Otherwise False.
+        """
+        cmdline = CeosNetwork._intf_cmd(intf, pid=pid)
+
+        try:
+            CeosNetwork.cmd(cmdline, retry=3, negative=True)
             return True
         except:
             return False
@@ -206,39 +234,68 @@ class CeosNetwork(object):
             return CeosNetwork.cmd('nsenter -t %s -n ip link set %s %s' % (pid, iface_name, state))
 
     @staticmethod
-    def cmd(cmdline, grep_cmd=None):
-        logging.debug('*** CMD: %s, grep: %s' % (cmdline, grep_cmd))
-        process = subprocess.Popen(
-            shlex.split(cmdline),
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
-        if grep_cmd:
-            process_grep = subprocess.Popen(
-                shlex.split(grep_cmd),
-                stdin=process.stdout,
+    def cmd(cmdline, grep_cmd=None, retry=1, negative=False):
+        """Execute a command and return the output
+
+        Args:
+            cmdline (str): The command line to be executed.
+            grep_cmd (str, optional): Grep command line. Defaults to None.
+            retry (int, optional): Max number of retry if command result is unexpected. Defaults to 1.
+            negative (bool, optional): If negative is True, expect the command to fail. Defaults to False.
+
+        Raises:
+            Exception: If command result is unexpected after max number of retries, raise an exception.
+
+        Returns:
+            str: Output of the command.
+        """
+
+        for attempt in range(retry):
+            logging.debug('*** CMD: %s, grep: %s, attempt: %d' % (cmdline, grep_cmd, attempt+1))
+            process = subprocess.Popen(
+                shlex.split(cmdline),
+                stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
-            out, err = process_grep.communicate()
-            ret_code = process_grep.returncode
+            if grep_cmd:
+                process_grep = subprocess.Popen(
+                    shlex.split(grep_cmd),
+                    stdin=process.stdout,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE)
+                out, err = process_grep.communicate()
+                ret_code = process_grep.returncode
+            else:
+                out, err = process.communicate()
+                ret_code = process.returncode
+            out, err = out.decode('utf-8'), err.decode('utf-8')
+
+            msg = {
+                'cmd': cmdline,
+                'grep_cmd': grep_cmd,
+                'ret_code': ret_code,
+                'stdout': out.splitlines(),
+                'stderr': err.splitlines()
+            }
+            logging.debug('*** OUTPUT: \n%s' % json.dumps(msg, indent=2))
+
+            if negative:
+                if ret_code != 0:
+                    # Result is expected, return early
+                    return out
+                else:
+                    # Result is unexpected, need to retry
+                    continue
+            else:
+                if ret_code == 0:
+                    # Result is expected, return early
+                    return out
+                else:
+                    # Result is unexpected, need to retry
+                    continue
         else:
-            out, err = process.communicate()
-            ret_code = process.returncode
-        out, err = out.decode('utf-8'), err.decode('utf-8')
-
-        msg = {
-            'cmd': cmdline,
-            'grep_cmd': grep_cmd,
-            'ret_code': ret_code,
-            'stdout': out.splitlines(),
-            'stderr': err.splitlines()
-        }
-        logging.debug('*** OUTPUT: \n%s' % json.dumps(msg, indent=2))
-
-        if ret_code != 0:
+            # Reached max retry, fail with exception
             raise Exception('ret_code=%d, error message="%s". cmd="%s"' % (ret_code, err, cmdline))
-
-        return out
 
     @staticmethod
     def get_ovs_br_ports(bridge):

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -3,6 +3,7 @@
 import datetime
 import logging
 import hashlib
+import json
 import re
 import subprocess
 import shlex
@@ -346,7 +347,7 @@ class VMTopology(object):
     def get_vm_bridges(self, vmname):
         brs = []
         vm_bridge_regx = OVS_FP_BRIDGE_REGEX % vmname
-        out = VMTopology.cmd('ifconfig -a', 'grep -E %s' % vm_bridge_regx)
+        out = VMTopology.cmd('ifconfig -a', grep_cmd='grep -E %s' % vm_bridge_regx, retry=3)
         for row in out.split('\n'):
             fields = row.split(':')
             if len(fields) > 0:
@@ -384,7 +385,7 @@ class VMTopology(object):
     def add_mgmt_port_to_docker(self, mgmt_bridge, mgmt_ip, mgmt_gw, mgmt_ipv6_addr=None, mgmt_gw_v6=None, api_server_pid=None):
         if api_server_pid:
             self.pid = api_server_pid
-        if not VMTopology.intf_exists(MGMT_PORT_NAME, self.pid):
+        if VMTopology.intf_not_exists(MGMT_PORT_NAME, self.pid):
             if api_server_pid is None:
                 tmp_mgmt_if = hashlib.md5((PTF_NAME_TEMPLATE % self.vm_set_name).encode("utf-8")).hexdigest()[0:6] + MGMT_PORT_NAME
                 self.add_br_if_to_docker(mgmt_bridge, PTF_MGMT_IF_TEMPLATE % self.vm_set_name, tmp_mgmt_if)
@@ -405,7 +406,7 @@ class VMTopology(object):
 
     def add_br_if_to_docker(self, bridge, ext_if, int_if):
         logging.info('=== For veth pair, add %s to bridge %s, set %s to PTF docker' % (ext_if, bridge, int_if))
-        if not VMTopology.intf_exists(ext_if):
+        if VMTopology.intf_not_exists(ext_if):
             VMTopology.cmd("ip link add %s type veth peer name %s" % (ext_if, int_if))
 
         _, if_to_br = VMTopology.brctl_show(bridge)
@@ -414,7 +415,7 @@ class VMTopology(object):
 
         VMTopology.iface_up(ext_if)
 
-        if VMTopology.intf_exists(int_if) and not VMTopology.intf_exists(int_if, self.pid):
+        if VMTopology.intf_exists(int_if) and VMTopology.intf_not_exists(int_if, self.pid):
             VMTopology.cmd("ip link set netns %s dev %s" % (self.pid, int_if))
 
         VMTopology.iface_up(int_if, self.pid)
@@ -440,18 +441,18 @@ class VMTopology(object):
     def add_dut_if_to_docker(self, iface_name, dut_iface):
         logging.info("=== Add DUT interface %s to PTF docker as %s ===" % (dut_iface, iface_name))
         if VMTopology.intf_exists(dut_iface) \
-            and not VMTopology.intf_exists(dut_iface, self.pid) \
-            and not VMTopology.intf_exists(iface_name, self.pid):
+            and VMTopology.intf_not_exists(dut_iface, self.pid) \
+            and VMTopology.intf_not_exists(iface_name, self.pid):
             VMTopology.cmd("ip link set netns %s dev %s" % (self.pid, dut_iface))
 
-        if VMTopology.intf_exists(dut_iface, self.pid) and not VMTopology.intf_exists(iface_name, self.pid):
+        if VMTopology.intf_exists(dut_iface, self.pid) and VMTopology.intf_not_exists(iface_name, self.pid):
             VMTopology.cmd("nsenter -t %s -n ip link set dev %s name %s" % (self.pid, dut_iface, iface_name))
 
         VMTopology.iface_up(iface_name, self.pid)
 
     def add_dut_vlan_subif_to_docker(self, iface_name, vlan_separator, vlan_id):
         """Create a vlan sub interface for the ptf interface."""
-        if not VMTopology.intf_exists(iface_name, self.pid):
+        if VMTopology.intf_not_exists(iface_name, self.pid):
             raise ValueError("Interface %s not present in docker" % iface_name)
         vlan_sub_iface_name = iface_name + vlan_separator + vlan_id
         VMTopology.cmd("nsenter -t %s -n ip link add link %s name %s type vlan id %s" % (self.pid, iface_name, vlan_sub_iface_name, vlan_id))
@@ -465,10 +466,10 @@ class VMTopology(object):
         if VMTopology.intf_exists(iface_name, self.pid):
             VMTopology.iface_down(iface_name, self.pid)
 
-            if not VMTopology.intf_exists(dut_iface, self.pid):
+            if VMTopology.intf_not_exists(dut_iface, self.pid):
                 VMTopology.cmd("nsenter -t %s -n ip link set dev %s name %s" % (self.pid, iface_name, dut_iface))
 
-        if not VMTopology.intf_exists(dut_iface) and VMTopology.intf_exists(dut_iface, self.pid):
+        if VMTopology.intf_not_exists(dut_iface) and VMTopology.intf_exists(dut_iface, self.pid):
             VMTopology.cmd("nsenter -t %s -n ip link set netns 1 dev %s" % (self.pid, dut_iface))
 
     def remove_dut_vlan_subif_from_docker(self, iface_name, vlan_separator, vlan_id):
@@ -499,7 +500,7 @@ class VMTopology(object):
         if VMTopology.intf_exists(t_int_if):
             VMTopology.cmd("ip link del dev %s" % t_int_if)
 
-        if not VMTopology.intf_exists(ext_if):
+        if VMTopology.intf_not_exists(ext_if):
             VMTopology.cmd("ip link add %s type veth peer name %s" % (ext_if, t_int_if))
             if create_vlan_subintf:
                 VMTopology.cmd("vconfig add %s %s" % (t_int_if, vlan_subintf_vlan_id))
@@ -523,20 +524,20 @@ class VMTopology(object):
         VMTopology.iface_up(ext_if)
 
         if VMTopology.intf_exists(t_int_if) \
-            and not VMTopology.intf_exists(t_int_if, self.pid) \
-            and not VMTopology.intf_exists(int_if, self.pid):
+            and VMTopology.intf_not_exists(t_int_if, self.pid) \
+            and VMTopology.intf_not_exists(int_if, self.pid):
             VMTopology.cmd("ip link set netns %s dev %s" % (self.pid, t_int_if))
         if create_vlan_subintf \
             and VMTopology.intf_exists(t_int_sub_if) \
-            and not VMTopology.intf_exists(t_int_sub_if, self.pid) \
-            and not VMTopology.intf_exists(int_sub_if, self.pid):
+            and VMTopology.intf_not_exists(t_int_sub_if, self.pid) \
+            and VMTopology.intf_not_exists(int_sub_if, self.pid):
             VMTopology.cmd("ip link set netns %s dev %s" % (self.pid, t_int_sub_if))
 
-        if VMTopology.intf_exists(t_int_if, self.pid) and not VMTopology.intf_exists(int_if, self.pid):
+        if VMTopology.intf_exists(t_int_if, self.pid) and VMTopology.intf_not_exists(int_if, self.pid):
             VMTopology.cmd("nsenter -t %s -n ip link set dev %s name %s" % (self.pid, t_int_if, int_if))
         if create_vlan_subintf \
             and VMTopology.intf_exists(t_int_sub_if, self.pid) \
-            and not VMTopology.intf_exists(int_sub_if, self.pid):
+            and VMTopology.intf_not_exists(int_sub_if, self.pid):
             VMTopology.cmd("nsenter -t %s -n ip link set dev %s name %s" % (self.pid, t_int_sub_if, int_sub_if))
 
         VMTopology.iface_up(int_if, self.pid)
@@ -604,7 +605,7 @@ class VMTopology(object):
 
     def bind_vm_backplane(self):
 
-        if not VMTopology.intf_exists(self.bp_bridge):
+        if VMTopology.intf_not_exists(self.bp_bridge):
             VMTopology.cmd('brctl addbr %s' % self.bp_bridge)
 
         VMTopology.iface_up(self.bp_bridge)
@@ -827,6 +828,14 @@ class VMTopology(object):
                     self.remove_dut_vlan_subif_from_docker(ptf_if, vlan_separator, vlan_id)
 
     @staticmethod
+    def _intf_cmd(intf, pid=None):
+        if pid:
+            cmdline = 'nsenter -t %s -n ifconfig -a %s' % (pid, intf)
+        else:
+            cmdline = 'ifconfig -a %s' % intf
+        return cmdline
+
+    @staticmethod
     def intf_exists(intf, pid=None):
         """Check if the specified interface exists.
 
@@ -841,13 +850,33 @@ class VMTopology(object):
         Returns:
             bool: True if the interface exists. Otherwise False.
         """
-        if pid:
-            cmdline = 'nsenter -t %s -n ifconfig -a %s' % (pid, intf)
-        else:
-            cmdline = 'ifconfig -a %s' % intf
+        cmdline = VMTopology._intf_cmd(intf, pid=pid)
 
         try:
-            VMTopology.cmd(cmdline)
+            VMTopology.cmd(cmdline, retry=3)
+            return True
+        except:
+            return False
+
+    @staticmethod
+    def intf_not_exists(intf, pid=None):
+        """Check if the specified interface does not exist.
+
+        This function uses command "ifconfig <intf name>" to check the existence of the specified interface. By default
+        the command is executed on host. If a pid is specified, this command is executed in the network namespace
+        of the specified pid. The meaning is to check if the interface exists in a specific docker.
+
+        Args:
+            intf (str): Name of the interface.
+            pid (str), optional): Pid of docker. Defaults to None.
+
+        Returns:
+            bool: True if the interface does not exist. Otherwise False.
+        """
+        cmdline = VMTopology._intf_cmd(intf, pid=pid)
+
+        try:
+            VMTopology.cmd(cmdline, retry=3, negative=True)
             return True
         except:
             return False
@@ -875,39 +904,68 @@ class VMTopology(object):
             return VMTopology.cmd('nsenter -t %s -n ethtool -K %s tx off' % (pid, iface_name))
 
     @staticmethod
-    def cmd(cmdline, grep_cmd=None):
-        logging.debug('*** CMD: %s, grep: %s' % (cmdline, grep_cmd))
-        process = subprocess.Popen(
-            shlex.split(cmdline),
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
-        if grep_cmd:
-            process_grep = subprocess.Popen(
-                shlex.split(grep_cmd),
-                stdin=process.stdout,
+    def cmd(cmdline, grep_cmd=None, retry=1, negative=False):
+        """Execute a command and return the output
+
+        Args:
+            cmdline (str): The command line to be executed.
+            grep_cmd (str, optional): Grep command line. Defaults to None.
+            retry (int, optional): Max number of retry if command result is unexpected. Defaults to 1.
+            negative (bool, optional): If negative is True, expect the command to fail. Defaults to False.
+
+        Raises:
+            Exception: If command result is unexpected after max number of retries, raise an exception.
+
+        Returns:
+            str: Output of the command.
+        """
+
+        for attempt in range(retry):
+            logging.debug('*** CMD: %s, grep: %s, attempt: %d' % (cmdline, grep_cmd, attempt+1))
+            process = subprocess.Popen(
+                shlex.split(cmdline),
+                stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
-            out, err = process_grep.communicate()
-            ret_code = process_grep.returncode
+            if grep_cmd:
+                process_grep = subprocess.Popen(
+                    shlex.split(grep_cmd),
+                    stdin=process.stdout,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE)
+                out, err = process_grep.communicate()
+                ret_code = process_grep.returncode
+            else:
+                out, err = process.communicate()
+                ret_code = process.returncode
+            out, err = out.decode('utf-8'), err.decode('utf-8')
+
+            msg = {
+                'cmd': cmdline,
+                'grep_cmd': grep_cmd,
+                'ret_code': ret_code,
+                'stdout': out.splitlines(),
+                'stderr': err.splitlines()
+            }
+            logging.debug('*** OUTPUT: \n%s' % json.dumps(msg, indent=2))
+
+            if negative:
+                if ret_code != 0:
+                    # Result is expected, return early
+                    return out
+                else:
+                    # Result is unexpected, need to retry
+                    continue
+            else:
+                if ret_code == 0:
+                    # Result is expected, return early
+                    return out
+                else:
+                    # Result is unexpected, need to retry
+                    continue
         else:
-            out, err = process.communicate()
-            ret_code = process.returncode
-        out, err = out.decode('utf-8'), err.decode('utf-8')
-
-        msg = {
-            'cmd': cmdline,
-            'grep_cmd': grep_cmd,
-            'ret_code': ret_code,
-            'stdout': out.splitlines(),
-            'stderr': err.splitlines()
-        }
-        logging.debug('*** OUTPUT: \n%s' % json.dumps(msg, indent=2))
-
-        if ret_code != 0:
+            # Reached max retry, fail with exception
             raise Exception('ret_code=%d, error message="%s". cmd="%s"' % (ret_code, err, cmdline))
-
-        return out
 
     @staticmethod
     def get_ovs_br_ports(bridge):

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -963,9 +963,9 @@ class VMTopology(object):
                 else:
                     # Result is unexpected, need to retry
                     continue
-        else:
-            # Reached max retry, fail with exception
-            raise Exception('ret_code=%d, error message="%s". cmd="%s"' % (ret_code, err, cmdline))
+
+        # Reached max retry, fail with exception
+        raise Exception('ret_code=%d, error message="%s". cmd="%s"' % (ret_code, err, cmdline))
 
     @staticmethod
     def get_ovs_br_ports(bridge):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
PR #4156 optimized the performance of the vm_topology module. However, the retry
logci of running a command is also removed. On some testbeds, command like "ifconfig -a"
may fail ocassionally and need to retry. Without the retry logic, add-topo and
restart-ptf may fail ocassionally.

#### How did you do it?
This change added back the retry logic of running commands in the vm_topology module and
should can increase robustness of calling the vm_topology module.
The ceos_network module is also enhanced in the similiar way.

#### How did you verify/test it?
Test run add-topo/remove-topo/restart-ptf/refresh-dut on physical and KVM testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
