### PR TITLE
[dhcp_relay] Add dhcpv6 relay tests to 2vlan topologies

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -150,7 +150,9 @@ test_t0() {
 
     # Run tests_2vlans on vlab-01 virtual switch
     tgname=2vlans
-    tests="dhcp_relay/test_dhcp_relay.py"
+    tests="\
+    dhcp_relay/test_dhcp_relay.py \
+    dhcp_relay/test_dhcpv6_relay.py"
 
     pushd $SONIC_MGMT_DIR/tests
     ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add dhcpv6 relay tests to 2vlan topologies
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Test dhcpv6 relay on 2 vlan topologies

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
