### PR TITLE
[skip support] fix the inventory path

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -90,7 +90,7 @@ def load_dut_basic_facts(session):
 
         dut_name = tbinfo['duts'][0]
         inv_name = tbinfo['inv_name']
-        ansible_cmd = 'ansible -m dut_basic_facts -i {} {} -o'.format(inv_name, dut_name)
+        ansible_cmd = 'ansible -m dut_basic_facts -i ../ansible/{} {} -o'.format(inv_name, dut_name)
 
         raw_output = subprocess.check_output(ansible_cmd.split()).decode('utf-8')
         logger.debug('raw dut basic facts:\n{}'.format(raw_output))


### PR DESCRIPTION
### Description of PR
Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The condition skip/xfail cannot condition on anything other than topology name/type.

#### How did you do it?
fix the inventory file path

#### How did you verify/test it?
Set any skip condition other than topo_name and/or topo_type

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
