### PR TITLE
everflow_ipv6: fix packet format (change source IP from multicast to unicast)

### DIFF
--- a/tests/everflow/files/ipv6_test_rules.yaml
+++ b/tests/everflow/files/ipv6_test_rules.yaml
@@ -1,10 +1,10 @@
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0002/128"
+      source-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0002/128"
 
 - qualifiers:
     ip:
-      destination-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0003/128"
+      destination-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0003/128"
 
 - qualifiers:
     ip:
@@ -40,8 +40,8 @@
 
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0004/128"
-      destination-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0005/128"
+      source-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0004/128"
+      destination-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0005/128"
       protocol: 6
     transport:
       source-port: "11200"
@@ -49,8 +49,8 @@
 
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0005/128"
-      destination-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0004/128"
+      source-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0005/128"
+      destination-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0004/128"
       protocol: 6
     transport:
       source-port: "11500..11999"
@@ -58,8 +58,8 @@
 
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0006/128"
-      destination-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0007/128"
+      source-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0006/128"
+      destination-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0007/128"
       protocol: 6
     transport:
       tcp-flags:
@@ -67,8 +67,8 @@
 
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0007/128"
-      destination-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0006/128"
+      source-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0007/128"
+      destination-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0006/128"
       protocol: 6
     transport:
       tcp-flags:
@@ -77,8 +77,8 @@
 
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0008/128"
-      destination-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0009/128"
+      source-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0008/128"
+      destination-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0009/128"
       protocol: 6
     transport:
       source-port: "12000"
@@ -88,8 +88,8 @@
 
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0009/128"
-      destination-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0008/128"
+      source-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0009/128"
+      destination-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0008/128"
       protocol: 6
     transport:
       source-port: "443"
@@ -100,8 +100,8 @@
 
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:000a/128"
-      destination-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:000b/128"
+      source-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:000a/128"
+      destination-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:000b/128"
       protocol: 17
       dscp: 8
     transport:
@@ -110,8 +110,8 @@
 
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:000b/128"
-      destination-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:000a/128"
+      source-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:000b/128"
+      destination-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:000a/128"
       protocol: 17
       dscp: 8
     transport:
@@ -120,13 +120,13 @@
 
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:000c/128"
-      destination-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:000d/128"
+      source-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:000c/128"
+      destination-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:000d/128"
 
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:000e/128"
-      destination-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:000f/128"
+      source-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:000e/128"
+      destination-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:000f/128"
       protocol: 127
       dscp: 16
     transport:
@@ -138,8 +138,8 @@
 
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:b000:0000:0000:0000:0000/64"
-      destination-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0010/128"
+      source-ip-address: "2002:0225:7c6b:b000:0000:0000:0000:0000/64"
+      destination-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0010/128"
       protocol: 6
     transport:
       source-port: "12006"
@@ -147,8 +147,8 @@
 
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:0010/128"
-      destination-ip-address: "ffbe:0225:7c6b:b000:0000:0000:0000:0000/64"
+      source-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:0010/128"
+      destination-ip-address: "2002:0225:7c6b:b000:0000:0000:0000:0000/64"
       protocol: 6
     transport:
       source-port: "12008"
@@ -156,8 +156,8 @@
 
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:c000:0000:0000:0000:0000/64"
-      destination-ip-address: "ffbe:0225:7c6b:d000:0000:0000:0000:0000/64"
+      source-ip-address: "2002:0225:7c6b:c000:0000:0000:0000:0000/64"
+      destination-ip-address: "2002:0225:7c6b:d000:0000:0000:0000:0000/64"
       protocol: 6
     transport:
       source-port: "12010"
@@ -165,8 +165,8 @@
 
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:e000:0000:0000:0000:0000/57"
-      destination-ip-address: "ffbe:0225:7c6b:f000:0000:0000:0000:0000/81"
+      source-ip-address: "2002:0225:7c6b:e000:0000:0000:0000:0000/57"
+      destination-ip-address: "2002:0225:7c6b:f000:0000:0000:0000:0000/81"
       protocol: 6
     transport:
       source-port: "12012"
@@ -174,8 +174,8 @@
 
 - qualifiers:
     ip:
-      source-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:001c/128"
-      destination-ip-address: "ffbe:0225:7c6b:a982:d48b:230e:f271:001d/128"
+      source-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:001c/128"
+      destination-ip-address: "2002:0225:7c6b:a982:d48b:230e:f271:001d/128"
     transport:
       source-port: "12002"
       destination-port: "12003"

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -26,8 +26,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         - Figure out some way to automate the acl.json file
     """
 
-    DEFAULT_SRC_IP = "ffbe:0225:7c6b:a982:d48b:230e:f271:0000"
-    DEFAULT_DST_IP = "ffbe:0225:7c6b:a982:d48b:230e:f271:0001"
+    DEFAULT_SRC_IP = "2002:0225:7c6b:a982:d48b:230e:f271:0000"
+    DEFAULT_DST_IP = "2002:0225:7c6b:a982:d48b:230e:f271:0001"
     tx_port_ids = []
 
     @pytest.fixture(scope='class',  autouse=True)
@@ -54,7 +54,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0002"
+            src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0002"
         )
 
         self.send_and_check_mirror_packets(setup_info,
@@ -70,7 +70,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0003"
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:0003"
         )
 
         self.send_and_check_mirror_packets(setup_info,
@@ -170,8 +170,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0004",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0005",
+            src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0004",
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:0005",
             sport=11200,
             dport=11700
         )
@@ -186,8 +186,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0005",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0004",
+            src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0005",
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:0004",
             sport=11700,
             dport=11200
         )
@@ -205,8 +205,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0006",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0007",
+            src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0006",
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:0007",
             flags=0x2
         )
 
@@ -220,8 +220,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0007",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0006",
+            src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0007",
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:0006",
             flags=0x12
         )
 
@@ -238,8 +238,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0008",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0009",
+            src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0008",
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:0009",
             sport=12000,
             dport=443,
             flags=0x2
@@ -255,8 +255,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0009",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0008",
+            src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0009",
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:0008",
             sport=443,
             dport=12000,
             flags=0x12
@@ -275,8 +275,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_udpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000a",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000b",
+            src_ip="2002:0225:7c6b:a982:d48b:230e:f271:000a",
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:000b",
             dscp=8,
             sport=12001,
             dport=514
@@ -291,8 +291,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_udpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000b",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000a",
+            src_ip="2002:0225:7c6b:a982:d48b:230e:f271:000b",
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:000a",
             dscp=8,
             sport=514,
             dport=12001
@@ -311,8 +311,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000c",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000d"
+            src_ip="2002:0225:7c6b:a982:d48b:230e:f271:000c",
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:000d"
         )
 
         self.send_and_check_mirror_packets(setup_info,
@@ -325,8 +325,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_udpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000c",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000d"
+            src_ip="2002:0225:7c6b:a982:d48b:230e:f271:000c",
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:000d"
         )
 
         self.send_and_check_mirror_packets(setup_info,
@@ -339,8 +339,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_udpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000c",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:000d",
+            src_ip="2002:0225:7c6b:a982:d48b:230e:f271:000c",
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:000d",
             next_header=0xAB
         )
 
@@ -357,8 +357,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:001c",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:001d",
+            src_ip="2002:0225:7c6b:a982:d48b:230e:f271:001c",
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:001d",
             sport=12002,
             dport=12003
         )
@@ -373,8 +373,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_udpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:001c",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:001d",
+            src_ip="2002:0225:7c6b:a982:d48b:230e:f271:001c",
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:001d",
             sport=12002,
             dport=12003
         )
@@ -401,8 +401,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:b000:0000:0000:0000:0010",
-            dst_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0010",
+            src_ip="2002:0225:7c6b:b000:0000:0000:0000:0010",
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:0010",
             sport=12006,
             dport=12007
         )
@@ -420,8 +420,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:a982:d48b:230e:f271:0010",
-            dst_ip="ffbe:0225:7c6b:b000:0000:0000:0000:0010",
+            src_ip="2002:0225:7c6b:a982:d48b:230e:f271:0010",
+            dst_ip="2002:0225:7c6b:b000:0000:0000:0000:0010",
             sport=12008,
             dport=12009
         )
@@ -439,8 +439,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:c000:0000:0000:0000:0010",
-            dst_ip="ffbe:0225:7c6b:d000:0000:0000:0000:0010",
+            src_ip="2002:0225:7c6b:c000:0000:0000:0000:0010",
+            dst_ip="2002:0225:7c6b:d000:0000:0000:0000:0010",
             sport=12010,
             dport=12011
         )
@@ -458,8 +458,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         test_packet = self._base_tcpv6_packet(
             ptfadapter,
             setup_info,
-            src_ip="ffbe:0225:7c6b:e000:0000:0000:0000:0010",
-            dst_ip="ffbe:0225:7c6b:f000:0000:0000:0000:0010",
+            src_ip="2002:0225:7c6b:e000:0000:0000:0000:0010",
+            dst_ip="2002:0225:7c6b:f000:0000:0000:0000:0010",
             sport=12012,
             dport=12013
         )


### PR DESCRIPTION
### Description of PR
The test case is generating packet with Router/DUT unicast MAC address + Multicast destination IPv6 address which is an invalid config just like having Multicast source IPv6 address. This should get dropped in data-plane packet sanity check. Fixed the packet format to have valid source IP address.

Summary:
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The test case is generating packet with Router/DUT unicast MAC address + Multicast destination IPv6 address which is an invalid config just like having Multicast source IPv6 address. This should get dropped in data-plane packet sanity check. Fixed the packet format to have valid source IP address.

#### How did you do it?

#### How did you verify/test it?
Verified it on T1 based setup with Cisco-8000 platform 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
