### PR TITLE
[TestbedProcessing] lab and veos files generator in YAML file format

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -38,6 +38,7 @@ parser = argparse.ArgumentParser(description="Process testbed.yml file")
 parser.add_argument('-i', help='a file for the testbed processing script', nargs="?", default="testbed-new.yaml")
 parser.add_argument('-basedir', help='base directory to find the files, points to /sonic-mgmt/ansible', default="")
 parser.add_argument('-backupdir', help='backup directory to store files,  points to /sonic-mgmt/ansible/backup',nargs="?", default="backup")
+parser.add_argument('-yaml', help='make lab and veos file in YAML format', action='store_true')
 args = parser.parse_args()
 
 # FILES TO BACKUP
@@ -552,6 +553,84 @@ def makeLab(data, devices, testbed, outfile):
                         toWrite.write(key2 + "=" + val2 + "\n")
                 toWrite.write("\n")
 
+
+def makeLabYAML(data, devices, testbed, outfile):
+    """
+    Generates /lab file in YAML format based on parsed dictionaries from testbed file.
+
+    Args:
+        data: reads from devices-groups, this helps separate the function into 3 components; sonic, fanout, ptf
+        devices: reads from devices
+        testbed: reads from testbed (to accomodate for PTF container(s))
+        outfile: writes to lab in YAML file format
+
+    """
+    deviceGroup = data
+    result = dict()
+    sonicDict = dict()
+    fanoutDict = dict()
+    ptfDict = dict()
+    dutDict = dict()
+
+    if "sonic" in deviceGroup['lab']['children']:
+        for group in deviceGroup['sonic']['children']:
+            sonicDict[group] = {'vars': {'iface_speed': deviceGroup[group].get("vars").get("iface_speed")}, 'hosts': {}}
+            for dut in deviceGroup[group]['host']:
+                if dut in devices:
+                    dutDict.update({dut:
+                        {'ansible_host': devices[dut].get("ansible").get("ansible_host"),
+                        'ansible_ssh_user': devices[dut].get("ansible").get("ansible_ssh_user"),
+                        'ansible_ssh_pass': devices[dut].get("ansible").get("ansible_ssh_pass"),
+                        'hwsku': devices[dut].get("hwsku"),
+                        'snmp_rocommunity': devices[dut].get("snmp_rocommunity"),
+                        'sonic_version': devices[dut].get("sonic_version"),
+                        'sonic_hwsku': devices[dut].get("sonic_hwsku"),
+                        'base_mac': devices[dut].get("base_mac"),
+                        'device_type': devices[dut].get("device_type"),
+                        'ptf_host': devices[dut].get("ptf_host"),
+                        'serial': devices[dut].get("serial"),
+                        'os': devices[dut].get("os"),
+                        'model': devices[dut].get("model")
+                        }
+                    })
+                    sonicDict[group]['hosts'].update(dutDict)
+    if "fanout" in deviceGroup['lab']['children']:
+        for fanout in deviceGroup['fanout']['host']:
+            if fanout in devices:
+                fanoutDict.update({fanout:
+                    {'ansible_host': devices[fanout].get("ansible").get("ansible_host"),
+                    'ansible_ssh_user': devices[fanout].get("ansible").get("ansible_ssh_user"),
+                    'ansible_ssh_pass': devices[fanout].get("ansible").get("ansible_ssh_pass"),
+                    'os': devices[fanout].get("os"),
+                    'device_type': devices[fanout].get("device_type")
+                    }
+                })
+    if 'ptf' in deviceGroup:
+        for ptfhost in deviceGroup['ptf']['host']:
+            if ptfhost in testbed:
+                ptfDict.update({ptfhost:
+                    {'ansible_host': testbed[ptfhost].get("ansible").get("ansible_host"),
+                    'ansible_ssh_user': testbed[ptfhost].get("ansible").get("ansible_ssh_user"),
+                    'ansible_ssh_pass': testbed[ptfhost].get("ansible").get("ansible_ssh_pass")
+                    }
+                })
+    result.update({'all':
+                    {'children':
+                        {'lab':
+                            {'vars': deviceGroup['lab']['vars'],
+                            'children':
+                                {'sonic': {'children': sonicDict},
+                                'fanout': {'hosts': fanoutDict}
+                                }
+                            },
+                        'ptf': {'hosts': ptfDict}
+                        }
+                    }
+    })
+
+    with open(outfile, "w") as toWrite:
+        yaml.dump(result, stream=toWrite, default_flow_style=False)
+
 """
 makeVeos(data, veos, devices, outfile)
 @:parameter data - reads from either veos-groups, this helps separate the function into 3 components; children, host, vars
@@ -604,6 +683,57 @@ def makeVeos(data, veos, devices, outfile):
                         toWrite.write(key2 + "=" + val2 + "\n")
                 toWrite.write("\n")
 
+
+def makeVeosYAML(data, veos, devices, outfile):
+    """
+    Generates /veos file in YAML format based on parsed dictionaries from testbed file.
+
+    Args:
+        data: reads from either veos-groups, this helps separate the function into 3 components; vm_host, eos, servers
+        veos: reads from either veos
+        devices: reads from devices
+        outfile: writes to veos in YAML file format
+
+    """
+    group = data
+    result = dict()
+    vmDict = dict()
+    eosDict = dict()
+    serversDict = dict()
+
+    if 'vm_host' in group:
+        for vm_host in group['vm_host']['children']:
+            vmDict.update({vm_host: None})
+            server = group[vm_host]['host'][0]
+            result.update({vm_host:
+                {'hosts':
+                    {server: {'ansible_host': devices[server.lower()].get("ansible").get("ansible_host")}}
+                }
+            })
+    if 'eos' in group:
+        for eos in group['eos']['children']:
+            eosDict.update({eos: None})
+            result.update({eos: {'hosts': veos[eos]}})
+    if 'servers' in group:
+        serversDict.update({'vars': group['servers'].get("vars"), 'children': {}})
+        for server in group['servers']['children']:
+            serversDict['children'].update({server: None})
+            result.update({server: {'children':{group[server]['children'][0]: None,
+                                                group[server]['children'][1]: None},
+                                    'vars': group[server]['vars']
+                                    }
+            })
+    result.update({'all':
+                    {'children':
+                        {'vm_host': {'children': vmDict},
+                        'eos': {'children': eosDict},
+                        'servers': serversDict
+                        }
+                    }
+    })
+
+    with open(outfile, "w") as toWrite:
+        yaml.dump(result, stream=toWrite, default_flow_style=False)
 
 """
 makeHost_var(data)
@@ -691,9 +821,15 @@ def main():
     print("\tCREATING MAIN.YML: " + args.basedir + main_file)
     makeMain(veos, args.basedir + main_file)  # Generate main.yml (MAIN)
     print("\tCREATING LAB FILE: " + args.basedir + lab_file)
-    makeLab(device_groups, devices, testbed, args.basedir + lab_file)  # Generate lab (LAB)
+    if args.yaml:
+        makeLabYAML(device_groups, devices, testbed, args.basedir + lab_file) # Generate lab in YAML file format (LAB)
+    else:
+        makeLab(device_groups, devices, testbed, args.basedir + lab_file)  # Generate lab in INI file format (LAB)
     print("\tCREATING VEOS FILE: " + args.basedir + veos_file)
-    makeVeos(veos_groups, veos, devices, args.basedir + veos_file)  # Generate veos (VEOS)
+    if args.yaml:
+        makeVeosYAML(veos_groups, veos, devices, args.basedir + veos_file)  # Generate veos in YAML file format(VEOS)
+    else:
+        makeVeos(veos_groups, veos, devices, args.basedir + veos_file)  # Generate veos in INI file format(VEOS)
     print("\tCREATING HOST VARS FILE(S): one or more files generated")
     makeHostVar(host_vars)  # Generate host_vars (HOST_VARS)
     print("UPDATING FILES FROM CONFIG FILE")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Added feature to generate lab and veos files in YAML format from testbed file using TestBed processing script
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
PR [2072](https://github.com/Azure/sonic-mgmt/pull/2072) introduced new approach that stores all configuration in YAML file format.
#### How did you do it?
Old approach with INI format of this files remained, but the possibility to create files in YAML format was added with use of -yaml argument in TestBed processing script.

veos YAML format example:  [Link]( https://github.com/Azure/sonic-mgmt/blob/master/ansible/veos)
lab YAML format example: 
```
all:
  children:
    lab:
      children:
        fanout:
          hosts:
            fanout-1:
              ansible_host: 1.1.1.1
              ansible_ssh_pass: your_password
              ansible_ssh_user: user_name
              device_type: device type
              os: os
	sonic:
          children:
            group1:
              hosts:
                dut1:
                  ansible_host: 1.1.1.2
                  ansible_ssh_pass: your_password
                  ansible_ssh_user: user_name
                  base_mac: mac address
                  device_type: device type
                  hwsku: hwsku
                  model: model
                  os: os
                  ptf_host: ptf1
                  serial: serial
                  snmp_rocommunity: snmp_rocommunity
                  sonic_hwsku: sonic hwsku
                  sonic_version: sonic version
	      vars:
                iface_speed: 'iface speed'
      vars:
        mgmt_subnet_mask_length: 'your mask length'
    ptf:
      hosts:
        ptf1:
          ansible_host: 1.1.1.3
          ansible_ssh_pass: your_password
          ansible_ssh_user: user_name
```
#### How did you verify/test it?
Generate YAML files and run tests
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
