### PR TITLE
Update test_fdb_mac_expire to support t0-56-po2vlan.

### DIFF
--- a/tests/fdb/files/fdb.j2
+++ b/tests/fdb/files/fdb.j2
@@ -1,4 +1,5 @@
+{# TODO: tagged port should be supported in future #}
 {% for vlan in minigraph_vlan_interfaces %}
-{{ vlan['subnet'] }} {% for ifname in minigraph_vlans[vlan['attachto']]['members'] %} {{ minigraph_port_indices[ifname] }} {% endfor %}
+{{ vlan['subnet'] }} {% for ifname in minigraph_vlans[vlan['attachto']]['members'] %} {% if ifname in minigraph_portchannels %} {% if minigraph_portchannels[ifname]['members'] %} {{ minigraph_port_indices[minigraph_portchannels[ifname]['members'][0]] }} {% endif %}{% else %} {{ minigraph_port_indices[ifname] }} {% endif %} {% endfor %}
 
 {% endfor %}

--- a/tests/fdb/test_fdb_mac_expire.py
+++ b/tests/fdb/test_fdb_mac_expire.py
@@ -6,7 +6,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm [py/unused-import]
 
 pytestmark = [
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0', 't0-56-po2vlan')
 ]
 
 logger = logging.getLogger(__name__)
@@ -125,6 +125,7 @@ class TestFdbMacExpire:
         ptfhost.host.options['variable_manager'].extra_vars.update({
             "minigraph_vlan_interfaces": mgFacts["minigraph_vlan_interfaces"],
             "minigraph_port_indices": mgFacts["minigraph_ptf_indices"],
+            "minigraph_portchannels": mgFacts["minigraph_portchannels"],
             "minigraph_vlans": mgFacts["minigraph_vlans"],
         })
 


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
