### PR TITLE
everflow_test_utilities: Adding Cisco8000 as part of ERSPANv2 compatibility device

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -597,7 +597,7 @@ class BaseEverflowTest(object):
         if duthost.facts["asic_type"] in ["mellanox"]:
             payload = binascii.unhexlify("0" * 44) + str(payload)
 
-        if duthost.facts["asic_type"] in ["barefoot"]:
+        if duthost.facts["asic_type"] in ["barefoot", "cisco-8000"]:
             payload = binascii.unhexlify("0" * 24) + str(payload)
 
         expected_packet = testutils.simple_gre_packet(
@@ -618,6 +618,8 @@ class BaseEverflowTest(object):
         expected_packet.set_do_not_care_scapy(packet.IP, "len")
         expected_packet.set_do_not_care_scapy(packet.IP, "flags")
         expected_packet.set_do_not_care_scapy(packet.IP, "chksum")
+        if duthost.facts["asic_type"] in ["cisco-8000"]:
+            expected_packet.set_do_not_care_scapy(packet.GRE, "seqnum_present")
         if not check_ttl:
             expected_packet.set_do_not_care_scapy(packet.IP, "ttl")
 


### PR DESCRIPTION
### Description of PR
Test case assumes ERSPANv1 header as default support option. Cisco8000 supports ERSPANv2 header. Updated the script to include Cisco8000 in ERSPANv2 compatibility devices

Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Test case assumes ERSPANv1 header as default support option. Cisco8000 supports ERSPANv2 header. Updated the script to include Cisco8000 in ERSPANv2 compatibility devices

#### How did you do it?

#### How did you verify/test it?
Verified on T1 setup with Cisco-8000 platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
