### PR TITLE
Skip testcase power_off_reboot for Cisco platform

### DIFF
--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -209,6 +209,9 @@ def test_power_off_reboot(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
     @param power_off_delay: Pytest parameter. The delay between turning off and on the PSU
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    UNSUPPORTED_ASIC_TYPE = ["cisco-8000"]
+    if duthost.facts["asic_type"] in UNSUPPORTED_ASIC_TYPE:
+        pytest.skip("Skipping test_power_off_reboot. Test unsupported on {} platform".format(duthost.facts["asic_type"]))
     pdu_ctrl = pdu_controller
     if pdu_ctrl is None:
         pytest.skip("No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)


### PR DESCRIPTION
### Description of PR
Added code to skip testcase test_power_off_reboot for Cisco platform

Summary:
Fixes # (issue)

### Type of change


- [ ] Bug fix
- [ X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Added code to skip testcase test_power_off_reboot for Cisco platform

#### How did you do it?

#### How did you verify/test it?
Verified against T1 topology against CIsco platform

#### Any platform specific information?
Cisco-8000

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
