### PR TITLE
[dualtor]: Adding Cisco-8000 to dual-tor supported platforms

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -23,6 +23,8 @@ barefoot_hwskus: [ "montara", "mavericks", "Arista-7170-64C", "newport", "Arista
 
 marvell_hwskus: [ "et6448m" ]
 
+cisco_hwskus: ["64x100Gb"]
+
 ## Note:
 ## Docker volumes should be list instead of dict. However, if we want to keep code DRY, we
 ## need to merge dictionaries, and convert them to list

--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -61,7 +61,7 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="module", autouse=True)
 def common_setup_teardown(rand_selected_dut, request, tbinfo, vmhost):
     # Skip dualtor test cases on unsupported platform
-    supported_platforms = ['broadcom_td3_hwskus', 'broadcom_th2_hwskus']
+    supported_platforms = ['broadcom_td3_hwskus', 'broadcom_th2_hwskus', 'cisco_hwskus']
     hostvars = get_host_visible_vars(rand_selected_dut.host.options['inventory'], rand_selected_dut.hostname)
     hwsku = rand_selected_dut.facts['hwsku']
     skip = True


### PR DESCRIPTION
### Description of PR
Adding Cisco-8000 to list of supported platforms for dual-tor tests

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Adding Cisco-8000 to list of supported platforms for dual-tor tests

#### How did you do it?

#### How did you verify/test it?
Verified on dualtor-56 topology with cisco-8000 platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
