### PR TITLE
Add Client Link Layer field in DHCPv6 Relay tests

### DIFF
--- a/ansible/roles/test/files/ptftests/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcpv6_relay_test.py
@@ -404,11 +404,13 @@ class DHCPTest(DataplaneBaseTest):
     def runTest(self):
         self.client_send_solicit()
         self.verify_isc_relayed_solicit_relay_forward()
+        self.client_send_solicit()
         self.verify_relayed_solicit_relay_forward()
         self.server_send_advertise_relay_reply()
         self.verify_relayed_advertise()
         self.client_send_request()
         self.verify_isc_relayed_request_relay_forward()
+        self.client_send_request()
         self.verify_relayed_request_relay_forward()
         self.server_send_reply_relay_reply()
         self.verify_relayed_reply()

--- a/ansible/roles/test/files/ptftests/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcpv6_relay_test.py
@@ -49,6 +49,41 @@ class DataplaneBaseTest(BaseTest):
 
 """
 
+dhcp6opts = {79: "OPTION_CLIENT_LINKLAYER_ADDR",  # RFC6939
+             }
+class _DHCP6OptGuessPayload(Packet):
+    @staticmethod
+    def _just_guess_payload_class(cls, payload):
+        # try to guess what option is in the payload
+        if len(payload) <= 2:
+            return conf.raw_layer
+        opt = struct.unpack("!H", payload[:2])[0]
+        clsname = dhcp6opts_by_code.get(opt, None)
+        if clsname is None:
+            return cls
+        return get_cls(clsname, cls)
+
+    def guess_payload_class(self, payload):
+        # this method is used in case of all derived classes
+        # from _DHCP6OptGuessPayload in this file
+        return _DHCP6OptGuessPayload._just_guess_payload_class(
+            DHCP6OptUnknown,
+            payload
+        )
+
+class _LLAddrField(MACField):
+    pass
+
+# "Client link-layer address type.  The link-layer type MUST be a valid hardware  # noqa: E501
+# type assigned by the IANA, as described in [RFC0826]
+class DHCP6OptClientLinkLayerAddr(_DHCP6OptGuessPayload):  # RFC6939
+    name = "DHCP6 Option - Client Link Layer address"
+    fields_desc = [ShortEnumField("optcode", 79, dhcp6opts),
+                   FieldLenField("optlen", None, length_of="clladdr",
+                                 adjust=lambda pkt, x: x + 2),
+                   ShortField("lltype", 1),  # ethernet
+                   _LLAddrField("clladdr", ETHER_ANY)]
+
 class DHCPTest(DataplaneBaseTest):
 
     BROADCAST_MAC = '33:33:00:01:00:02'
@@ -124,6 +159,7 @@ class DHCPTest(DataplaneBaseTest):
         solicit_relay_forward_packet /= IPv6()
         solicit_relay_forward_packet /= UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         solicit_relay_forward_packet /= DHCP6_RelayForward(msgtype=12, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
+        solicit_relay_forward_packet /= DHCP6OptClientLinkLayerAddr()
         solicit_relay_forward_packet /= DHCP6OptRelayMsg()
         solicit_relay_forward_packet /= DHCP6_Solicit(trid=12345)
 
@@ -164,6 +200,7 @@ class DHCPTest(DataplaneBaseTest):
         request_relay_forward_packet /= IPv6()
         request_relay_forward_packet /= UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         request_relay_forward_packet /= DHCP6_RelayForward(msgtype=12, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
+        request_relay_forward_packet /= DHCP6OptClientLinkLayerAddr()
         request_relay_forward_packet /= DHCP6OptRelayMsg()
         request_relay_forward_packet /= DHCP6_Request(trid=12345)
 
@@ -218,6 +255,8 @@ class DHCPTest(DataplaneBaseTest):
         masked_packet.set_do_not_care_scapy(IPv6, "nh")
         masked_packet.set_do_not_care_scapy(packet.UDP, "chksum")
         masked_packet.set_do_not_care_scapy(packet.UDP, "len")
+        masked_packet.set_do_not_care_scapy(DHCP6OptClientLinkLayerAddr, "clladdr")
+        masked_packet.set_do_not_care_scapy(scapy.layers.dhcp6.DHCP6_RelayForward, "linkaddr")
 
         # Count the number of these packets received on the ports connected to our leaves
         solicit_count = testutils.count_matched_packets_all_ports(self, masked_packet, self.server_port_indices)
@@ -270,7 +309,9 @@ class DHCPTest(DataplaneBaseTest):
         masked_packet.set_do_not_care_scapy(IPv6, "nh")
         masked_packet.set_do_not_care_scapy(packet.UDP, "chksum")
         masked_packet.set_do_not_care_scapy(packet.UDP, "len")
-
+        masked_packet.set_do_not_care_scapy(DHCP6OptClientLinkLayerAddr, "clladdr")
+        masked_packet.set_do_not_care_scapy(scapy.layers.dhcp6.DHCP6_RelayForward, "linkaddr")
+        
         # Count the number of these packets received on the ports connected to our leaves
         request_count = testutils.count_matched_packets_all_ports(self, masked_packet, self.server_port_indices)
         self.assertTrue(request_count >= 1,

--- a/ansible/roles/test/files/ptftests/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcpv6_relay_test.py
@@ -11,6 +11,9 @@ from ptf.mask import Mask
 
 IPv6 = scapy.layers.inet6.IPv6
 
+isc_solicit_count = 0
+isc_request_count = 0
+
 class DataplaneBaseTest(BaseTest):
     def __init__(self):
         BaseTest.__init__(self)
@@ -165,6 +168,17 @@ class DHCPTest(DataplaneBaseTest):
 
         return solicit_relay_forward_packet
 
+    def isc_create_dhcp_solicit_relay_forward_packet(self):
+
+        solicit_relay_forward_packet = Ether(src=self.relay_iface_mac)
+        solicit_relay_forward_packet /= IPv6()
+        solicit_relay_forward_packet /= UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
+        solicit_relay_forward_packet /= DHCP6_RelayForward(msgtype=12, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
+        solicit_relay_forward_packet /= DHCP6OptRelayMsg()
+        solicit_relay_forward_packet /= DHCP6_Solicit(trid=12345)
+
+        return solicit_relay_forward_packet
+
     def create_dhcp_advertise_packet(self):
 
         advertise_packet = Ether(src=self.relay_iface_mac, dst=self.client_mac)
@@ -193,6 +207,17 @@ class DHCPTest(DataplaneBaseTest):
         request_packet /= DHCP6_Request(trid=12345)
 
         return request_packet
+
+    def isc_create_dhcp_request_relay_forward_packet(self):
+
+        request_relay_forward_packet = Ether(src=self.relay_iface_mac)
+        request_relay_forward_packet /= IPv6()
+        request_relay_forward_packet /= UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
+        request_relay_forward_packet /= DHCP6_RelayForward(msgtype=12, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
+        request_relay_forward_packet /= DHCP6OptRelayMsg()
+        request_relay_forward_packet /= DHCP6_Request(trid=12345)
+
+        return request_relay_forward_packet
 
     def create_dhcp_request_relay_forward_packet(self):
 
@@ -238,6 +263,25 @@ class DHCPTest(DataplaneBaseTest):
         solicit_packet = self.create_dhcp_solicit_packet()
         testutils.send_packet(self, self.client_port_index, solicit_packet)
 
+    def verify_isc_relayed_solicit_relay_forward(self):
+        global isc_solicit_count 
+        isc_solicit_relay_forward_packet = self.isc_create_dhcp_solicit_relay_forward_packet()
+
+        # Temporary for isc-dhcp
+        isc_masked_packet = Mask(isc_solicit_relay_forward_packet)
+        isc_masked_packet.set_do_not_care_scapy(packet.Ether, "dst")
+        isc_masked_packet.set_do_not_care_scapy(IPv6, "src")
+        isc_masked_packet.set_do_not_care_scapy(IPv6, "dst")
+        isc_masked_packet.set_do_not_care_scapy(IPv6, "fl")
+        isc_masked_packet.set_do_not_care_scapy(IPv6, "tc")
+        isc_masked_packet.set_do_not_care_scapy(IPv6, "plen")
+        isc_masked_packet.set_do_not_care_scapy(IPv6, "nh")
+        isc_masked_packet.set_do_not_care_scapy(packet.UDP, "chksum")
+        isc_masked_packet.set_do_not_care_scapy(packet.UDP, "len")
+
+        # Count number of packets relayed by isc-dhcp
+        isc_solicit_count = testutils.count_matched_packets_all_ports(self, isc_masked_packet, self.server_port_indices)
+
     # Verify that the DHCP relay actually received and relayed the DHCPv6 SOLICIT message to all of
     # its known DHCP servers.
     def verify_relayed_solicit_relay_forward(self):
@@ -260,8 +304,8 @@ class DHCPTest(DataplaneBaseTest):
 
         # Count the number of these packets received on the ports connected to our leaves
         solicit_count = testutils.count_matched_packets_all_ports(self, masked_packet, self.server_port_indices)
-        self.assertTrue(solicit_count >= 1,
-                "Failed: Solicit count of %d" % (solicit_count))
+        self.assertTrue((solicit_count + isc_solicit_count) >= 1,
+                "Failed: Solicit count of %d" % (solicit_count + isc_solicit_count))
 
     # Simulate a DHCP server sending a DHCPv6 RELAY-REPLY encapsulating ADVERTISE packet message to client.
     # We do this by injecting a RELAY-REPLY encapsulating ADVERTISE message on the link connected to one
@@ -292,6 +336,25 @@ class DHCPTest(DataplaneBaseTest):
         request_packet = self.create_dhcp_request_packet()
         testutils.send_packet(self, self.client_port_index, request_packet)
 
+    def verify_isc_relayed_request_relay_forward(self):
+        global isc_request_count 
+        isc_request_relay_forward_packet = self.isc_create_dhcp_request_relay_forward_packet()
+
+        # Temporary for isc-dhcp
+        isc_masked_packet = Mask(isc_request_relay_forward_packet)
+        isc_masked_packet.set_do_not_care_scapy(packet.Ether, "dst")
+        isc_masked_packet.set_do_not_care_scapy(IPv6, "src")
+        isc_masked_packet.set_do_not_care_scapy(IPv6, "dst")
+        isc_masked_packet.set_do_not_care_scapy(IPv6, "fl")
+        isc_masked_packet.set_do_not_care_scapy(IPv6, "tc")
+        isc_masked_packet.set_do_not_care_scapy(IPv6, "plen")
+        isc_masked_packet.set_do_not_care_scapy(IPv6, "nh")
+        isc_masked_packet.set_do_not_care_scapy(packet.UDP, "chksum")
+        isc_masked_packet.set_do_not_care_scapy(packet.UDP, "len")
+
+        # Count number of packets relayed by isc-dhcp
+        isc_request_count = testutils.count_matched_packets_all_ports(self, isc_masked_packet, self.server_port_indices)
+
     # Verify that the DHCP relay actually received and relayed the DHCPv6 REQUEST message to all of
     # its known DHCP servers.
     def verify_relayed_request_relay_forward(self):
@@ -314,7 +377,7 @@ class DHCPTest(DataplaneBaseTest):
         
         # Count the number of these packets received on the ports connected to our leaves
         request_count = testutils.count_matched_packets_all_ports(self, masked_packet, self.server_port_indices)
-        self.assertTrue(request_count >= 1,
+        self.assertTrue((request_count + isc_request_count) >= 1,
                 "Failed: Request count of %d" % (request_count))
                 
     # Simulate a DHCP server sending a DHCPv6 RELAY-REPLY encapsulating REPLY packet message to client.
@@ -340,10 +403,12 @@ class DHCPTest(DataplaneBaseTest):
 
     def runTest(self):
         self.client_send_solicit()
+        self.verify_isc_relayed_solicit_relay_forward()
         self.verify_relayed_solicit_relay_forward()
         self.server_send_advertise_relay_reply()
         self.verify_relayed_advertise()
         self.client_send_request()
+        self.verify_isc_relayed_request_relay_forward()
         self.verify_relayed_request_relay_forward()
         self.server_send_reply_relay_reply()
         self.verify_relayed_reply()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add RFC6939 support field in DHCPv6 messages
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To support new dhcp6relay binary that replaced isc-dhcp-relay

#### How did you do it?
Add DHCPv6 Client Link Layer Address field in Relay-Forward packets

#### How did you verify/test it?
Run tests with dhcp6relay binary

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
