### PR TITLE
Ignore case of keys in syseeprom_info in test_get_system_eeprom_info

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -241,6 +241,8 @@ class TestChassisApi(PlatformApiTestBase):
         pytest_assert(re.match(REGEX_SERIAL_NUMBER, serial), "Serial number appears to be incorrect")
         host_vars = get_host_visible_vars(self.inv_files, duthost.hostname)
         expected_syseeprom_info_dict = host_vars.get('syseeprom_info')
+        # Ignore case of keys in syseeprom_info
+        expected_syseeprom_info_dict = {k.lower(): v for k, v in expected_syseeprom_info_dict.items()}
 
         for field in expected_syseeprom_info_dict:
             pytest_assert(field in syseeprom_info_dict, "Expected field '{}' not present in syseeprom on '{}'".format(field, duthost.hostname))


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The PR is to make ```test_get_system_eeprom_info``` more robust.
The key of syseeprom_info_dict is supposed to be case insensitive, for example
```
syseeprom_info:
        ......
        "0x2A": "254"
        "0x2B": "Mellanox"
        "0xFE": "0x723D"
```
should be euqal with
```
syseeprom_info:
        ......
        "0x2a": "254"
        "0x2b": "Mellanox"
        "0xfe": "0x723D"
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The PR is to make ```test_get_system_eeprom_info``` more robust.

#### How did you do it?
Ignore case of keys in syseeprom_info in test_get_system_eeprom_info

#### How did you verify/test it?
Verified on Mlnx-4600.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
