### PR TITLE
[test_decap] Support storage backend topology

### DIFF
--- a/tests/common/fixtures/fib_utils.py
+++ b/tests/common/fixtures/fib_utils.py
@@ -189,7 +189,7 @@ def gen_fib_info_file(ptfhost, fib_info, filename):
 
 
 @pytest.fixture(scope='module')
-def fib_info_files(duthosts, ptfhost, duts_running_config_facts, duts_minigraph_facts, tbinfo):
+def fib_info_files(duthosts, ptfhost, duts_running_config_facts, duts_minigraph_facts, tbinfo, request):
     """Get FIB info from database and store to text files on PTF host.
 
     For T2 topology, generate a single file to /root/fib_info_all_duts.txt to PTF host.
@@ -207,10 +207,16 @@ def fib_info_files(duthosts, ptfhost, duts_running_config_facts, duts_minigraph_
         list: List of FIB info file names on PTF host.
     """
     duts_config_facts = duts_running_config_facts
+    testname = request.node.name
     files = []
     if tbinfo['topo']['type'] != "t2":
         for dut_index, duthost in enumerate(duthosts):
             fib_info = get_fib_info(duthost, duts_config_facts[duthost.hostname], duts_minigraph_facts[duthost.hostname])
+            if 'test_decap' in testname and 'backend' in tbinfo['topo']['name']:
+                # if it is a storage backend topo and the testcase is test_decap
+                # add default routes with empty nexthops as the prefix matching failover
+                fib_info[u'0.0.0.0/0'] = []
+                fib_info[u'::/0'] = []
             filename = '/root/fib_info_dut{}.txt'.format(dut_index)
             gen_fib_info_file(ptfhost, fib_info, filename)
             files.append(filename)

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -11,6 +11,7 @@ from ansible.plugins.filter.core import to_bool
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import ptf_test_port_map
 from tests.common.fixtures.fib_utils import fib_info_files
 from tests.ptf_runner import ptf_runner


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3850

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
* Let's fix `test_decap` on storage backend topologies
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
1. use `set_ptf_port_mapping_mode` to select sub port interface for IO test
2. add default routes to `fib_info_files` as a failover in prefix matching since storage backend topologies have no default roue present

#### How did you verify/test it?
* run over both `t0-backend` and `t1-backend`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
