### PR TITLE
[dualtor][test_orch_stress] Fix the timing issue

### DIFF
--- a/tests/dualtor/test_orch_stress.py
+++ b/tests/dualtor/test_orch_stress.py
@@ -160,7 +160,7 @@ def test_change_mux_state(
     load_swss_config(dut, _swss_path(SWSS_MUX_STATE_STANDBY_CONFIG_FILE))
     load_swss_config(dut, _swss_path(SWSS_MUX_STATE_ACTIVE_CONFIG_FILE))
 
-    wait(3, 'extra wait for initial CRMs to be updated')
+    wait(10, 'extra wait for initial CRMs to be updated')
 
     crm_facts1 = dut.get_crm_facts()
     logger.info(json.dumps(crm_facts1, indent=4))
@@ -170,7 +170,7 @@ def test_change_mux_state(
         load_swss_config(dut, _swss_path(SWSS_MUX_STATE_STANDBY_CONFIG_FILE))
         load_swss_config(dut, _swss_path(SWSS_MUX_STATE_ACTIVE_CONFIG_FILE))
 
-    wait(3, 'extra wait for CRMs to be updated')
+    wait(10, 'extra wait for CRMs to be updated')
 
     crm_facts2 = dut.get_crm_facts()
     logger.info(json.dumps(crm_facts2, indent=4))


### PR DESCRIPTION
What is the motivation for this PR?
In test_orch_stress.py, it will check the CRM to stress test the resource leak issue. It may need some time to get the resource back after mux state change.

How did you do it?
Extend the wait time to 10s from 3s in the mux state change stress test.

How did you verify/test it?
Run the test_orch_stress.py

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
