### PR TITLE
[platform]: Fixed interface_utils.py for work correctly in case of empty description for interface

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -29,10 +29,17 @@ def parse_intf_status(lines):
     result = {}
     for line in lines:
         fields = line.split()
-        if len(fields) >= 5:
-            intf = fields[0]
+        intf = fields[0]
+        oper, admin, alias, desc = None, None, None, None
+
+        if len(fields) == 4:  # when port description is empty string ""
+            oper, admin, alias, desc = fields[1], fields[2], fields[3], ''
+        if len(fields) > 4:
             oper, admin, alias, desc = fields[1], fields[2], fields[3], ' '.join(fields[4:])
+
+        if oper and admin and alias:
             result[intf] = {"oper": oper, "admin": admin, "alias": alias, "desc": desc}
+
     return result
 
 


### PR DESCRIPTION
[platform]: Fixed interface_utils.py for work correctly in case of empty description for interface

* Fixed interface_utils.py - previously in case when description for interface was "" - it did not work correctly due to len of line.split()

Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Old logic did parse output for command "show interfaces description" correctly only in case when field "Description" not equal empty string ""
In case of empty string - it was unable to parse output correctly.

For now logic works in both cases:
```
Interface    Oper    Admin    Alias    Description
-----------  ------  -------  -------  -------------
  Ethernet0      up       up     etp1
  Ethernet4      up       up     etp2
  Ethernet8      up       up     etp3
```
and

```  
Interface    Oper    Admin    Alias    Description
-----------  ------  -------  -------  -------------
  Ethernet0      up       up     etp1            N/A
  Ethernet4      up       up     etp2            N/A
  Ethernet8      up       up     etp3            N/A
```

Summary: Fixed interface_utils.py for work correctly in case of empty description for interface
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Logic interface_utils.py did not work correctly in case of empty description for interface

#### How did you do it?
Fixed parser - see code

#### How did you verify/test it?
Executed test: "platform_tests/mellanox/test_check_sfp_using_ethtool.py" which use this logic

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
