### PR TITLE
When converting exceptions to strings, use str instead of message

### DIFF
--- a/ansible/library/config_facts.py
+++ b/ansible/library/config_facts.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import json
+import traceback
 from collections import defaultdict
 from natsort import natsorted
 from ansible.module_utils.port_utils import get_port_indices_for_asic

--- a/ansible/library/config_facts.py
+++ b/ansible/library/config_facts.py
@@ -164,7 +164,8 @@ def main():
         results = get_facts(config, namespace)
         module.exit_json(ansible_facts=results)
     except Exception as e:
-        module.fail_json(msg=e.message)
+        tb = traceback.format_exc()
+        module.fail_json(msg=str(e) + "\n" + tb)
 
 
 from ansible.module_utils.basic import AnsibleModule

--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -288,7 +288,7 @@ def main():
         extract_log(p['directory'], p['file_prefix'], p['start_string'], p['target_filename'])
     except:
         tb = traceback.format_exc()
-        module.fail_json(msg=e.message + "\n" + tb)
+        module.fail_json(msg=str(e) + "\n" + tb)
     module.exit_json()
 
 

--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -288,7 +288,7 @@ def main():
         extract_log(p['directory'], p['file_prefix'], p['start_string'], p['target_filename'])
     except:
         tb = traceback.format_exc()
-        module.fail_json(msg=str(e) + "\n" + tb)
+        module.fail_json(msg=tb)
     module.exit_json()
 
 

--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -831,7 +831,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         # all attempts to find a minigraph failed.
-        module.fail_json(msg=e.message + "\n" + tb)
+        module.fail_json(msg=str(e) + "\n" + tb)
 
 
 def print_parse_xml(hostname):


### PR DESCRIPTION
Python 3 exceptions don't have a message attribute anymore (at least,
AttributeError doesn't have it). Using str() appears to work for these
exceptions in both Python 2 and 3.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
