### PR TITLE
Ignore PTF unreachable when stop PTF portchannel

### DIFF
--- a/ansible/roles/vm_set/tasks/ptf_portchannel.yml
+++ b/ansible/roles/vm_set/tasks/ptf_portchannel.yml
@@ -22,8 +22,17 @@
   set_fact:
     portchannel_config: "{{ topology['DUT']['portchannel_config'] | default({})}}"
 
-- name: Control PTF portchannel
+- name: Start PTF portchannel
   ptf_portchannel:
-    cmd: "{{ ptf_portchannel_action }}"
+    cmd: start
     portchannel_config: "{{ portchannel_config }}"
   delegate_to: "{{ ptf_host }}"
+  when: ptf_portchannel_action == 'start'
+
+- name: Stop PTF portchannel
+  ptf_portchannel:
+    cmd: stop
+    portchannel_config: "{{ portchannel_config }}"
+  delegate_to: "{{ ptf_host }}"
+  ignore_unreachable: yes
+  when: ptf_portchannel_action == 'stop'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach

#### What is the motivation for this PR?
In case the PTF docker is already down for some reason, run 'testbed-cli.sh restart-ptf' will fail unnecessarily at
the step of trying to stop PTF portchannel on the PTF docker. Error of such step should be ignored because
the stopped PTF docker will be recreated in subsequent steps.

#### How did you do it?
This change improved the ptf_portchannel.yml playbook to ignore such errors when stopping PTF portchannel.

#### How did you verify/test it?
Stop the PTF docker and then run `testbed-cli.sh restart-ptf`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
