### PR TITLE
[platform_test/api][Fan/PSU led]: Skip cisco-8000 unsupported test cases

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -15,6 +15,24 @@ platform_tests/fwutil/test_fwutil.py::test_fwutil_auto:
   skip:
     reason: "Command not yet merged into sonic-utilites"
 
+platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_led:
+   skip:
+     reason: "On Cisco 8000 platform, fans do not have their own leds."
+     conditions:
+       - "asic_type=='cisco-8000'"
+
+ platform_tests/api/test_psu.py::TestPsuApi::test_led:
+   skip:
+     reason: "On Cisco 8000 platform, PSU led are unable to be controlled by software"
+     conditions:
+       - "asic_type=='cisco-8000'"
+
+ platform_tests/api/test_psu_fans.py::TestPsuFans::test_set_fans_led:
+   skip:
+     reason: "On Cisco 8000 platform, PSU led are unable to be controlled by software"
+     conditions:
+       - "asic_type=='cisco-8000'"
+
 qos/test_pfc_pause.py::test_pfc_pause_lossless:
   # For this test, we use the fanout connected to the DUT to send PFC pause frames.
   # The fanout needs to send PFC frames fast enough so that the queue remains completely paused for the entire duration


### PR DESCRIPTION
### Description of PR
On cisco-8000 platforms, PSU LEDs are not software controllable and individual FAN modules do not have separate LEDs.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To skip the test cases that are validating set/get functions for PSU and FAN LED functions.

#### How did you do it?
Marking these test cases to skip for Cisco 8000 platform

#### How did you verify/test it?
Verified on cisco-8000 platform.

#### Any platform specific information?


#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
