### PR TITLE
[sonic-mgmt\tests\tacacs]: Fix TACACS UT failed caused by SSH warning.

### DIFF
--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -17,7 +17,7 @@ TIMEOUT_LIMIT   = 120
 def ssh_remote_run(localhost, remote_ip, username, password, cmd):
     res = localhost.shell("sshpass -p {} ssh "\
                           "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "\
-                          "{}@{} {}".format(
+                          "{}@{} {} > >(grep -v \"Permanently added\" 1>&2)".format(
             password, username, remote_ip, cmd), module_ignore_errors=True)
     return res
 

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -16,8 +16,8 @@ TIMEOUT_LIMIT   = 120
 
 def ssh_remote_run(localhost, remote_ip, username, password, cmd):
     res = localhost.shell("sshpass -p {} ssh "\
-                          "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "\
-                          "{}@{} {} > >(grep -v \"Permanently added\" 1>&2)".format(
+                          "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR "\
+                          "{}@{} {}".format(
             password, username, remote_ip, cmd), module_ignore_errors=True)
     return res
 


### PR DESCRIPTION
[sonic-mgmt\tests\tacacs]: Fix TACACS UT failed caused by SSH warning.
### Description of PR

When tacacs UT first time run on a new test agent, the ssh command will trigger a warning:
			"Warning: Permanently added '10.250.0.101' (ECDSA) to the list of known hosts."

This warning will output to stderr and make the UT break because following code will check stderr:

def check_output(output, exp_val1, exp_val2):
    **pytest_assert(not output['failed'], output['stderr'])**

Summary:
Fixes # TACACS UT failed caused by SSH warning.


### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
    Fix UT break which currently block some PR.

#### How did you do it?
    Fix SSH command to ignore warning.

#### How did you verify/test it?
    Manually test and pass all UT.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
