### PR TITLE
Add test to do config reload and check for messages

### DIFF
--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -8,7 +8,7 @@ pytestmark = [
     pytest.mark.topology('any'),
 ]
 
-LOG_EXPECT_PO_CLEANUP_RE = "INFO kernel:.*{}:.*removed"
+LOG_EXPECT_PO_CLEANUP_RE = "cleanTeamProcesses: Sent SIGTERM to port channel.*{}.*"
 
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
@@ -41,7 +41,7 @@ def check_kernel_po_interface_cleaned(duthost, asic_index):
 
 @pytest.fixture(scope="module", autouse=True)
 def check_topo_and_restore(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
-    
+
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
@@ -60,6 +60,8 @@ def test_po_cleanup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_as
     if not wait_until(10, 1, 0, check_kernel_po_interface_cleaned, duthost, enum_asic_index):
         fail_msg = "PortChannel interface still exists in kernel"
         pytest.fail(fail_msg)
+    # Restore swss service.
+    duthost.asic_instance(enum_asic_index).start_service("swss")
 
 def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
     """


### PR DESCRIPTION
Summary:
Fixes https://github.com/Azure/sonic-mgmt/issues/4245

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Add a new test test_po_cleanup_after_reload, which checks if portchannels are removed during config reload.

Add a way to stress the device by making CPU busy when config reload is done.

#### How did you verify/test it?
```
jujoseph@1a78aa977682:/data/sonic-mgmt/tests$ ./run_tests.sh -n vms-kvm-t1-lag -d vlab-03 -c pc/test_po_cleanup.py::test_po_cleanup_after_reload -f vtestbed.csv -i veos_vtb -u -e "--skip_sanity"
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
=============================================================================================== test session starts ================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
plugins: metadata-1.11.0, repeat-0.9.1, forked-1.3.0, html-1.22.1, xdist-1.28.0, ansible-2.2.2
collecting ... ['conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut', 'inv_name', 'auto_recover', 'comment']
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 1 item                                                                                                                                                                                                   

pc/test_po_cleanup.py::test_po_cleanup_after_reload[vlab-03] PASSED                                                                                                                                          [100%]

------------------------------------------------------------------------------ generated xml file: /data/sonic-mgmt/tests/logs/tr.xml ------------------------------------------------------------------------------
============================================================================================ 1 passed in 314.83 seconds ============================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
