### PR TITLE
[tests/common] Checking device Asic type for Cisco platform

### DIFF
--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -1,0 +1,2 @@
+def is_cisco_device(dut):
+    return dut.facts["asic_type"] == "cisco-8000"


### PR DESCRIPTION
### Description of PR
Checking if device asic type is cisco-8000

Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Checking if device asic type is cisco-8000

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
