### PR TITLE
[multi-asic][vs]: Modify the start VM for vms-kvm-four-asic-t1-lag

### DIFF
--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -258,3 +258,7 @@ vms_1:
       ansible_host: 10.250.0.81
     VM0131:
       ansible_host: 10.250.0.82
+    VM0132:
+      ansible_host: 10.250.0.83
+    VM0133:
+      ansible_host: 10.250.0.84

--- a/ansible/vtestbed.csv
+++ b/ansible/vtestbed.csv
@@ -5,5 +5,5 @@ vms-kvm-t1-lag,vms6-2,t1-lag,docker-ptf,ptf-02,10.250.0.106/24,fec0::ffff:afa:6/
 vms-kvm-t0-2,vms6-3,t0,docker-ptf,ptf-03,10.250.0.108/24,fec0::ffff:afa:8/64,server_1,VM0104,[vlab-04],veos_vtb,False,Tests virtual switch vm
 vms-kvm-dual-t0,vms6-4,dualtor,docker-ptf,ptf-04,10.250.0.109/24,fec0::ffff:afa:9/64,server_1,VM0108,[vlab-05;vlab-06],veos_vtb,False,Dual-TOR testbed
 vms-kvm-multi-asic-t1-lag,vms6-4,t1-64-lag,docker-ptf,ptf-05,10.250.0.110/24,fec0::ffff:afa:a/64,server_1,VM0104,[vlab-07],veos_vtb,False,Tests multi-asic virtual switch vm
-vms-kvm-four-asic-t1-lag,vms6-4,t1-8-lag,docker-ptf,ptf-05,10.250.0.110/24,fec0::ffff:afa:a/64,server_1,VM0104,[vlab-08],veos_vtb,False,Tests multi-asic virtual switch vm
+vms-kvm-four-asic-t1-lag,vms6-4,t1-8-lag,docker-ptf,ptf-05,10.250.0.110/24,fec0::ffff:afa:a/64,server_1,VM0128,[vlab-08],veos_vtb,False,Tests multi-asic virtual switch vm
 vms-kvm-t2,vms6-4,t2-vs,docker-ptf,ptf-04,10.250.0.109/24,fec0::ffff:afa:9/64,server_1,VM0100,[vlab-t2-01;vlab-t2-02;vlab-t2-sup],veos_vtb,False,T2 Virtual chassis

--- a/ansible/vtestbed.yaml
+++ b/ansible/vtestbed.yaml
@@ -99,7 +99,7 @@
   ptf_ip: 10.250.0.110/24
   ptf_ipv6: fec0::ffff:afa:a/64
   server: server_1
-  vm_base: VM0104
+  vm_base: VM0128
   dut:
     - vlab-08
   inv_name: veos_vtb


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
[multi-asic][vs]: Modify the start VM for vms-kvm-four-asic-t1-lag so that t1-lag and vms-kvm-four-asic-t1-lag can be brought up in the same server at the same time.
#### How did you do it?
- Modify start VM for vms-kvm-four-asic-t1-lag 
- vms-kvm-four-asic-t1-lag  requires 6 VMs, so added 2 additional VMs.
#### How did you verify/test it?
- Use 4-asic VS image.
- Bring up tesbted using:./testbed-cli.sh -t vtestbed.csv -m veos_vtb -k ceos add-topo vms-kvm-four-asic-t1-lag password.txt

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
