### PR TITLE
[qos] Validate PG drop counters only on Mellanox

### DIFF
--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -676,7 +676,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
         ingress_counters, egress_counters = get_counter_names(sonic_version)
 
         # get a snapshot of PG drop packets counter
-        if '201811' not in sonic_version:
+        if '201811' not in sonic_version and 'mellanox' in asic_type:
             # According to SONiC configuration lossless dscps are classified as follows:
             # dscp  3 -> pg 3
             # dscp  4 -> pg 4
@@ -803,7 +803,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             for cntr in egress_counters:
                 assert(xmit_counters[cntr] == xmit_counters_base[cntr])
 
-            if '201811' not in sonic_version:
+            if '201811' not in sonic_version and 'mellanox' in asic_type:
                 pg_dropped_cntrs = sai_thrift_read_pg_drop_counters(self.client, port_list[src_port_id])
                 logging.info("Dropped packet counters on port #{} :{} packets, current dscp: {}".format(src_port_id, pg_dropped_cntrs[dscp], dscp))
                 # Check that counters per lossless PG increased


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
After the merge of #4176, the following failures were observed in our nightly runs on other platforms. This PR addresses this issue by invoking this check only for Mellanox platforms
```
E               "msg": "non-zero return code", 
E               "rc": 1, 
E               "start": "2021-09-20 21:31:42.428908", 
E               "stderr": "ptftests/remote.py:42: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.\n  constants = yaml.load(fd)\nsai_qos_tests.PFCtest ... test dst_port_id: 4, src_port_id: 5, src_vlan: 1000\nactual dst_port_id: 4\nFAIL\n\n======================================================================\nFAIL: sai_qos_tests.PFCtest\n----------------------------------------------------------------------\nTraceback (most recent call last):\n  File \"saitests/sai_qos_tests.py\", line 810, in runTest\n    assert pg_dropped_cntrs[dscp] > pg_dropped_cntrs_old[dscp]\nAssertionError\n\n----------------------------------------------------------------------\nRan 1 test in 47.442s\n\nFAILED (failures=1)\nNo handlers could be found for logger \"dataplane\"", 
E               "stderr_lines": [
E                   "ptftests/remote.py:42: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.", 
E                   "  constants = yaml.load(fd)", 
E                   "sai_qos_tests.PFCtest ... test dst_port_id: 4, src_port_id: 5, src_vlan: 1000", 
E                   "actual dst_port_id: 4", 
E                   "FAIL", 
E                   "", 
E                   "======================================================================", 
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

#### How did you verify/test it?
Ran the testcase that was failing with the fix and it passed