### PR TITLE
Disable https proxy explicitly for test_restapi

### DIFF
--- a/tests/restapi/restapi_operations.py
+++ b/tests/restapi/restapi_operations.py
@@ -20,6 +20,12 @@ class Restapi:
     def request(self, method, url, params=None):
         session = requests.Session()
         session.headers.update({'Content-type': 'application/json'})
+        # Disable proxies explicitly
+        proxies = {
+                    "http": "",
+                    "https": ""
+                    }
+        session.proxies.update(proxies)
         if method == GET:
             req = requests.Request(GET, url)
         elif method == POST:


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix test failure of ```test_restapi```. Error message was 
```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 1464, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 81, in get_result
    _reraise(*ex)  # noqa
  File "/usr/local/lib/python2.7/dist-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 174, in pytest_pyfunc_call
    testfunction(**testargs)
  File "/azp/agent/_work/6/s/tests/restapi/test_restapi.py", line 258, in test_create_vrf
    r = restapi.post_config_vrouter_vrf_id(construct_url, 'vnet-guid-10', params)
  File "/azp/agent/_work/6/s/tests/restapi/restapi_operations.py", line 56, in post_config_vrouter_vrf_id
    return self.request(POST, url, params)
  File "/azp/agent/_work/6/s/tests/restapi/restapi_operations.py", line 35, in request
    cert=clientcert
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 655, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/adapters.py", line 510, in send
    raise ProxyError(e, request=request)
ProxyError: HTTPSConnectionPool(host='x.x.x.x', port=8081): Max retries exceeded with url: /v1/config/vrouter/vnet-guid-10 (Caused by ProxyError('Cannot connect to proxy.', error('Tunnel connection failed: 403 Forbidden',)))
```
The issue is because ```https_proxy``` is set on some platform. 
This PR addressed the issue by disabling the proxy explicitly.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix test failure of ```test_restapi```. Error message was 

#### How did you do it?
This PR addressed the issue by disabling the proxy explicitly.

#### How did you verify/test it?
Verified on SN4600 T0 testbed, test can pass now.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
