### PR TITLE
[dualtor][orchagent] Flush dataplane cache before sending/verifying pkts

### DIFF
--- a/ansible/roles/test/files/ptftests/ip_in_ip_tunnel_test.py
+++ b/ansible/roles/test/files/ptftests/ip_in_ip_tunnel_test.py
@@ -167,6 +167,7 @@ class IpinIPTunnelTest(BaseTest):
         for i in range(0, PACKET_NUM_FOR_NEGATIVE_CHECK):
             inner_pkt = self.generate_packet_to_server('src-ip')
             unexpected_packet = self.generate_unexpected_packet(inner_pkt)
+            self.dataplane.flush()
             send_packet(self, src_port, inner_pkt)
             verify_no_packet(test=self,
                              port_id=self.server_port,
@@ -180,8 +181,9 @@ class IpinIPTunnelTest(BaseTest):
             for i in range(0, PACKET_NUM):
                 inner_pkt = self.generate_packet_to_server(hash_key)
                 tunnel_pkt = self.generate_expected_packet(inner_pkt)
-                self.logger.info("Sending packet dst_mac = {} src_mac = {} dst_ip = {} src_ip = {} from port {}" \
+                self.logger.debug("Sending packet dst_mac = {} src_mac = {} dst_ip = {} src_ip = {} from port {}" \
                     .format(inner_pkt[Ether].dst, inner_pkt[Ether].src, inner_pkt[IP].dst, inner_pkt[IP].src, src_port))
+                self.dataplane.flush()
                 send_packet(self, src_port, inner_pkt)
                 # Verify packet is received from IPinIP tunnel
                 idx, count = verify_packet_any_port(test=self,


### PR DESCRIPTION
Flush the cache to mitigate the workloads on ptf, otherwise, it might be not able to compare the expected pkts before timeout.

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
