### PR TITLE
sonic-mgmt voq test fix

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -549,6 +549,12 @@ def makeLab(data, devices, testbed, outfile):
                         except AttributeError:
                             print("\t\t" + host + " switch_type not found")
 
+                        try: #get slot_num                                                                                                                                                                                           slot_num = dev.get("slot_num")                                           
+                            if slot_num is not None:                                                 
+                               entry += "\tslot_num=" + str( slot_num )                              
+                        except AttributeError:
+                            print("\t\t" + host + " slot_num not found")
+
                         try: #get os
                             os = dev.get("os")
                             if os is not None:

--- a/tests/voq/conftest.py
+++ b/tests/voq/conftest.py
@@ -67,7 +67,8 @@ def nbr_macs(nbrhosts):
     logger.debug("Get MACS for all neighbor hosts.")
     results = parallel_run(_get_nbr_macs, [nbrhosts], {}, nbrhosts.keys(), timeout=120)
 
-    for res in results:
+    # result is DictProxy. Iterate it by using keys().
+    for res in results.keys():
         logger.info("parallel_results %s = %s", res, results[res])
 
     return results

--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -439,7 +439,7 @@ class TestTableValidation(object):
 
         intf = cfg_facts['VOQ_INBAND_INTERFACE']
         for port in intf:
-            for address in cfg_facts['BGP_INTERNAL_NEIGHBOR'].keys():
+            for address in cfg_facts['BGP_VOQ_CHASSIS_NEIGHBOR'].keys():
                 # self.check_is_connected(address, port, ipv4_routes, ipv6_routes)
                 ip_intf = ipaddress.ip_interface(address)
                 logger.info("Network %s v%s, is connected via: %s", str(ip_intf.network), ip_intf.network.version, port)
@@ -472,12 +472,12 @@ class TestTableValidation(object):
         asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
         cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
 
-        if 'BGP_INTERNAL_NEIGHBOR' not in cfg_facts:
+        if 'BGP_VOQ_CHASSIS_NEIGHBOR' not in cfg_facts:
             # There are no inband interfaces, this must be an asic not connected to fabric
             pytest.skip("Asic {} on {} has no inband interfaces, so must not be connected to fabric".format(asic.asic_index, per_host.hostname))
 
         bgp_facts = per_host.bgp_facts(instance_id=enum_asic_index)['ansible_facts']
-        for address in cfg_facts['BGP_INTERNAL_NEIGHBOR'].keys():
+        for address in cfg_facts['BGP_VOQ_CHASSIS_NEIGHBOR'].keys():
             pytest_assert(bgp_facts['bgp_neighbors'][address]['state'] == "established",
                           "BGP internal neighbor: %s is not established: %s" % (
                               address, bgp_facts['bgp_neighbors'][address]['state']))

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -464,6 +464,11 @@ def get_inband_info(cfg_facts):
         for a_intf in intf:
             for addrs in intf[a_intf]:
                 ret['port'] = a_intf
+
+                # Skip fields that are not inband address
+                if '/' not in addrs:
+                    continue
+
                 intf_ip = addrs.split('/')
                 if ':' in intf_ip[0]:
                     ret['ipv6_addr'] = intf_ip[0]
@@ -548,9 +553,9 @@ def find_system_port(dev_sysports, slot, asic_index, hostif):
     """
 
     if "portchannel" in hostif.lower():
-        sys_re = re.compile(r'^([a-zA-Z]+{})\|([a-zA-Z]+{})\|'.format(slot, asic_index))
+        sys_re = re.compile(r'^([a-zA-Z0-9\-]+{})\|([a-zA-Z]+{})\|'.format(slot, asic_index))
     else:
-        sys_re = re.compile(r'^([a-zA-Z]+{})\|([a-zA-Z]+{})\|{}$'.format(slot, asic_index, hostif))
+        sys_re = re.compile(r'^([a-zA-Z0-9\-]+{})\|([a-zA-Z]+{})\|{}$'.format(slot, asic_index, hostif))
     sys_info = {}
 
     for sysport in dev_sysports:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
This PR includes the following fixes to sonic-mgmt voq tests in t2 topo:

- Set slot_num to host in lab file
- Iterate through DictProxy with keys()
- Use BGP_VOQ_CHASSIS_NEIGHBOR, instead of BGP_INTERNAL_NEIGHBOR in voq test
- Skip inband_type field when retrieving inband address from VOQ_INBAND_INTERFACE table
- Update slot RE to include number and dash to match slot name like this dut123-5
- Add dut port name (not alias) to fanout port mapping

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
