### PR TITLE
Skip ```test_unknown_mac``` on Mellanox platform

### DIFF
--- a/tests/pfc/test_unknown_mac.py
+++ b/tests/pfc/test_unknown_mac.py
@@ -14,7 +14,7 @@ import ptf.packet as packet
 from tests.common import constants
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
 from tests.common.utilities import get_intf_by_sub_intf
@@ -53,6 +53,11 @@ def unknownMacSetup(duthosts, rand_one_dut_hostname, tbinfo):
 
     """
     duthost = duthosts[rand_one_dut_hostname]
+    # The behavior on Mellanox for unknown MAC is flooding rather than DROP,
+    # so we need to skip this test on Mellanox platform
+    asic_type = duthost.facts["asic_type"]
+    pytest_require(asic_type != "mellanox", "Skip on Mellanox platform")
+
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     is_backend_topology = mg_facts.get(constants.IS_BACKEND_TOPOLOGY_KEY, False)
     server_ips = []


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip ```test_unknown_mac``` on ```Mellanox``` platform.
The behavior on ```Mellanox``` for unknown MAC is flooding rather than DROP, so we need to skip this test on Mellanox platform.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to skip ```test_unknown_mac``` on ```Mellanox``` platform.

#### How did you do it?
Check the ASIC type with an autoused fixture.

#### How did you verify/test it?
Verified on SN2700, and the test cases were skipped.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
