### PR TITLE
[Mellanox] Check PSU capability against sysfs

### DIFF
--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -4,6 +4,10 @@ SPC2_HWSKUS = ["ACS-MSN3700", "ACS-MSN3700C", "ACS-MSN3800", "Mellanox-SN3800-D1
 SPC3_HWSKUS = ["ACS-MSN4700", "ACS-MSN4600C", "ACS-MSN4410", "ACS-MSN4600"]
 SWITCH_HWSKUS = SPC1_HWSKUS + SPC2_HWSKUS + SPC3_HWSKUS
 
+PSU_CAPABILITIES = [
+    ['psu{}_curr', 'psu{}_curr_in', 'psu{}_power', 'psu{}_power_in', 'psu{}_volt', 'psu{}_volt_in', 'psu{}_volt_out'],
+    ['psu{}_curr', 'psu{}_curr_in', 'psu{}_power', 'psu{}_power_in', 'psu{}_volt', 'psu{}_volt_out2']
+]
 SWITCH_MODELS = {
     "x86_64-mlnx_msn2700-r0": {
         "chip_type": "spectrum1",
@@ -18,7 +22,8 @@ SWITCH_MODELS = {
         },
         "psus": {
             "number": 2,
-            "hot_swappable": True
+            "hot_swappable": True,
+            "capabilities": PSU_CAPABILITIES[0]
         },
         "cpu_pack": {
             "number": 1
@@ -69,7 +74,8 @@ SWITCH_MODELS = {
         },
         "psus": {
             "number": 2,
-            "hot_swappable": True
+            "hot_swappable": True,
+            "capabilities": PSU_CAPABILITIES[0]
         },
         "cpu_pack": {
             "number": 0
@@ -117,7 +123,8 @@ SWITCH_MODELS = {
         },
         "psus": {
             "number": 2,
-            "hot_swappable": True
+            "hot_swappable": True,
+            "capabilities": PSU_CAPABILITIES[0]
         },
         "cpu_pack": {
             "number": 1
@@ -256,7 +263,8 @@ SWITCH_MODELS = {
         },
         "psus": {
             "number": 2,
-            "hot_swappable": True
+            "hot_swappable": True,
+            "capabilities": PSU_CAPABILITIES[1]
         },
         "cpu_pack": {
             "number": 1
@@ -314,7 +322,8 @@ SWITCH_MODELS = {
         },
         "psus": {
             "number": 2,
-            "hot_swappable": True
+            "hot_swappable": True,
+            "capabilities": PSU_CAPABILITIES[1]
         },
         "cpu_pack": {
             "number": 1
@@ -368,7 +377,8 @@ SWITCH_MODELS = {
         },
         "psus": {
             "number": 2,
-            "hot_swappable": True
+            "hot_swappable": True,
+            "capabilities": PSU_CAPABILITIES[1]
         },
         "cpu_pack": {
             "number": 1
@@ -422,7 +432,8 @@ SWITCH_MODELS = {
         },
         "psus": {
             "number": 2,
-            "hot_swappable": True
+            "hot_swappable": True,
+            "capabilities": PSU_CAPABILITIES[1]
         },
         "cpu_pack": {
             "number": 1
@@ -476,7 +487,8 @@ SWITCH_MODELS = {
         },
         "psus": {
             "number": 2,
-            "hot_swappable": True
+            "hot_swappable": True,
+            "capabilities": PSU_CAPABILITIES[1]
         },
         "cpu_pack": {
             "number": 1
@@ -530,7 +542,8 @@ SWITCH_MODELS = {
         },
         "psus": {
             "number": 2,
-            "hot_swappable": True
+            "hot_swappable": True,
+            "capabilities": PSU_CAPABILITIES[1]
         },
         "cpu_pack": {
             "number": 1
@@ -584,7 +597,8 @@ SWITCH_MODELS = {
         },
         "psus": {
             "number": 2,
-            "hot_swappable": True
+            "hot_swappable": True,
+            "capabilities": PSU_CAPABILITIES[1]
         },
         "cpu_pack": {
             "number": 1
@@ -638,7 +652,8 @@ SWITCH_MODELS = {
         },
         "psus": {
             "number": 2,
-            "hot_swappable": True
+            "hot_swappable": True,
+            "capabilities": PSU_CAPABILITIES[1]
         },
         "cpu_pack": {
             "number": 1

--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -129,6 +129,17 @@ def check_sysfs(dut):
                 assert "Invalid PSU fan speed value {} for PSU {}, exception: {}".format(psu_info["fan_speed"],
                                                                                          psu_id, e)
 
+            # Check consistency between voltage capability and sysfs
+            all_capabilities = platform_data["psus"].get("capabilities")
+            if all_capabilities:
+                for capabilities in all_capabilities:
+                    psu_cmd_prefix = 'cat /var/run/hw-management/power/{}_'.format(capabilities.format(psu_id))
+                    psu_capability = dut.command(psu_cmd_prefix + 'capability')['stdout'].split()
+                    for capability in psu_capability:
+                        # Each capability should exist
+                        output = dut.command(psu_cmd_prefix + capability)['stdout']
+                        assert output, "PSU capability {} doesn't not exist".format(capability)
+
     logging.info("Check SFP related sysfs")
     for sfp_id, sfp_info in sysfs_facts['sfp_info'].items():
         assert sfp_info["temp_fault"] == '0', "SFP%d temp fault" % sfp_id


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

Signed-off-by: Stephen Sun <stephens@nvidia.com>

### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Check the PSU sensors' capability against sysfs.
There is a capability list for each PSU sensor. If a capability is in the list, there should be a sysfs file for that capability.
This is to verify this.

#### How did you do it?

#### How did you verify/test it?
Run the test on Mellanox platforms.

#### Any platform specific information?
Mellanox specific test.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
