### PR TITLE
[test_default_route] Skip on t0-backend

### DIFF
--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -1,7 +1,10 @@
 import pytest
 import ipaddress
 import logging
-from tests.common.helpers.assertions import pytest_assert, pytest_require
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.storage_backend.backend_utils import skip_test_module_over_backend_topologies
+
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -10,13 +13,11 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
-def test_default_route_set_src(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index, tbinfo):
+def test_default_route_set_src(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index):
     """
     check if ipv4 and ipv6 default src address match Loopback0 address
 
     """
-    pytest_require('t1-backend' not in tbinfo['topo']['name'], "Skip this testcase since this topology {} has no default routes".format(tbinfo['topo']['name']))
-
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asichost = duthost.asic_instance(enum_asic_index)
 
@@ -48,13 +49,11 @@ def test_default_route_set_src(duthosts, enum_rand_one_per_hwsku_frontend_hostna
     pytest_assert(rtinfo['set_src'] == lo_ipv6.ip, \
             "default v6 route set src to wrong IP {} != {}".format(rtinfo['set_src'], lo_ipv6.ip))
 
-def test_default_ipv6_route_next_hop_global_address(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index, tbinfo):
+def test_default_ipv6_route_next_hop_global_address(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index):
     """
     check if ipv6 default route nexthop address uses global address
 
     """
-    pytest_require('t1-backend' not in tbinfo['topo']['name'], "Skip this testcase since this topology {} has no default routes".format(tbinfo['topo']['name']))
-
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asichost = duthost.asic_instance(enum_asic_index)
 


### PR DESCRIPTION
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
`test_default_route` should be skipped on `t0-backend`

#### How did you do it?
use fixture `skip_test_module_over_backend_topologies` to skip `test_default_route` on both `t0-backend` and `t1-backend`.

#### How did you verify/test it?
* run over `t0-backend`
```
route/test_default_route.py::test_default_route_set_src[str2-7050qx-32s-acs-02-None] SKIPPED                                                                                                                                                                           [ 50%]
route/test_default_route.py::test_default_ipv6_route_next_hop_global_address[str2-7050qx-32s-acs-02-None] SKIPPED                                                                                                                                                      [100%]

========================================================================================================================= 2 skipped in 27.53 seconds =========================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
