### PR TITLE
[restart ptf] wait for ptf container to be reachable before changing ptf interfaces' MAC addresses

### DIFF
--- a/ansible/roles/vm_set/tasks/ptf_change_mac.yml
+++ b/ansible/roles/vm_set/tasks/ptf_change_mac.yml
@@ -18,6 +18,15 @@
     groups:
       - ptf_host
 
+- name: wait until ptf is reachable
+  wait_for:
+    port: 22
+    host: "{{ ptf_host_ip }}"
+    state: started
+    delay: 0
+    timeout: 300
+  delegate_to: "localhost"
+
 - name: Change PTF interface MAC addresses
   script: change_mac.sh
   delegate_to: "{{ ptf_host }}"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
wait for ptf container to be reachable before changing ptf interfaces' MAC addresses

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Restart-ptf will try to update MAC addr after ptf port renumbered,
Renumber is quick, ptf container may just started 20-30 seconds when renumber done.
So there's a chance that ptf container is not reachable yet, and it raises connection timeout exception.
Should wait for ptf container reachable and then continue.

#### How did you do it?
wait for ptf container to be reachable before changing ptf interfaces' MAC addresses
#### How did you verify/test it?
Run restart-ptf on physical testbed and it always successes.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
