### PR TITLE
prolong ceos mgmt-ip wait timeout threshold

### DIFF
--- a/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
+++ b/ansible/roles/eos/tasks/ceos_ensure_reachable.yml
@@ -1,7 +1,7 @@
 - block:
   - name: set time out threshold
     set_fact:
-      timeout_threshold: 120
+      timeout_threshold: 240
 
   - name: wait until container's mgmt-ip is reachable
     wait_for:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Avoid frequently restart ceos containers, will shorten the time of add-topo, especially the testbed on the machine without high performance.
#### How did you do it?
Increase the ceos mgmt-ip wait timeout threshold
#### How did you verify/test it?
Run add-topo again
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
