### PR TITLE
[chassis] get frontend or backend asic only when present in metadata

### DIFF
--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -69,7 +69,7 @@ class SonicAsic(object):
         if self.sonichost.is_multi_asic:
             sub_role_cmd = 'sudo sonic-cfggen -d  -v DEVICE_METADATA.localhost.sub_role -n {}'.format(self.namespace)
             sub_role = self.sonichost.shell(sub_role_cmd)["stdout_lines"][0].decode("utf-8")
-            if sub_role is not None and sub_role.lower() == 'backend':
+            if sub_role is not None and (sub_role.lower() == 'backend' or sub_role.lower == 'fabric'):
                 return True
         return False
 

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -99,8 +99,8 @@ def collect_dut_info(dut):
     asic_services = defaultdict(list)
     for service in dut.sonichost.DEFAULT_ASIC_SERVICES:
         # for multi ASIC randomly select one frontend ASIC
-        # and one backend ASIC which is available
-        # in sonic chassis:
+        # or  one backend ASIC whichever is available
+        # in sonic chassis - 
         # the supervisor will only have fabric or backend asics
         # the linecards will only have frontend asics
         if dut.sonichost.is_multi_asic:

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -99,14 +99,21 @@ def collect_dut_info(dut):
     asic_services = defaultdict(list)
     for service in dut.sonichost.DEFAULT_ASIC_SERVICES:
         # for multi ASIC randomly select one frontend ASIC
-        # and one backend ASIC
+        # and one backend ASIC which is available
+        # in sonic chassis:
+        # the supervisor will only have fabric or backend asics
+        # the linecards will only have frontend asics
         if dut.sonichost.is_multi_asic:
-            fe = random.choice(front_end_asics)
-            be = random.choice(back_end_asics)
-            asic_services[service] = [
-                dut.get_docker_name(service, asic_index=fe),
-                dut.get_docker_name(service, asic_index=be)
-            ]
+            if front_end_asics:
+                fe = random.choice(front_end_asics)
+                asic_services[service].append(
+                    dut.get_docker_name(service, asic_index=fe)
+                )
+            if back_end_asics:
+                be = random.choice(back_end_asics)
+                asic_services[service].append(
+                    dut.get_docker_name(service, asic_index=be)
+                )
 
     dut_info = {
         "intf_status": status,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4441 

closes #4441 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
In chassis, the `test_update_testbed_metadata` fails in the function `collect_dut_info`.
This is because, the current assumption is a multi asic device will have frontend and backend asic.
In case of the chassis that may not be true.  The supervisor will have only backend or fabric asic and linecard will have only frontend asics. The PR address this issue

#### How did you do it?
Add check to get the asic_services of frontend and/or backend asic only when they are present on the DUT

#### How did you verify/test it?
run `test_pretest.py`

#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
