### PR TITLE
[console] improve console tests

### DIFF
--- a/tests/console/test_console_driver.py
+++ b/tests/console/test_console_driver.py
@@ -15,9 +15,9 @@ def test_console_driver(duthost):
     ttys = set(out.split())
     pytest_assert(len(ttys) > 0, "No virtual tty devices been created by console driver")
 
-    out = duthost.shell('redis-cli -n 4 keys CONSOLE_PORT* | grep -oP \'(?<=CONSOLE_PORT\|)[0-9]+\'', module_ignore_errors=True)['stdout']
-    for i in out.split():
-        expected_virtual_tty = "/dev/ttyUSB{}".format(int(i)-1)
+    out = duthost.console_facts()["ansible_facts"]["console_facts"]["lines"].keys()
+    for i in range(0, len(out)):
+        expected_virtual_tty = "/dev/ttyUSB{}".format(i)
         pytest_assert(
             expected_virtual_tty in ttys,
             "Expected virtual tty device [{}] not found.".format(expected_virtual_tty))

--- a/tests/console/test_console_driver.py
+++ b/tests/console/test_console_driver.py
@@ -15,8 +15,9 @@ def test_console_driver(duthost):
     ttys = set(out.split())
     pytest_assert(len(ttys) > 0, "No virtual tty devices been created by console driver")
 
-    for i in range(48):
-        expected_virtual_tty = "/dev/ttyUSB{}".format(i)
+    out = duthost.shell('redis-cli -n 4 keys CONSOLE_PORT* | grep -oP \'(?<=CONSOLE_PORT\|)[0-9]+\'', module_ignore_errors=True)['stdout']
+    for i in out.split():
+        expected_virtual_tty = "/dev/ttyUSB{}".format(int(i)-1)
         pytest_assert(
             expected_virtual_tty in ttys,
             "Expected virtual tty device [{}] not found.".format(expected_virtual_tty))

--- a/tests/console/test_console_udevrule.py
+++ b/tests/console/test_console_udevrule.py
@@ -15,8 +15,8 @@ def test_console_port_mapping(duthost):
     ttys = set(out.split())
     pytest_assert(len(ttys) > 0, "No console tty devices been created by udev rule")
 
-    out = duthost.shell('redis-cli -n 4 keys CONSOLE_PORT* | grep -oP \'(?<=CONSOLE_PORT\|)[0-9]+\'', module_ignore_errors=True)['stdout']
-    for i in out.split():
+    out = duthost.console_facts()["ansible_facts"]["console_facts"]["lines"].keys()
+    for i in out:
         expected_console_tty = "/dev/C0-{}".format(i)
         pytest_assert(
             expected_console_tty in ttys,

--- a/tests/console/test_console_udevrule.py
+++ b/tests/console/test_console_udevrule.py
@@ -15,7 +15,8 @@ def test_console_port_mapping(duthost):
     ttys = set(out.split())
     pytest_assert(len(ttys) > 0, "No console tty devices been created by udev rule")
 
-    for i in range(1, 49):
+    out = duthost.shell('redis-cli -n 4 keys CONSOLE_PORT* | grep -oP \'(?<=CONSOLE_PORT\|)[0-9]+\'', module_ignore_errors=True)['stdout']
+    for i in out.split():
         expected_console_tty = "/dev/C0-{}".format(i)
         pytest_assert(
             expected_console_tty in ttys,


### PR DESCRIPTION
get expected console device number from database

Signed-off-by: Xichen Lin <xichenlin@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Get console device number from database, rather than defaulting to 48.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Hard coding console device number to 48 might cause problems

#### How did you do it?
Get console device number from redis database.

#### How did you verify/test it?
On switch

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
