### PR TITLE
Skip test_buffer if no port to run

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -10,7 +10,7 @@ import pytest
 
 from tests.common import config_reload
 from tests.common.utilities import wait_until
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 
@@ -644,6 +644,7 @@ def port_to_test(request, duthost):
 
     testPort = set(mgFacts["minigraph_ports"].keys())
     testPort -= set(dutLagInterfaces)
+    pytest_require(len(testPort) > 0, "No port to run test")
 
     PORT_TO_TEST = list(testPort)[0]
     lanes = duthost.shell('redis-cli -n 4 hget "PORT|{}" lanes'.format(PORT_TO_TEST))['stdout']


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
A batch of failures were saw on t1-lag topo because of there is no port to run test
```
       testPort = set(mgFacts["minigraph_ports"].keys())
        testPort -= set(dutLagInterfaces)
    
>       PORT_TO_TEST = list(testPort)[0]
E       IndexError: list index out of range
```
This PR addressed the issue by checking the len og ```testPort```, and skip the test if ```testPort``` is empty.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix ```test_buffer``` on ```t1-lag``` topo.

#### How did you do it?
This PR addressed the issue by checking the len og ```testPort```, and skip the test if ```testPort``` is empty.

#### How did you verify/test it?
Verified on SN4600, t1-lag topo, and confirmed the test was skipped.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
