### PR TITLE
Ignore error log in sfputil test on Mellanox platform

### DIFF
--- a/tests/platform_tests/sfp/conftest.py
+++ b/tests/platform_tests/sfp/conftest.py
@@ -19,6 +19,8 @@ def disable_analyzer_for_mellanox(duthost):
         loganalyzer.load_common_config()
 
         loganalyzer.ignore_regex.append("kernel.*Eeprom query failed*")
+        # Ignore PMPE error https://github.com/Azure/sonic-buildimage/issues/7163
+        loganalyzer.ignore_regex.append(r".*ERR pmon#xcvrd: Receive PMPE error event on module.*")
         marker = loganalyzer.init()
     yield
 


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Issue reported in https://github.com/Azure/sonic-buildimage/issues/7163 caused LogAnalyzer report error. 
This PR is to ignore below error pattern since the error log has been confirmed as a known issue and don't have functional
 impaction.
```
Mar 26 07:41:33.053097 str2-msn4600c-acs-01 ERR pmon#xcvrd: Receive PMPE error event on module 36: status 3 error type 0
Mar 26 07:41:39.041888 str2-msn4600c-acs-01 ERR pmon#xcvrd: Receive PMPE error event on module 0: status 3 error type 0
Mar 26 07:41:45.097912 str2-msn4600c-acs-01 ERR pmon#xcvrd: Receive PMPE error event on module 54: status 3 error type 0
Mar 26 07:41:51.140115 str2-msn4600c-acs-01 ERR pmon#xcvrd: Receive PMPE error event on module 1: status 3 error type 0
Mar 26 07:41:57.130840 str2-msn4600c-acs-01 ERR pmon#xcvrd: Receive PMPE error event on module 46: status 3 error type 0
Mar 26 07:42:03.146810 str2-msn4600c-acs-01 ERR pmon#xcvrd: Receive PMPE error event on module 31: status 3 error type 0
Mar 26 07:42:09.237614 str2-msn4600c-acs-01 ERR pmon#xcvrd: Receive PMPE error event on module 45: status 3 error type 0
Mar 26 07:42:15.225932 str2-msn4600c-acs-01 ERR pmon#xcvrd: Receive PMPE error event on module 30: status 3 error type 0
Mar 26 07:42:21.227517 str2-msn4600c-acs-01 ERR pmon#xcvrd: Receive PMPE error event on module 59: status 3 error type 0
Mar 26 07:42:27.272594 str2-msn4600c-acs-01 ERR pmon#xcvrd: Receive PMPE error event on module 25: status 3 error type 0
Mar 26 07:42:33.429464 str2-msn4600c-acs-01 ERR pmon#xcvrd: Receive PMPE error event on module 21: status 3 error type 0
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to ignore some ERROR logs in sfputil test on Mellanox platform.

#### How did you do it?
Extend the ignore_regex of LogAnalyzer.

#### How did you verify/test it?
Verified on SN4600. Test can pass after the change.

#### Any platform specific information?
Only for Mellanox platform.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
