### PR TITLE
Fix ```test_dir_bcast```

### DIFF
--- a/tests/ipfwd/test_dir_bcast.py
+++ b/tests/ipfwd/test_dir_bcast.py
@@ -20,7 +20,8 @@ def test_dir_bcast(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     extra_vars = {
         'minigraph_vlan_interfaces': mg_facts['minigraph_vlan_interfaces'],
         'minigraph_vlans':           mg_facts['minigraph_vlans'],
-        'minigraph_port_indices':    mg_facts['minigraph_ptf_indices']
+        'minigraph_port_indices':    mg_facts['minigraph_ptf_indices'],
+        'minigraph_portchannels':    mg_facts['minigraph_portchannels']
     }
     ptfhost.host.options['variable_manager'].extra_vars.update(extra_vars)
     ptfhost.template(src="../ansible/roles/test/templates/fdb.j2", dest="/root/vlan_info.txt")


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes ```test_dir_bcast```
```test_dir_bcast``` was failed recently with below error
```
if (res.is_failed or 'exception' in res) and not module_ignore_errors:
>           raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
E           RunAnsibleModuleFail: run module template failed, Ansible Results =>
E           {
E               "changed": false, 
E               "failed": true, 
E               "msg": "AnsibleUndefinedVariable: Unable to look up a name or access an attribute in template string ({# TODO: tagged port should be supported in future #}\n{% for vlan in minigraph_vlan_interfaces %}\n{{ vlan['subnet'] }}\n{%- for ifname in minigraph_vlans[vlan['attachto']]['members'] -%}\n{%- if ifname in minigraph_portchannels -%}\n{%- if minigraph_portchannels[ifname]['members'] -%}\n{{ ' ' }}{{ minigraph_port_indices[minigraph_portchannels[ifname]['members'][0]] }}\n{%- endif -%}\n{%- else -%}\n{{ ' ' }}{{ minigraph_port_indices[ifname] }}\n{%- endif -%}\n{%- endfor %}\n\n{% endfor %}\n).\nMake sure your variable name does not contain invalid characters like '-': argument of type 'AnsibleUndefined' is not iterable"
E           }

common/devices/base.py:89: RunAnsibleModuleFail
```
The variable ```minigraph_portchannels``` is missing from host vars of ptf, but the reason is unclear for now.
This PR addressed the issue by updating ```minigraph_portchannels``` vars to ```extra_vars``` of ```ptfhost```.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix ```test_dir_bcast```.

#### How did you do it?
The variable ```minigraph_portchannels``` is missing from host vars of ptf, but the reason is unclear for now.
This PR addressed the issue by updating ```minigraph_portchannels``` vars to ```extra_vars``` of ```ptfhost```.

#### How did you verify/test it?
Verified on SN4600. Test can pass now.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
