### PR TITLE
Add CPU usage test when decreasing counterpoll for port-buffer-drop

### DIFF
--- a/tests/platform_tests/counterpoll/counterpoll_constants.py
+++ b/tests/platform_tests/counterpoll/counterpoll_constants.py
@@ -1,0 +1,38 @@
+
+class CounterpollConstants:
+    COUNTERPOLL_SHOW = 'counterpoll show'
+    COUNTERPOLL_DISABLE = 'counterpoll {} disable'
+    COUNTERPOLL_RESTORE = 'counterpoll {} {}'
+    COUNTERPOLL_INTERVAL_STR = 'counterpoll {} interval {}'
+    COUNTERPOLL_QUEST = 'counterpoll ?'
+    EXCLUDE_COUNTER_SUB_COMMAND = ['show', 'config-db']
+    INTERVAL = 'interval'
+    TYPE = 'type'
+    STATUS = 'status'
+    STDOUT ='stdout'
+    PG_DROP = 'pg-drop'
+    PG_DROP_STAT_TYPE = 'PG_DROP_STAT'
+    QUEUE_STAT_TYPE = 'QUEUE_STAT'
+    QUEUE = 'queue'
+    PORT_STAT_TYPE = 'PORT_STAT'
+    PORT = 'port'
+    PORT_BUFFER_DROP_TYPE = 'PORT_BUFFER_DROP'
+    PORT_BUFFER_DROP = 'port-buffer-drop'
+    RIF_STAT_TYPE = 'RIF_STAT'
+    RIF = 'rif'
+    WATERMARK = 'watermark'
+    QUEUE_WATERMARK_STAT_TYPE = 'QUEUE_WATERMARK_STAT'
+    PG_WATERMARK_STAT_TYPE = 'PG_WATERMARK_STAT'
+    BUFFER_POOL_WATERMARK_STAT_TYPE = 'BUFFER_POOL_WATERMARK_STAT'
+    COUNTERPOLL_MAPPING = {PG_DROP_STAT_TYPE: PG_DROP,
+                           QUEUE_STAT_TYPE: QUEUE,
+                           PORT_STAT_TYPE: PORT,
+                           PORT_BUFFER_DROP_TYPE: PORT_BUFFER_DROP,
+                           RIF_STAT_TYPE: RIF,
+                           BUFFER_POOL_WATERMARK_STAT_TYPE: WATERMARK,
+                           QUEUE_WATERMARK_STAT_TYPE: WATERMARK,
+                           PG_WATERMARK_STAT_TYPE: WATERMARK}
+    PORT_BUFFER_DROP_NEW_INTERVAL = '10000'
+    PORT_BUFFER_DROP_OLD_INTERVAL = '30000'
+    SX_SDK = 'sx_sdk'
+    MLNX_PLATFORM_STR = "x86_64-mlnx_msn"

--- a/tests/platform_tests/counterpoll/counterpoll_helper.py
+++ b/tests/platform_tests/counterpoll/counterpoll_helper.py
@@ -1,0 +1,54 @@
+import re
+
+from tests.platform_tests.counterpoll.counterpoll_constants import CounterpollConstants
+
+
+class ConterpollHelper:
+    @staticmethod
+    def get_counterpoll_show_output(duthost):
+        counterpoll_show = duthost.command(CounterpollConstants.COUNTERPOLL_SHOW)
+        return counterpoll_show[CounterpollConstants.STDOUT]
+
+    @staticmethod
+    def get_available_counterpoll_types(duthost):
+        available_option_list = []
+        COMMANDS = 'Commands:'
+        counterpoll_show = duthost.command(CounterpollConstants.COUNTERPOLL_QUEST)[CounterpollConstants.STDOUT]
+        index = counterpoll_show.find(COMMANDS) + len(COMMANDS) + 1
+        for line in counterpoll_show[index:].splitlines():
+            available_option_list.append(line.split()[0])
+        return [option for option in available_option_list if option not in CounterpollConstants.EXCLUDE_COUNTER_SUB_COMMAND]
+
+    @staticmethod
+    def get_parsed_counterpoll_show(counterpoll_show):
+        parsed_counterpoll = {}
+        for line in counterpoll_show.splitlines():
+            match = re.search('(?P<type>\w+)\s+(?P<interval>(default \(\d+\))|\d+)\s+(?P<status>\w+)', line)
+            if match:
+                parsed_counterpoll[match.group(CounterpollConstants.TYPE)] = {
+                    CounterpollConstants.INTERVAL: match.group(CounterpollConstants.INTERVAL),
+                    CounterpollConstants.STATUS: match.group(CounterpollConstants.STATUS)}
+        return parsed_counterpoll
+
+    @staticmethod
+    def restore_counterpoll_interval(duthost, counterpoll_before, counterpoll_after):
+        for counterpoll, value in counterpoll_before.items():
+            if counterpoll_after[counterpoll] != counterpoll_before[counterpoll]:
+                duthost.command(
+                    CounterpollConstants.COUNTERPOLL_INTERVAL_STR.format(
+                        CounterpollConstants.COUNTERPOLL_MAPPING[counterpoll],
+                        re.search('\d+', value[CounterpollConstants.INTERVAL]).group()))
+
+    @staticmethod
+    def restore_counterpoll_status(duthost, counterpoll_before, counterpoll_after):
+        for counterpoll, value in counterpoll_after.items():
+            if counterpoll_after[counterpoll][CounterpollConstants.STATUS] \
+                    != counterpoll_before[counterpoll][CounterpollConstants.STATUS]:
+                duthost.command(CounterpollConstants.COUNTERPOLL_RESTORE.format(
+                    CounterpollConstants.COUNTERPOLL_MAPPING[counterpoll],
+                    counterpoll_before[counterpoll][CounterpollConstants.STATUS]))
+
+    @staticmethod
+    def disable_counterpoll(duthost, counter_type_list):
+        for counterpoll_type in counter_type_list:
+            duthost.command(CounterpollConstants.COUNTERPOLL_DISABLE.format(counterpoll_type))

--- a/tests/platform_tests/counterpoll/cpu_memory_helper.py
+++ b/tests/platform_tests/counterpoll/cpu_memory_helper.py
@@ -1,0 +1,28 @@
+import pytest
+
+from tests.platform_tests.counterpoll.counterpoll_constants import CounterpollConstants
+from tests.platform_tests.counterpoll.counterpoll_helper import ConterpollHelper
+
+
+@pytest.fixture(params=[CounterpollConstants.WATERMARK,
+                        CounterpollConstants.PORT_BUFFER_DROP,
+                        CounterpollConstants.PORT,
+                        CounterpollConstants.QUEUE,
+                        CounterpollConstants.PG_DROP,
+                        CounterpollConstants.RIF])
+def counterpoll_type(request):
+    return request.param
+
+
+@pytest.fixture()
+def restore_counter_poll(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if "201811" in duthost.os_version or "201911" in duthost.os_version or "202012" in duthost.os_version:
+        pytest.skip("Test is supported for 202106 and later images. Skipping the test")
+    counter_poll_show = ConterpollHelper.get_counterpoll_show_output(duthost)
+    parsed_counterpoll_before = ConterpollHelper.get_parsed_counterpoll_show(counter_poll_show)
+    yield
+    counter_poll_show = ConterpollHelper.get_counterpoll_show_output(duthost)
+    parsed_counterpoll_after = ConterpollHelper.get_parsed_counterpoll_show(counter_poll_show)
+    ConterpollHelper.restore_counterpoll_interval(duthost, parsed_counterpoll_before, parsed_counterpoll_after)
+    ConterpollHelper.restore_counterpoll_status(duthost, parsed_counterpoll_before, parsed_counterpoll_after)

--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -121,8 +121,6 @@ def log_cpu_usage_by_vendor(cpu_usage_program_to_check, counterpoll_type):
 def get_manufacturer_program_to_check(duthost):
     if is_mlnx(duthost):
         return CounterpollConstants.SX_SDK
-    else:
-        None
 
 
 def is_mlnx(duthost):

--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -2,6 +2,10 @@ import logging
 import pytest
 
 from collections import namedtuple, Counter
+from tests.platform_tests.counterpoll.cpu_memory_helper import restore_counter_poll, counterpoll_type
+from tests.platform_tests.counterpoll.counterpoll_helper import ConterpollHelper
+from tests.platform_tests.counterpoll.counterpoll_constants import CounterpollConstants
+from tests.common.errors import RunAnsibleModuleFail
 
 
 pytestmark = [
@@ -33,33 +37,149 @@ def test_cpu_memory_usage(duthosts, enum_rand_one_per_hwsku_hostname, setup_thre
     outstanding_procs_counter = Counter()
     for i, monit_result in enumerate(MonitResult(*_) for _ in monit_results):
         logging.debug("------ Iteration %d ------", i)
-        if monit_result.memory['used_percent'] > memory_threshold:
-            logging.debug("system memory usage exceeds %d%%: %s",
-                          memory_threshold, monit_result.memory)
-            outstanding_mem_polls[i] = monit_result.memory
+        check_memory(i, memory_threshold, monit_result, outstanding_mem_polls)
         for proc in monit_result.processes:
-            if proc['cpu_percent'] >= cpu_threshold:
-                logging.debug("process %s(%d) cpu usage exceeds %d%%.",
-                              proc['name'], proc['pid'], cpu_threshold)
-                outstanding_procs[proc['pid']] = proc['name']
-                outstanding_procs_counter[proc['pid']] += 1
+            check_cpu_usage(cpu_threshold, outstanding_procs, outstanding_procs_counter, proc)
 
+    analyse_monitoring_results(cpu_threshold, memory_threshold, outstanding_mem_polls, outstanding_procs,
+                               outstanding_procs_counter, persist_threshold)
+
+
+def analyse_monitoring_results(cpu_threshold, memory_threshold, outstanding_mem_polls, outstanding_procs,
+                               outstanding_procs_counter, persist_threshold):
     persist_outstanding_procs = []
     for pid, freq in outstanding_procs_counter.most_common():
         if freq < persist_threshold:
             break
         persist_outstanding_procs.append(pid)
-
     if outstanding_mem_polls or persist_outstanding_procs:
-        failure_message = ""
-
         if outstanding_mem_polls:
-            failure_message += "System memory usage exceeds {}%".format(memory_threshold)
-            if persist_outstanding_procs:
-                failure_message += "; "
-
+            logging.error("system memory usage exceeds %d%%", memory_threshold)
         if persist_outstanding_procs:
-            failure_message += "Processes that persistently exceed CPU usage ({}%): {}".format(
-                cpu_threshold, [outstanding_procs[p] for p in persist_outstanding_procs])
+            logging.error(
+                "processes that persistently exceeds cpu usage %d%%: %s",
+                cpu_threshold,
+                [outstanding_procs[p] for p in persist_outstanding_procs]
+            )
+        pytest.fail("system cpu and memory usage check fails")
 
-        pytest.fail(failure_message)
+
+def test_cpu_memory_usage_counterpoll(duthosts, enum_rand_one_per_hwsku_hostname, setup_thresholds,
+                                           restore_counter_poll,
+                                           counterpoll_type):
+    """Check DUT memory usage and process cpu usage are within threshold.
+    If mlnx add additional check, when setting port-buffer-drop to 10000 or 30000 and compare cpu usage
+    Before the test check counterpoll status and interval
+    Disable all counterpoll types except tested
+    Check current CPU usage for 30 sec
+        IF mlnx and tested counerpoll is port-buffer-drop. Configure interval to 10000
+    Check current CPU usage for 30 sec
+    Restore counterpoll interval and status to state before the test
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    MonitResult = namedtuple('MonitResult', ['processes', 'memory'])
+    disable_all_counterpoll_type_except_tested(duthost, counterpoll_type)
+    monit_results = duthost.monit_process(iterations=30, delay_interval=1)['monit_results']
+
+    memory_threshold, cpu_threshold = setup_thresholds
+    persist_threshold = 4
+    outstanding_mem_polls = {}
+    outstanding_procs = {}
+    outstanding_procs_counter = Counter()
+
+    program_to_check = get_manufacturer_program_to_check(duthost)
+    cpu_usage_program_to_check = []
+
+    prepare_ram_cpu_usage_results(MonitResult, cpu_threshold, memory_threshold, monit_results, outstanding_mem_polls,
+                                  outstanding_procs, outstanding_procs_counter, program_to_check,
+                                  cpu_usage_program_to_check)
+
+    set_mellanox_counterpoll_port_bufer_drop(duthost, counterpoll_type)
+
+    monit_results.extend(duthost.monit_process(iterations=30, delay_interval=1)['monit_results'])
+    prepare_ram_cpu_usage_results(MonitResult, cpu_threshold, memory_threshold, monit_results, outstanding_mem_polls,
+                                  outstanding_procs, outstanding_procs_counter, program_to_check,
+                                  cpu_usage_program_to_check)
+    log_cpu_usage_by_vendor(cpu_usage_program_to_check, counterpoll_type)
+
+    analyse_monitoring_results(cpu_threshold, memory_threshold, outstanding_mem_polls, outstanding_procs,
+                               outstanding_procs_counter, persist_threshold)
+
+
+def log_cpu_usage_by_vendor(cpu_usage_program_to_check, counterpoll_type):
+    if cpu_usage_program_to_check:
+        logging.info('CPU usage for counterpoll type {} : {}'.format(
+                counterpoll_type, cpu_usage_program_to_check[:len(cpu_usage_program_to_check)//2]))
+        if counterpoll_type == CounterpollConstants.PORT_BUFFER_DROP:
+            logging.info('CPU usage after setting counterpoll {} to minimum allowed value next 30 seconds: {}'.format(
+                counterpoll_type, cpu_usage_program_to_check[len(cpu_usage_program_to_check)//2:]))
+        else:
+            logging.info('CPU usage for counterpoll type {} next 30 seconds: {}'.format(
+                counterpoll_type, cpu_usage_program_to_check[:len(cpu_usage_program_to_check) // 2]))
+
+
+def get_manufacturer_program_to_check(duthost):
+    if is_mlnx(duthost):
+        return CounterpollConstants.SX_SDK
+    else:
+        None
+
+
+def is_mlnx(duthost):
+    if CounterpollConstants.MLNX_PLATFORM_STR in duthost.facts["platform"]:
+        return True
+
+
+def prepare_ram_cpu_usage_results(MonitResult, cpu_threshold, memory_threshold, monit_results, outstanding_mem_polls,
+                                  outstanding_procs, outstanding_procs_counter, program_to_check,
+                                  program_to_check_cpu_usage):
+    for i, monit_result in enumerate(MonitResult(*_) for _ in monit_results):
+        logging.debug("------ Iteration %d ------", i)
+        check_memory(i, memory_threshold, monit_result, outstanding_mem_polls)
+        for proc in monit_result.processes:
+            update_cpu_usage_desired_program(proc, program_to_check, program_to_check_cpu_usage)
+            check_cpu_usage(cpu_threshold, outstanding_procs, outstanding_procs_counter, proc)
+
+
+def check_cpu_usage(cpu_threshold, outstanding_procs, outstanding_procs_counter, proc):
+    if proc['cpu_percent'] >= cpu_threshold:
+        logging.debug("process %s(%d) cpu usage exceeds %d%%.",
+                      proc['name'], proc['pid'], cpu_threshold)
+        outstanding_procs[proc['pid']] = proc['name']
+        outstanding_procs_counter[proc['pid']] += 1
+
+
+def update_cpu_usage_desired_program(proc, program_to_check, program_to_check_cpu_usage):
+    if program_to_check:
+        if proc['name'] == program_to_check:
+            program_to_check_cpu_usage.append(proc['cpu_percent'])
+
+
+def check_memory(i, memory_threshold, monit_result, outstanding_mem_polls):
+    if monit_result.memory['used_percent'] > memory_threshold:
+        logging.debug("system memory usage exceeds %d%%: %s",
+                      memory_threshold, monit_result.memory)
+        outstanding_mem_polls[i] = monit_result.memory
+
+
+def set_mellanox_counterpoll_port_bufer_drop(duthost, counterpoll_type):
+    if not is_mlnx(duthost) or counterpoll_type != CounterpollConstants.PORT_BUFFER_DROP:
+        return
+    try:
+        duthost.command(CounterpollConstants.COUNTERPOLL_INTERVAL_STR.format(
+            CounterpollConstants.PORT_BUFFER_DROP,
+            CounterpollConstants.PORT_BUFFER_DROP_NEW_INTERVAL))
+    except RunAnsibleModuleFail:
+        logging.warning('Version does not support new counterpoll interval for port-buffer-drop={}\n'
+                        'Setting old ounterpoll interval for port-buffer-drop={}'.format(
+            CounterpollConstants.PORT_BUFFER_DROP_NEW_INTERVAL,
+            CounterpollConstants.PORT_BUFFER_DROP_OLD_INTERVAL))
+        duthost.command(CounterpollConstants.COUNTERPOLL_INTERVAL_STR.format(
+            CounterpollConstants.PORT_BUFFER_DROP,
+            CounterpollConstants.PORT_BUFFER_DROP_OLD_INTERVAL))
+
+
+def disable_all_counterpoll_type_except_tested(duthost, counterpoll_type):
+    available_types = ConterpollHelper.get_available_counterpoll_types(duthost)
+    available_types.remove(counterpoll_type)
+    ConterpollHelper.disable_counterpoll(duthost, available_types)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Counterpoll for port-buffer-drop with newest sdk on mellanox could be decreased from 30000ms to 10000 ms
which will improve user experience

Test is skipped on 201811, 201911 and 202012. It should work on 202106 and later images
Test will check DUT memory usage and process cpu usage are within threshold for 1 counterpoll type.
If mlnx add additional check, when setting port-buffer-drop to 10000 or 30000 and compare cpu usag.
Before the test check counterpoll status and interval
Disable all counterpoll types except tested
Check current CPU usage for 30 sec
    IF mlnx and tested counerpoll is port-buffer-drop. Configure interval to 10000
Check current CPU usage for 30 sec
Restore counterpoll interval and status to state before the test
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://github.com/Azure/sonic-utilities/pull/1683

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
Physical
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
