### PR TITLE
[autonegotiation] Fixed parsers for speed which used in auto negotiation test case

### DIFF
--- a/tests/common/devices/onyx.py
+++ b/tests/common/devices/onyx.py
@@ -92,7 +92,7 @@ class OnyxHost(AnsibleHostBase):
         
         # The output should be something like: "Supported speeds:1G 10G 25G 50G"
         speeds = out.split(':')[-1].split()
-        return [x[:-1] + '000' for x in speeds]
+        return list(set([x.split('G')[0] + '000' for x in speeds]))
 
     def set_auto_negotiation_mode(self, interface_name, mode):
         """Set auto negotiation mode for a given interface

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -450,6 +450,6 @@ class MlnxCableSupportedSpeedsHelper(object):
         if pos == -1:
             return None
         speeds_str = output[pos+1:-1]
-        speeds =  [speed[:-1] + '000' for speed in speeds_str.split(',')]
+        speeds = list(set([speed.split('G')[0] + '000' for speed in speeds_str.split(',')]))
         cls.supported_speeds[(duthost, dut_port_name)] = speeds
         return speeds


### PR DESCRIPTION
[autonegotiation] Fixed parsers for speed which used in auto negotiation test case

Signed-off-by: Petro Pikh <petrop@nvidia.com>


### Description of PR
Parser which previously we used for parse supported speed for cable for fanout - did not work correctly in case when speed has format like:
(100G_4X,50G_2X,40G,25G,10G,1G)
or 
1G 10G 25G 40G 50Gx1 50Gx2 100Gx2 100Gx4 200Gx4 400Gx8
Previously it worked only with speed in format: 1G 10G 25G 40G
Now parser works in both cases.

Summary:
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
See description

#### How did you do it?
Fixed logic which doing parse for supported speed

#### How did you verify/test it?
Executed auto negotiation test case

#### Any platform specific information?
mellanox/nvidia related

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
