### PR TITLE
Add rotation capable logging tool for customized ansible modules

### DIFF
--- a/ansible/module_utils/debug_utils.py
+++ b/ansible/module_utils/debug_utils.py
@@ -1,25 +1,54 @@
 import os
+import re
+import logging
 from pprint import pprint
 from ansible.module_utils.basic import datetime
 
+MAX_LOG_FILES_PER_MODULE = 10
 
-def create_debug_file(debug_fname, add_timestamp=True):
+
+def config_module_logging(module_name, log_path='/tmp', log_level=logging.DEBUG):
+    """Tool for configure logging to file for customized ansible modules
+
+    This tool aims to easy the effort for logging in customized ansible modules. To use it in customized ansible
+    module, please follow below pattern.
+    ```
+        from asible.module_utils.debug_utils import config_module_logging
+
+        config_module_logging('your_module_name')
+
+        logging.debug('some message')
+        logging.info('some message')
+    ```
+
+    After the function is imported and called with ansible module name as argument, then we can simply call
+    logging.debug, logging.info, etc., to log a message. The messages are automatically logged to files like:
+        /tmp/<ansible_module_name>_<iso_format_timestamp>.log
+
+    The default log path '/tmp' can be changed by passing argument `log_path` when calling this function.
+
+    Another important feature is that this function will also try to remove old log files of this module. The number
+    of most recent log files will be kept is specified by the global constant `MAX_LOG_FILES_PER_MODULE`.
+
+    Args:
+        module_name (str): Name of the customized ansible module.
+        log_path (str, optional): Path of log file. Defaults to '/tmp'.
+        log_level (log level, optional): Log level. Defaults to logging.DEBUG.
+    """
+
+    # Cleanup old log files to rotate
+    pattern = re.compile('{}_[\d\-T:\.]+\.log'.format(module_name))
+    existing_log_files = sorted([f for f in os.listdir(log_path) if pattern.match(f)])
+    old_log_files = existing_log_files[:-(MAX_LOG_FILES_PER_MODULE-1)]
+    try:
+        [os.remove(os.path.join(log_path, f)) for f in old_log_files]
+    except Exception as e:
+        pass
+
+    # Configure logging to file
     curtime = datetime.datetime.now().isoformat()
-    if add_timestamp:
-        # Check if there is an extension
-        fname_split = os.path.splitext(debug_fname)
-        if fname_split[1] != '':
-            # We have an extension
-            timed_debug_fname = (fname_split[0] + ".%s" + fname_split[1]) % curtime
-        else:
-            timed_debug_fname = (fname_split[0] + ".%s") % curtime
-    else:
-        timed_debug_fname = debug_fname
-    if os.path.exists(timed_debug_fname) and os.path.isfile(timed_debug_fname):
-        os.remove(timed_debug_fname)
-    return timed_debug_fname
-
-
-def print_debug_msg(debug_fname, msg):
-    with open(debug_fname, 'a') as fp:
-        pprint(msg, fp)
+    log_filename = os.path.join(log_path, '{}_{}.log'.format(module_name, curtime))
+    logging.basicConfig(
+        filename=log_filename,
+        format='%(asctime)s %(levelname)s #%(lineno)d: %(message)s',
+        level=log_level)

--- a/ansible/module_utils/debug_utils.py
+++ b/ansible/module_utils/debug_utils.py
@@ -1,7 +1,6 @@
 import os
 import re
 import logging
-from pprint import pprint
 from ansible.module_utils.basic import datetime
 
 MAX_LOG_FILES_PER_MODULE = 10


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Currently ansible/module_utils/debug_utils provided some functions for logging
in customized ansible modules. There are two issues with current tool:
1. There is no log rotation. Currently the conn_graph_facts module is using this
tool. Each call of the conn_graph_facts module would generate a log file to /tmp
folder of the sonic-mgmt container. Massive number log files would be generated
after couple rounds of nightly tests.
2. It is tedious to use the tool.

#### How did you do it?
This PR improved the existing logging tool in two ways:
1. Add log rotation support. It will keep the most recent 10 files at most.
2. Much more easier to use. Just import it and call it. Then we can use
logging.debug, logging.info, etc., to log in customized ansible modules.

#### How did you verify/test it?
Test run a script using the conn_graph_facts module over 10 times. Check the generated logs.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
