### PR TITLE
Add Arista-7280CR3-C40

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -76,6 +76,12 @@ def get_port_alias_to_name_map(hwsku, asic_id=None):
             port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 5) * 4)
         for i in range(29, 37):
             port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % ((i - 5) * 4)
+    elif hwsku == "Arista-7280CR3-C40":
+        for i in range(1, 33):
+            port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
+        for i in range(33, 41, 2):
+            port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
+            port_alias_to_name_map["Ethernet%d/5" % i] = "Ethernet%d" % (i * 4)
     elif hwsku == "Arista-7260CX3-C64" or hwsku == "Arista-7170-64C":
         for i in range(1, 65):
             port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)


### PR DESCRIPTION
#### What is the motivation for this PR?
Add Arista-7280CR3-C40 ( JR2 based ) support in hwsku 

```
# name         lanes                     alias        index  speed
Ethernet0      0,1                       Ethernet1/1  1      100000
Ethernet4      2,3                       Ethernet2/1  2      100000
Ethernet8      4,5                       Ethernet3/1  3      100000
Ethernet12     6,7                       Ethernet4/1  4      100000
Ethernet16     8,9                       Ethernet5/1  5      100000
Ethernet20     10,11                     Ethernet6/1  6      100000
Ethernet24     12,13                     Ethernet7/1  7      100000
Ethernet28     14,15                     Ethernet8/1  8      100000
Ethernet32     16,17                     Ethernet9/1  9      100000
Ethernet36     18,19                     Ethernet10/1 10     100000
Ethernet40     20,21                     Ethernet11/1 11     100000
Ethernet44     22,23                     Ethernet12/1 12     100000
Ethernet48     24,25                     Ethernet13/1 13     100000
Ethernet52     26,27                     Ethernet14/1 14     100000
Ethernet56     28,29                     Ethernet15/1 15     100000
Ethernet60     30,31                     Ethernet16/1 16     100000
Ethernet64     72,73                     Ethernet17/1 17     100000
Ethernet68     74,75                     Ethernet18/1 18     100000
Ethernet72     76,77                     Ethernet19/1 19     100000
Ethernet76     78,79                     Ethernet20/1 20     100000
Ethernet80     64,65                     Ethernet21/1 21     100000
Ethernet84     66,67                     Ethernet22/1 22     100000
Ethernet88     68,69                     Ethernet23/1 23     100000
Ethernet92     70,71                     Ethernet24/1 24     100000
Ethernet96     56,57                     Ethernet25/1 25     100000
Ethernet100    58,59                     Ethernet26/1 26     100000
Ethernet104    60,61                     Ethernet27/1 27     100000
Ethernet108    62,63                     Ethernet28/1 28     100000
Ethernet112    48,49                     Ethernet29/1 29     100000
Ethernet116    50,51                     Ethernet30/1 30     100000
Ethernet120    52,53                     Ethernet31/1 31     100000
Ethernet124    54,55                     Ethernet32/1 32     100000
Ethernet128    32,33,34,35               Ethernet33/1 33     100000
Ethernet132    36,37,38,39               Ethernet33/5 33     100000
Ethernet136    40,41,42,43               Ethernet34/1 34     100000
Ethernet140    44,45,46,47               Ethernet34/5 34     100000
Ethernet144    88,89,90,91               Ethernet35/1 35     100000
Ethernet148    92,93,94,95               Ethernet35/5 35     100000
Ethernet152    80,81,82,83               Ethernet36/1 36     100000
Ethernet156    84,85,86,87               Ethernet36/5 36     100000
```

#### How did you do it?

#### How did you verify/test it?
Verified with a testcase which was earlier failing 

```
ujoseph@787876f7ada3:/var/src/sonic-mgmt-int/tests$  ./run_tests.sh -d str-a7280cr3-2 -n vms3-t1-7280 -i ../ansible/str,../ansible/veos -f ../ansible/testbed.csv -c pc/test_po_update.py -u -e "--disable_loganalyzer --skip_sanity"  
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
========================================================================================================= test session starts ==========================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collecting ... ['conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut', 'inv_name', 'auto_recover', 'comment']
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 1 item                                                                                                                                                                                                                       

pc/test_po_update.py::test_po_update[str-a7280cr3-2-None] PASSED                                                                                                                                                                 [100%]

------------------------------------------------------------------------------------ generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------------------------
====================================================================================================== 1 passed in 134.83 seconds ======================================================================================================

```




#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
