### PR TITLE
[copp] Update the way copp config is applied in test_copp

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -19,6 +19,8 @@ _TEMP_COPP_CONFIG = "/tmp/copp_config.json"
 _TEMP_COPP_TEMPLATE = "/tmp/copp.json.j2"
 _COPP_TEMPLATE_PATH = "/usr/share/sonic/templates/copp.json.j2"
 _SWSS_COPP_TEMPLATE = ":" + _COPP_TEMPLATE_PATH
+_DEFAULT_COPP_TEMPLATE = "/usr/share/sonic/templates/copp_cfg.j2"
+_BASE_COPP_TEMPLATE = "/tmp/copp_cfg_base.j2"
 
 _PTF_NN_TEMPLATE = "templates/ptf_nn_agent.conf.ptf.j2"
 _PTF_NN_DEST = "/etc/supervisor/conf.d/ptf_nn_agent.conf"
@@ -47,6 +49,7 @@ def limit_policer(dut, pps_limit, nn_target_namespace):
         dut.command("docker cp {} {}".format(swss_docker_name + _APP_DB_COPP_CONFIG, _BASE_COPP_CONFIG))
         config_format = "app_db"
     else:
+        dut.command("cp {} {}".format(_DEFAULT_COPP_TEMPLATE, _BASE_COPP_TEMPLATE))
         dut.command("cp {} {}".format(_CONFIG_DB_COPP_CONFIG, _BASE_COPP_CONFIG))
         config_format = "config_db"
 
@@ -67,7 +70,7 @@ def limit_policer(dut, pps_limit, nn_target_namespace):
         dut.command("docker cp {} {}".format(swss_docker_name + _SWSS_COPP_TEMPLATE, _TEMP_COPP_TEMPLATE))
         dut.command("docker cp {} {}".format(_TEMP_COPP_CONFIG, swss_docker_name + _SWSS_COPP_TEMPLATE))
     else:
-        dut.command("cp {} {}".format(_TEMP_COPP_CONFIG, _CONFIG_DB_COPP_CONFIG))
+        dut.command("cp {} {}".format(_TEMP_COPP_CONFIG, _DEFAULT_COPP_TEMPLATE))
 
 def restore_policer(dut, nn_target_namespace):
     """
@@ -87,7 +90,7 @@ def restore_policer(dut, nn_target_namespace):
         dut.command("docker cp {} {}".format(_BASE_COPP_CONFIG, swss_docker_name + _APP_DB_COPP_CONFIG))
         dut.command("docker cp {} {}".format(_TEMP_COPP_TEMPLATE, swss_docker_name + _SWSS_COPP_TEMPLATE))
     else:
-        dut.command("cp {} {}".format(_BASE_COPP_CONFIG, _CONFIG_DB_COPP_CONFIG))
+        dut.command("cp {} {}".format(_BASE_COPP_TEMPLATE, _DEFAULT_COPP_TEMPLATE))
 
 def configure_ptf(ptf, nn_target_port):
     """


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: test_copp.py started to fail after `SONiC.master.43510-dirty-20211014.091725` because new COPP config wasn't applied on DUT, this happened due to recent PR - [8969](https://github.com/Azure/sonic-buildimage/pull/8969) that binded copp-config.service to sonic.target. 
In order to apply new COPP config `copp_cfg.j2` file should be edited. This PR will updated the way COPP config is applied in test_copp.py. 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Update the way COPP config is applied in TC due to recent changes in - [8969](https://github.com/Azure/sonic-buildimage/pull/8969)
#### How did you do it?

#### How did you verify/test it?
Run test_copp.py on `SONiC.master.43510-dirty-20211014.091725`
```
copp/test_copp.py::TestCOPP::test_policer[ARP] PASSED                                                                                                             
copp/test_copp.py::TestCOPP::test_policer[IP2ME] PASSED                                                                                                           
copp/test_copp.py::TestCOPP::test_policer[SNMP] PASSED                                                                                                            
copp/test_copp.py::TestCOPP::test_policer[SSH] PASSED                                                                                                             
copp/test_copp.py::TestCOPP::test_no_policer[BGP] PASSED                                                                                                          
copp/test_copp.py::TestCOPP::test_no_policer[DHCP] PASSED                                                                                                         
copp/test_copp.py::TestCOPP::test_no_policer[LACP] PASSED                                                                                                         
copp/test_copp.py::TestCOPP::test_no_policer[LLDP] PASSED                                                                                                         
copp/test_copp.py::TestCOPP::test_no_policer[UDLD] PASSED
```

#### Any platform specific information?
```
SONiC Software Version: SONiC.master.43510-dirty-20211014.091725
Distribution: Debian 10.11
Kernel: 4.19.0-12-2-amd64
Build commit: b9366f3f8
Build date: Thu Oct 14 15:11:38 UTC 2021
Built by: AzDevOps@sonic-build-workers-000SG3
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
