### PR TITLE
[topo]: Fix BGP IPv6 flapping for t0-56-po2vlan

### DIFF
--- a/ansible/vars/topo_t0-56-po2vlan.yml
+++ b/ansible/vars/topo_t0-56-po2vlan.yml
@@ -190,7 +190,7 @@ configuration:
         ipv6: fc00::76/126
     bp_interface:
       ipv4: 10.10.246.30/24
-      ipv6: fc0a::3d/64
+      ipv6: fc0a::3b/64
 
   ARISTA03T1:
     properties:
@@ -212,7 +212,7 @@ configuration:
         ipv6: fc00::7a/126
     bp_interface:
       ipv4: 10.10.246.31/24
-      ipv6: fc0a::3e/64
+      ipv6: fc0a::3c/64
 
   ARISTA04T1:
     properties:
@@ -234,7 +234,7 @@ configuration:
         ipv6: fc00::7e/126
     bp_interface:
       ipv4: 10.10.246.32/24
-      ipv6: fc0a::41/64
+      ipv6: fc0a::3d/64
 
   ARISTA05T1:
     properties:
@@ -256,7 +256,7 @@ configuration:
         ipv6: fc00::82/126
     bp_interface:
       ipv4: 10.10.246.33/24
-      ipv6: fc0a::3a/64
+      ipv6: fc0a::3e/64
 
   ARISTA06T1:
     properties:
@@ -278,7 +278,7 @@ configuration:
         ipv6: fc00::86/126
     bp_interface:
       ipv4: 10.10.246.34/24
-      ipv6: fc0a::3d/64
+      ipv6: fc0a::3f/64
 
   ARISTA07T1:
     properties:
@@ -300,7 +300,7 @@ configuration:
         ipv6: fc00::8a/126
     bp_interface:
       ipv4: 10.10.246.35/24
-      ipv6: fc0a::3e/64
+      ipv6: fc0a::40/64
 
   ARISTA08T1:
     properties:
@@ -314,7 +314,7 @@ configuration:
     interfaces:
       Loopback0:
         ipv4: 100.1.0.36/32
-        ipv6: 2064:100::20/128
+        ipv6: 2064:100::24/128
       Ethernet1:
         lacp: 1
       Port-Channel1:


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

**Summary:**
Fixes https://github.com/Azure/sonic-utilities/issues/1865

This is a backport of: https://github.com/Azure/sonic-mgmt/pull/3793

**Before:**
```
root@sonic:/home/admin# show ipv6 bgp summary

IPv6 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 77853
RIB entries 12815, using 2357960 bytes of memory
Peers 8, using 167360 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
fc00::7a       4  64600      17665      35906         0      0       0  00:23:44             1473  ARISTA03T1
fc00::7e       4  64600      10071      35906         0      0       0  00:23:44                1  ARISTA04T1
fc00::8a       4  64600      17076      35906         0      0       0  00:23:44             6400  ARISTA07T1
fc00::8e       4  64600      13653      36741         0      0       0  00:23:46             6400  ARISTA08T1
fc00::72       4  64600      16873      35906         0      0       0  00:23:44             6398  ARISTA01T1
fc00::76       4  64600      16891      36739         0      0       0  00:23:45                1  ARISTA02T1
fc00::82       4  64600      13671      35906         0      0       0  00:23:43                1  ARISTA05T1
fc00::86       4  64600      19953      35906         0      0       0  00:23:43             5767  ARISTA06T1

Total number of neighbors 8
```

**After:**
```
root@sonic:/home/admin# show ipv6 bgp summary

IPv6 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 11151
RIB entries 12817, using 2358328 bytes of memory
Peers 8, using 167360 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
fc00::7a       4  64600       3230       3237         0      0       0  00:25:21             6400  ARISTA03T1
fc00::7e       4  64600       3230       3238         0      0       0  00:25:24             6400  ARISTA04T1
fc00::8a       4  64600       3230       3238         0      0       0  00:25:24             6400  ARISTA07T1
fc00::8e       4  64600       3230       3240         0      0       0  00:25:24             6400  ARISTA08T1
fc00::72       4  64600       3230       3240         0      0       0  00:25:24             6400  ARISTA01T1
fc00::76       4  64600       3232       3240         0      0       0  00:25:24             6400  ARISTA02T1
fc00::82       4  64600       3230       3237         0      0       0  00:25:23             6400  ARISTA05T1
fc00::86       4  64600       3230       3240         0      0       0  00:25:24             6400  ARISTA06T1

Total number of neighbors 8
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
* To fix BGP IPv6 flapping for `t0-56-po2vlan`

#### How did you do it?
* Fixed `topo_t0-56-po2vlan.yml`

#### How did you verify/test it?
* Ran `tests/fdb/test_fdb.py`

#### Any platform specific information?
* N/A

#### Supported testbed topology if it's a new test case?
* N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
* N/A