### PR TITLE
Added fix for getting of num_asics in TestbedProcessing

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -457,8 +457,9 @@ def makeLab(data, devices, testbed, outfile):
                             print("\t\t" + host + " num_fabric_asics not found")
 
                         try: #get num_asics
-                            num_asics = int(dev.get("num_asics"))
+                            num_asics = dev.get("num_asics")
                             if num_asics is not None:
+                               num_asics = int(num_asics)
                                entry += "\tnum_asics=" + str( num_asics )
                         except AttributeError:
                             print("\t\t" + host + " num_asics not found")


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added fix for getting of num_asics in TestbedProcessing

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Changes from [3746](https://github.com/Azure/sonic-mgmt/pull/3746) cause a minor issue in `TestbedProcessing.py` module. If `num_asics ` value is None, `makeLab ` function will fails due to TypeError.
```
Traceback (most recent call last):
  File "TestbedProcessing.py", line 857, in <module>
    main()
  File "TestbedProcessing.py", line 842, in main
    makeLab(device_groups, devices, testbed, args.basedir + lab_file)  # Generate lab in INI file format (LAB)
  File "TestbedProcessing.py", line 460, in makeLab
    num_asics = int(dev.get("num_asics"))
TypeError: int() argument must be a string or a number, not 'NoneType'
```
#### How did you do it?
Move converting of `num_asics` to `if `block.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
