### PR TITLE
[storage_backend] Skip vrf on storage backend topologies

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -7,6 +7,7 @@ import json
 import random
 import logging
 import tempfile
+import traceback
 
 from collections import OrderedDict
 from natsort import natsorted
@@ -14,8 +15,9 @@ from netaddr import IPNetwork
 
 import pytest
 
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                             # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses                                # lgtm[py/unused-import]
+from tests.common.storage_backend.backend_utils import skip_test_module_over_backend_topologies     # lgtm[py/unused-import]
 from tests.ptf_runner import ptf_runner
 from tests.common.utilities import wait_until
 from tests.common.reboot import reboot
@@ -389,7 +391,7 @@ def restore_config_db(localhost, duthost, ptfhost):
         cleanup_vlan_peer(ptfhost, g_vars['vlan_peer_vrf2ns_map'])
 
 @pytest.fixture(scope="module", autouse=True)
-def setup_vrf(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, localhost):
+def setup_vrf(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, localhost, skip_test_module_over_backend_topologies):
     duthost = duthosts[rand_one_dut_hostname]
 
     # backup config_db.json

--- a/tests/vrf/test_vrf_attr.py
+++ b/tests/vrf/test_vrf_attr.py
@@ -11,7 +11,9 @@ from test_vrf import vlan_mac      # lgtm[py/unused-import]
 from test_vrf import PTF_TEST_PORT_MAP
 
 from tests.ptf_runner import ptf_runner
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                             # lgtm[py/unused-import]
+from tests.common.storage_backend.backend_utils import skip_test_module_over_backend_topologies     # lgtm[py/unused-import]
+
 
 pytestmark = [
     pytest.mark.topology('t0')


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4034

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Skip `vrf` testcases on storage backend topologies

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
