### PR TITLE
[cable-test]: Remove cable-test from vm_set

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -206,13 +206,6 @@
     - ptf_imagename is defined
     - ptf_imagename == "docker-ptf-anvl"
 
-- name: VMs not needed for cable test
-  set_fact:
-    vm_required: false
-    VM_hosts:
-  when:
-    - topo == "cable-test"
-
 - name: Retrieve a list of the defined VMs
   virt: command=list_vms
         uri=qemu:///system


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Here is the related issue: https://github.com/Azure/sonic-mgmt/issues/4502
The PR: https://github.com/Azure/sonic-mgmt/pull/3691 introduced an error:

```
TASK [vm_set : VMs not needed for cable test] *******************************************************************************************************************************************
Friday 15 October 2021  23:17:37 +0000 (0:00:00.058)       0:00:36.440 ********
fatal: [STR-ACS-VSERV-01]: FAILED! => {"msg": "The conditional check 'topo == \"cable-test\"' failed. The error was: error while evaluating conditional (topo == \"cable-test\"): 'topo' is undefined\n\nThe error appears to be in '/data/sonic-mgmt/ansible/roles/vm_set/tasks/main.yml': line 209, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: VMs not needed for cable test\n  ^ here\n"}
```
when start vms by
```
./testbed-cli.sh -m veos_vtb -n 4 -k veos start-vms server_1 password.txt
```

#### How did you do it?

Temporarily remove the cable-test in vm_set to skip this error.

#### How did you verify/test it?

Run `./testbed-cli.sh -m veos_vtb -n 4 -k veos start-vms server_1 password.txt`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
