### PR TITLE
Fix issue of restart-ptf for dualtor testbed

### DIFF
--- a/ansible/group_vars/all/mux_simulator_http_port_map.yml
+++ b/ansible/group_vars/all/mux_simulator_http_port_map.yml
@@ -19,7 +19,7 @@ mux_simulator_http_port:
 
     # On server1
     dualtor-testbed-1: 8080
-    dualtor-testbed-1: 8082
+    dualtor-testbed-2: 8082
 
     # On server2
     dualtor-testbed-3: 8080

--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -46,6 +46,5 @@
       state: stopped
     become: yes
     ignore_errors: yes
-    when: record_file_content.rc != 0
 
   when: mux_simulator_action == "stop"

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -308,7 +308,9 @@ function renumber_topo
 
   read_file ${testbed_name}
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_renumber_vm_topology.yml --vault-password-file="${passwd}" -l "$server" -e duts_name="$duts" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" -e ptf_imagename="$ptf_imagename" -e ptf_ipv6="$ptf_ipv6" $@
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_renumber_vm_topology.yml --vault-password-file="${passwd}" \
+      -l "$server" -e testbed_name="$testbed_name" -e duts_name="$duts" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" \
+      -e topo="$topo" -e vm_set_name="$vm_set_name" -e ptf_imagename="$ptf_imagename" -e ptf_ipv6="$ptf_ipv6" $@
 
   ansible-playbook fanout_connect.yml -i $vmfile --limit "$server" --vault-password-file="${passwd}" -e "dut=$duts" $@
 
@@ -326,7 +328,9 @@ function restart_ptf
 
   echo "Restart ptf ptf_${vm_set_name} for testbed '${testbed_name}'"
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_renumber_vm_topology.yml --vault-password-file="${passwd}" -l "$server" -e duts_name="$duts" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" -e ptf_imagename="$ptf_imagename" -e ptf_ipv6="$ptf_ipv6" $@
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_renumber_vm_topology.yml --vault-password-file="${passwd}" \
+      -l "$server" -e testbed_name="$testbed_name" -e duts_name="$duts" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" \
+      -e topo="$topo" -e vm_set_name="$vm_set_name" -e ptf_imagename="$ptf_imagename" -e ptf_ipv6="$ptf_ipv6" $@
 
   echo Done
 }

--- a/ansible/testbed_renumber_vm_topology.yml
+++ b/ansible/testbed_renumber_vm_topology.yml
@@ -22,6 +22,10 @@
     fail: msg="Please use -l server_X to limit this playbook to one host"
     when: "{{ play_hosts|length }} != 1"
 
+  - name: Check that variable testbed_name is defined
+    fail: msg="Define testbed_name variable with -e testbed_name=something"
+    when: testbed_name is not defined
+
   - name: Check that variable vm_set_name is defined
     fail: msg="Define vm_set_name variable with -e vm_set_name=something"
     when: vm_set_name is not defined


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
There is an issue with running testbed-cli.sh restart-ptf on dualtor testbed. It failed at the
tasks of stopping and starting mux simulator.
```
TASK [vm_set : Set variable abs_root_path] *************************************
Tuesday 28 September 2021  04:14:54 +0000 (0:00:00.226)       0:00:11.223 ***** 
fatal: [STR2-ACS-SERV-17]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'testbed_name' is undefined\n\nThe error appears to be in '/azp/agent/_work/3/s/ansible/roles/vm_set/tasks/control_mux_simulator.yml': line 6, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Set variable abs_root_path\n  ^ here\n"}
```

The issue was introduced by https://github.com/Azure/sonic-mgmt/pull/4259. PR #4259 added
dependency of variable 'testbed_name' in playbook. The variable was not passed to playbook
in the testbed-cli.sh script.

#### How did you do it?
The fix is to pass variable 'testbed_name' to playbook 'testbed_renumber_vm_topology.yml' in
the testbed-cli.sh tool. This PR also removed a legacy condition checking which failed in
control_mux_simulator.py.

#### How did you verify/test it?
Run remove-topo add-topo restart-ptf on dualtor testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
