### PR TITLE
[restart_ptf] refine backplane port temporary name, use ptf fingerprint instead of random code

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -397,9 +397,8 @@ class VMTopology(object):
         VMTopology.iface_disable_txoff(BP_PORT_NAME, self.pid)
 
     def add_br_if_to_docker(self, bridge, ext_if, int_if):
-        # add random suffix to int_if to support multiple tasks run concurrently
-        random_suffix = generate_random_code(6)
-        tmp_int_if = int_if + random_suffix
+        # add ptf fingerprint suffix to int_if to support multiple tasks run concurrently
+        tmp_int_if = int_if + self.generate_ptf_fingerprint(6)
         logging.info('=== For veth pair, add %s to bridge %s, set %s to PTF docker, tmp intf %s' % (ext_if, bridge, int_if, tmp_int_if))
         if VMTopology.intf_not_exists(ext_if):
             VMTopology.cmd("ip link add %s type veth peer name %s" % (ext_if, tmp_int_if))
@@ -843,6 +842,17 @@ class VMTopology(object):
                     vlan_id = self.vlan_ids[str(intf)]
                     self.remove_dut_vlan_subif_from_docker(ptf_if, vlan_separator, vlan_id)
 
+    def generate_ptf_fingerprint(self, digit=6):
+        """
+            Generate ptf fingerprint
+            Args:
+                digit (int): digit of fingerprint, e.g. 6
+
+            Returns:
+                str: fingerprint, e.g. a9d24d
+            """
+        return hashlib.md5((PTF_NAME_TEMPLATE % self.vm_set_name).encode("utf-8")).hexdigest()[0:digit]
+
     @staticmethod
     def _intf_cmd(intf, pid=None):
         if pid:
@@ -1162,18 +1172,6 @@ def check_topo(topo, is_multi_duts=False):
         vms_exists = True
 
     return hostif_exists, vms_exists
-
-
-def generate_random_code(digit=6):
-    """
-    Generate random code
-    Args:
-        digit (int): digit of code, e.g. 6
-
-    Returns:
-        str: random code, e.g. k9A27L
-    """
-    return ''.join(random.sample("abcdefghijklmnABCDEFGHIJKLMN0123456789", digit))
 
 
 def check_params(module, params, mode):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
[restart_ptf] refine backplane port temporary name, use ptf fingerprint instead of random code

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
We used to use a random code as a suffix to create a temporary ptf backplane port, but if the function is terminated manually,
we can't get the name back at the next run.
Using a fingerprint of ptf name instead of a random code will help to avoid that scenario.

#### How did you do it?
Using a fingerprint of ptf name instead of a random code as the suffix of temporary ptf port.
#### How did you verify/test it?
Run restart-ptf on a physical testbed, and all things went well.

