### PR TITLE
[set MTU] Fix get MTU query from config DB when the iface is not a port channel

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -161,42 +161,57 @@ def get_intf_mtu(duthost, intf, asic_index):
 
 
 @pytest.fixture
-def mtu_config(duthosts):
+def mtu_config(duthosts, rand_one_dut_hostname):
     """ Fixture which prepare port MTU configuration for 'test_ip_pkt_with_exceeded_mtu' test case """
     class MTUConfig(object):
         iface = None
         mtu = None
         default_mtu = 9100
+        key = None
+        asic_index = None
 
         @classmethod
         def set_mtu(cls, mtu, iface, asic_index):
-            for duthost in duthosts:
-                namespace = duthost.get_namespace_from_asic_id(asic_index) if duthost.is_multi_asic else ''
-                cls.mtu = duthost.command("sonic-db-cli -n '{}' CONFIG_DB hget \"PORTCHANNEL|{}\" mtu".format(namespace, iface))["stdout"]
-                if not cls.mtu:
-                    cls.mtu = cls.default_mtu
-                if "PortChannel" in iface:
-                    duthost.command("sonic-db-cli -n '{}' CONFIG_DB hset \"PORTCHANNEL|{}\" mtu {}".format(namespace, iface, mtu))["stdout"]
-                elif "Ethernet" in iface:
-                    duthost.command("sonic-db-cli -n '{}' CONFIG_DB hset \"PORT|{}\" mtu {}".format(namespace, iface, mtu))["stdout"]
-                else:
-                    raise Exception("Unsupported interface parameter - {}".format(iface))
-                cls.iface = iface
-                check_mtu = lambda: get_intf_mtu(duthost, iface, asic_index) == mtu  # lgtm[py/loop-variable-capture]
-                pytest_assert(wait_until(5, 1, check_mtu), "MTU on interface {} not updated".format(iface))
-                cls.asic_index = asic_index
+            duthost = duthosts[rand_one_dut_hostname]
+            namespace = duthost.get_namespace_from_asic_id(asic_index) if duthost.is_multi_asic else ''
+            if "PortChannel" in iface:
+                cls.key = "PORTCHANNEL"
+            elif "Ethernet" in iface:
+                cls.key = "PORT"
+            else:
+                raise Exception("Unsupported interface parameter - {}".format(iface))
+
+            cls.mtu = duthost.command(
+                "sonic-db-cli -n '{}' CONFIG_DB hget \"{}|{}\" mtu".format(
+                    namespace, cls.key, iface
+                )
+            )["stdout"]
+
+            if not cls.mtu:
+                cls.mtu = cls.default_mtu
+
+            duthost.command(
+                "sonic-db-cli -n '{}' CONFIG_DB hset \"{}|{}\" mtu {}".format(
+                    namespace, cls.key, iface, mtu
+                )
+            )["stdout"]
+
+            cls.asic_index = asic_index
+            cls.iface = iface
+            check_mtu = lambda: get_intf_mtu(duthost, iface, asic_index) == mtu  # lgtm[py/loop-variable-capture]
+            pytest_assert(wait_until(5, 1, check_mtu), "MTU on interface {} not updated".format(iface))
 
         @classmethod
         def restore_mtu(cls):
-            for duthost in duthosts:
-                if cls.iface:
-                    namespace = duthost.get_namespace_from_asic_id(cls.asic_index) if duthost.is_multi_asic else ''
-                    if "PortChannel" in cls.iface:
-                        duthost.command("sonic-db-cli -n '{}' CONFIG_DB hset \"PORTCHANNEL|{}\" mtu {}".format(namespace, cls.iface, cls.mtu))["stdout"]
-                    elif "Ethernet" in cls.iface:
-                        duthost.command("sonic-db-cli -n '{}' CONFIG_DB hset \"PORT|{}\" mtu {}".format(namespace, cls.iface, cls.mtu))["stdout"]
-                    else:
-                        raise Exception("Trying to restore MTU on unsupported interface - {}".format(cls.iface))
+            duthost = duthosts[rand_one_dut_hostname]
+            namespace = duthost.get_namespace_from_asic_id(
+                cls.asic_index
+            ) if duthost.is_multi_asic else ''
+            duthost.command(
+                "sonic-db-cli -n '{}' CONFIG_DB hset \"{}|{}\" mtu {}".format(
+                    namespace, cls.key, cls.iface, cls.mtu
+                )
+            )["stdout"]
 
     yield MTUConfig
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
When the interface is a port, redis CLI args to get MTU from config DB was set incorrectly.

#### How did you do it?
Use key "PORTCHANNEL" or "PORT" based on the passed interface name.

#### How did you verify/test it?

"Ethernet64"
```
===========================================================================================
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ pytest  dummy/test_params_dummy3.py --testbed=vms12-t1-lag-1 --inventory=../ansible/str,../ansible/veos --testbed_file=../ansible/testbed.csv --host-pattern=str-s6000-acs-8 --module-path=../ansible/library --skip_sanity -k params6
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
========================================================================================================================================================================== test session starts ===========================================================================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collecting ... ['conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut', 'inv_name', 'auto_recover', 'comment']
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 8 items / 7 deselected / 1 selected                                                                                                                                                                                                                                  

dummy/test_params_dummy3.py .                                                                                                                                                                                                                                                                                                                                      [100%]

============================================================================================================================================================================ warnings summary ============================================================================================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================================================================================================== 1 passed, 7 deselected, 1 warnings in 59.77 seconds ===========================================================================================================================================================
```

"PortChannel2002"

```
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ pytest  dummy/test_params_dummy3.py --testbed=vms12-t1-lag-1 --inventory=../ansible/str,../ansible/veos --testbed_file=../ansible/testbed.csv --host-pattern=str-s6000-acs-8 --module-path=../ansible/library --skip_sanity -k params6
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
========================================================================================================================================================================== test session starts ===========================================================================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collecting ... ['conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut', 'inv_name', 'auto_recover', 'comment']
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 8 items / 7 deselected / 1 selected                                                                                                                                                                                                                                  

dummy/test_params_dummy3.py .                                                                                                                                                                                                                                                                                                                                      [100%]

============================================================================================================================================================================ warnings summary ============================================================================================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================================================================================================== 1 passed, 7 deselected, 1 warnings in 48.08 seconds ===========================================================================================================================================================

```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
