### PR TITLE
Skip span tests on Cisco 8000 Platform

### DIFF
--- a/tests/span/conftest.py
+++ b/tests/span/conftest.py
@@ -55,7 +55,7 @@ def ports_for_test(cfg_facts):
 
 @pytest.fixture(scope='module', autouse=True)
 def skip_unsupported_asic_type(duthost):
-    SPAN_UNSUPPORTED_ASIC_TYPE = ["broadcom"]
+    SPAN_UNSUPPORTED_ASIC_TYPE = ["broadcom", "cisco-8000"]
     if duthost.facts["asic_type"] in SPAN_UNSUPPORTED_ASIC_TYPE:
         pytest.skip(
             "Skipping span test on {} platform".format(duthost.facts["asic_type"]))


### PR DESCRIPTION
Description of PR
Currently span is not a requirement on Cisco 8000 platforms. Kindly skip it on the Cisco 8000 platform

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Currently span is not a requirement on Cisco 8000 platforms. Kindly skip it on the Cisco 8000 platform

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
