### PR TITLE
[test_bgp_gr_helper] Fix bgp session check

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -145,23 +145,32 @@ class EosHost(AnsibleHostBase):
             commands=['show ipv6 bgp summary | json'])
         logging.info("ipv6 bgp summary: {}".format(out_v6))
 
-        for k, v in out_v4['stdout'][0]['vrfs']['default']['peers'].items():
-            if v['peerState'].lower() == state.lower():
-                if k in neigh_ips:
-                    neigh_ips_ok.append(k)
-                if 'description' in v:
-                    neigh_desc_available = True
-                    if v['description'] in neigh_desc:
-                        neigh_desc_ok.append(v['description'])
+        # when bgpd is inactive, the bgp summary output: [{u'vrfs': {}, u'warnings': [u'BGP inactive']}]
+        if 'BGP inactive' in out_v4['stdout'][0].get('warnings', '') and 'BGP inactive' in out_v6['stdout'][0].get('warnings', ''):
+            return False
 
-        for k, v in out_v6['stdout'][0]['vrfs']['default']['peers'].items():
-            if v['peerState'].lower() == state.lower():
-                if k.lower() in neigh_ips:
-                    neigh_ips_ok.append(k)
-                if 'description' in v:
-                    neigh_desc_available = True
-                    if v['description'] in neigh_desc:
-                        neigh_desc_ok.append(v['description'])
+        try:
+            for k, v in out_v4['stdout'][0]['vrfs']['default']['peers'].items():
+                if v['peerState'].lower() == state.lower():
+                    if k in neigh_ips:
+                        neigh_ips_ok.append(k)
+                    if 'description' in v:
+                        neigh_desc_available = True
+                        if v['description'] in neigh_desc:
+                            neigh_desc_ok.append(v['description'])
+
+            for k, v in out_v6['stdout'][0]['vrfs']['default']['peers'].items():
+                if v['peerState'].lower() == state.lower():
+                    if k.lower() in neigh_ips:
+                        neigh_ips_ok.append(k)
+                    if 'description' in v:
+                        neigh_desc_available = True
+                        if v['description'] in neigh_desc:
+                            neigh_desc_ok.append(v['description'])
+        except KeyError:
+            # ignore any KeyError due to unexpected BGP summary output
+            pass
+
         logging.info("neigh_ips_ok={} neigh_desc_available={} neigh_desc_ok={}"\
             .format(str(neigh_ips_ok), str(neigh_desc_available), str(neigh_desc_ok)))
         if neigh_desc_available:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/Azure/sonic-buildimage/issues/8817

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
* `check_bgp_session_state` might returns unexpected result due to inactive bgpd after starting bgpd on the eos VM.

#### How did you do it?
* if the bgpd is inactive, `check_bgp_session_state` returns `False` directly
* ignore those `KeyError`  if the output doesn't contains expected fields

#### How did you verify/test it?
* run `test_bgp_gr_helper` 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
