### PR TITLE
[advance-reboot] Move clear-counters call before reboot command

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -921,10 +921,14 @@ class ReloadTest(BaseTest):
         self.examine_flow()
         self.log("Packet flow examine finished after %s" % str(datetime.datetime.now() - examine_start))
 
-        self.no_routing_stop, self.no_routing_start = datetime.datetime.fromtimestamp(self.no_routing_stop), datetime.datetime.fromtimestamp(self.no_routing_start)
-        self.log("Dataplane disruption lasted %.3f seconds. %d packet(s) lost." % (self.max_disrupt_time, self.max_lost_id))
-        self.log("Total disruptions count is %d. All disruptions lasted %.3f seconds. Total %d packet(s) lost" % \
-            (self.disrupts_count, self.total_disrupt_time, self.total_disrupt_packets))
+        if self.lost_packets:
+            self.no_routing_stop, self.no_routing_start = datetime.datetime.fromtimestamp(self.no_routing_stop), datetime.datetime.fromtimestamp(self.no_routing_start)
+            self.log("Dataplane disruption lasted %.3f seconds. %d packet(s) lost." % (self.max_disrupt_time, self.max_lost_id))
+            self.log("Total disruptions count is %d. All disruptions lasted %.3f seconds. Total %d packet(s) lost" % \
+                (self.disrupts_count, self.total_disrupt_time, self.total_disrupt_packets))
+        else:
+            self.no_routing_start = self.reboot_start
+            self.no_routing_stop  = self.reboot_start
 
     def handle_warm_reboot_health_check(self):
         self.send_and_sniff()
@@ -1160,6 +1164,7 @@ class ReloadTest(BaseTest):
             self.wait_dut_to_warm_up()
             self.fails['dut'].clear()
 
+            self.clear_dut_counters()
             self.log("Schedule to reboot the remote switch in %s sec" % self.reboot_delay)
             thr = threading.Thread(target=self.reboot_dut)
             thr.setDaemon(True)
@@ -1310,19 +1315,6 @@ class ReloadTest(BaseTest):
             packets_list = self.packets_list
         self.sniffer_started.wait(timeout=10)
         with self.dataplane_io_lock:
-            # Clear the counters before starting the IO traffic
-            # this is done so that drops can be accurately calculated
-            # after reboot test is finished
-            clear_counter_cmds = [ "sonic-clear counters",
-            "sonic-clear queuecounters",
-            "sonic-clear dropcounters",
-            "sonic-clear rifcounters",
-            "sonic-clear pfccounters"
-            ]
-            if 'broadcom' in self.test_params['asic_type']:
-                clear_counter_cmds.append("bcmcmd 'clear counters'")
-            for cmd in clear_counter_cmds:
-                self.dut_connection.execCommand(cmd)
             sent_packet_count = 0
             # While running fast data plane sender thread there are two reasons for filter to be applied
             #  1. filter out data plane traffic which is tcp to free up the load on PTF socket (sniffer thread is using a different one)
@@ -1644,6 +1636,21 @@ class ReloadTest(BaseTest):
            raise Exception("{} flapped while waiting for the warm up".format(fail))
 
         # Everything is good
+
+    def clear_dut_counters(self):
+        # Clear the counters after the WARM UP is complete
+        # this is done so that drops can be accurately calculated
+        # after reboot test is finished
+        clear_counter_cmds = [ "sonic-clear counters",
+        "sonic-clear queuecounters",
+        "sonic-clear dropcounters",
+        "sonic-clear rifcounters",
+        "sonic-clear pfccounters"
+        ]
+        if 'broadcom' in self.test_params['asic_type']:
+            clear_counter_cmds.append("bcmcmd 'clear counters'")
+        for cmd in clear_counter_cmds:
+            self.dut_connection.execCommand(cmd)
 
     def check_alive(self):
         # This function checks that DUT routes the packets in the both directions.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix flaky errors and false-negatives during test_fast_reboot.
Improve handling of packet loss check to avoid failing with `FAILED:dut:a float is required`.

The errors originally are due to incorrect timing of issuing clear-counter commands.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To fix recent fast-reboot test regression and false negatives.

Test regression is an error thrown while examining packet losses.

```
advanced-reboot.ReloadTest ... FAIL
======================================================================
FAIL: advanced-reboot.ReloadTest
----------------------------------------------------------------------
Traceback (most recent call last):\n  File "ptftests/advanced-reboot.py", line 1203, in runTest
    self.handle_post_reboot_test_reports()
	File "ptftests/advanced-reboot.py", line 1153, in handle_post_reboot_test_reports
    self.assertTrue(is_good, errors)\nAssertionError: 
	Something went wrong. Please check output below:
	FAILED:dut:a float is required\n
	----------------------------------------------------------------------
	Ran 1 test in 605.136s\n
	FAILED (failures=1)",
```

This error occurred as the test wrongly detects that there are no packet loss during fast reboot process.

Furthermore, the test fails to detect packet loss because of the new clear-counters call that was added.
The clear-couters call takes time, or even fails as the DUT's mgmt addr becomes unreachable.

While the clear-counters take time, the downtime window starts and ends.
Finally, due to above reasons, the test sometimes starts sending traffic after the downtime window, and hence detects no packet loss.

#### How did you do it?

Moved the clear counters call before reboot command is issued.
This would help ensure that the mgmt addr is reachable and downtime window hasn't begun when clear-counters is issued.

#### How did you verify/test it?
Tested on a physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
