### PR TITLE
[platform_tests/api] Setting fan speed range for Cisco-8000 platform

### DIFF
--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -190,8 +190,11 @@ class TestChassisFans(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_set_fans_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-
-        target_speed = random.randint(1, 100)
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        if duthost.facts["asic_type"] in ["cisco-8000"]:
+            target_speed = random.randint(40, 60)
+        else:
+            target_speed = random.randint(1, 100)
 
         for i in range(self.num_fans):
             speed = fan.get_speed(platform_api_conn, i)


### PR DESCRIPTION
## Description of PR
 Setting fan speed range for Cisco-8000 platform

Summary:
Fixes # (issue)

### Type of change
- [] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
 Setting fan speed range for Cisco-8000 platform

#### How did you do it?

#### How did you verify/test it?
Tested on T0 setup with Cisco-8000 platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
