### PR TITLE
[dir_bcast] add debug information for direct bcast test

### DIFF
--- a/ansible/roles/test/files/ptftests/dir_bcast_test.py
+++ b/ansible/roles/test/files/ptftests/dir_bcast_test.py
@@ -128,7 +128,7 @@ class BcastTest(BaseTest):
         Check if broadcast packet is received on all member ports of vlan
         '''
         logging.info("Received " + str(pkt_count) + " broadcast packets, expecting " + str(len(dst_port_list)))
-        assert (pkt_count == len(dst_port_list))
+        assert (pkt_count == len(dst_port_list)), "received {} expected {}".format(pkt_count, len(dst_port_list))
 
         return
 
@@ -171,7 +171,7 @@ class BcastTest(BaseTest):
         Check if broadcast BOOTP packet is received on all member ports of vlan
         '''
         logging.info("Received " + str(pkt_count) + " broadcast BOOTP packets, expecting " + str(len(dst_port_list)))
-        assert (pkt_count == len(dst_port_list))
+        assert (pkt_count == len(dst_port_list)), "received {} expected {}".format(pkt_count, len(dst_port_list))
 
         return
 


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
direct broadcast test could fail and not having enough information for deugging.

#### How did you do it?
add debug information to show expected v.s. received packets.

#### How did you verify/test it?
run dir_bcast test, check output when failure happens.

