### PR TITLE
[pytest][nhop resources] Filter out inband port when run on a chassis

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -17,6 +17,7 @@ from tests.common.devices.base import AnsibleHostBase
 from tests.common.helpers.dut_utils import is_supervisor_node
 from tests.common.cache import cached
 from tests.common.helpers.constants import DEFAULT_ASIC_ID, DEFAULT_NAMESPACE
+from tests.common.helpers.platform_api.chassis import is_inband_port
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common import constants
 
@@ -1657,23 +1658,26 @@ Totals               6450                 6449
         except socket.error:
             raise Exception("Invalid IPv4 address {}".format(ipv4))
 
+        netns_arg = ""
+        if ns_arg is not DEFAULT_NAMESPACE:
+            netns_arg = "sudo ip netns exec {} ".format(ns_arg)
+
         try:
             self.shell("{}ping -q -c{} {} > /dev/null".format(
-                ns_arg, count, ipv4
+                netns_arg, count, ipv4
             ))
         except RunAnsibleModuleFail:
             return False
         return True
 
-    def is_backend_portchannel(self, port_channel):
-        mg_facts = self.minigraph_facts(host = self.hostname)['ansible_facts']
+    def is_backend_portchannel(self, port_channel, mg_facts):
         ports = mg_facts["minigraph_portchannels"].get(port_channel)
         # minigraph facts does not have backend portchannel IFs
         if ports is None:
             return True
         return False if "Ethernet-BP" not in ports["members"][0] else True
 
-    def active_ip_interfaces(self, ip_ifs, ns_arg=""):
+    def active_ip_interfaces(self, ip_ifs, tbinfo, ns_arg=DEFAULT_NAMESPACE):
         """
         Return a dict of active IP (Ethernet or PortChannel) interfaces, with
         interface and peer IPv4 address.
@@ -1681,11 +1685,12 @@ Totals               6450                 6449
         Returns:
             Dict of Interfaces and their IPv4 address
         """
+        mg_facts = self.get_extended_minigraph_facts(tbinfo, ns_arg)
         ip_ifaces = {}
         for k,v in ip_ifs.items():
-            if (k.startswith("Ethernet") or
+            if ((k.startswith("Ethernet") and not is_inband_port(k)) or
                (k.startswith("PortChannel") and not
-                self.is_backend_portchannel(k))
+                self.is_backend_portchannel(k, mg_facts))
             ):
                 # Ping for some time to get ARP Re-learnt.
                 # We might have to tune it further if needed.

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -268,7 +268,7 @@ class SonicAsic(object):
                 return False
         return True
 
-    def get_active_ip_interfaces(self):
+    def get_active_ip_interfaces(self, tbinfo):
         """
         Return a dict of active IP (Ethernet or PortChannel) interfaces, with
         interface and peer IPv4 address.
@@ -277,7 +277,9 @@ class SonicAsic(object):
             Dict of Interfaces and their IPv4 address
         """
         ip_ifs = self.show_ip_interface()["ansible_facts"]["ip_interfaces"]
-        return self.sonichost.active_ip_interfaces(ip_ifs, self.ns_arg)
+        return self.sonichost.active_ip_interfaces(
+            ip_ifs, tbinfo, self.namespace
+        )
 
     def bgp_drop_rule(self, ip_version, state="present"):
         """

--- a/tests/common/helpers/platform_api/chassis.py
+++ b/tests/common/helpers/platform_api/chassis.py
@@ -3,9 +3,11 @@
 
 import json
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
+INBAND_PORT_REGEX = (r"(Ethernet-IB)(\d+)$")
 
 def chassis_api(conn, name, args=None):
     if args is None:
@@ -190,3 +192,9 @@ def get_my_slot(conn):
 
 def is_modular_chassis(conn):
     return chassis_api(conn, 'is_modular_chassis')
+
+
+def is_inband_port(port):
+    if re.match(INBAND_PORT_REGEX, port):
+        return True
+    return False

--- a/tests/ipfwd/test_nhop_count.py
+++ b/tests/ipfwd/test_nhop_count.py
@@ -225,12 +225,39 @@ def combinations(iterable, r):
 
 def loganalyzer_ignore_regex_list():
     ignore = [
-        ".*Unaccounted_ROUTE_ENTRY_TABLE_entries.*"
+        ".*Unaccounted_ROUTE_ENTRY_TABLE_entries.*",
+        ".*ERR swss#orchagent: :- addAclTable: Failed to.*",
+        ".*ERR swss#orchagent: :- create: create status:.*",
+        ".*ERR syncd#syncd: [none] SAI_API_ACL:brcm_sai_dnx_create_acl_table:338 create table.*",
+        ".*ERR syncd#syncd: [none] SAI_API_ACL:_brcm_sai_dnx_create_acl_table:7807 field group.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_ACL_BIND_POINT_TYPE_LIST:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_ACL_STAGE:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_DSCP:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_DST_IP:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_ICMP_CODE:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_ICMP_TYPE:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_ICMPV6_CODE:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_ICMPV6_TYPE:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_IPV6_NEXT_HEADER:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_L4_SRC_PORT:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_SRC_IP:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_SRC_IPV6:.*",
+        ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_TCP_FLAGS:.*",
+        ".*ERR syncd#syncd: :- sendApiResponse: api SAI_COMMON_API_CREATE.*",
+        ".*brcm_sai_dnx_create_acl_table:.*",
     ]
     return ignore
 
 
-def test_nhop(request, duthost):
+def test_nhop(request, duthost, tbinfo):
     """
     Test next hop group resource count. Steps:
     - Add test IP address to an active IP interface
@@ -261,7 +288,7 @@ def test_nhop(request, duthost):
     nhop_group_count = min(max_nhop, nhop_group_limit) + extra_nhops
 
     # find out an active IP port
-    ip_ifaces = asic.get_active_ip_interfaces().keys()
+    ip_ifaces = asic.get_active_ip_interfaces(tbinfo).keys()
     pytest_assert(len(ip_ifaces), "No IP interfaces found")
     eth_if = ip_ifaces[0]
 

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -73,12 +73,12 @@ def fake_storm(request, duthosts, rand_one_dut_hostname):
     return request.config.getoption('--fake-storm') if not isMellanoxDevice(duthost) else False
 
 
-def update_t1_test_ports(duthost, mg_facts, test_ports, asic_index):
+def update_t1_test_ports(duthost, mg_facts, test_ports, asic_index, tbinfo):
     """
     Find out active IP interfaces and use the list to
     remove inactive ports from test_ports
     """
-    ip_ifaces = duthost.asic_instance(asic_index).get_active_ip_interfaces()
+    ip_ifaces = duthost.asic_instance(asic_index).get_active_ip_interfaces(tbinfo)
     port_list = []
     for iface in ip_ifaces.keys():
         if iface.startswith("PortChannel"):
@@ -135,7 +135,7 @@ def setup_pfc_test(
     topo = tbinfo["topo"]["name"]
     if topo in SUPPORTED_T1_TOPOS:
         test_ports = update_t1_test_ports(
-            duthost, mg_facts, test_ports, enum_frontend_asic_index
+            duthost, mg_facts, test_ports, enum_frontend_asic_index, tbinfo
         )
 
     # select a subset of ports from the generated port list

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -545,7 +545,7 @@ class QosSaiBase(QosBase):
             testPortIps = self.__assignTestPortIps(mgFacts)
 
         elif topo in self.SUPPORTED_T1_TOPOS:
-            for iface,addr in dut_asic.get_active_ip_interfaces().items():
+            for iface,addr in dut_asic.get_active_ip_interfaces(tbinfo).items():
                 vlan_id = None
                 if iface.startswith("Ethernet"):
                     if "." in iface:
@@ -1451,7 +1451,7 @@ class QosSaiBaseMasic(QosBase):
         pytest_require(duthost.is_multi_asic, "Not a multi asic platform")
 
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-        ip_ifaces = duthost.get_active_ip_interfaces(asic_index="all")
+        ip_ifaces = duthost.get_active_ip_interfaces(tbinfo, asic_index="all")
 
         port_ips = dict()
         for idx in range(len(ip_ifaces)):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

On chassis in band port and interface ports start with the same string. When getting active ports inband ports must be excluded.

Also optimized backend port check to call 'mgfacts' only once instead of for every port.

#### How did you do it?

Add a check for inband port

#### How did you verify/test it?

get_active_ports() on a chassis line card

```
[   {   u'Ethernet100': {   'bgp_neighbor': u'ARISTA26T3',                                                                                                                                                                                                                                                 'ipv4': u'10.0.0.50',
                            'peer_ipv4': u'10.0.0.51'},                                                                                                                                                                                                                                u'Ethernet104': {   'bgp_neighbor': u'ARISTA27T3',                                                                                                                                                                                                                                                 'ipv4': u'10.0.0.52',                                                                                                                                                                                                                                                          'peer_ipv4': u'10.0.0.53'},                                                                                                                                                                                                                                u'Ethernet108': {   'bgp_neighbor': u'ARISTA28T3',                                                                                                                                                                                                                                                 'ipv4': u'10.0.0.54',                                                                                                                                                                                                                                                          'peer_ipv4': u'10.0.0.55'},                                                                                                                                                                                                                                u'Ethernet112': {   'bgp_neighbor': u'ARISTA29T3',                                                                                                                                                                                                                                                 'ipv4': u'10.0.0.56',
                            'peer_ipv4': u'10.0.0.57'},
        u'Ethernet116': {   'bgp_neighbor': u'ARISTA30T3',
                            'ipv4': u'10.0.0.58',
                            'peer_ipv4': u'10.0.0.59'},
        u'Ethernet120': {   'bgp_neighbor': u'ARISTA31T3',
                            'ipv4': u'10.0.0.60',
                            'peer_ipv4': u'10.0.0.61'},
        u'Ethernet64': {   'bgp_neighbor': u'ARISTA17T3',
                           'ipv4': u'10.0.0.32',                                                                                                                                                                                                                                                          'peer_ipv4': u'10.0.0.33'},
        u'Ethernet72': {   'bgp_neighbor': u'ARISTA19T3',                                                                                                                                                                                                                                                 'ipv4': u'10.0.0.36',                                                                                                                                                                                                                                                          'peer_ipv4': u'10.0.0.37'},
        u'Ethernet76': {   'bgp_neighbor': u'ARISTA20T3',
                           'ipv4': u'10.0.0.38',
                           'peer_ipv4': u'10.0.0.39'},
        u'Ethernet80': {   'bgp_neighbor': u'ARISTA21T3',
                           'ipv4': u'10.0.0.40',
                           'peer_ipv4': u'10.0.0.41'},
        u'Ethernet84': {   'bgp_neighbor': u'ARISTA22T3',
                           'ipv4': u'10.0.0.42',
                           'peer_ipv4': u'10.0.0.43'},                                                                                                                                                                                                                                 u'Ethernet88': {   'bgp_neighbor': u'ARISTA23T3',
                           'ipv4': u'10.0.0.44',                                                                                                                                                                                                                                                          'peer_ipv4': u'10.0.0.45'},                                                                                                                                                                                                                                 u'Ethernet92': {   'bgp_neighbor': u'ARISTA24T3',                                                                                                                                                                                                                                                 'ipv4': u'10.0.0.46',                                                                                                                                                                                                                                                          'peer_ipv4': u'10.0.0.47'},                                                                                                                                                                                                                                 u'Ethernet96': {   'bgp_neighbor': u'ARISTA25T3',
                           'ipv4': u'10.0.0.48',
                           'peer_ipv4': u'10.0.0.49'},
        u'PortChannel0002': {   'bgp_neighbor': u'ARISTA01T3',
                                'ipv4': u'10.0.0.0',
                                'peer_ipv4': u'10.0.0.1'},
        u'PortChannel0004': {   'bgp_neighbor': u'ARISTA05T3',
                                'ipv4': u'10.0.0.8',
                                'peer_ipv4': u'10.0.0.9'},
        u'PortChannel0006': {   'bgp_neighbor': u'ARISTA07T3',                                                                                                                                                                                                                                                 'ipv4': u'10.0.0.12',
                                'peer_ipv4': u'10.0.0.13'},                                                                                                                                                                                                                            u'PortChannel0008': {   'bgp_neighbor': u'ARISTA09T3',                                                                                                                                                                                                                                                 'ipv4': u'10.0.0.16',
                                'peer_ipv4': u'10.0.0.17'},
        u'PortChannel0010': {   'bgp_neighbor': u'ARISTA11T3',
                                'ipv4': u'10.0.0.20',
                                'peer_ipv4': u'10.0.0.21'},
        u'PortChannel0012': {   'bgp_neighbor': u'ARISTA13T3',
                                'ipv4': u'10.0.0.24',                                                                                                                                                                                                                                                          'peer_ipv4': u'10.0.0.25'},
        u'PortChannel0014': {   'bgp_neighbor': u'ARISTA15T3',
                                'ipv4': u'10.0.0.28',
                                'peer_ipv4': u'10.0.0.29'}}]

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
