### PR TITLE
[show techsupport command] allow DUT doesn't have QOS configuration to pass

### DIFF
--- a/tests/show_techsupport/tech_support_cmds.py
+++ b/tests/show_techsupport/tech_support_cmds.py
@@ -178,6 +178,11 @@ copy_config_cmds = [
     "cp .{}/sai.profile",
 ]
 
+copy_config_cmds_no_qos = [
+    "cp .{}/port_config.ini",
+    "cp .{}/sai.profile",
+]
+
 broadcom_cmd_bcmcmd = [
     'bcmcmd{} -t5 version',
     'bcmcmd{} -t5 soc',

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -369,10 +369,22 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
                     add_asic_arg(" -n {}", cmds.broadcom_cmd_bcmcmd, num),
                 "broadcom_cmd_misc": 
                     add_asic_arg("{}", cmds.broadcom_cmd_misc, num),
-                "copy_config_cmds": 
-                    add_asic_arg("/{}", cmds.copy_config_cmds, num),
             }
         )
+        if duthost.facts["platform"] in ['x86_64-cel_e1031-r0']:
+            cmds_to_check.update(
+                {
+                    "copy_config_cmds":
+                        add_asic_arg("/{}", cmds.copy_config_cmds_no_qos, num),
+                }
+            )
+        else:
+            cmds_to_check.update(
+                {
+                    "copy_config_cmds":
+                        add_asic_arg("/{}", cmds.copy_config_cmds, num),
+                }
+            )
     # Remove /proc/dma for armh
     elif duthost.facts["asic_type"] == "marvell":
         if 'armhf-' in duthost.facts["platform"]:


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Device without QoS configuration will fail the show tech support command testcase due to a few copy commands missing.

#### How did you do it?
Allow these platforms to not have these copy commands.

#### How did you verify/test it?
Run the show techsupport commands test on such platform and get pass.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
