### PR TITLE
[VxLAN] Work around for vxlan_decap flooding issue

### DIFF
--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 VTEP2_IP = "8.8.8.8"
 VNI_BASE = 336
-COUNT = 10
+COUNT = 1
 
 
 def prepare_ptf(ptfhost, mg_facts, duthost):


### PR DESCRIPTION
What is the motivation for this PR?
After decap of VxLAN header, the packets are flooding to all access ports on some platforms. It may cause the ptf can't
catch up with verify each packet.

How did you do it?
Modify the packet sending count from 10 to 1 between two ports to mitigate the flooding packets.

How did you verify/test it?
Run test_vlan_decap.py.

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
