### PR TITLE
[rdma] Reset-failed for swss dependent services

### DIFF
--- a/tests/ixia/pfcwd/test_pfcwd_basic.py
+++ b/tests/ixia/pfcwd/test_pfcwd_basic.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [ pytest.mark.topology('tgen') ]
 
+DEPENDENT_SERVICES = ['teamd', 'snmp', 'dhcp_relay', 'radv']
+
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])
 def test_pfcwd_basic_single_lossless_prio(ixia_api,
                                           ixia_testbed_config,
@@ -289,7 +291,9 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(ixia_api,
     lossless_prio = int(lossless_prio)
 
     logger.info("Issuing a restart of service {} on the dut {}".format(restart_service, duthost.hostname))
-    duthost.command("systemctl reset-failed {}".format(restart_service))
+    services_to_reset = DEPENDENT_SERVICES + [restart_service]
+    for service in services_to_reset:
+        duthost.command("systemctl reset-failed {}".format(service))
     duthost.command("systemctl restart {}".format(restart_service))
     logger.info("Wait until the system is stable")
     pytest_assert(wait_until(300, 20, duthost.critical_services_fully_started),
@@ -350,7 +354,9 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(ixia_api,
     testbed_config, port_config_list = ixia_testbed_config
 
     logger.info("Issuing a restart of service {} on the dut {}".format(restart_service, duthost.hostname))
-    duthost.command("systemctl reset-failed {}".format(restart_service))
+    services_to_reset = DEPENDENT_SERVICES + [restart_service]
+    for service in services_to_reset:
+        duthost.command("systemctl reset-failed {}".format(service))
     duthost.command("systemctl restart {}".format(restart_service))
     logger.info("Wait until the system is stable")
     pytest_assert(wait_until(300, 20, duthost.critical_services_fully_started),


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We see some flakiness in tgen pfcwd testcases related to swss restart. This is because in some cases we restart swss more than 3 times in a short interval. The test currently resets the failed status of only swss not any of its dependent services. This PR addresses that gap

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

#### How did you verify/test it?
Ran pfcwd swss restart cases multiple times and no longer see the issue