### PR TITLE
[platform_tests/api]: Adding Cisco-8000 platform watchdog thresholds

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -83,3 +83,10 @@ armhf-nokia_ixs7215_52x-r0:
     valid_timeout: 30
     greater_timeout: 170
     too_big_timeout: 200
+
+# Cisco-8000 watchdog
+x86_64-8102_64h_o-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554


### PR DESCRIPTION
### Description of PR
Fixes watchdog failed test case on the x86_64-8102_64h_o-r0 platform

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fixes watchdog failed test case on the x86_64-8102_64h_o-r0 platform

#### How did you do it?
Add the definition of too_big_timeout value in watchdog.yml which will be used to compare to the x86_64-8102_64h_o-r0 watchdog max time setting.

#### How did you verify/test it?
Run the pytest platform watchdog test case.

#### Any platform specific information?
Cisco x86_64-8102_64h_o-r0 platform

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
