### PR TITLE
[Sub-ports] Add test case which validates load-balancing when sub-port is part of ECMP

### DIFF
--- a/tests/common/pkt_filter/filter_pkt_in_buffer.py
+++ b/tests/common/pkt_filter/filter_pkt_in_buffer.py
@@ -70,14 +70,14 @@ class FilterPktBuffer(object):
     """
     FilterPktBuffer class for finding of packets in the buffer of PTF
     """
-    def __init__(self, ptfadapter, exp_pkt, dst_port_number, match_fields=None, ignore_fields=None):
+    def __init__(self, ptfadapter, exp_pkt, dst_port_numbers, match_fields=None, ignore_fields=None):
         """
         Initialize an object for finding packets in the buffer
 
         Args:
             ptfadapter: PTF adapter
             exp_pkt: Expected packet
-            dst_port_number: Destination port number
+            dst_port_numbers: Destination port numbers
             match_fields: List of packet fields that should be matched
             ignore_fields: List of packet fields that should be ignored
         """
@@ -85,8 +85,8 @@ class FilterPktBuffer(object):
         self.received_pkt_diff = []
         self.ptfadapter = ptfadapter
         self.pkt = exp_pkt
-        self.dst_port_number = [dst_port_number] if not isinstance(dst_port_number, list) else dst_port_number
-        self.matched_index = {port_number: 0 for port_number in self.dst_port_number}
+        self.dst_port_numbers = [dst_port_numbers] if not isinstance(dst_port_numbers, list) else dst_port_numbers
+        self.matched_index = {port_number: 0 for port_number in self.dst_port_numbers}
 
         if match_fields is None:
             match_fields = []
@@ -214,7 +214,7 @@ class FilterPktBuffer(object):
         Returns:
             Bool value or difference between received packet and expected packet
         """
-        for dst_port in self.dst_port_number:
+        for dst_port in self.dst_port_numbers:
             matched_index, received_pkt = self.__find_pkt_in_buffer(dst_port)
 
             if received_pkt:

--- a/tests/common/pkt_filter/filter_pkt_in_buffer.py
+++ b/tests/common/pkt_filter/filter_pkt_in_buffer.py
@@ -85,7 +85,8 @@ class FilterPktBuffer(object):
         self.received_pkt_diff = []
         self.ptfadapter = ptfadapter
         self.pkt = exp_pkt
-        self.dst_port_number = dst_port_number
+        self.dst_port_number = [dst_port_number] if not isinstance(dst_port_number, list) else dst_port_number
+        self.matched_index = {port_number: 0 for port_number in self.dst_port_number}
 
         if match_fields is None:
             match_fields = []
@@ -128,16 +129,18 @@ class FilterPktBuffer(object):
         return pkt_dict
 
 
-    def __find_pkt_in_buffer(self):
+    def __find_pkt_in_buffer(self, dst_port_number):
         """
         Find expected packet in buffer by using matched fields
 
         Returns:
             Received packet
         """
-        time.sleep(0.1)
+        time.sleep(3)
         common_buffer = self.ptfadapter.dataplane.packet_queues
-        packet_buffer = common_buffer[(0, self.dst_port_number)][:]
+        packet_buffer = common_buffer[(0, dst_port_number)][:]
+        matched_index = 0
+        received_pkt = None
 
         for pkt in packet_buffer:
             packet_dict = convert_pkt_to_dict(Ether(pkt[0]))
@@ -149,9 +152,13 @@ class FilterPktBuffer(object):
                 except KeyError:
                     break
             else:
-                return Ether(pkt[0])
+                matched_index += 1
+                received_pkt = Ether(pkt[0])
 
-        return None
+        if received_pkt:
+            return ({dst_port_number: matched_index}, received_pkt)
+
+        return (None, None)
 
 
     def __diff_between_dict(self, rcv_pkt_dict, exp_pkt_dict, path=''):
@@ -207,7 +214,12 @@ class FilterPktBuffer(object):
         Returns:
             Bool value or difference between received packet and expected packet
         """
-        self.received_pkt = self.__find_pkt_in_buffer()
+        for dst_port in self.dst_port_number:
+            matched_index, received_pkt = self.__find_pkt_in_buffer(dst_port)
+
+            if received_pkt:
+                self.received_pkt = received_pkt
+                self.matched_index.update(matched_index)
 
         if self.received_pkt:
             return self.masked_exp_pkt.pkt_match(self.received_pkt) or self._diff_between_pkt(self.received_pkt)

--- a/tests/sub_port_interfaces/Sub-ports-test-plan.md
+++ b/tests/sub_port_interfaces/Sub-ports-test-plan.md
@@ -1,6 +1,6 @@
 # Sub-port interfaces Test Plan
 
-## Rev 0.3
+## Rev 0.6
 
 - [Revision](#revision)
 - [Overview](#overview)
@@ -17,6 +17,7 @@
   - [test_routing_between_sub_ports](#Test-case-test_routing_between_sub_ports)
   - [test_routing_between_sub_ports_and_port](#Test-case-test_routing_between_sub_ports_and_port)
   - [test_tunneling_between_sub_ports](#Test-case-test_tunneling_between_sub_ports)
+  - [test_balancing_sub_ports](#Test-case-test_balancing_sub_ports)
 
 ## Revision
 
@@ -27,6 +28,7 @@
 | 0.3 |  03/18/2021 | Intel: Oleksandr Kozodoi |          New test cases           |
 | 0.4 |  06/09/2021 | Intel: Oleksandr Kozodoi |          New test cases           |
 | 0.5 |  07/12/2021 | Intel: Oleksandr Kozodoi |          New test cases           |
+| 0.6 |  10/22/2021 | Intel: Oleksandr Kozodoi |          New test cases           |
 
 
 ## Overview
@@ -498,5 +500,58 @@ Example the customized testbed with applied T0 topo for test_tunneling_between_s
 - Clear configuration of sub-ports on the PTF.
 
 ### Test teardown
+- reload_dut_config function: reload DUT configuration
+- reload_ptf_config function: remove all sub-ports configuration
+
+## Test case test_balancing_sub_ports
+
+### Test objective
+
+Validates load-balancing when sub-port is part of ECMP
+
+### Test set up
+- apply_config_on_the_dut fixture(scope="function"): enable and configures sub-port interfaces on the DUT
+- apply_config_on_the_ptf fixture(scope="function"): enable and configures sub-port interfaces on the PTF
+- apply_balancing_config fixture(scope="function"): setup balancing configuration on the DUT
+
+Example the customized testbed with applied T0 topo for test_balancing_sub_ports test case:
+```
+              VM    VM    VM    VM
+              []    []    []    []
+       _______[]____[]____[]____[]________________
+  ╔═══|══════════════════════╦════╦════╦════╗     |
+  ║   |   _________    DUT  _║____║____║____║__   |
+  ║   |  [Ethernet4]       [ ║  Ethernet8   ║  ]  |
+  ║   |__[_________]_______[.10__.20__.30__.40_]__|
+  ║      [         ]       [ ║|   ║|   ║|   ║| ]
+  ║      [         ]       [ ║|   ║|   ║|   ║| ]
+  ║      [         ]       [ ║|   ║|   ║|   ║| ]
+  ║    __[_________]_______[_║|___║|___║|___║|_]__
+  ║   |  [         ]       [.10  .20  .30  .40 ]  |
+  ╚═══|═>[__eth1___]       [_║____║eth2║____║__]  |
+      |                      ║    ║    ║    ║     |
+      |                PTF   ║    ║    ║    ║     |
+      |                      ║    ║    ║    ║     |
+      |______________________║____║____║____║_____|
+                             ║    ║    ║    ║
+                             ║    ║    ║    ║
+                             V    V    V    V
+                           ┌──────────────────┐
+                           │    1.1.1.0/30    │
+                           └──────────────────┘
+```
+### Test steps
+- Setup configuration of sub-ports on the DUT.
+- Setup configuration of sub-ports on the PTF.
+- Setup static routes to the network by different sub-ports on the DUT.
+- Create packets with different source ip addresses.
+- Send packets.
+- Verify that sub-port gets received packets on the PTF.
+- Verify load-balancing by using number of packets on different sub-ports.
+- Remove static routes from DUT.
+- Clear configuration of sub-ports on the DUT.
+- Clear configuration of sub-ports on the PTF.
+### Test teardown
+
 - reload_dut_config function: reload DUT configuration
 - reload_ptf_config function: remove all sub-ports configuration

--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -1,6 +1,7 @@
 import os
 import time
 import random
+import ipaddress
 
 from collections import OrderedDict
 
@@ -21,10 +22,13 @@ DUT_TMP_DIR = os.path.join('tmp', os.path.basename(BASE_DIR))
 TEMPLATE_DIR = os.path.join(BASE_DIR, 'templates')
 SUB_PORTS_TEMPLATE = 'sub_port_config.j2'
 TUNNEL_TEMPLATE = 'tunnel_config.j2'
+PTF_NN_AGENT_TEMPLATE = 'ptf_nn_agent.conf.ptf.j2'
 ACTION_FWD = 'fwd'
 ACTION_DROP = 'drop'
 TCP_PORT = 80
 UDP_PORT = 161
+BALANCING_TEST_TIMES = 625
+DEFAULT_BALANCING_RANGE = 0.25
 
 
 def create_packet(eth_dst, eth_src, ip_dst, ip_src, vlan_vid, tr_type, ttl, dl_vlan_enable=False, icmp_type=8, pktlen=100, ip_tunnel=None):
@@ -67,8 +71,9 @@ def create_packet(eth_dst, eth_src, ip_dst, ip_src, vlan_vid, tr_type, ttl, dl_v
 
     return None
 
-def generate_and_verify_traffic(duthost, ptfadapter, src_port, dst_port, ip_src, ip_dst, pkt_action=None,
-                                type_of_traffic=None, ttl=64, pktlen=100, ip_tunnel=None, **kwargs):
+
+def generate_and_verify_traffic(duthost, ptfadapter, src_port, dst_port, ptfhost=None, ip_src='', ip_dst='', pkt_action=None,
+                                type_of_traffic='ICMP', ttl=64, pktlen=100, ip_tunnel=None, **kwargs):
     """
     Send packet from PTF to DUT and
     verify that DUT sends/doesn't packet to PTF.
@@ -78,6 +83,7 @@ def generate_and_verify_traffic(duthost, ptfadapter, src_port, dst_port, ip_src,
         ptfadapter: PTF adapter
         src_port: Port of PTF
         dst_port: Port of DUT
+        ptfhost: PTF host object
         ip_src: Source IP address of PTF
         ip_dst: Destination IP address of DUT
         pkt_action: Packet action (forwarded or drop)
@@ -86,8 +92,7 @@ def generate_and_verify_traffic(duthost, ptfadapter, src_port, dst_port, ip_src,
         pktlen: packet length
         ip_tunnel: Tunnel IP address of DUT
     """
-    if not type_of_traffic:
-        type_of_traffic = ['ICMP',]
+    type_of_traffic = [type_of_traffic] if not isinstance(type_of_traffic, list) else type_of_traffic
 
     for tr_type in type_of_traffic:
         if 'TCP' in tr_type or 'UDP' in tr_type:
@@ -96,6 +101,8 @@ def generate_and_verify_traffic(duthost, ptfadapter, src_port, dst_port, ip_src,
             generate_and_verify_icmp_traffic(duthost, ptfadapter, src_port, dst_port, ip_src, ip_dst, pkt_action, tr_type, ttl, untagged_icmp_request=kwargs.pop("untagged_icmp_request", False))
         elif 'decap' in tr_type:
             generate_and_verify_decap_traffic(duthost, ptfadapter, src_port, dst_port, ip_src, ip_dst, tr_type, ip_tunnel)
+        elif 'balancing' in tr_type:
+            generate_and_verify_balancing_traffic(duthost, ptfhost, ptfadapter, src_port, dst_port, ip_src, ip_dst, pktlen, ttl)
         else:
             pytest.skip('Unsupported type of traffic')
 
@@ -157,6 +164,8 @@ def generate_and_verify_tcp_udp_traffic(duthost, ptfadapter, src_port, dst_port,
                             pktlen=pktlen)
 
     ptfadapter.dataplane.flush()
+    time.sleep(1)
+
     testutils.send_packet(ptfadapter, src_port_number, pkt)
 
     pkt_filter = FilterPktBuffer(ptfadapter=ptfadapter,
@@ -227,6 +236,8 @@ def generate_and_verify_icmp_traffic(duthost, ptfadapter, src_port, dst_port, ip
     masked_exp_pkt.set_do_not_care_scapy(packet.ICMP, "chksum")
 
     ptfadapter.dataplane.flush()
+    time.sleep(1)
+
     testutils.send_packet(ptfadapter, src_port_number, pkt)
 
     dst_port_list = [src_port_number]
@@ -278,6 +289,7 @@ def generate_and_verify_decap_traffic(duthost, ptfadapter, src_port, dst_port, i
 
     update_dut_arp_table(duthost, ip_dst)
     ptfadapter.dataplane.flush()
+    time.sleep(1)
 
     testutils.send_packet(ptfadapter, src_port_number, pkt)
 
@@ -290,6 +302,71 @@ def generate_and_verify_decap_traffic(duthost, ptfadapter, src_port, dst_port, i
     pkt_in_buffer = pkt_filter.filter_pkt_in_buffer()
 
     pytest_assert(pkt_in_buffer is True, "Expected packet not available:\n{}".format(pkt_in_buffer))
+
+
+def generate_and_verify_balancing_traffic(duthost, ptfhost, ptfadapter, src_port, dst_port, ip_src, ip_dst, pktlen, ttl):
+    """
+    Send TCP packets and verify balancing range between sub-ports.
+    Args:
+        duthost: DUT host object
+        ptfhost: PTF host object
+        ptfadapter: PTF adapter
+        src_port: Port of PTF
+        dst_port: Port of DUT
+        ip_src: Source IP address of PTF
+        ip_dst: Destination IP address of DUT
+        pkt_action: Packet action (forwarded or drop)
+        pktlen: packet length
+        ttl: Time to live
+    """
+    router_mac = duthost.facts['router_mac']
+    src_port_number = int(get_port_number(src_port))
+    src_mac = ptfadapter.dataplane.get_mac(0, src_port_number)
+    ip_src = ipaddress.ip_address(u'10.0.0.1')
+    ip_dst = ip_dst.split('/')[0]
+
+    ptfadapter.dataplane.flush()
+    time.sleep(1)
+
+    for _ in range(BALANCING_TEST_TIMES * len(dst_port)):
+
+        pkt = create_packet(eth_src=src_mac,
+                            eth_dst=router_mac,
+                            ip_src=str(ip_src),
+                            ip_dst=ip_dst,
+                            vlan_vid=None,
+                            dl_vlan_enable=False,
+                            tr_type='TCP',
+                            ttl=64)
+
+        testutils.send_packet(ptfadapter, src_port_number, pkt)
+
+        ip_src += 1
+
+    exp_pkt = create_packet(eth_src=router_mac,
+                            eth_dst=src_mac,
+                            ip_src=str(ip_src),
+                            ip_dst=ip_dst,
+                            vlan_vid=None,
+                            dl_vlan_enable=False,
+                            tr_type='TCP',
+                            ttl=ttl,
+                            pktlen=pktlen)
+
+    ifaces_map = ptfhost.host.options['variable_manager'].extra_vars['ifaces_map']
+    config_port_indices = {v: k for k, v in ifaces_map.items()}
+    dst_port_number = [config_port_indices[k] for k in config_port_indices if k in dst_port]
+
+    pkt_filter = FilterPktBuffer(ptfadapter=ptfadapter,
+                                 exp_pkt=exp_pkt,
+                                 dst_port_number=dst_port_number,
+                                 match_fields=[("Ethernet", "src"), ("IP", "dst"), ('TCP', "dport")],
+                                 ignore_fields=[("Ether", "dst"), ("IP", "src"), ("IP", "chksum"), ("TCP", "chksum")])
+
+    pkt_in_buffer = pkt_filter.filter_pkt_in_buffer()
+
+    pytest_assert(pkt_in_buffer is True, "Expected packet not available:\n{}".format(pkt_in_buffer))
+    pytest_assert(check_balancing(pkt_filter.matched_index), "Balancing error:\n{}".format(pkt_filter.matched_index))
 
 
 def shutdown_port(duthost, interface):
@@ -589,7 +666,7 @@ def add_port_to_namespace(ptfhost, name_of_namespace, port_name, port_ip):
     ptfhost.shell('ip -n {} link set {} up'.format(name_of_namespace, port_name))
 
 
-def add_static_route(ptfhost, network_ip, next_hop_ip, name_of_namespace=None):
+def add_static_route_to_ptf(ptfhost, network_ip, next_hop_ip, name_of_namespace=None):
     """
     Add static route on the PTF
 
@@ -606,6 +683,18 @@ def add_static_route(ptfhost, network_ip, next_hop_ip, name_of_namespace=None):
     else:
         ptfhost.shell('ip route add {} nexthop via {}'
                       .format(network_ip, next_hop_ip))
+
+
+def add_static_route_to_dut(duthost, network_ip, next_hop_ip):
+    """
+    Add static route on the DUT
+    Args:
+        duthost: DUT host object
+        network_ip: Network IP address
+        next_hop_ip: Next hop IP address
+    """
+    next_hop_ip = next_hop_ip.split('/')[0]
+    duthost.shell('config route add prefix {} nexthop {}'.format(network_ip, next_hop_ip))
 
 
 def check_namespace(ptfhost, name_of_namespace):
@@ -751,7 +840,7 @@ def remove_namespace(ptfhost, name_of_namespace):
         ptfhost.shell('ip netns del {}'.format(name_of_namespace))
 
 
-def remove_static_route(ptfhost, network_ip, next_hop_ip, name_of_namespace=None):
+def remove_static_route_from_ptf(ptfhost, network_ip, next_hop_ip, name_of_namespace=None):
     """
     Remove static route from the PTF
 
@@ -768,6 +857,18 @@ def remove_static_route(ptfhost, network_ip, next_hop_ip, name_of_namespace=None
     else:
         ptfhost.shell('ip route del {} nexthop via {}'
                       .format(network_ip, next_hop_ip))
+
+
+def remove_static_route_from_dut(duthost, network_ip, next_hop_ip):
+    """
+    Remove static route from the DUT
+    Args:
+        duthost: DUT host object
+        network_ip: Network IP address
+        next_hop_ip: Next hop IP address
+    """
+    next_hop_ip = next_hop_ip.split('/')[0]
+    duthost.shell('config route del prefix {} nexthop {}'.format(network_ip, next_hop_ip))
 
 
 def get_ptf_port_list(ptfhost):
@@ -857,3 +958,73 @@ def update_dut_arp_table(duthost, ip):
         ip: IP address of directly connected interface
     """
     duthost.command("ping {} -c 3".format(ip), module_ignore_errors=True)
+
+
+def configure_ptf_nn_agent(ptfhost, ptfadapter, ifaces):
+    """
+    Add new interfaces to interfaces map of ptfadapter
+    Args:
+        ptfhost: PTF host object
+        ptfadapter: PTF adapter
+        ifaces: List of interface names
+    """
+    ifaces = [ifaces] if not isinstance(ifaces, list) else ifaces
+    last_iface_id = sorted(ptfhost.host.options['variable_manager'].extra_vars['ifaces_map'].keys())[-1]
+
+    for iface_id, iface in enumerate(ifaces, last_iface_id+1):
+        ptfhost.host.options['variable_manager'].extra_vars['ifaces_map'][iface_id] = iface
+        ptfadapter.ptf_port_set.append(iface_id)
+
+    restart_ptf_nn_agent(ptfhost)
+
+    ptfadapter.reinit()
+
+
+def cleanup_ptf_nn_agent(ptfhost, ptfadapter, ifaces):
+    """
+    Remove interfaces from interfaces map of ptfadapter
+    Args:
+        ptfhost: PTF host object
+        ptfadapter: PTF adapter
+        ifaces: List of interface names
+    """
+    ifaces = [ifaces] if not isinstance(ifaces, list) else ifaces
+    ifaces_map = ptfhost.host.options['variable_manager'].extra_vars['ifaces_map']
+    config_port_indices = {v: k for k, v in ifaces_map.items()}
+
+    for iface in ifaces:
+        ptfhost.host.options['variable_manager'].extra_vars['ifaces_map'].pop(config_port_indices[iface])
+        iface_index = ptfadapter.ptf_port_set.index(config_port_indices[iface])
+        ptfadapter.ptf_port_set.pop(iface_index)
+
+    restart_ptf_nn_agent(ptfhost)
+
+    ptfadapter.reinit()
+
+
+def check_balancing(port_hit_cnt):
+    """
+    Verify load-balancing
+    Args:
+        port_hit_cnt: Dictionary of matched packets on different sub-ports
+    """
+    for pkt_cnt in port_hit_cnt.values():
+        percentage = (pkt_cnt - BALANCING_TEST_TIMES) / float(BALANCING_TEST_TIMES)
+        if not abs(percentage) <= DEFAULT_BALANCING_RANGE:
+            break
+    else:
+        return True
+
+    return False
+
+
+def restart_ptf_nn_agent(ptfhost):
+    """
+    Restart ptf_nn_agent
+    Args:
+        ptfhost: PTF host object
+    """
+    ptfhost.template(src=os.path.join(TEMPLATE_DIR, PTF_NN_AGENT_TEMPLATE), dest='/etc/supervisor/conf.d/ptf_nn_agent.conf')
+    ptfhost.command('supervisorctl reread')
+    ptfhost.command('supervisorctl update')
+    ptfhost.command('supervisorctl restart ptf_nn_agent')

--- a/tests/sub_port_interfaces/templates/ptf_nn_agent.conf.ptf.j2
+++ b/tests/sub_port_interfaces/templates/ptf_nn_agent.conf.ptf.j2
@@ -1,0 +1,11 @@
+[program:ptf_nn_agent]
+command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket {{ device_num }}@tcp://0.0.0.0:{{ ptf_nn_port }} {% for id in ifaces_map -%} -i {{ device_num }}-{{ id }}@{{ ifaces_map[id] }} {% endfor %}
+
+process_name=ptf_nn_agent
+stdout_logfile=/tmp/ptf_nn_agent.out.log
+stderr_logfile=/tmp/ptf_nn_agent.err.log
+redirect_stderr=false
+autostart=true
+autorestart=true
+startsecs=1
+numprocs=1

--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -474,6 +474,5 @@ class TestSubPorts(object):
                                         src_port=src_port,
                                         dst_port=dst_ports,
                                         ip_dst=ip_dst,
-                                        pkt_action='fwd',
                                         type_of_traffic='balancing',
                                         ttl=63)

--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -438,5 +438,42 @@ class TestSubPorts(object):
                                             ip_dst=sub_ports[sub_port]['neighbor_ip'],
                                             ip_tunnel=sub_ports[src_port]['ip'],
                                             pkt_action='fwd',
-                                            type_of_traffic=['decap',],
+                                            type_of_traffic='decap',
                                             ttl=63)
+
+
+    def test_balancing_sub_ports(self, duthost, ptfhost, ptfadapter, apply_balancing_config):
+        """
+        Validates load-balancing when sub-port is part of ECMP
+        Test steps:
+            1.) Setup configuration of sub-ports on the DUT.
+            2.) Setup configuration of sub-ports on the PTF.
+            3.) Setup static routes to the network by different sub-ports on the DUT.
+            4.) Create packets with different source ip addresses.
+            5.) Send packets.
+            6.) Verify that sub-port gets received packets on the PTF.
+            7.) Verify load-balancing by using number of packets on different sub-ports.
+            8.) Remove static routes from DUT.
+            9.) Clear configuration of sub-ports on the DUT.
+            10.) Clear configuration of sub-ports on the PTF.
+        Pass Criteria:
+            1.) PTF sub-ports get received packet.
+            2.) Balancing range between sub-ports is less than 25%.
+        """
+        new_sub_ports = apply_balancing_config['new_sub_ports']
+        sub_ports = apply_balancing_config['sub_ports']
+        src_ports = apply_balancing_config['src_ports']
+        src_port = random.choice(src_ports)
+
+        for ports, subnet in new_sub_ports:
+            ip_dst = [str(ip) for ip in subnet.hosts()][0]
+            dst_ports = [sub_ports[sub_port]['neighbor_port'] for sub_port in ports]
+            generate_and_verify_traffic(duthost=duthost,
+                                        ptfhost=ptfhost,
+                                        ptfadapter=ptfadapter,
+                                        src_port=src_port,
+                                        dst_port=dst_ports,
+                                        ip_dst=ip_dst,
+                                        pkt_action='fwd',
+                                        type_of_traffic='balancing',
+                                        ttl=63)


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
- Added new sub-ports tests: [test_balancing_sub_ports](https://github.com/OleksandrKozodoi/sonic-mgmt/blob/add_balancing_sub_ports_test_case/tests/sub_port_interfaces/test_sub_port_interfaces.py#L362-L396)
- Added fixture for setup balancing configuration and remove after tests: [apply_balancing_config](https://github.com/OleksandrKozodoi/sonic-mgmt/blob/add_balancing_sub_ports_test_case/tests/sub_port_interfaces/conftest.py#L443-L490)
- Added new helpers methods
- Added template for updating ptf_nn_agent configuration on the PTF: [ptf_nn_agent.conf.ptf.j2](https://github.com/OleksandrKozodoi/sonic-mgmt/blob/add_balancing_sub_ports_test_case/tests/sub_port_interfaces/templates/ptf_nn_agent.conf.ptf.j2)
- Added new helpers methods for adding sub port interfaces to ptf_nn_agent configuration on the PTF: [configure_ptf_nn_agent](https://github.com/OleksandrKozodoi/sonic-mgmt/blob/add_balancing_sub_ports_test_case/tests/sub_port_interfaces/sub_ports_helpers.py#L961-L1000)
- Added approach for returning multiple packets in buffer match the exp_pkt: [filter_pkt_in_buffer](https://github.com/OleksandrKozodoi/sonic-mgmt/blob/add_balancing_sub_ports_test_case/tests/common/pkt_filter/filter_pkt_in_buffer.py#L159)
- Updated Test Plan
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Coverage of sub-ports feature by test cases to improve the quality of SONiC.
#### How did you do it?
Added new test cases to PyTest.
Implementation is based on the [Sub-ports design spec](https://github.com/Azure/SONiC/blob/master/doc/subport/sonic-sub-port-intf-hld.md)
#### How did you verify/test it?
`py.test --testbed=testbed-t0 --inventory=../ansible/lab --testbed_file=../ansible/testbed.csv --host-pattern=testbed-t0 -- module-path=../ansible/library sub_port_interfaces`
#### Any platform specific information?
SONiC Software Version: SONiC.master.41057-dirty-20211002.165842
Distribution: Debian 10.10
Kernel: 4.19.0-12-2-amd64
Build commit: df6361f50
Build date: Sat Oct  2 17:08:02 UTC 2021
ASIC: barefoot
#### Supported testbed topology if it's a new test case?
T0, T1
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
