### PR TITLE
Increase test server reboot timeout from 600s to 900s

### DIFF
--- a/ansible/update_reboot.yml
+++ b/ansible/update_reboot.yml
@@ -8,7 +8,6 @@
   become: true
 
 - name: reboot vm_host
-  reboot: reboot_timeout=600
+  reboot: reboot_timeout=900
   when: '"0 upgraded" not in apt_update_res.stdout'
   become: true
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Some test server may need more than 600 seconds to reboot.

#### How did you do it?
 This change increased the test server reboot timeout from 600 seconds to 900 seconds.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
