### PR TITLE
[advanced-reboot] Capture interface counters before and after tests

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -156,6 +156,7 @@ class ReloadTest(BaseTest):
         self.check_param('vnet_pkts', None, required=False)
         self.check_param('target_version', '', required=False)
         self.check_param('bgp_v4_v6_time_diff', 40, required=False)
+        self.check_param('asic_type', '', required=False)
         self.check_param('logfile_suffix', None, required=False)
         if not self.test_params['preboot_oper'] or self.test_params['preboot_oper'] == 'None':
             self.test_params['preboot_oper'] = None
@@ -1304,6 +1305,19 @@ class ReloadTest(BaseTest):
             packets_list = self.packets_list
         self.sniffer_started.wait(timeout=10)
         with self.dataplane_io_lock:
+            # Clear the counters before starting the IO traffic
+            # this is done so that drops can be accurately calculated
+            # after reboot test is finished
+            clear_counter_cmds = [ "sonic-clear counters",
+            "sonic-clear queuecounters",
+            "sonic-clear dropcounters",
+            "sonic-clear rifcounters",
+            "sonic-clear pfccounters"
+            ]
+            if 'broadcom' in self.test_params['asic_type']:
+                clear_counter_cmds.append("bcmcmd 'clear counters'")
+            for cmd in clear_counter_cmds:
+                self.dut_connection.execCommand(cmd)
             # While running fast data plane sender thread there are two reasons for filter to be applied
             #  1. filter out data plane traffic which is tcp to free up the load on PTF socket (sniffer thread is using a different one)
             #  2. during warm neighbor restoration DUT will send a lot of ARP requests which we are not interested in

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -509,7 +509,8 @@ class AdvancedReboot:
             "setup_fdb_before_test" : True,
             "vnet" : self.vnet,
             "vnet_pkts" : self.vnetPkts,
-            "bgp_v4_v6_time_diff": self.bgpV4V6TimeDiff
+            "bgp_v4_v6_time_diff": self.bgpV4V6TimeDiff,
+            "asic_type": self.duthost.facts["asic_type"]
         }
 
         if not isinstance(rebootOper, SadOperation):

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -354,7 +354,7 @@ def advanceboot_neighbor_restore(duthosts, rand_one_dut_hostname, nbrhosts, tbin
 
 
 @pytest.fixture()
-def print_logs(duthosts, rand_one_dut_hostname):
+def capture_interface_counters(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     logging.info("Run commands to print logs")
 

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -353,6 +353,54 @@ def advanceboot_neighbor_restore(duthosts, rand_one_dut_hostname, nbrhosts, tbin
     neighbor_vm_restore(duthost, nbrhosts, tbinfo)
 
 
+@pytest.fixture()
+def print_logs(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    logging.info("Run commands to print logs")
+
+    show_counter_cmds = [
+        "show interfaces counters",
+        "show interfaces counters rif",
+        "show queue counters",
+        "show pfc counters"
+    ]
+    clear_counter_cmds = [
+        "sonic-clear counters",
+        "sonic-clear queuecounters",
+        "sonic-clear dropcounters",
+        "sonic-clear rifcounters",
+        "sonic-clear pfccounters"
+    ]
+    if duthost.facts["asic_type"] == "broadcom":
+        bcm_show_cmds = [
+            "bcmcmd 'show counters'",
+            "bcmcmd 'cstat all'"
+        ]
+        bcm_clear_cmds = [
+            "bcmcmd 'clear counters'"
+        ]
+        show_counter_cmds = show_counter_cmds + bcm_show_cmds
+        clear_counter_cmds = clear_counter_cmds + bcm_clear_cmds
+    duthost.shell_cmds(cmds=clear_counter_cmds, module_ignore_errors=True, verbose=False)
+    results = duthost.shell_cmds(cmds=show_counter_cmds, module_ignore_errors=True, verbose=False)['results']
+    outputs = []
+    for res in results:
+        res.pop('stdout')
+        res.pop('stderr')
+        outputs.append(res)
+    logging.info("Counters before reboot test: dut={}, cmd_outputs={}".format(duthost.hostname,json.dumps(outputs, indent=4)))
+
+    yield
+
+    results = duthost.shell_cmds(cmds=show_counter_cmds, module_ignore_errors=True, verbose=False)['results']
+    outputs = []
+    for res in results:
+        res.pop('stdout')
+        res.pop('stderr')
+        outputs.append(res)
+    logging.info("Counters after reboot test: dut={}, cmd_outputs={}".format(duthost.hostname,json.dumps(outputs, indent=4)))
+
+
 def pytest_addoption(parser):
     add_advanced_reboot_args(parser)
     add_cont_warm_reboot_args(parser)

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -24,7 +24,7 @@ pytestmark = [
 ### Tetcases to verify normal reboot procedure ###
 @pytest.mark.usefixtures('get_advanced_reboot')
 def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
-    advanceboot_loganalyzer, print_logs):
+    advanceboot_loganalyzer, capture_interface_counters):
     '''
     Fast reboot test case is run using advacned reboot test fixture
 
@@ -37,7 +37,7 @@ def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
 
 @pytest.mark.device_type('vs')
 def test_warm_reboot(request, get_advanced_reboot, verify_dut_health,
-    advanceboot_loganalyzer, print_logs):
+    advanceboot_loganalyzer, capture_interface_counters):
     '''
     Warm reboot test case is run using advacned reboot test fixture
 

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -22,8 +22,9 @@ pytestmark = [
 
 
 ### Tetcases to verify normal reboot procedure ###
+@pytest.mark.usefixtures('get_advanced_reboot')
 def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
-    advanceboot_loganalyzer):
+    advanceboot_loganalyzer, print_logs):
     '''
     Fast reboot test case is run using advacned reboot test fixture
 
@@ -36,7 +37,7 @@ def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
 
 @pytest.mark.device_type('vs')
 def test_warm_reboot(request, get_advanced_reboot, verify_dut_health,
-    advanceboot_loganalyzer):
+    advanceboot_loganalyzer, print_logs):
     '''
     Warm reboot test case is run using advacned reboot test fixture
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Improve advance reboot cases to capture interface counters before and after reboot. This is useful in debugging failures where unexpected drops are seen.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To make it easier to debug unexpected drops during reboots.

#### How did you do it?
Added a fixture which clear and shows counters at the start of the testcase. 
The same fixture captures the counters again after reboot (as part of fixture teardown).

#### How did you verify/test it?
Tested on a physical testbed, and counters before and after test are captured in the logs.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
