### PR TITLE
Increase memory limit of PTF containers

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -75,8 +75,8 @@
             capabilities:
               - net_admin
             privileged: yes
-            memory: 4G
-            memory_swap: 4G
+            memory: 8G
+            memory_swap: 8G
           become: yes
 
         - name: Bind ptf_ip to keysight_api_server
@@ -111,8 +111,8 @@
         capabilities:
           - net_admin
         privileged: yes
-        memory: 4G
-        memory_swap: 4G
+        memory: 8G
+        memory_swap: 8G
       become: yes
 
     - name: Get dut ports
@@ -164,8 +164,8 @@
       capabilities:
         - net_admin
       privileged: yes
-      memory: 4G
-      memory_swap: 4G
+      memory: 8G
+      memory_swap: 8G
     become: yes
 
   - name: Enable ipv6 for docker container ptf_{{ vm_set_name }}

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -46,8 +46,8 @@
       capabilities:
         - net_admin
       privileged: yes
-      memory: 4G
-      memory_swap: 4G
+      memory: 8G
+      memory_swap: 8G
     become: yes
 
   - name: Enable ipv6 for docker container ptf_{{ vm_set_name }}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Increase memory limit of PTF containers to 8GB
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
There are recent warm reboot test failures observed due to the memory consumption exceeds the recently added limit of ptf containers. This PR aims to resolve the problem by increasing the memory consumption limit of ptf containers. 

#### How did you do it?
Increase memory limit of PTF containers to 8GB

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
