### PR TITLE
Add more retry for toggling mux active side to random ToR

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -382,10 +382,10 @@ def toggle_all_simulator_ports_to_rand_selected_tor(duthosts, mux_server_url, tb
         return True
 
     # Allow retry for mux cable toggling
-    RETRY = 3
+    RETRY = 5
     while RETRY > 0:
         _post(mux_server_url, data)
-        time.sleep(5)
+        time.sleep(10)
         if _check_all_active(duthost):
             break
         RETRY -= 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Toggle mux active side to randomly selected dualtor side may fail because of some issue we are still debugging. 

#### How did you do it?
This change added retry times and increased wait time as a work around to increase toggle success rate.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
