### PR TITLE
Ignore Non-IP packet in sai_qos_test

### DIFF
--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -1541,6 +1541,9 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                     pkts.append(recv_pkt)
             except AttributeError:
                 continue
+            except IndexError:
+                # Ignore captured non-IP packet
+                continue
 
         queue_pkt_counters = [0] * (prio_list[-1] + 1)
         queue_num_of_pkts  = [0] * (prio_list[-1] + 1)


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to make ```sai_qos_test``` more robust.
We saw several test failure related to ```sai_qos_tests```. Error message was
```
"======================================================================", 
E                   "ERROR: sai_qos_tests.WRRtest", 
E                   "----------------------------------------------------------------------", 
E                   "Traceback (most recent call last):", 
E                   "  File \"saitests/sai_qos_tests.py\", line 1539, in runTest", 
E                   "    if recv_pkt[scapy.IP].src == src_port_ip and recv_pkt[scapy.IP].dst == dst_port_ip and recv_pkt[scapy.IP].id == exp_ip_id:", 
E                   "  File \"/usr/local/lib/python2.7/dist-packages/scapy/packet.py\", line 772, in __getitem__", 
E                   "    raise IndexError(\"Layer [%s] not found\" % lname)", 
E                   "IndexError: Layer [IP] not found", 
E                   "", 
```
The reason for the exception is some None-IP packet (without IP layer) was captured and exception was raised when attempting to read the ```IP``` layer from packet.
This PR addressed the issue by ignore ```IndexError```. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to make ```sai_qos_test``` more robust.

#### How did you do it?
This PR addressed the issue by ignore ```IndexError```

#### How did you verify/test it?
Verified on SN4600, T0. The test is consistently passing now.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
