### PR TITLE
[chassis][config reload] Wait longer for chassis line cards

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -74,4 +74,7 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
     if config_source == 'config_db':
         duthost.shell(cmd, executable="/bin/bash")
 
+    modular_chassis = duthost.get_facts().get("modular_chassis")
+    wait = max(wait, 240) if modular_chassis else wait
+
     time.sleep(wait)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
#4394
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
test_neighbor_mac_noptf.py failing on chassis

#### How did you do it?
Test performs config reload for each parameter. Config reload takes longer on chassis linecards causing the second test to fail all the time. Increased the wait time for chassis linecards.

#### How did you verify/test it?
```
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$   pytest --count=5 arp/test_neighbor_mac_noptf.py  --testbed=vms26-t2-chassis-1 --inventory=../ansible/str2,../ansible/veos  --testbed_file=../ansible/testbed.yaml --host-pattern=str2-7804-lc3
-1  --module-path=../ansible/libra
ry --disable_loganalyzer --skip_sanity

/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed i
n the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================================= test session starts ===========================================================================================
==================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 10 items


arp/test_neighbor_mac_noptf.py ..........
                           [100%]

============================================================================================================================== warnings summary =============================================================================================
==================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================================================== 10 passed, 1 warnings in 2892.92 seconds =================================================================================
==================================

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
