### PR TITLE
upgrade ceos to version 4.25.5.1M

### DIFF
--- a/ansible/group_vars/all/ceos.yml
+++ b/ansible/group_vars/all/ceos.yml
@@ -1,4 +1,9 @@
-ceos_image_filename: cEOS64-lab-4.23.2F.tar.xz
-ceos_image_orig: ceosimage:4.23.2F
-ceos_image: ceosimage:4.23.2F-1
+# upgrade cEOS to 4.25.5.1M from 4.23.2F at 2021/09/24
+
+#ceos_image_filename: cEOS64-lab-4.23.2F.tar.xz
+#ceos_image_orig: ceosimage:4.23.2F
+#ceos_image: ceosimage:4.23.2F-1
+ceos_image_filename: cEOS64-lab-4.25.5.1M.tar
+ceos_image_orig: ceosimage:4.25.5.1M
+ceos_image: ceosimage:4.25.5.1M-1
 skip_ceos_image_downloading: false


### PR DESCRIPTION
upgrade ceos to version 4.25.5.1M, fix cEOS containers' mgmt-ip occasionally unavaillable issue

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
cEOS containers' mgmt-ip occasionally unavaillable, upgrade cEOS image version will fix that

#### How did you do it?
upgrade cEOS image version

#### How did you verify/test it?
Run platform_tests/test_advanced_reboot.py testcases which is related to c/vEOS closely on physical testbed

platform_tests/test_advanced_reboot.py::test_fast_reboot SKIPPED         [  9%]
platform_tests/test_advanced_reboot.py::test_warm_reboot PASSED          [ 18%]
platform_tests/test_advanced_reboot.py::test_cancelled_fast_reboot SKIPPED [ 27%]
platform_tests/test_advanced_reboot.py::test_cancelled_warm_reboot PASSED [ 36%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad SKIPPED     [ 45%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_multi_sad SKIPPED [ 54%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_multi_sad_inboot SKIPPED [ 63%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad_bgp SKIPPED [ 72%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad_lag_member SKIPPED [ 81%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad_lag SKIPPED [ 90%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad_vlan_port SKIPPED [100%]

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
