### PR TITLE
Improve mac noptf

### DIFF
--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -113,7 +113,7 @@ class TestNeighborMacNoPtf:
                 for intf, status in intfStatus.items():
                     if "routed" in status["vlan"] and "up" in status["oper_state"]:
                         testRoutedInterface[asichost.asic_index] = intf
-                return testRoutedInterface
+            return testRoutedInterface
 
         if not wait_until(120, 2, find_routed_interface):
             pytest.fail('Failed to find routed interface in 120 s')

--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -115,7 +115,7 @@ class TestNeighborMacNoPtf:
                         testRoutedInterface[asichost.asic_index] = intf
                 return testRoutedInterface
 
-        if not wait_until(120, 2.0, find_routed_interface):
+        if not wait_until(120, 2, find_routed_interface):
             pytest.fail('Failed to find routed interface in 120 s')
 
         yield testRoutedInterface

--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -106,12 +106,17 @@ class TestNeighborMacNoPtf:
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         testRoutedInterface = {}
-        for asichost in duthost.asics:
-            intfStatus = asichost.show_interface(command="status")["ansible_facts"]["int_status"]
-            for intf, status in intfStatus.items():
-                if "routed" in status["vlan"] and "up" in status["oper_state"]:
-                    testRoutedInterface[asichost.asic_index] = intf
-            pytest_assert(testRoutedInterface, "Failed to find a routed interface in '%s'" % intfStatus)
+
+        def find_routed_interface():
+            for asichost in duthost.asics:
+                intfStatus = asichost.show_interface(command="status")["ansible_facts"]["int_status"]
+                for intf, status in intfStatus.items():
+                    if "routed" in status["vlan"] and "up" in status["oper_state"]:
+                        testRoutedInterface[asichost.asic_index] = intf
+                return testRoutedInterface
+
+        if not wait_until(120, 2.0, find_routed_interface):
+            pytest.fail('Failed to find routed interface in 120 s')
 
         yield testRoutedInterface
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In setupDutConfig of this test, it will do config reload, and the wait time is 120s. Sometimes for some platforms such as sn3800, 120s is not enough for interface to be up.  So use wait_until to check the interface is up or not, it will make the test more stable.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Use wait_until to check the interface is up or not, and make the test more stability.

#### How did you do it?
Use wait_until to check the interface is up or not.

#### How did you verify/test it?
run the test : test_neighbor_mac_noptf.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
