### PR TITLE
Changing src mac address from multicast to unicast

### DIFF
--- a/tests/common/helpers/pfc_gen.py
+++ b/tests/common/helpers/pfc_gen.py
@@ -122,7 +122,7 @@ def main():
     pause time      |        0x0000         |
                     -------------------------
     """
-    src_addr = "\x01\x02\x03\x04\x05\x06" 
+    src_addr = "\x8e\x94\x1f\x8c\x26\x44" 
     dst_addr = "\x01\x80\xc2\x00\x00\x01"
     if options.global_pf:
         opcode = "\x00\x01"


### PR DESCRIPTION
### Description of PR
Changing src mac address from multicast to unicast

Summary:
Fixes # (issue)

### Type of change

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
In our tests we have noticed that using src mac address as a multicast address causes the packet to be dropped. Hence changing it to unicast address.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
