### PR TITLE
[techsupport] Fixed expected cmd in test_techsupport_commands test case

### DIFF
--- a/tests/show_techsupport/tech_support_cmds.py
+++ b/tests/show_techsupport/tech_support_cmds.py
@@ -113,7 +113,7 @@ redis_db_cmds = [
 ]
 
 docker_cmds = [
-    "docker exec -it syncd{} saidump",
+    "docker exec syncd{} saidump",
     "docker stats --no-stream",
     "docker ps -a",
     "docker top pmon",


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Fixed expected cmd in test_techsupport_commands test case
Previously test case "test_techsupport_commands" expected in output: "docker exec -it syncd{} saidump"
Now it expects: "docker exec syncd{} saidump"

Summary: Fixed expected cmd in test_techsupport_commands test case
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fixed test case test_techsupport_commands failure: Failed: defaultdict(<type 'list'>, {'docker_cmds': ['docker exec -it syncd saidump']})

#### How did you do it?
Changed expected cmd to be without "-it" argument, similar to line(120) "docker exec lldp{} lldpcli show statistics"

#### How did you verify/test it?
Executed test test_techsupport_commands 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
