### PR TITLE
[link flap] Check portchannel interface status after link flap

### DIFF
--- a/tests/platform_tests/link_flap/link_flap_utils.py
+++ b/tests/platform_tests/link_flap/link_flap_utils.py
@@ -113,6 +113,25 @@ def build_test_candidates(dut, fanouthosts, port, completeness_level=None):
     return candidates
 
 
+def check_portchannel_status(dut, dut_port_channel, exp_state, verbose=False):
+    """
+    Check portchannel status on the DUT.
+
+    Args:
+        dut: DUT host object
+        dut_port_channel: Portchannel of DUT
+        exp_state: State of DUT's port ('up' or 'down')
+        verbose: Logging port state.
+
+    Returns:
+        Bool value which confirm port state
+    """
+    status = __get_dut_if_status(dut, dut_port_channel)[dut_port_channel]
+    if verbose:
+        logger.debug("Portchannel status : %s", status)
+    return status['oper_state'] == exp_state
+
+
 def toggle_one_link(dut, dut_port, fanout, fanout_port, watch=False):
     """
     Toggle one link on the fanout.


### PR DESCRIPTION
What is the motivation for this PR?
There is a flaky issue caused by the inconsistent bgp routes count after link flap.

How did you do it?
This PR is to guarantee all the portchannels are up before checking bgp routes count.

How did you verify/test it?
Run the cont link flap test case.

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
