### PR TITLE
Fix test_configurable_drop_counters on t0-backend

### DIFF
--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -26,6 +26,7 @@ from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py       # lgtm[py/unused-import]
 from tests.common.utilities import is_ipv4_address
 from tests.common import constants
+from tests.common import config_reload
 
 
 pytestmark = [
@@ -87,7 +88,7 @@ def apply_fdb_config(duthost, vlan_id, iface, mac_address, op, type):
 
 @pytest.mark.parametrize("drop_reason", ["L3_EGRESS_LINK_DOWN"])
 def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_dut_hostname, mock_server,
-                            send_dropped_traffic, drop_reason):
+                            send_dropped_traffic, drop_reason, generate_dropped_packet, tbinfo):
     """
     Verifies counters that check for a neighbor link being down.
 
@@ -104,12 +105,10 @@ def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_d
     rx_port = random.choice([port
                              for port in testbed_params["physical_port_map"].keys()
                              if port != mock_server["server_dst_port"]])
-    rx_mac = duthost.get_dut_iface_mac(testbed_params["physical_port_map"][rx_port])
-    logging.info("Selected port %s, mac = %s to send traffic", rx_port, rx_mac)
+    logging.info("Selected port %s to send traffic", rx_port)
 
-    src_mac = "DE:AD:BE:EF:12:34"
     src_ip = MOCK_DEST_IP
-    pkt = _get_simple_ip_packet(src_mac, rx_mac, src_ip, mock_server["server_dst_addr"])
+    pkt = generate_dropped_packet(rx_port, src_ip, mock_server["server_dst_addr"])
 
     try:
         # Add a static fdb entry
@@ -126,11 +125,15 @@ def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_d
         apply_fdb_config(duthost, testbed_params['vlan_interface']['attachto'],
                             mock_server['server_dst_intf'], mock_server['server_dst_mac'],
                             "DEL", "static")
+        # FIXME: Add config reload on t0-backend as a workaround to keep DUT healthy because the following
+        # drop packet testcases will suffer from the brcm_sai_get_port_stats errors flooded in syslog
+        if "backend" in tbinfo["topo"]["name"]:
+            config_reload(duthost)
 
 
 @pytest.mark.parametrize("drop_reason", ["DIP_LINK_LOCAL"])
 def test_dip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_hostname,
-                        send_dropped_traffic, drop_reason, add_default_route_to_dut):
+                        send_dropped_traffic, drop_reason, add_default_route_to_dut, generate_dropped_packet):
     """
     Verifies counters that check for link local dst IP.
 
@@ -141,13 +144,10 @@ def test_dip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_h
     counter_type = setup_counters([drop_reason])
 
     rx_port = random.choice(testbed_params["physical_port_map"].keys())
-    rx_mac = duthost.get_dut_iface_mac(testbed_params["physical_port_map"][rx_port])
-    logging.info("Selected port %s, mac = %s to send traffic", rx_port, rx_mac)
+    logging.info("Selected port %s to send traffic", rx_port)
 
-    src_mac = "DE:AD:BE:EF:12:34"
     src_ip = "10.10.10.10"
-
-    pkt = _get_simple_ip_packet(src_mac, rx_mac, src_ip, LINK_LOCAL_IP)
+    pkt = generate_dropped_packet(rx_port, src_ip, LINK_LOCAL_IP)
 
     try:
         send_dropped_traffic(counter_type, pkt, rx_port)
@@ -158,7 +158,7 @@ def test_dip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_h
 
 @pytest.mark.parametrize("drop_reason", ["SIP_LINK_LOCAL"])
 def test_sip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_hostname,
-                        send_dropped_traffic, drop_reason, add_default_route_to_dut):
+                        send_dropped_traffic, drop_reason, add_default_route_to_dut, generate_dropped_packet):
     """
     Verifies counters that check for link local src IP.
 
@@ -169,13 +169,10 @@ def test_sip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_h
     counter_type = setup_counters([drop_reason])
 
     rx_port = random.choice(testbed_params["physical_port_map"].keys())
-    rx_mac = duthost.get_dut_iface_mac(testbed_params["physical_port_map"][rx_port])
-    logging.info("Selected port %s, mac = %s to send traffic", rx_port, rx_mac)
+    logging.info("Selected port %s to send traffic", rx_port)
 
-    src_mac = "DE:AD:BE:EF:12:34"
     dst_ip = "10.10.10.10"
-
-    pkt = _get_simple_ip_packet(src_mac, rx_mac, LINK_LOCAL_IP, dst_ip)
+    pkt = generate_dropped_packet(rx_port, LINK_LOCAL_IP, dst_ip)
 
     try:
         send_dropped_traffic(counter_type, pkt, rx_port)
@@ -240,9 +237,12 @@ def testbed_params(duthosts, rand_one_dut_hostname, tbinfo):
                   for ifname
                   in mgFacts["minigraph_vlans"].values()[VLAN_INDEX]["members"]]
 
+    vlan_interface = mgFacts["minigraph_vlan_interfaces"][VLAN_INDEX].copy()
+    vlan_interface["type"] = mgFacts["minigraph_vlans"].values()[VLAN_INDEX].get("type", "untagged").lower()
+
     return {"physical_port_map": physical_port_map,
             "vlan_ports": vlan_ports,
-            "vlan_interface": mgFacts["minigraph_vlan_interfaces"][VLAN_INDEX]}
+            "vlan_interface": vlan_interface}
 
 
 @pytest.fixture(scope="module")
@@ -331,7 +331,7 @@ def send_dropped_traffic(duthosts, rand_one_dut_hostname, ptfadapter, testbed_pa
                          recv_count, dst_port, PACKET_COUNT)
             return recv_count == PACKET_COUNT
 
-        pytest_assert(wait_until(5, 1, _check_drops), "Expected {} drops".format(PACKET_COUNT))
+        pytest_assert(wait_until(10, 2, _check_drops), "Expected {} drops".format(PACKET_COUNT))
 
     return _runner
 
@@ -410,6 +410,35 @@ def mock_server(fanouthosts, testbed_params, arp_responder, ptfadapter, duthosts
             "fanout_intf": fanout_intf}
 
 
+@pytest.fixture
+def generate_dropped_packet(duthosts, rand_one_dut_hostname, testbed_params):
+
+    def _get_simple_ip_packet(rx_port, src_ip, dst_ip):
+        dst_mac = duthost.get_dut_iface_mac(testbed_params["physical_port_map"][rx_port])
+        src_mac = "DE:AD:BE:EF:12:34"
+        # send tagged packet for t0-backend whose vlan mode is tagged
+        enable_vlan = rx_port in testbed_params["vlan_ports"] and testbed_params["vlan_interface"]["type"] == "tagged"
+        packet_params = dict(
+            eth_src=src_mac,
+            eth_dst=dst_mac,
+            ip_src=src_ip,
+            ip_dst=dst_ip
+        )
+        if enable_vlan:
+            packet_params["dl_vlan_enable"] = enable_vlan
+            packet_params["vlan_vid"] = int(testbed_params["vlan_interface"]["attachto"].lstrip("Vlan"))
+        pkt = testutils.simple_ip_packet(**packet_params)
+
+        logging.info("Generated simple IP packet (SMAC=%s, DMAC=%s, SIP=%s, DIP=%s)",
+                    src_mac, dst_mac, src_ip, dst_ip)
+
+        return pkt
+
+    duthost = duthosts[rand_one_dut_hostname]
+
+    return _get_simple_ip_packet
+
+
 def _generate_vlan_servers(vlan_network, vlan_ports):
     vlan_host_map = defaultdict(dict)
 
@@ -428,20 +457,6 @@ def _generate_vlan_servers(vlan_network, vlan_ports):
         vlan_host_map[port][str(addr)] = mac
 
     return vlan_host_map
-
-
-def _get_simple_ip_packet(src_mac, dst_mac, src_ip, dst_ip):
-    pkt = testutils.simple_ip_packet(
-        eth_src=src_mac,
-        eth_dst=dst_mac,
-        ip_src=src_ip,
-        ip_dst=dst_ip
-    )
-
-    logging.info("Generated simple IP packet (SMAC=%s, DMAC=%s, SIP=%s, DIP=%s)",
-                 src_mac, dst_mac, src_ip, dst_ip)
-
-    return pkt
 
 
 def _send_packets(duthost, ptfadapter, pkt, ptf_tx_port_id,


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3856
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
the following two test cases were still failing on `t0-backend`
* test_dip_link_local
* test_sip_link_local

#### How did you do it?
Two improvements:
1. for `rx_port` that is a member of `Vlan1000`, the packet generated should be tagged with vlan id as 1000 on `t0-backend` since the vlan mode is tagged.
2. `test_neighbor_link_down` will floods the syslog with `brcm_sai_get_port_stats` errors, `show drop counts` will not work correctly to get port statistics. Adding a `config_reload` in the teardown of `test_neighbor_link_down` to ensure device health.

#### How did you verify/test it?
```
drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[PORT_INGRESS_DROPS-L3_EGRESS_LINK_DOWN] PASSED                                                                                                                                                [ 33%]
drop_packets/test_configurable_drop_counters.py::test_dip_link_local[PORT_INGRESS_DROPS-DIP_LINK_LOCAL] PASSED                                                                                                                                                         [ 66%]
drop_packets/test_configurable_drop_counters.py::test_sip_link_local[PORT_INGRESS_DROPS-SIP_LINK_LOCAL] PASSED                                                                                                                                                         [100%]

================================================================================================================== 3 passed, 3 deselected in 423.29 seconds ==================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
