### PR TITLE
[test_bgp_bounce] Support storage backend topology

### DIFF
--- a/tests/bgp/templates/bgp_no_export.j2
+++ b/tests/bgp/templates/bgp_no_export.j2
@@ -19,7 +19,7 @@ enable password zebra
 !
 ! bgp multiple-instance
 !
-{% if DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
+{% if 'LeafRouter' in DEVICE_METADATA['localhost']['type'] %}
 route-map TO_TIER0_V4 permit 30
  set community no-export additive
 !
@@ -69,7 +69,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% if bgp_session['asn'] | int != 0 %}
   neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
   neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}
-{% if DEVICE_METADATA['localhost']['type'] == 'LeafRouter' and DEVICE_NEIGHBOR_METADATA[bgp_session['name']]['type'] == 'ToRRouter' or DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
+{% if 'LeafRouter' in DEVICE_METADATA['localhost']['type'] and 'ToRRouter' in DEVICE_NEIGHBOR_METADATA[bgp_session['name']]['type'] or 'ToRRouter' in DEVICE_METADATA['localhost']['type'] %}
   neighbor {{ neighbor_addr }} allowas-in 1
 {% endif %}
 {% if 'admin_status' in bgp_session and bgp_session['admin_status'] == 'down' or 'admin_status' not in bgp_session and 'default_bgp_status' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['default_bgp_status'] == 'down' and DEVICE_METADATA.localhost.type != 'ToRRouter' %}
@@ -79,8 +79,8 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   address-family ipv4
     neighbor {{ neighbor_addr }} activate
     maximum-paths 64
-{% if DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
- {%- if DEVICE_NEIGHBOR_METADATA[bgp_session['name']]['type'] == 'ToRRouter' %}
+{% if 'LeafRouter' in DEVICE_METADATA['localhost']['type'] %}
+ {%- if 'ToRRouter' in DEVICE_NEIGHBOR_METADATA[bgp_session['name']]['type'] %}
     neighbor {{ neighbor_addr }} route-map TO_TIER0_V4 out
     neighbor {{ neighbor_addr }} send-community
     neighbor {{ neighbor_addr }} allowas-in 1

--- a/tests/bgp/test_bgp_bounce.py
+++ b/tests/bgp/test_bgp_bounce.py
@@ -4,6 +4,7 @@ Test bgp no-export community in SONiC.
 
 import random
 import pytest
+import time
 
 from tests.common.helpers.assertions import pytest_assert
 from bgp_helpers import apply_bgp_config


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
* fix `test_bgp_bounce` on `t1-backend` topology

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
* fix the BGP templates to match correct neighbor type on `t1-backend`
* previous regression in kvm-test is because PR #4066 added `no bgp ebgp-requires-policy` in the templates, which will enable the device to advertise all routes to its neighbors. But on `t1-lag` topo in kvm test, the command `show ip bgp community no-export` on eos VM might suffer from timeout issue because the VM now receives full-copy of the DUT routes and the VM might needs more time to process. Removing this extra config line to ease the eos VM command processing.

#### How did you verify/test it?
* run over `t1-lag` and `t1-backend` topo

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
