### PR TITLE
gen-mg broken for multi-asic kvm - issue #4343

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -492,47 +492,62 @@ def makeLab(data, devices, testbed, outfile):
                         except AttributeError:
                             print("\t\t" + host + " asics_host_ipv6 not found")
 
-                        try: #get voq_inband_ip
-                            voq_inband_ip = dev.get("voq_inband_ip")
-                            if voq_inband_ip is not None:
-                               entry += "\tvoq_inband_ip=" + str( voq_inband_ip )
-                        except AttributeError:
-                            print("\t\t" + host + " voq_inband_ip not found")
-
-                        try: #get voq_inband_ipv6
-                            voq_inband_ipv6 = dev.get("voq_inband_ipv6")
-                            if voq_inband_ipv6 is not None:
-                               entry += "\tvoq_inband_ipv6=" + str( voq_inband_ipv6 )
-                        except AttributeError:
-                            print("\t\t" + host + " voq_inband_ipv6 not found")
-
-                        try: #get voq_inband_intf
-                            voq_inband_intf = dev.get("voq_inband_intf")
-                            if voq_inband_intf is not None:
-                               entry += "\tvoq_inband_intf=" + str( voq_inband_intf )
-                        except AttributeError:
-                            print("\t\t" + host + " voq_inband_intf not found")
-
-                        try: #get voq_inband_type
-                            voq_inband_type = dev.get("voq_inband_type")
-                            if voq_inband_type is not None:
-                               entry += "\tvoq_inband_type=" + str( voq_inband_type )
-                        except AttributeError:
-                            print("\t\t" + host + " voq_inband_type not found")
-
                         try: #get switch_type
                             switch_type = dev.get("switch_type")
                             if switch_type is not None:
-                               entry += "\tswitch_type=" + str( switch_type )
+                                entry += "\tswitch_type=" + str( switch_type )
+                                if switch_type == 'voq' and card_type != 'supervisor':
+                                    if num_asics is None:
+                                        num_asics = 1
+
+                                    # All fields are a list. For single asic the list is of size 1.
+                                    switchids = dev.get("switchids")                       # switchids, single asic example "[4]", 3 asic example "[4,6,8]"
+                                    voq_inband_ip = dev.get("voq_inband_ip")               # voq_inband_ip
+                                    voq_inband_ipv6 = dev.get("voq_inband_ipv6")           # voq_inband_ipv6
+                                    voq_inband_intf = dev.get("voq_inband_intf")           # voq_inband_intf
+                                    voq_inband_type = dev.get("voq_inband_type")           # voq_inband_type
+                                    max_cores = dev.get("max_cores")                       # max cores
+                                    lo4096_ip = dev.get("loopback4096_ip")                 # loopback4096_ip
+                                    lo4096_ipv6 = dev.get("loopback4096_ipv6")             # loopback4096_ipv6
+                                    num_cores_per_asic = dev.get("num_cores_per_asic", 1)  # number of cores per asic - to be used in calculating the switchids, assuming to be the same for all linecards
+
+                                    # Add fields
+                                    if switchids is None:
+                                        switchids = [start_switchid + (asic_id * num_cores_per_asic) for asic_id in range(num_asics)]
+                                    entry += "\tswitchids=" + str(switchids)
+
+                                    if voq_inband_ip is None:
+                                        voq_inband_ip = ["1.1.1.{}/32".format(start_switchid + asic_id) for asic_id in range(num_asics)]
+                                    entry += "\tvoq_inband_ip=" + str(voq_inband_ip)
+
+                                    if voq_inband_ipv6 is None:
+                                        voq_inband_ip = ["1111::1:{}/128".format(start_switchid + asic_id) for asic_id in range(num_asics)]
+                                    entry += "\tvoq_inband_ipv6=" + str(voq_inband_ip)
+
+                                    if voq_inband_intf is None:
+                                        voq_inband_intf = ["Ethernet-IB{}".format(asic_id) for asic_id in range(num_asics)]
+                                    entry += "\tvoq_inband_intf=" + str(voq_inband_intf)
+
+                                    if voq_inband_type is None:
+                                        voq_inband_type = "port"
+                                    entry += "\tvoq_inband_type=" + voq_inband_type
+
+                                    if max_cores is None:
+                                        max_cores = 48
+                                    entry += "\tmax_cores=" + str(max_cores)
+
+                                    if lo4096_ip is None:
+                                        lo4096_ip = ["8.0.0.{}/32".format(start_switchid + asic_id) for asic_id in range(num_asics)]
+                                    entry += "\tloopback4096_ip=" + lo4096_ip
+
+                                    if lo4096_ipv6 is None:
+                                        lo4096_ipv6 = ["2603:10e2:400::{}/128".format(start_switchid + asic_id) for asic_id in range(num_asics)]
+                                    entry += "\tloopback4096_ipv6=" + lo4096_ipv6
+
+                                    start_switchid += (num_asics * num_cores_per_asic)
+
                         except AttributeError:
                             print("\t\t" + host + " switch_type not found")
-
-                        try: #get max_cores
-                            max_cores = dev.get("max_cores")
-                            if max_cores is not None:
-                               entry += "\tmax_cores=" + str( max_cores )
-                        except AttributeError:
-                            print("\t\t" + host + " max_cores not found")
 
                         try: #get os
                             os = dev.get("os")

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -83,7 +83,7 @@
       hwsku: "{{ hwsku }}"
       card_type: "{{ card_type | default('fixed') }}"
       hostname: "{{ inventory_hostname | default('') }}"
-      switchids: "{{ switchids | default([0]) }}"
+      switchids: "{{ switchids | default([]) }}"
     when: deploy is defined and deploy|bool == true
 
   - name: find interface name mapping and individual interface speed if defined with local data
@@ -92,7 +92,7 @@
       num_asic: "{{ num_asics }}"
       card_type: "{{ card_type | default('fixed') }}"
       hostname: "{{ inventory_hostname | default('') }}"
-      switchids: "{{ switchids | default([0]) }}"
+      switchids: "{{ switchids | default([]) }}"
     delegate_to: localhost
     when: deploy is not defined or deploy|bool == false
 

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -83,7 +83,7 @@
       hwsku: "{{ hwsku }}"
       card_type: "{{ card_type | default('fixed') }}"
       hostname: "{{ inventory_hostname | default('') }}"
-      start_switchid: "{{ start_switchid | default(0) }}"
+      switchids: "{{ switchids | default([0]) }}"
     when: deploy is defined and deploy|bool == true
 
   - name: find interface name mapping and individual interface speed if defined with local data
@@ -92,7 +92,7 @@
       num_asic: "{{ num_asics }}"
       card_type: "{{ card_type | default('fixed') }}"
       hostname: "{{ inventory_hostname | default('') }}"
-      start_switchid: "{{ start_switchid | default(0) }}"
+      switchids: "{{ switchids | default([0]) }}"
     delegate_to: localhost
     when: deploy is not defined or deploy|bool == false
 
@@ -110,8 +110,7 @@
 
   - name: set all VoQ information for iBGP
     set_fact:
-      all_inbands: "{{ all_inbands | default( [] ) + [ hostvars[item]['voq_inband_ip'] ] }}"
-      all_hostnames: "{{ all_hostnames | default( [] ) + [ item ] }}"
+      all_inbands: "{{ all_inbands | default( {} ) | combine( { item : hostvars[item]['voq_inband_ip']}) }}"
     when: hostvars[item]['voq_inband_ip'] is defined
     loop: "{{ ansible_play_batch }}"
 

--- a/ansible/library/fabric_info.py
+++ b/ansible/library/fabric_info.py
@@ -23,8 +23,8 @@ EXAMPLES = '''
 
 RETURN = '''
       ansible_facts{
-        fabric_info: [{'asicname': 'ASIC0', 'ip_prefix': '10.1.0.1/32', 'ip6_prefix': 'FC00:1::1/128'},
-                      {'asicname': 'ASIC1', 'ip_prefix': '10.1.0.2/32', 'ip6_prefix': 'FC00:1::2/128'}]
+        fabric_info: [{'asicname': 'ASIC0', 'asic_id': 0, 'ip_prefix': '10.1.0.1/32', 'ip6_prefix': 'FC00:1::1/128'},
+                      {'asicname': 'ASIC1', 'asic_id': 1, 'ip_prefix': '10.1.0.2/32', 'ip6_prefix': 'FC00:1::2/128'}]
       }
 '''
 
@@ -55,6 +55,7 @@ def main():
             next_v4addr = str( ipaddress.IPv4Address(v4base + asic_id) )
             next_v6addr = str( ipaddress.IPv6Address(v6base + asic_id) )
             data = { 'asicname': key,
+                     'asic_id' : asic_id,
                      'ip_prefix': next_v4addr + "/" + v4pfx[-1],
                      'ip6_prefix': next_v6addr + "/" + v6pfx[-1] }
             fabric_info.append( data )

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -236,7 +236,7 @@ def main():
            return
         allmap = SonicPortAliasMap(m_args['hwsku'])
         switchids = None
-        if 'switchids' in m_args and m_args['switchids'] != None:
+        if 'switchids' in m_args and m_args['switchids'] != None and len(m_args['switchids']):
            switchids = m_args['switchids']
         # When this script is invoked on sonic-mgmt docker, num_asic 
         # parameter is passed.

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -104,8 +104,8 @@ class SonicPortAliasMap():
         port_coreid_index = -1
         port_core_portid_index = -1
         num_voq_index = -1
-        # default to ASIC0 as minigraph.py parsing code has that assumption.
-        asic_name = "ASIC0" if asic_id is None else "ASIC" + str(asic_id)
+        # default to Asic0 as minigraph.py parsing code has that assumption.
+        asic_name = "Asic0" if asic_id is None else "asic" + str(asic_id)
 
         filename = self.get_portconfig_path(asic_id)
         if filename is None:
@@ -209,7 +209,7 @@ def main():
             include_internal=dict(required=False, type='bool', default=False),
             card_type=dict(type='str', required=False),
             hostname=dict(type='str', required=False),
-            start_switchid=dict(type='int', required=False)
+            switchids=dict(type='list', required=False)
         ),
         supports_check_mode=True
     )
@@ -235,10 +235,10 @@ def main():
                                            'sysports': sysports})
            return
         allmap = SonicPortAliasMap(m_args['hwsku'])
-        start_switchid = 0
-        if  'start_switchid' in m_args and m_args['start_switchid'] != None:
-           start_switchid = int(m_args['start_switchid'])
-        # When this script is invoked on sonic-mgmt docker, num_asic
+        switchids = None
+        if 'switchids' in m_args and m_args['switchids'] != None:
+           switchids = m_args['switchids']
+        # When this script is invoked on sonic-mgmt docker, num_asic 
         # parameter is passed.
         if m_args['num_asic'] is not None:
             num_asic = m_args['num_asic']
@@ -264,8 +264,8 @@ def main():
         if 'hostname' in m_args:
             hostname = m_args['hostname']
         for asic_id in range(num_asic):
-            if asic_id is not None:
-                switchid = start_switchid + asic_id
+            if switchids and asic_id is not None:
+                switchid = switchids[asic_id]
             if num_asic == 1:
                 asic_id = None
             (aliases_asic, portmap_asic, aliasmap_asic, portspeed_asic, front_panel_asic, asicifnames_asic,

--- a/ansible/templates/minigraph_cpg.j2
+++ b/ansible/templates/minigraph_cpg.j2
@@ -80,19 +80,39 @@
 {% endfor %}
 {% endif %}
 {% if switch_type is defined and switch_type == 'voq' %}
-{% for all_idx in range(all_inbands|length) %}
-{% if voq_inband_ip != all_inbands[all_idx] %}
+{% set voq_peers = dict() %}
+{% for asic_id in range(num_asics) %}
+{% if num_asics == 1 %}
+{% set start_rtr = inventory_hostname %}
+{% else %}
+{% set start_rtr = "ASIC" + asic_id|string %}
+{% endif %}
+{% for a_linecard in all_inbands %}
+{% for idx in range(all_inbands[a_linecard]|length) %}
+{% if voq_inband_ip[asic_id] != all_inbands[a_linecard][idx] %}
       <BGPSession>
-        <StartRouter>{{ inventory_hostname  }}</StartRouter>
-        <StartPeer>{{ voq_inband_ip.split('/')[0] }}</StartPeer>
-        <EndRouter>{{ all_hostnames[all_idx] }}</EndRouter>
-        <EndPeer>{{ all_inbands[all_idx].split('/')[0] }}</EndPeer>
+        <StartRouter>{{ start_rtr }}</StartRouter>
+        <StartPeer>{{ voq_inband_ip[asic_id].split('/')[0] }}</StartPeer>
+{% if all_inbands[a_linecard]|length == 1 %}
+{% set end_rtr = a_linecard %}
+{% else %}
+{% if a_linecard == inventory_hostname %}
+{% set end_rtr = "ASIC" + idx|string %}
+{% else %}
+{% set end_rtr = a_linecard + "-ASIC" + idx|string %}
+{% endif %}
+{% endif %}
+{% set _ = voq_peers.update({ all_inbands[a_linecard][idx].split('/')[0] : end_rtr }) %}
+        <EndRouter>{{ end_rtr }}</EndRouter>
+        <EndPeer>{{ all_inbands[a_linecard][idx].split('/')[0] }}</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>0</HoldTime>
         <KeepAliveTime>0</KeepAliveTime>
         <VoQChassisInternal>true</VoQChassisInternal>
       </BGPSession>
 {% endif %}
+{% endfor %}
+{% endfor %}
 {% endfor %}
 {% endif %}
     </PeeringSessions>
@@ -112,16 +132,14 @@
           </BGPPeer>
 {% endif %}
 {% endfor %}
-{% if switch_type is defined and switch_type == 'voq' %}
-{% for all_idx in range(all_inbands|length) %}
-{% if voq_inband_ip != all_inbands[all_idx] %}
+{% if num_asics == 1 and switch_type is defined and switch_type == 'voq' %}
+{% for a_voq_peer in voq_peers %}
           <BGPPeer>
-            <Address>{{ all_inbands[all_idx].split('/')[0] }}</Address>
+            <Address>{{ a_voq_peer }}</Address>
             <RouteMapIn i:nil="true"/>
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
           </BGPPeer>
-{% endif %}
 {% endfor %}
 {% endif %}
 {% if 'tor' in vm_topo_config['dut_type'] | lower %}
@@ -147,17 +165,6 @@
         </a:Peers>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
-{% if switch_type is defined and switch_type == 'voq' %}
-{% for all_idx in range(all_inbands|length) %}
-{% if voq_inband_ip != all_inbands[all_idx] %}
-      <a:BGPRouterDeclaration>
-        <a:ASN>{{ vm_topo_config['dut_asn'] }}</a:ASN>
-        <a:Hostname>{{ all_hostnames[all_idx]  }}</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-{% endif %}
-{% endfor %}
-{% endif %}
 {% for index in range( vms_number) %}
 {% if vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|length > 0 %}
       <a:BGPRouterDeclaration>
@@ -174,7 +181,7 @@
         <a:Hostname>{{ asic }}</a:Hostname>
         <a:Peers>
 {% for index in range( vms_number) %}
-{% if vm_asic_ifnames[vms[index]][0].split('-')[1] == asic %}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic %}
           <BGPPeer>
             <Address>{{ vm_topo_config['vm'][vms[index]]['peer_ipv4'][dut_index|int] }}</Address>
             <RouteMapIn i:nil="true"/>
@@ -197,6 +204,52 @@
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
 {% endfor %}
+{% if switch_type is defined and switch_type == 'voq' %}
+{% for a_linecard in all_inbands %}
+{% if a_linecard != inventory_hostname %}
+{% for idx in range(all_inbands[a_linecard]|length) %}
+      <a:BGPRouterDeclaration>
+        <a:ASN>{{ vm_topo_config['dut_asn'] }}</a:ASN>
+        <a:Hostname>{{ voq_peers[all_inbands[a_linecard][idx].split('/')[0]] }}</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% if num_asics > 1 %}
+{% for asic_id in range(num_asics) %}
+{% set asic_name = "ASIC" + asic_id|string %}
+      <a:BGPRouterDeclaration>
+        <a:ASN>{{ vm_topo_config['dut_asn'] }}</a:ASN>
+        <a:Hostname>{{ asic_name }}</a:Hostname>
+        <a:Peers>
+{% for index in range( vms_number) %}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
+          <BGPPeer>
+            <Address>{{ vm_topo_config['vm'][vms[index]]['peer_ipv4'][dut_index|int] }}</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+{% endif %}
+{% endfor %}
+{% for a_linecard in all_inbands %}
+{% for idx in range(all_inbands[a_linecard]|length) %}
+{% if voq_inband_ip[asic_id] != all_inbands[a_linecard][idx] %}
+          <BGPPeer>
+            <Address>{{ all_inbands[a_linecard][idx] }}</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+{% endif %}
+{% endfor %}
+{% endfor %}
+        </a:Peers>
+      </a:BGPRouterDeclaration>
+{% endfor %}
+{% endif %}
+{% endif %}
     </Routers>
   </CpgDec>
 

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -19,6 +19,26 @@
           </a:Prefix>
           <a:PrefixStr>{{ lp_ipv6 }}</a:PrefixStr>
         </a:LoopbackIPInterface>
+      {% if num_asics == 1 and switch_type is defined and switch_type == 'voq' %}
+      {% if loopback4096_ip is defined %}
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback4096</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>{{ loopback4096_ip[0] }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ loopback4096_ip[0] }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback4096</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>{{ loopback4096_ipv6[0] }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ loopback4096_ipv6[0] }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+      {% endif %}
+      {% endif %}
       {%- if 'addl_loopbacks' in dual_tor_facts -%}
       {%- for loopback_num in dual_tor_facts['addl_loopbacks'][inventory_hostname] -%}
         {%- set loopback_facts = dual_tor_facts['addl_loopbacks'][inventory_hostname][loopback_num] -%}
@@ -61,24 +81,24 @@
         </a:ManagementIPInterface>
       </ManagementIPInterfaces>
       <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
-{% if voq_inband_ip is defined or voq_inband_ipv6 is defined %}
+{% if num_asics == 1 and (voq_inband_ip is defined or voq_inband_ipv6 is defined) %}
       <VoqInbandInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% if voq_inband_ip is defined %}
         <a:VoqInbandInterface>
-          <Name>{{ voq_inband_intf }}</Name>
+          <Name>{{ voq_inband_intf[0] }}</Name>
           <Type>{{ voq_inband_type }}</Type>
-          <a:PrefixStr>{{ voq_inband_ip }}</a:PrefixStr>
+          <a:PrefixStr>{{ voq_inband_ip[0] }}</a:PrefixStr>
         </a:VoqInbandInterface>
 {% endif %}
 {% if voq_inband_ipv6 is defined %}
         <a:VoqInbandInterface>
-          <Name>{{ voq_inband_intf }}</Name>
+          <Name>{{ voq_inband_intf[0] }}</Name>
           <Type>{{ voq_inband_type }}</Type>
-          <a:PrefixStr>{{ voq_inband_ipv6 }}</a:PrefixStr>
+          <a:PrefixStr>{{ voq_inband_ipv6[0] }}</a:PrefixStr>
         </a:VoqInbandInterface>
 {% endif %}
       </VoqInbandInterfaces>
-{% endif %}      
+{% endif %}
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
@@ -246,5 +266,6 @@
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
 {% include 'minigraph_dpg_asic.j2' %}
+{% include 'minigraph_dpg_voq_asic.j2' %}
   </DpgDec>
 

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -61,7 +61,7 @@
       {%- endfor -%}
       {%- endif -%}
 {% endif %}
-      </LoopbackIPInterfaces>
+</LoopbackIPInterfaces>
       <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
         <a:ManagementIPInterface>
           <Name>HostIP</Name>

--- a/ansible/templates/minigraph_dpg_voq_asic.j2
+++ b/ansible/templates/minigraph_dpg_voq_asic.j2
@@ -1,0 +1,218 @@
+{% if num_asics > 1 and switch_type is defined and switch_type == 'voq' %}
+{% for asic_index in range(num_asics) %}
+{% set asic_name = "ASIC" + asic_index|string %}
+    <DeviceDataPlaneInfo>
+      <IPSecTunnels/>
+      <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>{{ lp_ipv4 }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ lp_ipv4 }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>{{ lp_ipv6 }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ lp_ipv6 }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+{% if loopback4096_ip is defined %}
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback4096</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>{{ loopback4096_ip[asic_index] }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ loopback4096_ip[asic_index] }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback4096</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>{{ loopback4096_ipv6[asic_index] }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ loopback4096_ipv6[asic_index] }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+{% endif %}
+      </LoopbackIPInterfaces>
+      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:ManagementIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>{{ ansible_host }}/{{ mgmt_subnet_mask_length }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ ansible_host }}/{{ mgmt_subnet_mask_length }}</a:PrefixStr>
+        </a:ManagementIPInterface>
+        <a:ManagementIPInterface>
+          <Name>V6HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>{{ ansible_hostv6 if ansible_hostv6 is defined else 'FC00:2::32' }}/64</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ ansible_hostv6 if ansible_hostv6 is defined else 'FC00:2::32' }}/64</a:PrefixStr>
+        </a:ManagementIPInterface>
+      </ManagementIPInterfaces>
+      <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+{% if voq_inband_ip is defined or voq_inband_ipv6 is defined %}
+      <VoqInbandInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+{% if voq_inband_ip is defined %}
+        <a:VoqInbandInterface>
+          <Name>{{ voq_inband_intf[asic_index] }}</Name>
+          <Type>{{ voq_inband_type }}</Type>
+          <a:PrefixStr>{{ voq_inband_ip[asic_index] }}</a:PrefixStr>
+        </a:VoqInbandInterface>
+{% endif %}
+{% if voq_inband_ipv6 is defined %}
+        <a:VoqInbandInterface>
+          <Name>{{ voq_inband_intf[asic_index] }}</Name>
+          <Type>{{ voq_inband_type }}</Type>
+          <a:PrefixStr>{{ voq_inband_ipv6[asic_index] }}</a:PrefixStr>
+        </a:VoqInbandInterface>
+{% endif %}
+      </VoqInbandInterfaces>
+{% endif %}
+      <MplsInterfaces/>
+      <MplsTeInterfaces/>
+      <RsvpInterfaces/>
+      <Hostname>{{ asic_name }}</Hostname>
+      <PortChannelInterfaces>
+{% for index in range(vms_number) %}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
+{% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
+{% set port_channel_intf=';'.join(vm_asic_ifnames[vms[index]])  %}
+        <PortChannel>
+          <Name>PortChannel{{ ((index+1)|string).zfill(4) }}</Name>
+          <AttachTo>{{ port_channel_intf }}</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+{% endif %}
+{% endif %}
+{% endfor %}
+      </PortChannelInterfaces>
+      <SubInterfaces/>
+      <VlanInterfaces/>
+      <IPInterfaces>
+{% for index in range(vms_number) %}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
+{% if vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int] is not none %}
+        <IPInterface>
+          <Name i:nil="true"/>
+{% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
+          <AttachTo>PortChannel{{ ((index+1) |string).zfill(4) }}</AttachTo>
+{% else %}
+          <AttachTo>{{ front_panel_asic_ifnames[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
+{% endif %}
+          <Prefix>{{ vm_topo_config['vm'][vms[index]]['bgp_ipv4'][dut_index|int] }}/{{ vm_topo_config['vm'][vms[index]]['ipv4mask'][dut_index|int] }}</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+{% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
+          <AttachTo>PortChannel{{ ((index+1) |string).zfill(4) }}</AttachTo>
+{% else %}
+          <AttachTo>{{ front_panel_asic_ifnames[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
+{% endif %}
+          <Prefix>{{ vm_topo_config['vm'][vms[index]]['bgp_ipv6'][dut_index|int] }}/{{ vm_topo_config['vm'][vms[index]]['ipv6mask'][dut_index|int] }}</Prefix>
+        </IPInterface>
+{% endif %}
+{% endif %}
+{% endfor %}
+      </IPInterfaces>
+      <DataAcls/>
+      <AclInterfaces>
+        <AclInterface>
+          <InAcl>SNMP_ACL</InAcl>
+          <AttachTo>SNMP</AttachTo>
+          <Type>SNMP</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPAN</AttachTo>
+          <InAcl>Everflow</InAcl>
+          <Type>Everflow</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPANV6</AttachTo>
+          <InAcl>EverflowV6</InAcl>
+          <Type>EverflowV6</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>VTY_LINE</AttachTo>
+          <InAcl>ssh-only</InAcl>
+          <Type>SSH</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>
+{%- set acl_intfs = [] -%}
+{%- for index in range(vms_number) %}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
+{% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][0]|lower %}
+{% set a_intf = 'PortChannel' + ((index+1) |string).zfill(4) %}
+{{- acl_intfs.append(a_intf) -}}
+{% endif %}
+{% endif %}
+{% endfor %}
+{%- for index in range(vms_number) -%}
+{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
+{% if 'port-channel' not in vm_topo_config['vm'][vms[index]]['ip_intf'][0]|lower %}
+{% if vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|length %}
+{% set a_intf = front_panel_asic_ifnames[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] %}
+{{- acl_intfs.append(a_intf) -}}
+{% endif %}
+{% endif %}
+{% endif %}
+{% endfor -%}
+{{- acl_intfs|join(';') -}}
+          </AttachTo>
+          <InAcl>DataAcl</InAcl>
+          <Type>DataPlane</Type>
+        </AclInterface>
+      </AclInterfaces>
+      <DownstreamSummaries/>
+      <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    </DeviceDataPlaneInfo>
+{% endfor %}
+{% endif %}
+{% if switch_type is defined and switch_type == 'fabric' %}
+{% for asic in fabric_info %}
+    <DeviceDataPlaneInfo>
+      <IPSecTunnels/>
+      <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+            <b:IPPrefix>{{ asic['ip_prefix'] }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ asic['ip_prefix'] }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+            <b:IPPrefix>{{ asic['ip6_prefix'] }}</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>{{ asic['ip6_prefix'] }}</a:PrefixStr>
+        </a:LoopbackIPInterface>
+      </LoopbackIPInterfaces>
+      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      </ManagementIPInterfaces>
+      <MplsInterfaces/>
+      <MplsTeInterfaces/>
+      <RsvpInterfaces/>
+      <Hostname>{{ asic['asicname'] }}</Hostname>
+      <PortChannelInterfaces/>
+      <VlanInterfaces/>
+      <IPInterfaces/>
+      <DataAcls/>
+      <AclInterfaces/>
+      <DownstreamSummaries/>
+      <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    </DeviceDataPlaneInfo>
+{% endfor %}
+{% endif %}
+
+

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -91,7 +91,7 @@
             <a:Value>{{ erspan_dest_str }}</a:Value>
          </a:DeviceProperty>
 {% endif %}
-{% if switch_type is defined and switch_type == 'voq' %}
+{% if num_asics == 1 and switch_type is defined and switch_type == 'voq' %}
           <a:DeviceProperty>
             <a:Name>SwitchType</a:Name>
             <a:Reference i:nil="true"/>
@@ -100,8 +100,8 @@
           <a:DeviceProperty>
             <a:Name>SwitchId</a:Name>
             <a:Reference i:nil="true"/>
-            <a:Value>{{ start_switchid }}</a:Value>
-          </a:DeviceProperty>         
+            <a:Value>{{ switchids[0] }}</a:Value>
+          </a:DeviceProperty>
 {% endif %}
 {% if max_cores is defined %}
           <a:DeviceProperty>
@@ -112,7 +112,38 @@
 {% endif %}
         </a:Properties>
       </a:DeviceMetadata>
-{% set idx = 0 %}
+{% if num_asics > 1 and switch_type is defined and switch_type == 'voq' %}
+{% for asic_index in range(num_asics) %}
+{% set asic_name = "ASIC" + asic_index|string %}
+     <a:DeviceMetadata>
+        <a:Name>{{ asic_name }}</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>SubRole</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>FrontEnd</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SwitchType</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ switch_type }}</a:Value>
+         </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SwitchId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ switchids[asic_index] }}</a:Value>
+          </a:DeviceProperty>
+{% if max_cores is defined %}
+          <a:DeviceProperty>
+            <a:Name>MaxCores</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ max_cores }}</a:Value>
+         </a:DeviceProperty>
+        </a:Properties>
+{% endif %}
+      </a:DeviceMetadata>
+{% endfor %}
+{% endif %}
 {% for asic in asic_topo_config %}
       <a:DeviceMetadata>
         <a:Name>{{ asic }}</a:Name>
@@ -145,7 +176,6 @@
 {% endif %}
       </a:DeviceMetadata>
 {% endfor %}
-
 {% for asic in fabric_info %}
       <a:DeviceMetadata>
         <a:Name>{{ asic['asicname'] }}</a:Name>
@@ -160,10 +190,14 @@
             <a:Reference i:nil="true"/>
             <a:Value>Fabric</a:Value>
           </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SwitchId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ switchids[asic['asic_id']] }}</a:Value>
+          </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
 {% endfor %}
-
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -73,9 +73,10 @@
 {% endfor %}
 {% endfor %}
 {% for asic_intf in front_panel_asic_ifnames %}
+{% if port_alias[loop.index - 1] in device_conn[inventory_hostname] %}
       <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
-        <Bandwidth>40000</Bandwidth>
+        <Bandwidth>{{ port_speed[port_alias[loop.index - 1]] }}</Bandwidth>
         <ChassisInternal>true</ChassisInternal>
         <EndDevice>{{ asic_intf.split('-')[1] }}</EndDevice>
         <EndPort>{{ asic_intf }}</EndPort>
@@ -84,6 +85,7 @@
         <StartPort>{{ port_alias[loop.index - 1] }}</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
+{% endif %}
 {% endfor %}
 {% endif %}
     </DeviceInterfaceLinks>
@@ -217,6 +219,15 @@
         <HwSku>Broadcom-Trident2</HwSku>
       </Device>
 {% endfor %}
+{% if num_asics > 1 and switch_type is defined and switch_type == 'voq' %}
+{% for asic_index in range(num_asics) %}
+{% set asic_name = "ASIC" + asic_index|string %}
+      <Device i:type="Asic">
+        <ElementType>Asic</ElementType>
+        <Hostname>{{ asic_name }}</Hostname>
+      </Device>
+{% endfor %}
+{% endif %}
 {% for asic in fabric_info %}
       <Device i:type="Asic">
         <Hostname>{{ asic['asicname'] }}</Hostname>

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -73,10 +73,14 @@
 {% endfor %}
 {% endfor %}
 {% for asic_intf in front_panel_asic_ifnames %}
-{% if port_alias[loop.index - 1] in device_conn[inventory_hostname] %}
+{% if inventory_hostname not in device_conn or port_alias[loop.index - 1] in device_conn[inventory_hostname] %}
       <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
+{% if port_alias[loop.index - 1] in port_speed %}
         <Bandwidth>{{ port_speed[port_alias[loop.index - 1]] }}</Bandwidth>
+{% else %}
+        <Bandwidth>40000</Bandwidth>
+{% endif %}
         <ChassisInternal>true</ChassisInternal>
         <EndDevice>{{ asic_intf.split('-')[1] }}</EndDevice>
         <EndPort>{{ asic_intf }}</EndPort>

--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -5,14 +5,11 @@ pytestmark = [
     pytest.mark.device_type('vs')
 ]
 
-def test_bgp_facts(duthosts, enum_dut_hostname, enum_asic_index):
+
+def test_bgp_facts(duthosts, enum_frontend_dut_hostname, enum_asic_index):
     """compare the bgp facts between observed states and target state"""
 
-    duthost = duthosts[enum_dut_hostname]
-
-    # Check if duthost is 'supervisor' card, and skip the test if dealing with supervisor card.
-    if duthost.is_supervisor_node():
-        pytest.skip("bgp_facts not valid on supervisor card '%s'" % enum_dut_hostname)
+    duthost = duthosts[enum_frontend_dut_hostname]
 
     bgp_facts = duthost.bgp_facts(instance_id=enum_asic_index)['ansible_facts']
     namespace = duthost.get_namespace_from_asic_id(enum_asic_index)
@@ -32,6 +29,8 @@ def test_bgp_facts(duthosts, enum_dut_hostname, enum_asic_index):
     nbrs_in_cfg_facts = {}
     nbrs_in_cfg_facts.update(config_facts.get('BGP_NEIGHBOR', {}))
     nbrs_in_cfg_facts.update(config_facts.get('BGP_INTERNAL_NEIGHBOR', {}))
+    # In VoQ Chassis, we would have BGP_VOQ_CHASSIS_NEIGHBOR as well.
+    nbrs_in_cfg_facts.update(config_facts.get('BGP_VOQ_CHASSIS_NEIGHBOR', {}))
     for k, v in nbrs_in_cfg_facts.items():
         # Compare the bgp neighbors name with config db bgp neighbors name
         assert v['name'] == bgp_facts['bgp_neighbors'][k]['description']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix for issue https://github.com/Azure/sonic-mgmt/issues/4343 when running gen-mg for multi-asic kvm.



#### How did you do it?

PR #3746 introduced generating minigraphs for multi-asic linecards in a VoQ chassis. 

In generating minigraph for mulit-asic linecards in a VoQ chassis, switchids are required to be defined per asic. But, switchid for each asic doesn't exist for multi-asic KVM (pizza box) switchid.  To fix this:

- Use empty list as the default for switchids in the call to port_alias.
    - Originally the default was a list [0], but with multi-asic KVM, 
- In port_alias ansible library, check the length of switchids before using it.

- Also, in minigraph_png, made the following fixes:
  - For supporting not all ports connected to fanout, in minigraph_png.j2, we added DeviceInterfaceLink for only ports that are defined in the device_conn (from connection graph). But, for masic KVM, device_conn is not defined, and thus we were not adding any port. The fix is that if the inventory_hostname is not present in the device_conn, then add DeviceInterfaceLink for all front_panel_asic_ifnames
  - 'Bandwidth' for each DeviceInterfaceLink was hard-coded to 40G, we added code to get it from port_speed which also gets populated from the connection graph. However, port_speed is empty for KVM, and thus generation was failing. Fix is to check if the port is present in port_speed, and if so, use the speed defined in port_speed. Else, use default 40G.

- Reverted PR #4351
#### How did you verify/test it?
Ran the steps defined in https://github.com/Azure/sonic-mgmt/issues/4343, and made sure that the generated minigraph with the 'master' code (which reverted PR #3746) and the above code changes are the same.

Also, ran for multi-asic and single-asic linecards of a VoQ Chassis - as long a switchids are defined in the ansible inventory for each linecard, it works.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
