### PR TITLE
Fix variable typo and skip ip_proto 253 for inner hash testing

### DIFF
--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -171,14 +171,14 @@ class HashTest(BaseTest):
         # ip_proto 2 is IGMP, should not be forwarded by router
         # ip_proto 254 is experimental
         # MLNX ASIC can't forward ip_proto 254, BRCM is OK, skip for all for simplicity
-        skip_ports = [2, 253, 254]
+        skip_protos = [2, 253, 254]
         if ipv6:
             # Skip ip_proto 0 for IPv6
-            skip_ports.append(0)
+            skip_protos.append(0)
 
         while True:
             ip_proto = random.randint(0, 255)
-            if ip_proto not in skip_ports:
+            if ip_proto not in skip_protos:
                 return ip_proto
 
     def check_ipv4_route(self, hash_key, src_port, dst_port_list):

--- a/ansible/roles/test/files/ptftests/inner_hash_test.py
+++ b/ansible/roles/test/files/ptftests/inner_hash_test.py
@@ -139,10 +139,10 @@ class InnerHashTest(BaseTest):
         # ip_proto 2 is IGMP, should not be forwarded by router
         # ip_proto 254 is experimental
         # MLNX ASIC can't forward ip_proto 254, BRCM is OK, skip for all for simplicity
-        skip_protos = [2, 254]
+        skip_protos = [2, 253, 254]
         if ipv6:
             # Skip ip_proto 0 for IPv6
-            skip_ports.append(0)
+            skip_protos.append(0)
 
         while True:
             ip_proto = random.randint(0, 255)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix some issues in FIB hash and inner_hash testing.

#### How did you do it?
1. Fix variable typo in inner_hash_test.py
2. Skip ip proto 253 for inner hash testing for the same reason of PR #4274
3. Rename variable `skip_ports` to `skip_protos` in hash_test.py for better readability.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
