### PR TITLE
Improve run_tests.sh to skip running if no tests collected

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -146,6 +146,11 @@ function setup_test_options()
     done
     TEST_CASES=$(python -c "print '\n'.join('''${FINAL_CASES}'''.split())")
 
+    if [[ -z $TEST_CASES ]]; then
+        echo "No test case to run based on conditions of '-c', '-I' and '-S'. Please check..."
+        show_help_and_exit 1
+    fi
+
     PYTEST_COMMON_OPTS="--inventory ${INVENTORY} \
                       --host-pattern ${DUT_NAME} \
                       --testbed ${TESTBED_NAME} \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
If we issue a run_tests.sh command like below:

 ./run_tests.sh -i ../ansible/veos_vtb -f vtestbed.csv -n vms-kvm-t0 -c bgp/test_bgp_fact.py -I NOT_EXIST

 The command line has option "-c bgp/test_bgp_fact.py" specified the script to be executed. Option "-I NOT_EXIST"
 specified that only scripts in the "NOT_EXIST" folder will be executed. Combined with the "-c bgp/test_bgp_fact.py"
 condition, no test script should be executed because "bgp/test_bgp_fact.py" is not in "NOT_EXIST" folder.
 The eventual list of collected test scripts will be empty. For the group test mode, pytest without test
 script specified will collect all test scripts under the tests folder. Then the actual behavior is that
 all test scripts will be executed. This is unexpected.

#### How did you do it?
 This change added explicit check of collected test scripts. If no test script is collected by the given
 conditions, then show help and exit.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
