### PR TITLE
Update test_syslog to test 2 syslog servers

### DIFF
--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -2,7 +2,6 @@ import logging
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 

--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -30,7 +30,7 @@ def _check_pcap(dummy_ip_a, dummy_ip_b, filepath):
             is_ok_a = True
         if is_ok_b is False and data[proto].dst == dummy_ip_b:
             is_ok_b = True
-        if is_ok_a and is_ok_b is True:
+        if is_ok_a and is_ok_b:
             return True
 
     return False

--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -10,67 +10,67 @@ pytestmark = [
     pytest.mark.topology("any")
 ]
 
-SYSLOG_STARTUP_TIMEOUT = 30
-SYSLOG_STARTUP_POLLING_INTERVAL = 3
+DUT_PCAP_FILEPATH = "/tmp/test_syslog_tcpdump.pcap"
+DOCKER_TMP_PATH = "/tmp/"
 
-SYSLOG_MESSAGE_TEST_TIMEOUT = 10
-
-
-def config_syslog_srv(ptfhost):
-    logger.info("Configuring the syslog server")
-
-    # Add the imudp configuration if not present
-    ptfhost.shell("sed -i -e '/^input(type/d' -e '/^module/d' /etc/rsyslog.conf; sed -i -e '$amodule(load=\"imudp\")' -e '$ainput(type=\"imudp\" port=\"514\")' /etc/rsyslog.conf")
-
-    # Restart Syslog Daemon
-    logger.info("Restarting rsyslog service")
-    ptfhost.shell("service rsyslog stop && rm -rf /var/log/syslog && touch /var/log/syslog && service rsyslog restart")
-
-    # Wait a little bit for service to start
-    rsyslog_running_msg="rsyslogd is running"
-    def _is_syslog_running():
-        result = ptfhost.shell("service rsyslog status | grep \"{}\"".format(rsyslog_running_msg))["stdout"]
-        return rsyslog_running_msg in result
-
-    logger.debug("Waiting for rsyslog server to restart")
-    wait_until(SYSLOG_STARTUP_TIMEOUT, SYSLOG_STARTUP_POLLING_INTERVAL, _is_syslog_running)
-    logger.debug("rsyslog server restarted")
-
-
-@pytest.fixture(scope="module")
-def config_dut(tbinfo, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    logger.info("Configuring the DUT")
-    local_syslog_srv_ip = tbinfo["ptf_ip"]
-    logger.info("test_syslog_srv_ip %s", local_syslog_srv_ip)
-
-    # Add Rsyslog destination for testing
-    duthost.shell("sudo config syslog add {}".format(local_syslog_srv_ip))
-    logger.debug("Added new rsyslog server IP {}".format(local_syslog_srv_ip))
-
-    yield
-
-    # Remove the syslog configuration
-    duthost.shell("sudo config syslog del {}".format(local_syslog_srv_ip))
-
-
-def test_syslog(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, config_dut):
+@pytest.mark.parametrize("dummy_syslog_server_ip_a, dummy_syslog_server_ip_b", [("10.0.80.166", None), ("fd82:b34f:cc99::100", None), ("10.0.80.165", "10.0.80.166"), ("fd82:b34f:cc99::100", "10.0.80.166"), ("fd82:b34f:cc99::100", "fd82:b34f:cc99::200")])
+def test_syslog(duthosts, enum_rand_one_per_hwsku_frontend_hostname, dummy_syslog_server_ip_a, dummy_syslog_server_ip_b):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     logger.info("Starting syslog tests")
     test_message = "Basic Test Message"
 
-    logger.debug("Configuring rsyslog server")
-    config_syslog_srv(ptfhost)
+    logger.info("Configuring the DUT")
+    # Add dummy rsyslog destination for testing
+    if dummy_syslog_server_ip_a is not None:
+        duthost.shell("sudo config syslog add {}".format(dummy_syslog_server_ip_a))
+        logger.debug("Added new rsyslog server IP {}".format(dummy_syslog_server_ip_a))
+    if dummy_syslog_server_ip_b is not None:
+        duthost.shell("sudo config syslog add {}".format(dummy_syslog_server_ip_b))
+        logger.debug("Added new rsyslog server IP {}".format(dummy_syslog_server_ip_b))
+
+    logger.info("Start tcpdump")
+    tcpdump_task, tcpdump_result = duthost.shell("sudo timeout 20 tcpdump -i any -s0 -A -w {} \"udp and port 514\"".format(DUT_PCAP_FILEPATH), module_async=True)
+    # wait for starting tcpdump
+    time.sleep(5)
 
     logger.debug("Generating log message from DUT")
     # Generate a syslog from the DUT
     duthost.shell("logger --priority INFO {}".format(test_message))
 
-    # Check syslog messages for the test message
-    def _check_syslog():
-        result = ptfhost.shell("grep {} /var/log/syslog | grep -v ansible | grep -c \"{}\""
-                               .format(duthost.hostname, test_message))["stdout"]
-        return result != "0"
+    # wait for stoping tcpdump 
+    tcpdump_task.close()
+    tcpdump_task.join()
 
-    pytest_assert(wait_until(SYSLOG_MESSAGE_TEST_TIMEOUT, 1, _check_syslog),
-                  "Test syslog message not seen on the server after {}s".format(SYSLOG_MESSAGE_TEST_TIMEOUT))
+    # Remove the syslog configuration
+    if dummy_syslog_server_ip_a is not None:
+        duthost.shell("sudo config syslog del {}".format(dummy_syslog_server_ip_a))
+    if dummy_syslog_server_ip_b is not None:
+        duthost.shell("sudo config syslog del {}".format(dummy_syslog_server_ip_b))
+
+    duthost.fetch(src=DUT_PCAP_FILEPATH, dest=DOCKER_TMP_PATH)
+
+    # Check pcap file for the destination IPs
+    def _check_pcap(dummy_ip_a, dummy_ip_b):
+        is_ok_a = False
+        is_ok_b = False
+
+        if dummy_ip_a is None:
+            is_ok_a = True
+        if dummy_ip_b is None:
+            is_ok_b = True
+
+        filepath = DOCKER_TMP_PATH + duthost.hostname + DUT_PCAP_FILEPATH
+        packets = rdpcap(filepath)
+        for data in packets:
+            proto = "IPv6" if "IPv6" in data else "IP"
+            if is_ok_a is False and data[proto].dst == dummy_ip_a:
+                is_ok_a = True
+            if is_ok_b is False and data[proto].dst == dummy_ip_b:
+                is_ok_b = True
+            if is_ok_a and is_ok_b is True:
+                return True
+
+        return False
+
+    pytest_assert(_check_pcap(dummy_syslog_server_ip_a, dummy_syslog_server_ip_b),
+                  "Dummy syslog server IP not seen in the pcap file")

--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -70,7 +70,7 @@ def test_syslog(duthosts, enum_rand_one_per_hwsku_frontend_hostname, dummy_syslo
         duthost.shell("sudo config syslog del {}".format(dummy_syslog_server_ip_b))
 
     duthost.fetch(src=DUT_PCAP_FILEPATH, dest=DOCKER_TMP_PATH)
-    filepath = DOCKER_TMP_PATH + duthost.hostname + DUT_PCAP_FILEPATH
+    filepath = os.path.join(DOCKER_TMP_PATH, duthost.hostname, DUT_PCAP_FILEPATH.lstrip(os.path.sep))
 
     pytest_assert(_check_pcap(dummy_syslog_server_ip_a, dummy_syslog_server_ip_b, filepath),
                   "Dummy syslog server IP not seen in the pcap file")


### PR DESCRIPTION
Signed-off-by: Yuxuan Ye yuxuanye@microsoft.com

### Description of PR

Summary:
Fixes #3592

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

The motivation is to update syslog test to test 2 syslog servers and support IPv6 test

#### How did you do it?

- Use tcpdump to capture syslog packets on DUT
- Use scapy to analysis pcap file and determine whether it can find all the server IPs used for testing

#### How did you verify/test it?

Run syslog test cases

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
