### PR TITLE
[tgen] Specify neighbor metadata for tgen topology

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -67,8 +67,7 @@
 
     - name: set vm
       set_fact:
-        vm_base: "{{ testbed_facts['vm_base'] }}"
-      when: "testbed_facts['vm_base'] != ''"
+        vm_base: "{% if testbed_facts['vm_base'] != '' %}{{ testbed_facts['vm_base'] }}{% else %}''{% endif %}"
     when: testbed_name is defined
 
   - topo_facts: topo={{ topo }} hwsku={{ hwsku }}
@@ -147,7 +146,7 @@
     when: vm_file is not defined
 
   - set_fact:
-      VM_topo: "{% if 'ptf' in topo or 'docker-keysight-api-server' in ptf_image %}False{% else %}True{% endif %}"
+      VM_topo: "{% if 'ptf' in topo %}False{% else %}True{% endif %}"
       remote_dut: "{{ ansible_ssh_host }}"
 
   - name: gather testbed VM informations


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4223

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

#### What is the motivation for this PR?
On running RDMA tests, RX drops were seen on lag member interface. This was due to no pg profile attached to this port since the cable len was set to 0m. The cable len table is populated based on DEVICE_NEIGHBOR and DEVICE_NEIGHBOR_METADATA. DEVICE_NEIGHBOR_METADATA table is currently missing for tgen topology. This PR makes the necessary enhancement needed so that this table gets generated during minigraph deploy.

#### How did you do it?
Changes done so that the 'Devices' section of the minigraph will get populated with the neighbor info during rendering minigraph_png.j2 for tgen topology

#### How did you verify/test it?
Ran deploy-mg on tgen topology and ensured that the necessary table was generated
Ran deploy-mg on backend T0 topology to ensure that the new changes didn't cause any regression
