### PR TITLE
[pfcwd] check that real detection/restore time is not less than configured only when poll period less than configured detection/restore time

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -170,17 +170,19 @@ class TestPfcwdAllTimer(object):
                                                                          config_detect_time))
         pytest_assert(self.all_detect_time[9] < config_detect_time, err_msg)
 
-        logger.info("Verify that real detection time is not less than configured")
-        err_msg = ("Real detection time is less than configured: Real detect time: {} "
-                   "Expected: {} (wd_detect_time)".format(self.all_detect_time[9],
-                                                          self.timers['pfc_wd_detect_time']))
-        pytest_assert(self.all_detect_time[9] > self.timers['pfc_wd_detect_time'], err_msg)
+        if self.timers['pfc_wd_poll_time'] < self.timers['pfc_wd_detect_time']:
+            logger.info("Verify that real detection time is not less than configured")
+            err_msg = ("Real detection time is less than configured: Real detect time: {} "
+                       "Expected: {} (wd_detect_time)".format(self.all_detect_time[9],
+                                                              self.timers['pfc_wd_detect_time']))
+            pytest_assert(self.all_detect_time[9] > self.timers['pfc_wd_detect_time'], err_msg)
 
-        logger.info("Verify that real restoration time is not less than configured")
-        err_msg = ("Real restoration time is less than configured: Real restore time: {} "
-                   "Expected: {} (wd_restore_time)".format(self.all_restore_time[9],
-                                                           self.timers['pfc_wd_restore_time']))
-        pytest_assert(self.all_restore_time[9] > self.timers['pfc_wd_restore_time'], err_msg)
+        if self.timers['pfc_wd_poll_time'] < self.timers['pfc_wd_restore_time']:
+            logger.info("Verify that real restoration time is not less than configured")
+            err_msg = ("Real restoration time is less than configured: Real restore time: {} "
+                       "Expected: {} (wd_restore_time)".format(self.all_restore_time[9],
+                                                               self.timers['pfc_wd_restore_time']))
+            pytest_assert(self.all_restore_time[9] > self.timers['pfc_wd_restore_time'], err_msg)
 
         logger.info("Verify that real restoration time is less than configured")
         config_restore_time = self.timers['pfc_wd_restore_time'] + self.timers['pfc_wd_poll_time']


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix test failure that appears during running pdcwd_timer_accurancy test :
It is possible that PFC storm can be registered faster than detection time will expire.
For example, if polling interval and detection time are the same
https://github.com/Azure/sonic-swss/blob/master/orchagent/pfc_detect_mellanox.lua#L74
we will detect and throw "storm" message faster than detection time expire.
If storm start between p0 and p1 and (p1-p0 == detection_time) such scenario is possible.

#### How did you do it?
Add checking if poll time is less then configured detection/restoration time

#### How did you verify/test it?
run **pfcwd_timer_accurancy** test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
