### PR TITLE
[IP_decap_test.py]: Log expected ttl.

### DIFF
--- a/ansible/roles/test/files/ptftests/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/IP_decap_test.py
@@ -358,10 +358,15 @@ class DecapPacketTest(BaseTest):
                 inner_ttl_info = pkt['IPv6'].payload.hlim
                 inner_tos = pkt['IPv6'].payload.tc
 
+        exp_ttl = 'any'
         if inner_pkt_type == 'ipv4':
             exp_tos = exp_pkt.tos
+            if not self.ignore_ttl:
+                exp_ttl = exp_pkt.ttl
         else:
             exp_tos = exp_pkt.tc
+            if not self.ignore_ttl:
+                exp_ttl = exp_pkt.hlim
 
         #send and verify the return packets
         send_packet(self, src_port, pkt)
@@ -384,7 +389,7 @@ class DecapPacketTest(BaseTest):
                     inner_src_ip,
                     dst_ip,
                     exp_tos,
-                    'any',
+                    exp_ttl,
                     str(expected_ports)))
 
         matched, received = verify_packet_any_port(self, masked_exp_pkt, expected_ports)


### PR DESCRIPTION
Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Decap tests does not ignore TTL when ignore_ttl is false. So log must also print correct ttl instead of 'any' to improve debuggability.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ -] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Decap tests does not ignore TTL when ignore_ttl is false. So log must also print correct ttl instead of 'any' to improve debuggability.

#### How did you do it?
Log exp_ttl from exp_pkt

#### How did you verify/test it?
Ran the Test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
