### PR TITLE
[multi-asic][vs]: Use the right KVM platform string for multi-asic vs

### DIFF
--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -249,6 +249,12 @@ def main():
                 num_asic = multi_asic.get_num_asics()
             except Exception as e:
                 num_asic = 1
+        # Modify KVM platform string based on num_asic
+        global KVM_PLATFORM
+        if num_asic == 4:
+            KVM_PLATFORM = "x86_64-kvm_x86_64_4_asic-r0"
+        if num_asic == 6:
+            KVM_PLATFORM = "x86_64-kvm_x86_64_6_asic-r0"
 
         switchid = 0
         include_internal = False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Error is seen when doing add-topo to bring up a multi-asic testbed.
```
./testbed-cli.sh -t vtestbed.csv -m veos_vtb add-topo vms-kvm-four-asic-t1-lag password.txt
..
TASK [find interface name mapping and individual interface speed if defined from dut] ***
Wednesday 22 September 2021  00:05:06 +0000 (0:00:00.937)       0:00:05.518 *** 
[WARNING]: Platform linux on host vlab-08 is using the discovered Python
interpreter at /usr/bin/python, but future installation of another Python
interpreter could change this. See https://docs.ansible.com/ansible/2.8/referen
ce_appendices/interpreter_discovery.html for more information.
fatal: [vlab-08]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "changed": false, "msg": "failed to find the correct port config for msft_four_asic_vslist index out of range"
```
Reason:
https://github.com/Azure/sonic-buildimage/pull/8269 added new multi-asic KVM platforms, for 4-asic and 6-asic VS.
When add-topo is done, port_alias.py runs on localhost to get the right front-panel interfaces so that VS can be brought up with the right number of front-panel interfaces. With the above PR, new platform string was added due to which port-config.ini file was under a new KVM platform directory, due to which the port config file was not being retrieved correctly. 

#### How did you do it?
Based on number of asics, use the right KVM platform string so that the right port-config file can be retrieved when bringing up VS testbed.
#### How did you verify/test it?
Was able to bring up VS testbed without the above error.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
