### PR TITLE
[test_pfcwd_wb] Test case failed with loganalyzer exit with "SystemExit: -3"

### DIFF
--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -103,7 +103,7 @@ def extract_lines(directory, filename, target_string):
         # Prehandle lines to remove these sub-strings
         dt = datetime.datetime.fromtimestamp(os.path.getctime(path))
         sz = os.path.getsize(path)
-        result = [(filename, dt, line.replace('\x00', ''), sz) for line in file if target_string in line and 'nsible' not in line]
+        result = [(filename, dt, line.replace('\x00', ''), sz) for line in file if target_string in line and 'extract_log' not in line]
 
     return result
 

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -435,7 +435,7 @@ class AnsibleLogAnalyzer:
                     continue
 
             if not stdin_as_input:
-                if rev_line.find(start_marker) != -1 and 'nsible' not in rev_line:
+                if rev_line.find(start_marker) != -1 and 'extract_log' not in rev_line:
                     self.print_diagnostic_message('found start marker: %s' % start_marker)
                     if (found_start_marker):
                         print('ERROR: duplicate start marker found')


### PR DESCRIPTION
When analyzing the syslog, it will looking for the start_marker line in the syslog, and the restrication for searching the start_marker line is not correct

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: When analyzing the syslog, it will looking for the start_marker line in the syslog, and the restrication for searching the start_marker line is not correct
Fixes # (issue) test_pfcwd_wb failed with loganalyzer exit with "SystemExit: -3"(the end marker not found)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
In the PR https://github.com/Azure/sonic-mgmt/pull/4230- [loganalyzer]: add more logging to debug loganalyzer #4230, one line in the syslog file: 'loglogger.debug("extract_log for start string {}".format(target_string.replace("start-", "")))' , 

So in the syslog it look like following in most of the syslog file:
> Oct 22 14:21:59.473062 r-tigon-11 INFO start-LogAnalyzer-pfcwd_wb_storm_detect_port_Ethernet208_queue_4.2021-10-22-14:21:58
> ...
> Oct 22 14:22:30.713873 r-tigon-11 INFO end-LogAnalyzer-pfcwd_wb_storm_detect_port_Ethernet208_queue_4.2021-10-22-14:21:58
> Oct 22 14:22:30.714124 r-tigon-11 INFO 
> Oct 22 14:23:31.773340 r-tigon-11 INFO ansible-extract_log: Invoked with start_string=start-LogAnalyzer-pfcwd_wb_storm_detect_port_Ethernet208_queue_4.2021-10-22-14:21:58 directory=/var/log target_filename=/tmp/syslog file_prefix=syslog
> **Oct 22 14:23:31.773688 r-tigon-11 DEBUG extract_log for start string LogAnalyzer-pfcwd_wb_storm_detect_port_Ethernet208_queue_4.2021-10-22-14:21:58**

But for the loganalyzer when the start_maker is gavien, it will look like this:
> Oct 22 14:27:12.810197 r-tigon-11 NOTICE swss#orchagent: :- setWarmStartState: orchagent warm start state changed to initialized
> ...
> Oct 22 14:31:02.725672 r-tigon-11 INFO ansible-extract_log: Invoked with start_string=NOTICE swss#orchagent: :- setWarmStartState: orchagent warm start state changed to initialized directory=/var/log target_filename=/tmp/syslog file_prefix=syslog
> **Oct 22 14:31:02.725955 r-tigon-11 DEBUG extract_log for start string NOTICE swss#orchagent: :- setWarmStartState: orchagent warm start state changed to initialized**

so when looking for the start_marker line with the corrent logic:

> if rev_line.find(start_marker) != -1 and '**nsible**' not in rev_line:

it will take following line as the start_maker line, but it should not

> Oct 22 14:31:02.725955 r-tigon-11 DEBUG extract_log for start string NOTICE swss#orchagent: :- setWarmStartState: orchagent warm start state changed to initialized
#### How did you do it?
change the logic of searching the start_marker line:

> if rev_line.find(start_marker) != -1 and '**extract_log**' not in rev_line:
#### How did you verify/test it?
run the test_pfcwd_wb and the test case can pass
py.test pfcwd/test_pfcwd_warm_reboot.py --inventory="../ansible/inventory,../ansible/veos" --host-pattern mtbc-sonic-03-2700 --module-path                ../ansible/library/ --testbed mtbc-sonic-03-2700-t0 --testbed_file ../ansible/testbed.csv                --allow_recover  --session_id 5279766 --mars_key_id 0.7.1.1.3.1.1.4.5.1.1                --junit-xml junit_5279766_0.7.1.1.3.1.1.4.5.1.1.xml --assert plain --log-cli-level info --show-capture=no -ra --showlocals -v --clean-alluredir --alluredir=/tmp/allure-results --allure_server_addr="10.215.11.120" --allure_server_project_id=mtbc-sonic-03-2700-pfcwd-test-pfcwd-warm-reboot-py 
#### Any platform specific information?
No

