### PR TITLE
Repace fixture toggle_all_simulator_ports_to_rand_selected_tor with toggle_all_simulator_ports_to_upper_tor

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -21,7 +21,7 @@ from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py, run_garp_service, change_mac_addresses
 from tests.common.utilities import wait_until
 from tests.conftest import duthost
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr
 
 logger = logging.getLogger(__name__)

--- a/tests/arp/test_tagged_arp.py
+++ b/tests/arp/test_tagged_arp.py
@@ -10,7 +10,7 @@ import ipaddress
 import pprint
 
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor  # lgtm[py/unused-import]
 from tests.common.fixtures.duthost_utils import ports_list, vlan_ports_list
 from tests.common.helpers.assertions import pytest_require
 
@@ -135,7 +135,7 @@ def verify_arp_packets(ptfadapter, vlan_ports_list, vlan_port, vlan_id, untagged
 
 
 @pytest.mark.bsl
-def test_tagged_arp_pkt(ptfadapter, vlan_ports_list, duthosts, rand_one_dut_hostname, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_tagged_arp_pkt(ptfadapter, vlan_ports_list, duthosts, rand_one_dut_hostname, toggle_all_simulator_ports_to_upper_tor):
     """
     Send tagged GARP packets from each port.
     Verify packets egress without tag from ports whose PVID same with ingress port.

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -12,7 +12,7 @@ from tests.common.helpers.bgp import BGPNeighbor
 
 
 from tests.common.dualtor.mux_simulator_control import mux_server_url
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
 
 
 pytestmark = [
@@ -137,7 +137,7 @@ def constants(is_quagga, setup_interfaces):
 
 
 def test_bgp_update_timer(common_setup_teardown, constants, duthosts, rand_one_dut_hostname,
-                          toggle_all_simulator_ports_to_rand_selected_tor):
+                          toggle_all_simulator_ports_to_upper_tor):
 
     def bgp_update_packets(pcap_file):
         """Get bgp update packets from pcap file."""

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -6,7 +6,7 @@ import logging
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
 from tests.ptf_runner import ptf_runner
 from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import check_link_status
@@ -145,7 +145,7 @@ def check_routes_to_dhcp_server(duthost, dut_dhcp_relay_data):
                 logger.info("Found route to DHCP server via default GW(MGMT interface)")
                 return False
     return True
-        
+
 
 @pytest.fixture(scope="module")
 def validate_dut_routes_exist(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data):
@@ -222,7 +222,7 @@ def testing_config(request, duthosts, rand_one_dut_hostname, tbinfo):
             restart_dhcp_service(duthost)
 
 
-def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config, toggle_all_simulator_ports_to_upper_tor):
     """Test DHCP relay functionality on T0 topology.
 
        For each DHCP relay agent running on the DuT, verify DHCP packets are relayed properly
@@ -275,7 +275,7 @@ def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_r
         # Bring all uplink interfaces back up
         for iface in dhcp_relay['uplink_interfaces']:
             duthost.shell('ifconfig {} up'.format(iface))
-            
+
         # Wait until uplinks are up and routes are recovered
         pytest_assert(wait_until(50, 5, 0, check_routes_to_dhcp_server, duthost, dut_dhcp_relay_data),
                       "Not all DHCP servers are routed")
@@ -361,7 +361,7 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")
 
 
-def test_dhcp_relay_unicast_mac(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_dhcp_relay_unicast_mac(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config, toggle_all_simulator_ports_to_upper_tor):
     """Test DHCP relay functionality on T0 topology with unicast mac
        Instead of using broadcast MAC, use unicast MAC of DUT and verify that DHCP relay functionality is entact.
     """
@@ -394,7 +394,7 @@ def test_dhcp_relay_unicast_mac(ptfhost, dut_dhcp_relay_data, validate_dut_route
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log")
 
 
-def test_dhcp_relay_random_sport(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_dhcp_relay_random_sport(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config, toggle_all_simulator_ports_to_upper_tor):
     """Test DHCP relay functionality on T0 topology with random source port (sport)
 
        If the client is SNAT'd, the source port could be changed to a non-standard port (i.e., not 68).

--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -24,7 +24,7 @@ import configurable_drop_counters as cdc
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import fanout_switch_port_lookup
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py       # lgtm[py/unused-import]
 from tests.common.utilities import is_ipv4_address
 from tests.common import constants
@@ -110,7 +110,7 @@ def verifyFdbArp(duthost, dst_ip, dst_mac, dst_intf):
     pytest_assert(fdb_count == 1, "FDB entry doesn't exist for {}, fdb_count is {}".format(dst_mac, fdb_count))
 
 @pytest.mark.parametrize("drop_reason", ["L3_EGRESS_LINK_DOWN"])
-def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_dut_hostname, toggle_all_simulator_ports_to_rand_selected_tor, mock_server,
+def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_dut_hostname, toggle_all_simulator_ports_to_upper_tor, mock_server,
                             send_dropped_traffic, drop_reason, generate_dropped_packet, tbinfo):
     """
     Verifies counters that check for a neighbor link being down.

--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -18,7 +18,7 @@ from tests.common.dualtor.dual_tor_mock import *
 from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
 from tests.common.dualtor.dual_tor_utils import rand_selected_interface
 from tests.common.dualtor.dual_tor_utils import get_ptf_server_intf_index
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
 from tests.common.utilities import is_ipv4_address
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder
@@ -108,7 +108,7 @@ def test_decap_active_tor(
     if is_t0_mocked_dualtor(tbinfo):
         request.getfixturevalue('apply_active_state_to_orchagent')
     else:
-        request.getfixturevalue('toggle_all_simulator_ports_to_rand_selected_tor')
+        request.getfixturevalue('toggle_all_simulator_ports_to_upper_tor')
 
     tor = rand_selected_dut
     encapsulated_packet = build_encapsulated_packet

--- a/tests/dualtor/test_tor_ecn.py
+++ b/tests/dualtor/test_tor_ecn.py
@@ -21,7 +21,7 @@ from scapy.all import Ether, IP
 from tests.common.dualtor.dual_tor_mock import *
 from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
 from tests.common.dualtor.dual_tor_utils import rand_selected_interface
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
 from tests.common.utilities import is_ipv4_address
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder
@@ -58,7 +58,7 @@ def setup_dualtor_tor_active(
     if is_t0_mocked_dualtor(tbinfo):
         request.getfixturevalue('apply_active_state_to_orchagent')
     else:
-        request.getfixturevalue('toggle_all_simulator_ports_to_rand_selected_tor')
+        request.getfixturevalue('toggle_all_simulator_ports_to_upper_tor')
 
 @pytest.fixture(scope="function")
 def setup_dualtor_tor_standby(
@@ -67,13 +67,13 @@ def setup_dualtor_tor_standby(
     if is_t0_mocked_dualtor(tbinfo):
         request.getfixturevalue('apply_standby_state_to_orchagent')
     else:
-        request.getfixturevalue('toggle_all_simulator_ports_to_rand_selected_tor')
+        request.getfixturevalue('toggle_all_simulator_ports_to_upper_tor')
 
 @pytest.fixture(scope="function")
 def build_encapsulated_ip_packet(
-    rand_selected_interface, 
-    ptfadapter, 
-    rand_selected_dut, 
+    rand_selected_interface,
+    ptfadapter,
+    rand_selected_dut,
     tunnel_traffic_monitor
 ):
     """
@@ -119,9 +119,9 @@ def build_encapsulated_ip_packet(
 
 @pytest.fixture(scope="function")
 def build_non_encapsulated_ip_packet(
-    rand_selected_interface, 
-    ptfadapter, 
-    rand_selected_dut, 
+    rand_selected_interface,
+    ptfadapter,
+    rand_selected_dut,
     tunnel_traffic_monitor
 ):
     """
@@ -158,8 +158,8 @@ def build_non_encapsulated_ip_packet(
     return packet
 
 def get_ptf_server_intf_index(
-    tor, 
-    tbinfo, 
+    tor,
+    tbinfo,
     iface
 ):
     """
@@ -188,8 +188,8 @@ def build_expected_packet_to_server(
     return exp_pkt
 
 def get_queue_id_of_received_packet(
-    duthosts, 
-    rand_one_dut_hostname, 
+    duthosts,
+    rand_one_dut_hostname,
     rand_selected_interface
 ):
     """
@@ -199,7 +199,7 @@ def get_queue_id_of_received_packet(
     queue_counter = duthost.shell('show queue counters {} | grep "UC"'.format(rand_selected_interface[0]))['stdout']
     logging.info('queue_counter:\n{}'.format(queue_counter))
 
-    """ 
+    """
     regex search will look for following pattern in queue_counter o/p for interface
     ----------------------------------------------------------------------------_---
     Port           TxQ    Counter/pkts     Counter/bytes     Drop/pkts    Drop/bytes
@@ -219,9 +219,9 @@ def get_queue_id_of_received_packet(
     return queue
 
 def verify_ecn_on_received_packet(
-    ptfadapter, 
-    exp_pkt, 
-    exp_ptf_port_index, 
+    ptfadapter,
+    exp_pkt,
+    exp_ptf_port_index,
     exp_ecn
 ):
     """
@@ -243,7 +243,7 @@ def test_dscp_to_queue_during_decap_on_active(
     ptfhost, setup_dualtor_tor_active,
     build_encapsulated_ip_packet, request,
     rand_selected_interface, ptfadapter,
-    tbinfo, rand_selected_dut, tunnel_traffic_monitor, 
+    tbinfo, rand_selected_dut, tunnel_traffic_monitor,
     duthosts, rand_one_dut_hostname
 ):
     """
@@ -299,10 +299,10 @@ def test_dscp_to_queue_during_encap_on_standby(
     setup_dualtor_tor_standby,
     build_non_encapsulated_ip_packet,
     rand_selected_interface, ptfadapter,
-    tbinfo, 
-    rand_selected_dut, 
-    tunnel_traffic_monitor, 
-    duthosts, 
+    tbinfo,
+    rand_selected_dut,
+    tunnel_traffic_monitor,
+    duthosts,
     rand_one_dut_hostname,
     write_standby
 ):

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -15,7 +15,7 @@ from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # lgtm
 from tests.common.fixtures.duthost_utils import disable_fdb_aging
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
-from tests.common.dualtor.mux_simulator_control import mux_server_url, toggle_all_simulator_ports_to_rand_selected_tor
+from tests.common.dualtor.mux_simulator_control import mux_server_url, toggle_all_simulator_ports_to_upper_tor
 
 pytestmark = [
     pytest.mark.topology('t0', 't0-56-po2vlan'),
@@ -250,7 +250,7 @@ def record_mux_status(request, rand_selected_dut, tbinfo):
 
 @pytest.mark.bsl
 @pytest.mark.parametrize("pkt_type", PKT_TYPES)
-def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, pkt_type, toggle_all_simulator_ports_to_rand_selected_tor, record_mux_status):
+def test_fdb(ansible_adhoc, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, pkt_type, toggle_all_simulator_ports_to_upper_tor, record_mux_status):
 
     # Perform FDB clean up before each test and at the end of the final test
     fdb_cleanup(duthosts, rand_one_dut_hostname)

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -12,7 +12,7 @@ from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # lg
 from tests.common.fixtures.ptfhost_utils import ptf_test_port_map
 from tests.ptf_runner import ptf_runner
 from tests.common.dualtor.mux_simulator_control import mux_server_url
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_random_side
 from tests.common.utilities import is_ipv4_address
 
@@ -255,7 +255,7 @@ def add_default_route_to_dut(duts_running_config_facts, duthosts, tbinfo):
 
 
 def test_hash(add_default_route_to_dut, duthosts, fib_info_files_per_function, setup_vlan, hash_keys, ptfhost, ipver,
-              toggle_all_simulator_ports_to_rand_selected_tor,
+              toggle_all_simulator_ports_to_upper_tor,
               tbinfo, mux_server_url, router_macs,
               ignore_ttl, single_fib_for_duts):
 

--- a/tests/pfc/test_unknown_mac.py
+++ b/tests/pfc/test_unknown_mac.py
@@ -16,7 +16,7 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
 from tests.common.utilities import get_intf_by_sub_intf
 
 logger = logging.getLogger(__name__)
@@ -147,7 +147,7 @@ def flushArpFdb(duthosts, rand_one_dut_hostname):
 
 @pytest.fixture(autouse=True)
 def populateArp(unknownMacSetup, flushArpFdb, ptfhost, duthosts, rand_one_dut_hostname,
-                toggle_all_simulator_ports_to_rand_selected_tor):
+                toggle_all_simulator_ports_to_upper_tor):
     """
     Fixture to populate ARP entry on the DUT for the traffic destination
 

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -11,7 +11,7 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses, copy_arp_r
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
 from tests.common.dualtor.mux_simulator_control import mux_server_url
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
 from tests.common.utilities import wait_until, get_intf_by_sub_intf
 from tests.common import config_reload
 import ptf.testutils as testutils
@@ -231,7 +231,7 @@ def get_nexthops(duthost, tbinfo, ipv6=False, count=1):
     return prefix_len, [nexthop_addrs[_] for _ in indices], [nexthop_devs[_] for _ in indices], [nexthop_interfaces[_] for _ in indices]
 
 
-def test_static_route(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_static_route(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggle_all_simulator_ports_to_upper_tor):
     duthost = rand_selected_dut
     skip_201911_and_older(duthost)
     prefix_len, nexthop_addrs, nexthop_devs, nexthop_interfaces = get_nexthops(duthost, tbinfo)
@@ -239,7 +239,7 @@ def test_static_route(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggle_all
                           nexthop_addrs, prefix_len, nexthop_devs, nexthop_interfaces)
 
 
-def test_static_route_ecmp(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_static_route_ecmp(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggle_all_simulator_ports_to_upper_tor):
     duthost = rand_selected_dut
     skip_201911_and_older(duthost)
     prefix_len, nexthop_addrs, nexthop_devs, nexthop_interfaces = get_nexthops(duthost, tbinfo, count=3)
@@ -247,7 +247,7 @@ def test_static_route_ecmp(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggl
                           nexthop_addrs, prefix_len, nexthop_devs, nexthop_interfaces, config_reload_test=True)
 
 
-def test_static_route_ipv6(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_static_route_ipv6(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggle_all_simulator_ports_to_upper_tor):
     duthost = rand_selected_dut
     skip_201911_and_older(duthost)
     prefix_len, nexthop_addrs, nexthop_devs, nexthop_interfaces = get_nexthops(duthost, tbinfo, ipv6=True)
@@ -255,7 +255,7 @@ def test_static_route_ipv6(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggl
                           nexthop_addrs, prefix_len, nexthop_devs, nexthop_interfaces, ipv6=True)
 
 
-def test_static_route_ecmp_ipv6(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_static_route_ecmp_ipv6(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggle_all_simulator_ports_to_upper_tor):
     duthost = rand_selected_dut
     skip_201911_and_older(duthost)
     prefix_len, nexthop_addrs, nexthop_devs, nexthop_interfaces = get_nexthops(duthost, tbinfo, ipv6=True, count=3)

--- a/tests/snmp/test_snmp_fdb.py
+++ b/tests/snmp/test_snmp_fdb.py
@@ -4,7 +4,7 @@ import logging
 import pprint
 
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor  # lgtm[py/unused-import]
 from tests.common.fixtures.duthost_utils import ports_list, vlan_ports_list
 from tests.common.utilities import wait_until
 from tests.common.helpers.snmp_helpers import get_snmp_facts
@@ -60,7 +60,7 @@ def build_icmp_packet(vlan_id, src_mac="00:22:00:00:00:02", dst_mac="ff:ff:ff:ff
 
 
 @pytest.mark.bsl
-def test_snmp_fdb_send_tagged(ptfadapter, vlan_ports_list, toggle_all_simulator_ports_to_rand_selected_tor, duthost, localhost, creds_all_duts):
+def test_snmp_fdb_send_tagged(ptfadapter, vlan_ports_list, toggle_all_simulator_ports_to_upper_tor, duthost, localhost, creds_all_duts):
     """
     Send tagged packets from each port.
     Verify SNMP FDB entry

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -10,7 +10,7 @@ import ipaddress
 
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor  # lgtm[py/unused-import]
 from tests.common.config_reload import config_reload
 from tests.common.fixtures.duthost_utils import ports_list, vlan_ports_list
 
@@ -331,7 +331,7 @@ def verify_unicast_packets(ptfadapter, send_pkt, exp_pkt, src_port, dst_ports):
 
 
 @pytest.mark.bsl
-def test_vlan_tc1_send_untagged(ptfadapter, work_vlan_ports_list, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_vlan_tc1_send_untagged(ptfadapter, work_vlan_ports_list, toggle_all_simulator_ports_to_upper_tor):
     """
     Test case #1
     Verify packets egress without tag from ports whose PVID same with ingress port
@@ -359,7 +359,7 @@ def test_vlan_tc1_send_untagged(ptfadapter, work_vlan_ports_list, toggle_all_sim
 
 
 @pytest.mark.bsl
-def test_vlan_tc2_send_tagged(ptfadapter, work_vlan_ports_list, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_vlan_tc2_send_tagged(ptfadapter, work_vlan_ports_list, toggle_all_simulator_ports_to_upper_tor):
     """
     Test case #2
     Send tagged packets from each port.
@@ -379,7 +379,7 @@ def test_vlan_tc2_send_tagged(ptfadapter, work_vlan_ports_list, toggle_all_simul
 
 
 @pytest.mark.bsl
-def test_vlan_tc3_send_invalid_vid(ptfadapter, work_vlan_ports_list, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_vlan_tc3_send_invalid_vid(ptfadapter, work_vlan_ports_list, toggle_all_simulator_ports_to_upper_tor):
     """
     Test case #3
     Send packets with invalid VLAN ID
@@ -404,7 +404,7 @@ def test_vlan_tc3_send_invalid_vid(ptfadapter, work_vlan_ports_list, toggle_all_
 
 
 @pytest.mark.bsl
-def test_vlan_tc4_tagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_dict, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_vlan_tc4_tagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_dict, toggle_all_simulator_ports_to_upper_tor):
     """
     Test case #4
     Send packets w/ src and dst specified over tagged ports in vlan
@@ -445,7 +445,7 @@ def test_vlan_tc4_tagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_di
 
 
 @pytest.mark.bsl
-def test_vlan_tc5_untagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_dict, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_vlan_tc5_untagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_dict, toggle_all_simulator_ports_to_upper_tor):
     """
     Test case #5
     Send packets w/ src and dst specified over untagged ports in vlan
@@ -487,7 +487,7 @@ def test_vlan_tc5_untagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_
 
 
 @pytest.mark.bsl
-def test_vlan_tc6_tagged_untagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_dict, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_vlan_tc6_tagged_untagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_dict, toggle_all_simulator_ports_to_upper_tor):
     """
     Test case #6
     Send packets w/ src and dst specified over tagged port and untagged port in vlan
@@ -539,7 +539,7 @@ def test_vlan_tc6_tagged_untagged_unicast(ptfadapter, work_vlan_ports_list, vlan
         logger.info("Tagged({}) packet successfully sent from port {} to port {}".format(test_vlan, dst_port, src_port))
 
 
-def test_vlan_tc7_tagged_qinq_switch_on_outer_tag(ptfadapter, work_vlan_ports_list, vlan_intfs_dict, duthost, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_vlan_tc7_tagged_qinq_switch_on_outer_tag(ptfadapter, work_vlan_ports_list, vlan_intfs_dict, duthost, toggle_all_simulator_ports_to_upper_tor):
     """
     Test case #7
     Send qinq packets w/ src and dst specified over tagged ports in vlan

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -14,7 +14,7 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # lgtm[py/unused-import]
 from tests.ptf_runner import ptf_runner
-from tests.common.dualtor.mux_simulator_control import mux_server_url, toggle_all_simulator_ports_to_rand_selected_tor
+from tests.common.dualtor.mux_simulator_control import mux_server_url, toggle_all_simulator_ports_to_upper_tor
 pytestmark = [
     pytest.mark.topology('t0')
 ]
@@ -49,7 +49,7 @@ def prepare_ptf(ptfhost, mg_facts, duthost):
     vlan_table = duthost.get_running_config_facts()['VLAN']
     vlan_name = list(vlan_table.keys())[0]
     vlan_mac = duthost.get_dut_iface_mac(vlan_name)
-    
+
     vxlan_decap = {
         "minigraph_port_indices": mg_facts["minigraph_ptf_indices"],
         "minigraph_portchannel_interfaces": mg_facts["minigraph_portchannel_interfaces"],
@@ -152,7 +152,7 @@ def vxlan_status(setup, request, duthosts, rand_one_dut_hostname):
         return False, request.param
 
 
-def test_vxlan_decap(setup, vxlan_status, duthosts, rand_one_dut_hostname, ptfhost, creds, toggle_all_simulator_ports_to_rand_selected_tor):
+def test_vxlan_decap(setup, vxlan_status, duthosts, rand_one_dut_hostname, ptfhost, creds, toggle_all_simulator_ports_to_upper_tor):
     duthost = duthosts[rand_one_dut_hostname]
 
     sonic_admin_alt_password = duthost.host.options['variable_manager']._hostvars[duthost.hostname].get("ansible_altpassword")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Because of mux simulator issues we are still debugging, toggle mux to lower tor may fail ocassionally.
Toggle mux to upper tor is much more stable. 


#### How did you do it?
This change replaced using of fixture toggle_all_simulator_ports_to_rand_selected_tor with toggle_all_simulator_ports_to_upper_tor for now until the mux simulator issue is fully resolved.

#### How did you verify/test it?
Tested run a few touched scripts:
snmp/test_snmp_fdb.py
bgp/test_bgp_update_timer.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
