### PR TITLE
Skip VLAN interfaces in route perf tests

### DIFF
--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -100,6 +100,8 @@ def generate_intf_neigh(duthost, num_neigh, ip_version):
     for itfs_name in up_interfaces:
         if not itfs_name.startswith("PortChannel") and interfaces[itfs_name]['vlan'].startswith("PortChannel"):
             continue
+        if interfaces[itfs_name]['vlan'] == 'trunk':
+            continue
         if ip_version == 4:
             intf_neigh = {
                 'interface' : itfs_name,
@@ -125,6 +127,9 @@ def generate_intf_neigh(duthost, num_neigh, ip_version):
         idx_neigh += 1
         if idx_neigh == num_neigh:
             break
+
+    if not intf_neighs:
+        raise Exception('DUT does not have interfaces available for test')
 
     return intf_neighs, str_intf_nexthop
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip VLAN interfaces in route perf tests
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
According to https://github.com/Azure/sonic-utilities/pull/1374, the command fails when adding IP to an interface that is a member of VLAN with the following error message:
```
Interface Ethernet8 is a member of vlan
Aborting!
```
Therefore, we need to avoid using interfaces that are a member of VLAN in route perf tests.

#### How did you do it?
Skip interface if it is a member of a VLAN.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
