### PR TITLE
Fix issue: should check remote file existence in ThermalPolicyFileContext

### DIFF
--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -263,7 +263,7 @@ def restart_thermal_control_daemon(dut):
     assert output["rc"] == 0, "Run command '%s' failed" % find_thermalctld_pid_cmd
     # Usually there should be 2 thermalctld processes, but there is chance that
     # sonic platform API might use subprocess which creates extra thermalctld process.
-    # For example, chassis.get_all_sfps will call sfp constructor, and sfp constructor may 
+    # For example, chassis.get_all_sfps will call sfp constructor, and sfp constructor may
     # use subprocess to call ethtool to do initialization.
     # So we check here thermalcltd must have at least 2 processes.
     assert len(output["stdout_lines"]) >= 2, "There should be at least 2 thermalctld process"
@@ -303,7 +303,8 @@ class ThermalPolicyFileContext:
         thermal control daemon to make it effect.
         :return:
         """
-        if os.path.exists(self.thermal_policy_file_path):
+        out = self.dut.stat(path=self.thermal_policy_file_path)
+        if out['stat']['exists']:
             self.dut.command('mv -f {} {}'.format(self.thermal_policy_file_path, self.thermal_policy_file_backup_path))
         else:
             logging.warning("Thermal Policy file {} not found".format(self.thermal_policy_file_path))
@@ -318,8 +319,8 @@ class ThermalPolicyFileContext:
         :param exc_tb: Not used.
         :return:
         """
-
-        if os.path.exists(self.thermal_policy_file_backup_path):
+        out = self.dut.stat(path=self.thermal_policy_file_backup_path)
+        if out['stat']['exists']:
             self.dut.command('mv -f {} {}'.format(self.thermal_policy_file_backup_path, self.thermal_policy_file_path))
             restart_thermal_control_daemon(self.dut)
 
@@ -328,7 +329,7 @@ class ThermalPolicyFileContext:
 def disable_thermal_policy(duthosts, enum_rand_one_per_hwsku_hostname):
     """Fixture to help disable thermal policy during the test. After test, it will
        automatically re-enable thermal policy. The idea here is to make thermalctld
-       load a invalid policy file. To use this fixture, the test case will probably 
+       load a invalid policy file. To use this fixture, the test case will probably
        marked as @pytest.mark.disable_loganalyzer.
 
     Args:


### PR DESCRIPTION
Change-Id: Id66f592d8addefaa0b9e189608663794ca721210

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes issue in ThermalPolicyFileContext, it should always check the file existence in remote DUT, not local machine. Without the fix, the thermal policy file will not be recovered and it could cause following test case fail.
This issue is introduced by PR https://github.com/Azure/sonic-mgmt/pull/4262

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

Fixes issue in ThermalPolicyFileContext, it should always check the file existence in remote DUT, not local machine. Without the fix, the thermal policy file will not be recovered and it could cause following test case fail.

#### How did you do it?

Check remote file existence via dut.stat method

#### How did you verify/test it?

Manual run the test and check thermal_policy.json is recovered

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
