### PR TITLE
[QoS/Dynamic_buffer] get lossy pg size via number lanes of a port instead of port speed

### DIFF
--- a/tests/qos/files/dynamic_buffer_param.json
+++ b/tests/qos/files/dynamic_buffer_param.json
@@ -26,7 +26,7 @@
 	    }
 	},
 	"lossy_pg": {
-	    "400000": "37888",
+	    "8": "37888",
 	    "default": "19456"
 	},
 	"shared-headroom-pool": {

--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -1413,6 +1413,8 @@ def test_port_admin_down(duthosts, rand_one_dut_hostname, conn_graph_facts, port
 
     duthost = duthosts[rand_one_dut_hostname]
     original_speed = duthost.shell('redis-cli -n 4 hget "PORT|{}" speed'.format(port_to_test))['stdout']
+    raw_lanes_str =  duthost.shell('redis-cli -n 4 hget "PORT|{}" lanes'.format(port_to_test))['stdout']
+    list_of_lanes = raw_lanes_str.split(',')
     original_cable_len = duthost.shell('redis-cli -n 4 hget "CABLE_LENGTH|AZURE" {}'.format(port_to_test))['stdout']
     if check_qos_db_fv_reference_with_table(duthost) == True:
         original_profile = duthost.shell('redis-cli hget "BUFFER_PG_TABLE:{}:3-4" profile'.format(port_to_test))['stdout'][1:-1]
@@ -1424,7 +1426,7 @@ def test_port_admin_down(duthosts, rand_one_dut_hostname, conn_graph_facts, port
 
     new_cable_len = '15m'
 
-    lossy_pg_size = TESTPARAM_LOSSY_PG.get(original_speed)
+    lossy_pg_size = TESTPARAM_LOSSY_PG.get(str(len(list_of_lanes)))
     if not lossy_pg_size:
         lossy_pg_size = TESTPARAM_LOSSY_PG.get('default')
         if not lossy_pg_size:


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>


### Description of PR

Summary:
On the Mellanox platform, ports with 8 lanes have different lossy pg size with ports have 4 or fewer lanes. 
The previous assumption is that for 8 lanes port the speed will always be 400G, so the key for the lossy PG size value is port speed. But this is not true, it can also be configured to 100G or other speeds. In these cases will not be able to get the correct lossy PG size.  So use the number of lanes as the key for the lossy PG size is proper, it's stable in the lifetime of a port.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix an issue that when 8 lanes ports speed set to a speed which is not 400G, will result in the test case not able to fetch a correct lossy pg size for the port.

#### How did you do it?
Use the number of lanes as the key for the lossy PG size, instead of using port speed. 

#### How did you verify/test it?
run test_buffer:test_port_admin_down on a testbed with 8 lanes port and speed was set to none 400G.

#### Any platform specific information?
Mellanox platform only.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
