### PR TITLE
Assign mux simulator http port for the vms-kvm-dual-t0 testbed

### DIFF
--- a/ansible/group_vars/all/mux_simulator_http_port_map.yml
+++ b/ansible/group_vars/all/mux_simulator_http_port_map.yml
@@ -25,4 +25,7 @@ mux_simulator_http_port:
     dualtor-testbed-3: 8080
     dualtor-testbed-4: 8082
 
+    # For vs setup
+    vms-kvm-dual-t0: 8080
+
     #### Add your own port assignment after here ###


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
PR#4259 introduced a map file for testbed and mux simulator http port. The dualtor VS setup also needs to be assigned a mux simulator http port.

#### How did you do it?
This change added an assignment to the map file for the vms-kvm-dual-t0 testbed.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
