### PR TITLE
compatible show lacp peer/neighbor in different EOS versions

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -88,7 +88,11 @@ class Arista(object):
             prompt = self.arista_prompt
 
         if cmd is not None:
-            self.shell.send(cmd + '\n')
+            if cmd.endswith('?'):
+                # '?' will auto trigger an 'enter', no need to add '\n' manually
+                self.shell.send(cmd)
+            else:
+                self.shell.send(cmd + '\n')
 
         input_buffer = ''
         while re.search(prompt, input_buffer) is None:
@@ -135,7 +139,13 @@ class Arista(object):
             cur_time = time.time()
             info = {}
             debug_info = {}
-            lacp_output = self.do_cmd('show lacp neighbor')
+            lacp_help = self.do_cmd('show lacp ?')
+            show_lacp_command = self.parse_supported_show_lacp_command(lacp_help)
+            self.log("show lacp command is %s"%(show_lacp_command))
+            # sent 'show lacp ?' in previous step already, so there are 'show lacp' in cmd ssh pipe
+            # only need to send 'peer' or 'neighbor' to complete the command
+            # don't send whole command('show lacp peer/neighbor') instead, it will mess the output pipe up
+            lacp_output = self.do_cmd(show_lacp_command)
             info['lacp'] = self.parse_lacp(lacp_output)
             bgp_neig_output = self.do_cmd('show ip bgp neighbors')
             info['bgp_neig'] = self.parse_bgp_neighbor(bgp_neig_output)
@@ -175,6 +185,7 @@ class Arista(object):
                     'show ip route bgp' : bgp_route_v4_output,
                     'show ipv6 route bgp' : bgp_route_v6_output,
                 }
+            time.sleep(5)
 
         attempts = 60
         log_present = False
@@ -386,6 +397,26 @@ class Arista(object):
                 prefixes.add(prefix)
 
         return set(expects) == prefixes
+
+    def parse_supported_show_lacp_command(self, lacp_help):
+        # lacp_help is the result of 'show lacp ?', be like :
+        #   aggregates  Display info about LACP aggregates
+        #   counters    Display LACP counters
+        #   internal    Display information internal to the Link Aggregation Control Protocol
+        #   neighbor    Display identity and info about LACP neighbor(s)
+        #   peer        Display identity and info about LACP neighbor(s)
+        #   sys-id      Display System Identifier used by LACP
+        #   $           list end
+        #   <1-2000>    Channel Group ID(s)
+
+        # 'show lacp neighbor' is deprecated by 'show lacp peer' in high EOS versions,
+        # so if 'show lacp neighbor' is supported, use 'show lacp neighbor'
+        # otherwise use 'show lacp peer' instead
+
+        for line in lacp_help.split('\n'):
+            if re.match('neighbor *Display.*', line.strip()):
+                return 'neighbor'
+        return 'peer'
 
     def check_bgp_route(self, expects, ipv6=False):
         cmd = 'show ip route {} | json'

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -448,7 +448,6 @@ class Arista(object):
             str: rest command of 'show lacp ', neighbor or peer
         """
 
-
         for line in lacp_help.split('\n'):
             if re.match('neighbor *Display.*', line.strip()):
                 return 'neighbor'

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -399,19 +399,24 @@ class Arista(object):
         return set(expects) == prefixes
 
     def parse_supported_show_lacp_command(self, lacp_help):
-        # lacp_help is the result of 'show lacp ?', be like :
-        #   aggregates  Display info about LACP aggregates
-        #   counters    Display LACP counters
-        #   internal    Display information internal to the Link Aggregation Control Protocol
-        #   neighbor    Display identity and info about LACP neighbor(s)
-        #   peer        Display identity and info about LACP neighbor(s)
-        #   sys-id      Display System Identifier used by LACP
-        #   $           list end
-        #   <1-2000>    Channel Group ID(s)
+        """
+        'show lacp neighbor' is deprecated by 'show lacp peer' in high EOS versions,
+        so if 'show lacp neighbor' is supported, use 'show lacp neighbor'
+        otherwise use 'show lacp peer' instead
+        Args:
+            lacp_help (str): result of command 'show lacp ?', be like :
+                                   aggregates  Display info about LACP aggregates
+                                   counters    Display LACP counters
+                                   internal    Display information internal to the Link Aggregation Control Protocol
+                                   neighbor    Display identity and info about LACP neighbor(s)
+                                   peer        Display identity and info about LACP neighbor(s)
+                                   sys-id      Display System Identifier used by LACP
+                                   $           list end
+                                   <1-2000>    Channel Group ID(s)
+        Returns:
+            str: rest command of 'show lacp ', neighbor or peer
+        """
 
-        # 'show lacp neighbor' is deprecated by 'show lacp peer' in high EOS versions,
-        # so if 'show lacp neighbor' is supported, use 'show lacp neighbor'
-        # otherwise use 'show lacp peer' instead
 
         for line in lacp_help.split('\n'):
             if re.match('neighbor *Display.*', line.strip()):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
1. Make show lacp command compatible in different EOS versions
2. Add interval to polling to avoid meaningless command request
#### How did you do it?
1. 'show lacp neighbor' is deprecated by 'show lacp peer' in high EOS versions,
so if 'show lacp neighbor' is supported, use 'show lacp neighbor'
otherwise use 'show lacp peer' instead
2. Add time.sleep in polling
#### How did you verify/test it?
run platform_tests/test_advanced_reboot.py which is related to EOS VMs closely.

platform_tests/test_advanced_reboot.py::test_fast_reboot SKIPPED [ 9%]
platform_tests/test_advanced_reboot.py::test_warm_reboot PASSED [ 18%]
platform_tests/test_advanced_reboot.py::test_cancelled_fast_reboot SKIPPED [ 27%]
platform_tests/test_advanced_reboot.py::test_cancelled_warm_reboot PASSED [ 36%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad SKIPPED [ 45%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_multi_sad SKIPPED [ 54%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_multi_sad_inboot SKIPPED [ 63%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad_bgp SKIPPED [ 72%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad_lag_member SKIPPED [ 81%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad_lag SKIPPED [ 90%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad_vlan_port SKIPPED [100%]

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
