### PR TITLE
[201911] Verify buffer priority groups for all platforms

### DIFF
--- a/tests/qos/test_buffer_traditional.py
+++ b/tests/qos/test_buffer_traditional.py
@@ -9,8 +9,8 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
-global DEFAULT_LOSSLESS_PROFILES
-global RECLAIM_BUFFER_ON_ADMIN_DOWN
+DEFAULT_LOSSLESS_PROFILES = None
+RECLAIM_BUFFER_ON_ADMIN_DOWN = None
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_module(duthosts, rand_one_dut_hostname):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Verify buffer priority groups for non-Mellanox platforms as well.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How did you do it?

To verify:
- On Mellanox platform, the lossless buffer profile is applied on PG 3-4 only if the port is admin down 
- On non-Mellanox platforms, the lossless buffer profile is applied on PG 3-4 of all interfaces regardless of their admin status.

#### How did you verify/test it?

It was verified on Mellanox platform. An old image without reclaiming buffer is adapted to simulate non-Mellanox platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
