### PR TITLE
[Sanity check] Add one more condition to fail BGP status check

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -188,6 +188,18 @@ def check_bgp(duthosts):
         def _check_bgp_status_helper():
             asic_check_results = []
             bgp_facts = dut.bgp_facts(asic_index='all')
+
+            # Conditions to fail BGP check
+            #   1. No BGP neighbor.
+            #   2. Any BGP neighbor down.
+            #   3. Failed to get BGP status (In theory, this should be protected by previous check, but adding this check
+            #      here will make BGP check more robust, and it is necessary since many operations highly depends on
+            #      the BGP status)
+
+            if len(bgp_facts) == 0:
+                logger.info("Failed to get BGP status on host %s ..." % dut.hostname)
+                asic_check_results.append(True)
+
             for asic_index, a_asic_facts in enumerate(bgp_facts):
                 a_asic_result = False
                 a_asic_neighbors = a_asic_facts['ansible_facts']['bgp_neighbors']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  
For some reason, get BGP status could return an empty dict, which will fool the check of BGP status, and consider it as a success, which will fail subsequent test cases depending on the result of BGP check. To add one more condition check for empty dict case.   
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix issue in the pre test sanity check.   
#### How did you do it?  
Add check for the the dict returned by bgp_facts.  
#### How did you verify/test it?
  
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
