### PR TITLE
[pfc] Fix issue in unknown mac test case

### DIFF
--- a/tests/pfc/test_unknown_mac.py
+++ b/tests/pfc/test_unknown_mac.py
@@ -164,8 +164,6 @@ def populateArp(unknownMacSetup, flushArpFdb, ptfhost, duthosts, rand_one_dut_ho
     # Wait 5 seconds for secondary ARP before proceeding to clear FDB
     time.sleep(5)
 
-    yield
-
     logger.info("Clean up all ips on the PTF")
     ptfhost.script("./scripts/remove_ip.sh")
 


### PR DESCRIPTION
What is the motivation for this PR?
Currently, the IP of a random interface in ptf will be clear at the end of each case. That means this interface can respond to the ARP request during the test period. If that happens, the DUT's fdb entry is learned.

How did you do it?
Clean the IP at the beginning of each test.

How did you verify/test it?
Run pfc/test_unknown_mac.py

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
