### PR TITLE
Fix SFP test failures on Arista 7050QX-32S platform

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -400,7 +400,7 @@ class TestChassisApi(PlatformApiTestBase):
         except:
             pytest.fail("num_sfps is not an integer")
 
-        list_sfps = list(set(physical_port_indices))
+        list_sfps = physical_port_indices
 
         logging.info("Physical port indices = {}".format(list_sfps))
 
@@ -417,7 +417,7 @@ class TestChassisApi(PlatformApiTestBase):
         for i in range(len(list_sfps)):
             index = list_sfps[i]
             sfp = chassis.get_sfp(platform_api_conn, index)
-            self.expect(sfp and sfp == sfp_list[i], "SFP number {} object is incorrect index {}".format(i, index))
+            self.expect(sfp and sfp in sfp_list, "SFP object for PORT{} NOT found".format(index))
         self.assert_expectations()
 
     def test_status_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):


### PR DESCRIPTION
Signed-off-by: Prince George <prgeor@microsoft.com>

### Description of PR
Platforms like 7050QX-32S doesn't map all of their physical ports (1 to 36) to the logical ports because of which there could be unused indices in sequence of port indices. The current test assumes all physical port indices are mapped to logical ports. The SFP objects are stored sequentially(increasing order of physical port indices)  in the Chassis object so there is no need to do 1:1 mapping as long as the SFP object is in the list of Chassis's SFP objects. Also, platform.json stores the list of SFP port names(Eg SFP1, SFP2, QSFP4, QSFP5...and so on in the increasing order of physical port indices). So, its sufficient to check if the SFP name is contained in the platform.json

Summary:
Fixes #4444 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

#### How did you verify/test it?
Run test_sfp.py and test_chassis.py and ensure no failures


