### PR TITLE
[parallel_run] Run parallel tasks in batches of specified size.

### DIFF
--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -84,7 +84,7 @@ def parallel_run(target, args, kwargs, nodes, timeout=None, concurrent_tasks=20)
         running_processes = [worker for worker in workers if worker.is_alive()]
         if len(running_processes) > 0:
             logger.info(
-                'Found processes still running: {}. Try to kill them.'.format(
+                'Found processes still running: {}. Try to kill them.'.format( #lgtm [py/clear-text-logging-sensitive-data]
                     str(running_processes)
                 )
             )
@@ -95,7 +95,7 @@ def parallel_run(target, args, kwargs, nodes, timeout=None, concurrent_tasks=20)
                 except OSError:
                     pass
 
-            assert (
+            pt_assert(
                 False,
                 """Processes running target "{}" could not be terminated.
                 Tried killing them. But please check""".format(target.__name__)
@@ -108,7 +108,7 @@ def parallel_run(target, args, kwargs, nodes, timeout=None, concurrent_tasks=20)
     tasks_done = 0
     total_tasks = len(nodes)
     tasks_running = 0
-    total_timeout = timeout * (len(nodes)/concurrent_tasks) if timeout else None
+    total_timeout = timeout * int(len(nodes)/concurrent_tasks) if timeout else None
 
     while tasks_done < total_tasks:
 
@@ -188,7 +188,7 @@ def parallel_run(target, args, kwargs, nodes, timeout=None, concurrent_tasks=20)
                         process_name, p_exitcode, p_exception, p_traceback
                     )
                 )
-            assert(
+            pt_assert(
                 False,
                 'Processes "{}" had failures. Please check the logs'.format(
                     failed_processes.keys()

--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -50,7 +50,7 @@ class SonicProcess(Process):
         return self._exception
 
 
-def parallel_run(target, args, kwargs, nodes, timeout=None, concurrent_tasks=5):
+def parallel_run(target, args, kwargs, nodes, timeout=None, concurrent_tasks=20):
     """Run target function on nodes in parallel
 
     Args:

--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -5,7 +5,10 @@ import shutil
 import tempfile
 import signal
 import traceback
+
 from multiprocessing import Process, Manager, Pipe
+from psutil import wait_procs
+
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 
 logger = logging.getLogger(__name__)
@@ -32,6 +35,14 @@ class SonicProcess(Process):
             self._cconn.send((e, tb))
             raise e
 
+    # for wait_procs
+    def wait(self, timeout):
+        return self.join(timeout=timeout)
+
+    # for wait_procs
+    def is_running(self):
+        return self.is_alive()
+
     @property
     def exception(self):
         if self._pconn.poll():
@@ -39,7 +50,7 @@ class SonicProcess(Process):
         return self._exception
 
 
-def parallel_run(target, args, kwargs, nodes, timeout=None):
+def parallel_run(target, args, kwargs, nodes, timeout=None, concurrent_tasks=5):
     """Run target function on nodes in parallel
 
     Args:
@@ -61,69 +72,134 @@ def parallel_run(target, args, kwargs, nodes, timeout=None):
         dict: An instance of multiprocessing.Manager().dict(). It is a proxy to the shared dict that is used by all the
             spawned processes.
     """
+
+    # Callback API for wait_procs
+    def on_terminate(worker):
+        logger.info("process {} terminated with exit code {}".format(
+            worker.name, worker.returncode)
+        )
+
+    def force_terminate(workers):
+        # Some processes cannot be terminated. Try to kill them and raise flag.
+        running_processes = [worker for worker in workers if worker.is_alive()]
+        if len(running_processes) > 0:
+            logger.info(
+                'Found processes still running: {}. Try to kill them.'.format(
+                    str(running_processes)
+                )
+            )
+            for p in running_processes:
+                results[p.name] = [{'failed': True}]
+                try:
+                    os.kill(p.pid, signal.SIGKILL)
+                except OSError:
+                    pass
+
+            assert (
+                False,
+                """Processes running target "{}" could not be terminated.
+                Tried killing them. But please check""".format(target.__name__)
+            )
+
+
     workers = []
     results = Manager().dict()
     start_time = datetime.datetime.now()
-    for node in nodes:
-        kwargs['node'] = node
-        kwargs['results'] = results
-        process_name = "{}--{}".format(target.__name__, node)
-        worker = SonicProcess(name=process_name, target=target, args=args, kwargs=kwargs)
-        worker.start()
-        logger.debug('Started process {} running target "{}"'.format(worker.pid, process_name))
-        workers.append(worker)
+    tasks_done = 0
+    total_tasks = len(nodes)
+    tasks_running = 0
+    total_timeout = timeout * (len(nodes)/concurrent_tasks) if timeout else None
 
-    for worker in workers:
-        logger.debug('Wait for process "{}" with pid "{}" to complete, timeout={}'.format(worker.name, worker.pid, timeout))
-        worker.join(timeout)
-        logger.debug('Process "{}" with pid "{}" completed'.format(worker.name, worker.pid))
+    while tasks_done < total_tasks:
 
-        # If execution time of processes exceeds timeout, need to force terminate them all.
-        if timeout is not None:
-            if (datetime.datetime.now() - start_time).seconds > timeout:
-                logger.error('Process execution time exceeds {} seconds.'.format(str(timeout)))
+        # If execution time of processes exceeds timeout, need to force
+        # terminate them all.
+        if total_timeout is not None:
+            if (datetime.datetime.now() - start_time).seconds > total_timeout:
+                logger.error('Process execution time exceeds {} seconds.'.format(
+                    str(total_timeout)
+                ))
                 break
 
-    # check if we have any processes that failed - have exitcode non-zero
-    failed_processes = {}
-    for worker in workers:
-        if worker.exitcode != 0:
-            failed_processes[worker.name] = {}
-            failed_processes[worker.name]['exit_code'] = worker.exitcode
-            failed_processes[worker.name]['exception'] = worker.exception
+        while len(nodes) and tasks_running < concurrent_tasks:
+            node = nodes.pop(0)
+            kwargs['node'] = node
+            kwargs['results'] = results
+            process_name = "{}--{}".format(target.__name__, node)
+            worker = SonicProcess(
+                        name=process_name, target=target, args=args,
+                        kwargs=kwargs
+                    )
+            worker.start()
+            tasks_running += 1
+            logger.debug('Started process {} running target "{}"'.format(
+                worker.pid, process_name
+            ))
+            workers.append(worker)
 
-    # Force terminate spawned processes
+        gone, alive = wait_procs(workers, timeout=timeout, callback=on_terminate)
+
+        logger.debug("task completed {}, running {}".format(
+            len(gone), len(alive)
+        ))
+
+        if len(gone) == 0:
+            logger.debug("all processes have timedout")
+            tasks_running -= len(workers)
+            tasks_done += len(workers)
+            force_terminate(workers)
+        else:
+            tasks_running -= len(gone)
+            tasks_done += len(gone)
+
+        # check if we have any processes that failed - have exitcode non-zero
+        failed_processes = {}
+        for worker in gone:
+            if worker.exitcode != 0:
+                failed_processes[worker.name] = {}
+                failed_processes[worker.name]['exit_code'] = worker.exitcode
+                failed_processes[worker.name]['exception'] = worker.exception
+
+    # In case of timeout force terminate spawned processes
     for worker in workers:
         if worker.is_alive():
-            logger.error('Process {} with pid {} is still alive, try to force terminate it.'.format(worker.name, worker.pid))
+            logger.error('Process {} is alive, force terminate it.'.format(
+                worker.name
+            ))
             worker.terminate()
+            results[worker.name] = [{'failed': True}]
 
     end_time = datetime.datetime.now()
     delta_time = end_time - start_time
 
-    # Some processes cannot be terminated. Try to kill them and raise flag.
-    running_processes = [worker for worker in workers if worker.is_alive()]
-    if len(running_processes) > 0:
-        logger.error('Found processes still running: {}. Try to kill them.'.format(str(running_processes)))
-        for p in running_processes:
-            try:
-                os.kill(p.pid, signal.SIGKILL)
-            except OSError:
-                pass
+    # force terminate any workers still running
+    force_terminate(workers)
 
-        pt_assert(False, \
-            'Processes running target "{}" could not be terminated. Tried killing them. But please check'.format(target.__name__))
-
-    # if we have failed processes, we should log the exception and exit code of each Process and fail
+    # if we have failed processes, we should log the exception and exit code
+    # of each Process and fail
     if len(failed_processes.keys()):
         for process_name, process in failed_processes.items():
-            p_exception = process['exception'][0]
-            p_traceback = process['exception'][1]
-            p_exitcode = process['exit_code']
-            logger.error('Process {} had exit code {} and exception {} and traceback {}'.format(process_name, p_exitcode, p_exception, p_traceback))
-        pt_assert(False, 'Processes "{}" had failures. Please check the logs'.format(failed_processes.keys()))
+            if 'exception' in process and process['exception']:
+                p_exception = process['exception'][0]
+                p_traceback = process['exception'][1]
+                p_exitcode = process['exit_code']
+                logger.error("""Process {} had exit code {} and exception {}
+                    and traceback {}""".format(
+                        process_name, p_exitcode, p_exception, p_traceback
+                    )
+                )
+            assert(
+                False,
+                'Processes "{}" had failures. Please check the logs'.format(
+                    failed_processes.keys()
+                )
+            )
 
-    logger.info('Completed running processes for target "{}" in {} seconds'.format(target.__name__, str(delta_time)))
+    logger.info(
+        'Completed running processes for target "{}" in {} seconds'.format(
+            target.__name__, str(delta_time)
+        )
+    )
 
     return results
 

--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -50,7 +50,9 @@ class SonicProcess(Process):
         return self._exception
 
 
-def parallel_run(target, args, kwargs, nodes, timeout=None, concurrent_tasks=20):
+def parallel_run(
+    target, args, kwargs, nodes_list, timeout=None, concurrent_tasks=20
+):
     """Run target function on nodes in parallel
 
     Args:
@@ -72,7 +74,7 @@ def parallel_run(target, args, kwargs, nodes, timeout=None, concurrent_tasks=20)
         dict: An instance of multiprocessing.Manager().dict(). It is a proxy to the shared dict that is used by all the
             spawned processes.
     """
-
+    nodes = [node for node in nodes_list]
     # Callback API for wait_procs
     def on_terminate(worker):
         logger.info("process {} terminated with exit code {}".format(
@@ -112,7 +114,6 @@ def parallel_run(target, args, kwargs, nodes, timeout=None, concurrent_tasks=20)
     failed_processes = {}
 
     while tasks_done < total_tasks:
-
         # If execution time of processes exceeds timeout, need to force
         # terminate them all.
         if total_timeout is not None:

--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -50,7 +50,7 @@ class SonicProcess(Process):
 
 
 def parallel_run(
-    target, args, kwargs, nodes_list, timeout=None, concurrent_tasks=20
+    target, args, kwargs, nodes_list, timeout=None, concurrent_tasks=24
 ):
     """Run target function on nodes in parallel
 

--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import math
 import os
 import shutil
 import tempfile
@@ -97,7 +98,6 @@ def parallel_run(
                     logger.debug("Unable to kill {}:{}, error:{}".format(
                         p.pid, p.name, err
                     ))
-                    pass
 
             pt_assert(
                 False,
@@ -112,7 +112,9 @@ def parallel_run(
     tasks_done = 0
     total_tasks = len(nodes)
     tasks_running = 0
-    total_timeout = timeout * (int(len(nodes)/concurrent_tasks) + 1) if timeout else None
+    total_timeout = timeout * math.ceil(
+        len(nodes)/float(concurrent_tasks)
+    ) if timeout else None
     failed_processes = {}
 
     while tasks_done < total_tasks:

--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -109,6 +109,7 @@ def parallel_run(target, args, kwargs, nodes, timeout=None, concurrent_tasks=20)
     total_tasks = len(nodes)
     tasks_running = 0
     total_timeout = timeout * int(len(nodes)/concurrent_tasks) if timeout else None
+    failed_processes = {}
 
     while tasks_done < total_tasks:
 
@@ -153,7 +154,6 @@ def parallel_run(target, args, kwargs, nodes, timeout=None, concurrent_tasks=20)
             tasks_done += len(gone)
 
         # check if we have any processes that failed - have exitcode non-zero
-        failed_processes = {}
         for worker in gone:
             if worker.exitcode != 0:
                 failed_processes[worker.name] = {}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Currently the 'parallel_run' API runs the parallel tasks depending on the number of nodes provided in API.

In case of chassis, in some cases, e.g. BGP graceful restart config, the number of parallel tasks can be huge. In T2 
topology number of VMs are around 90, this ends up creating 90 parallel tasks which can sometimes overload the 
sonic-mgmt server resulting in OOM issues.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
Run parallel tasks in batches of specified size, default is 20.

If a task times out, it remains in workers queue until when the API kills remaining tasks in the end.

If all the tasks in an iteration times out, all those are killed and the test exits with a failure.

If a subset of tasks in an iteration timeout, they continue to be counted as 'tasks running' towards count of concurrent tasks.

#### What is the motivation for this PR?
Run specific amount of tasks in parallel so that large amount of parallel tasks do not freeze the host

#### How did you do it?
Run only specified number of tasks in parallel.

#### How did you verify/test it?

test scenarion: 7 tasks (1,2,3...7), 3 concurrent tasks

* regular case - 7 tasks, 3 concurrent
* few tasks blocked [task 1, 6 blocked]  -- check block tasks are killed, rest of the tasks are completed 
* All tasks in the same iteration are blocked [tasks 1,2,3 are blocked] -- tasks are killed and the test stops.
* All tasks are blocked -- verify tasks are killed


* regular case - 9 tasks, 3 concurrent

![image](https://user-images.githubusercontent.com/10645050/139483545-9c181071-25cf-43d2-ab3a-1e317a428fd0.png)

* few tasks blocked [task 1, 6, 8 blocked]  -- check block tasks are killed, rest of the tasks are completed 

![image](https://user-images.githubusercontent.com/10645050/139483608-15bf0f98-7455-40fa-b285-0264a0a9bd22.png)

* - All tasks in the same iteration are blocked [tasks 1,2,3 are blocked] -- These tasks are killed and the test exits

![image](https://user-images.githubusercontent.com/10645050/139483645-b754e447-0de2-482c-9a9b-5487a79a0367.png)


* All tasks are blocked -- verify all tasks are killed

Test exits in the first iteration as all the tasks are blocked. Same as above.


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
