### PR TITLE
[link flap] increase port state change wait time to 60 seconds

### DIFF
--- a/tests/platform_tests/link_flap/link_flap_utils.py
+++ b/tests/platform_tests/link_flap/link_flap_utils.py
@@ -131,9 +131,10 @@ def toggle_one_link(dut, dut_port, fanout, fanout_port, watch=False):
     logger.info("Shutting down fanout switch %s port %s connecting to %s", fanout.hostname, fanout_port, dut_port)
 
     need_recovery = True
+    wait_secs = 60
     try:
         fanout.shutdown(fanout_port)
-        pytest_assert(wait_until(30, 1, __check_if_status, dut, dut_port, 'down', True), "dut port {} didn't go down as expected".format(dut_port))
+        pytest_assert(wait_until(wait_secs, 1, __check_if_status, dut, dut_port, 'down', True), "dut port {} didn't go down as expected".format(dut_port))
 
         if watch:
             time.sleep(1)
@@ -142,11 +143,11 @@ def toggle_one_link(dut, dut_port, fanout, fanout_port, watch=False):
         logger.info("Bring up fanout switch %s port %s connecting to %s", fanout.hostname, fanout_port, dut_port)
         fanout.no_shutdown(fanout_port)
         need_recovery = False
-        pytest_assert(wait_until(30, 1, __check_if_status, dut, dut_port, 'up', True), "dut port {} didn't go up as expected".format(dut_port))
+        pytest_assert(wait_until(wait_secs, 1, __check_if_status, dut, dut_port, 'up', True), "dut port {} didn't go up as expected".format(dut_port))
     finally:
         if need_recovery:
             fanout.no_shutdown(fanout_port)
-            wait_until(30, 1, __check_if_status, dut, dut_port, 'up', True)
+            wait_until(wait_secs, 1, __check_if_status, dut, dut_port, 'up', True)
 
 
 def watch_system_status(dut):


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
test_cont_link_flap.py fails randomly during nightly tests timing out waiting for a port to go down. Syslog shows that these port went down eventually just not within the timeframe test expected.

#### How did you do it?
Increase the wait time to 60 seconds.

#### How did you verify/test it?
Tested locally to make sure test passes.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

