### PR TITLE
Add test_wjh.py::test_loopback_filter which should be skipped to the test_mark_conditions.yaml

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -7,6 +7,15 @@ drop_packets/test_drop_counters.py::test_loopback_filter:
   skip:
     reason: "SONiC can't enable loop-back filter feature"
 
+drop_packets/test_wjh.py::test_loopback_filter:
+  # Test case is skipped, because SONiC does not have a control to adjust loop-back filter settings.
+  # Default SONiC behavior is to forward the traffic, so loop-back filter does not triggers for IP packets.
+  # All router interfaces has attribute "sx_interface_attributes_t.loopback_enable" - enabled.
+  # To enable loop-back filter drops - need to disable that attribute when create RIF.
+  # To do this can be used SAI attribute SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION, which is not exposed to SONiC
+  skip:
+    reason: "SONiC can't enable loop-back filter feature"
+
 platform_tests/test_sequential_restart.py::test_restart_syncd:
   skip:
     reason: "Restarting syncd is not supported yet"


### PR DESCRIPTION

test_loopback_filter will be used in both test_drop_counters.py and test_wjh.py, test_drop_counters.py::test_loopback_filter  is skippped, test_wjh.py::test_loopback_filter also need to be skipped.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
Skip test_wjh.py::test_loopback_filter due to SONiC can't enable loop-back filter feature
-->

Summary:
Fixes # the test_wjh.py::test_loopback_filter get failure since SONiC can't enable loop-back filter feature, so need to skip it.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
skip the test_wjh.py::test_loopback_filter test case
#### How did you do it?
Add test_wjh.py::test_loopback_filter test case into the test_mark_conditions.yaml
#### How did you verify/test it?
Run the test_wjh.py, the test_loopback_filter  is skipped as expected
#### Any platform specific information?
No
