### PR TITLE
[platform_tests] check C0 device after reboot

### DIFF
--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -255,4 +255,4 @@ def test_continuous_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost
     ls_ending_out = set(duthost.shell("ls /dev/C0-*", module_ignore_errors=True)["stdout"].split())
     pytest_assert(ls_ending_out.difference(ls_starting_out).size() == 0 and
             ls_starting_out.difference(ls_ending_out).size() == 0,
-            "Console devices have changed.")
+            "Console devices have changed:\n\texpected console devices: %s\n\tgot: %s" % (", ".join(sorted(ls_starting_out)), ", ".join(sorted(ls_ending_out))))

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -22,7 +22,7 @@ from tests.common.platform.transceiver_utils import check_transceiver_basic
 from tests.common.platform.interface_utils import check_all_interface_information, get_port_map
 from tests.common.platform.daemon_utils import check_pmon_daemon_status
 from tests.common.platform.processes_utils import wait_critical_processes, check_critical_processes
-
+from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -249,5 +249,10 @@ def test_continuous_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost
     @summary: This test case is to perform 3 cold reboot in a row
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    ls_starting_out = set(duthost.shell("ls /dev/C0-*", module_ignore_errors=True)["stdout"].split())
     for i in range(3):
         reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD)
+    ls_ending_out = set(duthost.shell("ls /dev/C0-*", module_ignore_errors=True)["stdout"].split())
+    pytest_assert(ls_ending_out.difference(ls_starting_out).size() == 0 and
+            ls_starting_out.difference(ls_ending_out).size() == 0,
+            "Console devices have changed.")

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -255,4 +255,4 @@ def test_continuous_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost
     ls_ending_out = set(duthost.shell("ls /dev/C0-*", module_ignore_errors=True)["stdout"].split())
     pytest_assert(ls_ending_out.difference(ls_starting_out).size() == 0 and
             ls_starting_out.difference(ls_ending_out).size() == 0,
-            "Console devices have changed:\n\texpected console devices: %s\n\tgot: %s" % (", ".join(sorted(ls_starting_out)), ", ".join(sorted(ls_ending_out))))
+            "Console devices have changed: expected console devices: {}, got: {}".format(", ".join(sorted(ls_starting_out)), ", ".join(sorted(ls_ending_out))))


### PR DESCRIPTION
Check that C0 devices are consistent before and after multiple reboot to
make sure console connectivity.

Signed-off-by: Xichen Lin <xichenlin@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Check that C0 devices are consistent before and after multiple reboot to
make sure console connectivity.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Console is our last resort of communication and it should be tested to ensure its stability.

#### How did you do it?
Check that /dev/C0-* are the same before and after reboots.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
