### PR TITLE
[qos] Specify correct handle to access dut resources

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -145,7 +145,7 @@ class QosSaiBase(QosBase):
         else:
             db = "4"
             keystr = "BUFFER_POOL|"
-        if check_qos_db_fv_reference_with_table(duthost) == True:
+        if check_qos_db_fv_reference_with_table(dut_asic) == True:
             pool = bufferProfile["pool"].encode("utf-8").translate(None, "[]")
         else:
             pool = keystr + bufferProfile["pool"].encode("utf-8")
@@ -171,7 +171,7 @@ class QosSaiBase(QosBase):
             Returns:
                 Updates bufferProfile with VOID/ROID obtained from Redis db
         """
-        if check_qos_db_fv_reference_with_table(duthost) == True:
+        if check_qos_db_fv_reference_with_table(dut_asic) == True:
             if self.isBufferInApplDb(dut_asic):
                 bufferPoolName = bufferProfile["pool"].encode("utf-8").translate(
                     None, "[]").replace("BUFFER_POOL_TABLE:",''
@@ -220,7 +220,7 @@ class QosSaiBase(QosBase):
             keystr = "{0}|{1}|{2}".format(table, port, priorityGroup)
             bufkeystr = "BUFFER_POOL|"
 
-        if check_qos_db_fv_reference_with_table(duthost) == True:
+        if check_qos_db_fv_reference_with_table(dut_asic) == True:
             bufferProfileName = dut_asic.run_redis_cmd(
                 argv = ["redis-cli", "-n", db, "HGET", keystr, "profile"]
             )[0].encode("utf-8").translate(None, "[]")
@@ -289,7 +289,7 @@ class QosSaiBase(QosBase):
             Returns:
                 wredProfile (dict): Map of ECN/WRED attributes
         """
-        if check_qos_db_fv_reference_with_table(duthost) == True:
+        if check_qos_db_fv_reference_with_table(dut_asic) == True:
             wredProfileName = dut_asic.run_redis_cmd(
                 argv = [
                     "redis-cli", "-n", "4", "HGET",
@@ -345,7 +345,7 @@ class QosSaiBase(QosBase):
             Returns:
                 SchedulerParam (dict): Map of scheduler parameters
         """
-        if check_qos_db_fv_reference_with_table(duthost) == True:
+        if check_qos_db_fv_reference_with_table(dut_asic) == True:
             schedProfile = dut_asic.run_redis_cmd(
                 argv = [
                     "redis-cli", "-n", "4", "HGET",


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Qos sai failures seen due to changes in #3824

```
>       if check_qos_db_fv_reference_with_table(duthost) == True:
E       NameError: global name 'duthost' is not defined
bufkeystr  = 'BUFFER_POOL_TABLE:'
db         = '0'
dut_asic   = <tests.common.devices.sonic_asic.SonicAsic object at 0x7f8fd676a050>
keystr     = 'BUFFER_PG_TABLE:Ethernet8:3-4'
os_version = '20201231.31'
port       = 'Ethernet8'
priorityGroup = '3-4'
request    = <SubRequest 'ingressLosslessProfile' for <Function testQosSaiPfcXoffLimit[None-xoff_2]>>
self       = <tests.qos.test_qos_sai.TestQosSai instance at 0x7f8fd82a6820>
table      = 'BUFFER_PG_TABLE'
qos/qos_sai_base.py:222: NameError
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

#### How did you verify/test it?
Ran qos sai test with the changes on backend T0 and they pass
