### PR TITLE
Mark test_inner_hashing xfail

### DIFF
--- a/tests/ecmp/test_inner_hashing.py
+++ b/tests/ecmp/test_inner_hashing.py
@@ -151,7 +151,9 @@ def symmetric_hashing(duthosts, rand_one_dut_hostname):
 def ipver(request):
     return request.param
 
-
+# The test case is expected to fail since some setup is missing.
+# Please remove the xfail marker when the issue is fixed.
+@pytest.mark.xfail
 def test_inner_hashing(hash_keys, ptfhost, ipver, router_mac, vlan_ptf_ports, symmetric_hashing, build_fib, setup):
     logging.info("Executing inner hash test for " + ipver + " with symmetric_hashing set to " + str(symmetric_hashing))
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
@@ -176,7 +178,7 @@ def test_inner_hashing(hash_keys, ptfhost, ipver, router_mac, vlan_ptf_ports, sy
                     "router_mac": router_mac,
                     "src_ports": vlan_ptf_ports,
                     "hash_keys": hash_keys,
-                    "vxlan_port": VXLAN_PORT, 
+                    "vxlan_port": VXLAN_PORT,
                     "inner_src_ip_range": ",".join(inner_src_ip_range),
                     "inner_dst_ip_range": ",".join(inner_dst_ip_range),
                     "outer_src_ip_range": ",".join(outer_src_ip_range),


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
```test_inner_hashing``` is expected to fail since some setup is missing.
This PR marks it as ```xfail``` explicitly.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR marks ```test_inner_hashing``` as ```xfail``` since the test failure is expected for now.

#### How did you do it?
Add a pytest marker.

#### How did you verify/test it?
Verified on MSN-2700, and confirmed no failure and error. The result is ```xfailed```.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
