### PR TITLE
[bgp bbr] add debug code to learn why get_route failed

### DIFF
--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -265,6 +265,8 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
         tor1_asn = setup['tor1_asn']
 
         vm_route = nbrhosts[node]['host'].get_route(route.prefix)
+        if not isinstance(vm_route, dict):
+            logging.warn("DEBUG: unexpected vm_route type {}, {}".format(type(vm_route), vm_route))
         vm_route['failed'] = False
         vm_route['message'] = 'Checking route {} on {} passed'.format(str(route), node)
         if accepted:


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
bgp bbr test randomly fails due to get_route returned error. Current code cannot show what these errors are.

#### How did you do it?
log the error message should get_route() returns a none dict object.

#### How did you verify/test it?
run the test case and get pass, flip the condition to show the warning messages and make sure that the debug log won't cause failure.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

