### PR TITLE
[T2][Topology] Fix ASN numbers for T1s and T3s, update AS path for routes advertised to T3.

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -45,6 +45,7 @@ TOR_SUBNET_SIZE = 128
 NHIPV4 = '10.10.246.254'
 NHIPV6 = 'fc0a::ff'
 SPINE_ASN = 65534
+CORE_RA_ASN = 65900
 LEAF_ASN_START = 64600
 TOR_ASN_START = 65500
 IPV4_BASE_PORT = 5000
@@ -126,10 +127,10 @@ def get_uplink_router_as_path(uplink_router_type, spine_asn):
 
 
 def generate_routes(family, podset_number, tor_number, tor_subnet_number,
-                    spine_asn, leaf_asn_start, tor_asn_start,
-                    nexthop, nexthop_v6,
-                    tor_subnet_size, max_tor_subnet_number, topo,
-                    router_type = "leaf", tor_index=None, set_num=None, no_default_route=False):
+                    spine_asn, leaf_asn_start, tor_asn_start, nexthop,
+                    nexthop_v6, tor_subnet_size, max_tor_subnet_number, topo,
+                    router_type = "leaf", tor_index=None, set_num=None,
+                    no_default_route=False, core_ra_asn=CORE_RA_ASN):
     routes = []
     if not no_default_route and router_type != "tor":
         default_route_as_path = get_uplink_router_as_path(router_type, spine_asn)
@@ -206,7 +207,7 @@ def generate_routes(family, podset_number, tor_number, tor_subnet_number,
 
                 aspath = None
                 if router_type == "core":
-                    aspath = "{} {}".format(leaf_asn, tor_asn)
+                    aspath = "{} {}".format(leaf_asn, core_ra_asn)
                 elif router_type == "spine":
                     aspath = "{} {}".format(leaf_asn, tor_asn)
                 elif router_type == "leaf":
@@ -372,6 +373,7 @@ def generate_t2_routes(dut_vm_dict, topo, ptf_ip):
     nhipv6 = common_config.get("nhipv6", NHIPV6)
     leaf_asn_start = common_config.get("leaf_asn_start", LEAF_ASN_START)
     tor_asn_start = common_config.get("tor_asn_start", TOR_ASN_START)
+    core_ra_asn = common_config.get("core_ra_asn", CORE_RA_ASN)
 
     # generate routes for t1 vms
     for a_dut_index in dut_vm_dict:
@@ -404,11 +406,13 @@ def generate_t2_routes(dut_vm_dict, topo, ptf_ip):
                 routes_v4 = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
                                             common_config['dut_asn'], leaf_asn_start, tor_asn_start,
                                             nhipv4, nhipv6, tor_subnet_size, max_tor_subnet_number, "t2",
-                                            router_type=router_type, tor_index=tor_index, set_num=set_num)
+                                            router_type=router_type, tor_index=tor_index, set_num=set_num,
+                                            core_ra_asn=core_ra_asn)
                 routes_v6 = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
                                             common_config['dut_asn'], leaf_asn_start, tor_asn_start,
                                             nhipv4, nhipv6, tor_subnet_size, max_tor_subnet_number, "t2",
-                                            router_type=router_type, tor_index=tor_index, set_num=set_num)
+                                            router_type=router_type, tor_index=tor_index, set_num=set_num,
+                                            core_ra_asn=core_ra_asn)
                 announce_routes(ptf_ip, port, routes_v4)
                 announce_routes(ptf_ip, port6, routes_v6)
 

--- a/ansible/vars/topo_t2.yml
+++ b/ansible/vars/topo_t2.yml
@@ -376,7 +376,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65201
+      asn: 65200
       peers:
         65100:
           - 10.0.0.4
@@ -402,7 +402,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65202
+      asn: 65200
       peers:
         65100:
           - 10.0.0.8
@@ -428,7 +428,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65203
+      asn: 65200
       peers:
         65100:
           - 10.0.0.12
@@ -454,7 +454,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65204
+      asn: 65200
       peers:
         65100:
           - 10.0.0.16
@@ -480,7 +480,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65205
+      asn: 65200
       peers:
         65100:
           - 10.0.0.20
@@ -506,7 +506,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65206
+      asn: 65200
       peers:
         65100:
           - 10.0.0.24
@@ -532,7 +532,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65207
+      asn: 65200
       peers:
         65100:
           - 10.0.0.28
@@ -558,7 +558,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65208
+      asn: 65200
       peers:
         65100:
           - 10.0.0.32
@@ -579,7 +579,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65209
+      asn: 65200
       peers:
         65100:
           - 10.0.0.34
@@ -600,7 +600,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65210
+      asn: 65200
       peers:
         65100:
           - 10.0.0.36
@@ -621,7 +621,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65211
+      asn: 65200
       peers:
         65100:
           - 10.0.0.38
@@ -642,7 +642,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65212
+      asn: 65200
       peers:
         65100:
           - 10.0.0.40
@@ -663,7 +663,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65213
+      asn: 65200
       peers:
         65100:
           - 10.0.0.42
@@ -684,7 +684,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65214
+      asn: 65200
       peers:
         65100:
           - 10.0.0.44
@@ -705,7 +705,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65215
+      asn: 65200
       peers:
         65100:
           - 10.0.0.46
@@ -726,7 +726,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65216
+      asn: 65200
       peers:
         65100:
           - 10.0.0.48
@@ -747,7 +747,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65217
+      asn: 65200
       peers:
         65100:
           - 10.0.0.50
@@ -768,7 +768,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65218
+      asn: 65200
       peers:
         65100:
           - 10.0.0.52
@@ -789,7 +789,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65219
+      asn: 65200
       peers:
         65100:
           - 10.0.0.54
@@ -810,7 +810,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65220
+      asn: 65200
       peers:
         65100:
           - 10.0.0.56
@@ -831,7 +831,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65221
+      asn: 65200
       peers:
         65100:
           - 10.0.0.58
@@ -852,7 +852,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65222
+      asn: 65200
       peers:
         65100:
           - 10.0.0.60
@@ -873,7 +873,7 @@ configuration:
       - common
       - core
     bgp:
-      asn: 65223
+      asn: 65200
       peers:
         65100:
           - 10.0.0.62
@@ -894,7 +894,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65001
       peers:
         65100:
           - 10.0.0.64
@@ -920,7 +920,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65002
       peers:
         65100:
           - 10.0.0.68
@@ -946,7 +946,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65003
       peers:
         65100:
           - 10.0.0.72
@@ -972,7 +972,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65004
       peers:
         65100:
           - 10.0.0.76
@@ -998,7 +998,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65005
       peers:
         65100:
           - 10.0.0.80
@@ -1024,7 +1024,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65006
       peers:
         65100:
           - 10.0.0.84
@@ -1050,7 +1050,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65007
       peers:
         65100:
           - 10.0.0.88
@@ -1076,7 +1076,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65008
       peers:
         65100:
           - 10.0.0.92
@@ -1102,7 +1102,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65009
       peers:
         65100:
           - 10.0.0.96
@@ -1128,7 +1128,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65010
       peers:
         65100:
           - 10.0.0.98
@@ -1154,7 +1154,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65011
       peers:
         65100:
           - 10.0.0.100
@@ -1175,7 +1175,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65012
       peers:
         65100:
           - 10.0.0.102
@@ -1196,7 +1196,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65013
       peers:
         65100:
           - 10.0.0.104
@@ -1217,7 +1217,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65014
       peers:
         65100:
           - 10.0.0.106
@@ -1238,7 +1238,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65015
       peers:
         65100:
           - 10.0.0.108
@@ -1259,7 +1259,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65016
       peers:
         65100:
           - 10.0.0.110
@@ -1280,7 +1280,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65017
       peers:
         65100:
           - 10.0.0.112
@@ -1301,7 +1301,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65018
       peers:
         65100:
           - 10.0.0.114
@@ -1322,7 +1322,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65019
       peers:
         65100:
           - 10.0.0.116
@@ -1343,7 +1343,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65020
       peers:
         65100:
           - 10.0.0.118
@@ -1364,7 +1364,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65021
       peers:
         65100:
           - 10.0.0.120
@@ -1385,7 +1385,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65022
       peers:
         65100:
           - 10.0.0.122
@@ -1406,7 +1406,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65023
       peers:
         65100:
           - 10.0.0.124
@@ -1427,7 +1427,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65024
       peers:
         65100:
           - 10.0.0.126
@@ -1448,7 +1448,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65025
       peers:
         65100:
           - 10.0.0.128
@@ -1474,7 +1474,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65026
       peers:
         65100:
           - 10.0.0.132
@@ -1500,7 +1500,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65027
       peers:
         65100:
           - 10.0.0.136
@@ -1526,7 +1526,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65028
       peers:
         65100:
           - 10.0.0.140
@@ -1552,7 +1552,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65029
       peers:
         65100:
           - 10.0.0.144
@@ -1578,7 +1578,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65030
       peers:
         65100:
           - 10.0.0.148
@@ -1604,7 +1604,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65031
       peers:
         65100:
           - 10.0.0.152
@@ -1630,7 +1630,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65032
       peers:
         65100:
           - 10.0.0.156
@@ -1656,7 +1656,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65033
       peers:
         65100:
           - 10.0.0.160
@@ -1677,7 +1677,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65034
       peers:
         65100:
           - 10.0.0.162
@@ -1698,7 +1698,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65035
       peers:
         65100:
           - 10.0.0.164
@@ -1719,7 +1719,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65036
       peers:
         65100:
           - 10.0.0.166
@@ -1740,7 +1740,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65037
       peers:
         65100:
           - 10.0.0.168
@@ -1761,7 +1761,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65038
       peers:
         65100:
           - 10.0.0.170
@@ -1782,7 +1782,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65039
       peers:
         65100:
           - 10.0.0.172
@@ -1803,7 +1803,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65040
       peers:
         65100:
           - 10.0.0.174
@@ -1829,7 +1829,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65041
       peers:
         65100:
           - 10.0.0.176
@@ -1855,7 +1855,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65042
       peers:
         65100:
           - 10.0.0.178
@@ -1876,7 +1876,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65043
       peers:
         65100:
           - 10.0.0.180
@@ -1897,7 +1897,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65044
       peers:
         65100:
           - 10.0.0.182
@@ -1918,7 +1918,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65045
       peers:
         65100:
           - 10.0.0.184
@@ -1939,7 +1939,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65046
       peers:
         65100:
           - 10.0.0.186
@@ -1960,7 +1960,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65047
       peers:
         65100:
           - 10.0.0.188
@@ -1981,7 +1981,7 @@ configuration:
       - common
       - leaf
     bgp:
-      asn: 65000
+      asn: 65048
       peers:
         65100:
           - 10.0.0.190


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fix the ASN numbers for T1 and T3 tiers as is typical of a DC topology.
In a typical DC topology a T2 router connects to a T1 router from a different podset. Each podset is assigned a unique ASN.  And in upstream direction T2 connects to T3s belonging to a single IDF (or plane) that have the same ASN. 

Also updated the AS path for routes advertised in T3 VMs.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix ASN numbers to reflect a typical DC topology.

#### How did you do it?
Assigned different ASNs for each of T1 VMs.
Assign same ASN for all T3 VMs.
Updated AS path for routes advertised to T3 VM.

#### How did you verify/test it?
Core RA AS path update:
![image](https://user-images.githubusercontent.com/10645050/137415310-b1780d11-f02b-416b-9fb9-5f8debaae945.png)



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
