### PR TITLE
[RESTAPI] Test configuring routes with incorrect CIDR addresses

### DIFF
--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -100,7 +100,8 @@ def test_data_path(construct_url, vlan_members):
     # Add routes
     params = '[{"cmd": "add", "ip_prefix": "100.0.20.4/32", "nexthop": "100.3.152.52", "vnid": 7036001, "mac_address": null}, \
                 {"cmd": "add", "ip_prefix": "101.0.20.5/32", "nexthop": "100.3.152.52", "vnid": 7036001, "mac_address": "1c:34:da:72:b0:8a"}, \
-                {"cmd": "add", "ip_prefix": "192.168.20.4/32", "nexthop": "100.3.152.52", "vnid": 7036001, "mac_address": null}]'
+                {"cmd": "add", "ip_prefix": "192.168.20.4/32", "nexthop": "100.3.152.52", "vnid": 7036001, "mac_address": null}, \
+                {"cmd": "add", "ip_prefix": "100.0.30.0/24", "nexthop": "100.3.152.52", "vnid": 7036001, "mac_address": null}]'
     logger.info("Adding routes with vnid: 7036001 to VNET vnet-guid-2")
     r = restapi.patch_config_vrouter_vrf_id_routes(construct_url, 'vnet-guid-2', params)
     pytest_assert(r.status_code == 204)
@@ -114,10 +115,31 @@ def test_data_path(construct_url, vlan_members):
     logger.info(r.json())
     expected = [{"nexthop": "100.3.152.52", "ip_prefix": "192.168.20.4/32", "vnid": 7036001},
                 {"nexthop": "100.3.152.52", "ip_prefix": "101.0.20.5/32", "mac_address": "1c:34:da:72:b0:8a", "vnid": 7036001},
-                {"nexthop": "100.3.152.52", "ip_prefix": "100.0.20.4/32", "vnid": 7036001}]
+                {"nexthop": "100.3.152.52", "ip_prefix": "100.0.20.4/32", "vnid": 7036001},
+                {"nexthop": "100.3.152.52", "ip_prefix": "100.0.30.0/24", "vnid": 7036001}]
     for route in expected:
         pytest_assert(route in r.json())
     logger.info("Routes with vnid: 7036001 to VNET vnet-guid-2 have been added successfully")
+
+    # Add routes
+    params = '[{"cmd": "add", "ip_prefix": "100.0.50.4/24", "nexthop": "100.3.152.52", "vnid": 7036001, "mac_address": null}, \
+                {"cmd": "add", "ip_prefix": "100.0.70.0/16", "nexthop": "100.3.152.52", "vnid": 7036001, "mac_address": null}]'
+    logger.info("Adding routes with incorrect CIDR addresses with vnid: 7036001 to VNET vnet-guid-2")
+    r = restapi.patch_config_vrouter_vrf_id_routes(construct_url, 'vnet-guid-2', params)
+    pytest_assert(r.status_code == 207)
+
+    # Verify routes have not been added
+    # Add some delay before query
+    time.sleep(5)
+    params = '{}'
+    r = restapi.get_config_vrouter_vrf_id_routes(construct_url, 'vnet-guid-2', params)
+    pytest_assert(r.status_code == 200)
+    logger.info(r.json())
+    expected = [{"nexthop": "100.3.152.52", "ip_prefix": "100.0.50.4/24", "vnid": 7036001},
+                {"nexthop": "100.3.152.52", "ip_prefix": "100.0.70.0/16", "vnid": 7036001}]
+    for route in expected:
+        pytest_assert(route not in r.json())
+    logger.info("Routes with incorrect CIDR addresses with vnid: 7036001 to VNET vnet-guid-2 have not been added successfully")
 
 
     #
@@ -186,7 +208,8 @@ def test_data_path(construct_url, vlan_members):
     # Add routes
     params = '[{"cmd": "add", "ip_prefix": "100.0.20.4/32", "nexthop": "100.3.152.52", "vnid": 7036002, "mac_address": null}, \
                 {"cmd": "add", "ip_prefix": "101.0.20.5/32", "nexthop": "100.3.152.52", "vnid": 7036002, "mac_address": "1c:34:da:72:b0:8a"}, \
-                {"cmd": "add", "ip_prefix": "192.168.20.4/32", "nexthop": "100.3.152.52", "vnid": 7036002, "mac_address": null}]'
+                {"cmd": "add", "ip_prefix": "192.168.20.4/32", "nexthop": "100.3.152.52", "vnid": 7036002, "mac_address": null}, \
+                {"cmd": "add", "ip_prefix": "100.0.30.0/24", "nexthop": "100.3.152.52", "vnid": 7036002, "mac_address": null}]'
     logger.info("Adding routes with vnid: 7036002 to VNET vnet-guid-3")
     r = restapi.patch_config_vrouter_vrf_id_routes(construct_url, 'vnet-guid-3', params)
     pytest_assert(r.status_code == 204)
@@ -198,10 +221,31 @@ def test_data_path(construct_url, vlan_members):
     logger.info(r.json())
     expected = [{"nexthop": "100.3.152.52", "ip_prefix": "192.168.20.4/32", "vnid": 7036002},
                 {"nexthop": "100.3.152.52", "ip_prefix": "101.0.20.5/32", "mac_address": "1c:34:da:72:b0:8a", "vnid": 7036002},
-                {"nexthop": "100.3.152.52", "ip_prefix": "100.0.20.4/32", "vnid": 7036002}]
+                {"nexthop": "100.3.152.52", "ip_prefix": "100.0.20.4/32", "vnid": 7036002},
+                {"nexthop": "100.3.152.52", "ip_prefix": "100.0.30.0/24", "vnid": 7036002}]
     for route in expected:
         pytest_assert(route in r.json())
     logger.info("Routes with vnid: 3000 to VNET vnet-guid-3 have been added successfully")
+
+    # Add routes
+    params = '[{"cmd": "add", "ip_prefix": "100.0.50.4/24", "nexthop": "100.3.152.52", "vnid": 7036002, "mac_address": null}, \
+                {"cmd": "add", "ip_prefix": "100.0.70.0/16", "nexthop": "100.3.152.52", "vnid": 7036002, "mac_address": null}]'
+    logger.info("Adding routes with incorrect CIDR addresses with vnid: 7036002 to VNET vnet-guid-3")
+    r = restapi.patch_config_vrouter_vrf_id_routes(construct_url, 'vnet-guid-3', params)
+    pytest_assert(r.status_code == 207)
+
+    # Verify routes have not been added
+    # Add some delay before query
+    time.sleep(5)
+    params = '{}'
+    r = restapi.get_config_vrouter_vrf_id_routes(construct_url, 'vnet-guid-3', params)
+    pytest_assert(r.status_code == 200)
+    logger.info(r.json())
+    expected = [{"nexthop": "100.3.152.52", "ip_prefix": "100.0.50.4/24", "vnid": 7036002},
+                {"nexthop": "100.3.152.52", "ip_prefix": "100.0.70.0/16", "vnid": 7036002}]
+    for route in expected:
+        pytest_assert(route not in r.json())
+    logger.info("Routes with incorrect CIDR addresses with vnid: 7036002 to VNET vnet-guid-3 have not been added successfully")
 
 
 '''


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Configuring incorrect CIDR addresses as routes is not permitted in SONiC and REST-API is designed to reject such incorrect routes. Refer to https://github.com/Azure/sonic-restapi/pull/91
This new testcase will check if this design in RESTAPI is working as expected by trying to configure incorrect CIDR addresses.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To test if REST-API is checking for incorrect CIDR addresses in the route configuration path and appropriately rejecting them.
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
