### PR TITLE
Adding instruction of portname to alias mapping

### DIFF
--- a/docs/testbed/README.testbed.Minigraph.md
+++ b/docs/testbed/README.testbed.Minigraph.md
@@ -16,7 +16,7 @@ is the testbed name defined in `testbed.csv`, `lab` is the inventory file.
 **Note**
 
 - To configure your SONiC switch with different port speeds, you need to specify port speed in `port_config.ini`. Example [port_config.ini](https://github.com/Azure/sonic-buildimage/blob/master/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/port_config.ini).
-
+- You have to make sure that the hwsku in 'lab' can be found in [port_utils.py](https://github.com/Azure/sonic-mgmt/blob/master/ansible/module_utils/port_utils.py#L15). If you cannot find the hwsku of your SONiC device in the port-utils file, you should add your SONiC switch 'portname-to-alias' mapping information in [port_utils.py](https://github.com/Azure/sonic-mgmt/blob/master/ansible/module_utils/port_utils.py#L15).
 ## How it works
 
 The tool works as follows:

--- a/docs/testbed/README.testbed.Minigraph.md
+++ b/docs/testbed/README.testbed.Minigraph.md
@@ -35,4 +35,4 @@ The tool works as follows:
 
 - Save the configuration in config db.
 
-For more details, please refer the comments in [`config_sonic_basedon_testbed.yml`](/ansible/config_sonic_basedon_testbed.yml).
+For more details, please refer the comments in [`config_sonic_basedon_testbed.yml`](/ansible/config_sonic_basedon_testbed.yml). 

--- a/docs/testbed/README.testbed.Minigraph.md
+++ b/docs/testbed/README.testbed.Minigraph.md
@@ -33,6 +33,6 @@ The tool works as follows:
 
 - Load the minigraph on DUT.
 
-- Save the configuration in config db.
+- Save the configuration in config db. 
 
 For more details, please refer the comments in [`config_sonic_basedon_testbed.yml`](/ansible/config_sonic_basedon_testbed.yml).

--- a/docs/testbed/README.testbed.Minigraph.md
+++ b/docs/testbed/README.testbed.Minigraph.md
@@ -33,6 +33,6 @@ The tool works as follows:
 
 - Load the minigraph on DUT.
 
-- Save the configuration in config db. 
+- Save the configuration in config db.
 
 For more details, please refer the comments in [`config_sonic_basedon_testbed.yml`](/ansible/config_sonic_basedon_testbed.yml).

--- a/docs/testbed/README.testbed.Minigraph.md
+++ b/docs/testbed/README.testbed.Minigraph.md
@@ -35,4 +35,4 @@ The tool works as follows:
 
 - Save the configuration in config db.
 
-For more details, please refer the comments in [`config_sonic_basedon_testbed.yml`](/ansible/config_sonic_basedon_testbed.yml). 
+For more details, please refer the comments in [`config_sonic_basedon_testbed.yml`](/ansible/config_sonic_basedon_testbed.yml).


### PR DESCRIPTION
Some developers' SONiC platforms are still not merged into the community. This instruction gives them a help.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adding port alias to name mapping instruction.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Update the minigraph part instruction
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
