### PR TITLE
[test gap] announce/withdraw ipv4/ipv6 routes repeatedly to identify resource leak

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -27,6 +27,10 @@ Options:
     - option-name: action
       description: announce or withdraw routes
       required: False
+      
+    - option-name: path
+      description: to figure out the path of topo_{}.yml 
+      required: False
 '''
 
 EXAMPLES = '''

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -80,8 +80,8 @@ def get_topo_type(topo_name):
     return topo_type
 
 
-def read_topo(topo_name):
-    topo_file_path = os.path.join(TOPO_FILE_FOLDER, TOPO_FILENAME_TEMPLATE.format(topo_name))
+def read_topo(topo_name, path):
+    topo_file_path = os.path.join(path, TOPO_FILE_FOLDER, TOPO_FILENAME_TEMPLATE.format(topo_name))
     try:
         with open(topo_file_path) as f:
             return yaml.safe_load(f)
@@ -436,13 +436,15 @@ def main():
         argument_spec=dict(
             topo_name=dict(required=True, type='str'),
             ptf_ip=dict(required=True, type='str'),
-            action=dict(required=False, type='str', default='announce')
+            action=dict(required=False, type='str', default='announce'),
+            path=dict(required=False, type='str', default='')
         ),
         supports_check_mode=False)
 
     topo_name = module.params['topo_name']
     ptf_ip = module.params['ptf_ip']
     action = module.params['action']
+    path = module.params['path']
 
     topo = read_topo(topo_name)
     if not topo:

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -446,7 +446,7 @@ def main():
     action = module.params['action']
     path = module.params['path']
 
-    topo = read_topo(topo_name)
+    topo = read_topo(topo_name, path)
     if not topo:
         module.fail_json(msg='Unable to load topology "{}"'.format(topo_name))
 

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -440,7 +440,7 @@ def main():
         argument_spec=dict(
             topo_name=dict(required=True, type='str'),
             ptf_ip=dict(required=True, type='str'),
-            action=dict(required=False, type='str', default='announce'),
+            action=dict(required=False, type='str', default='announce', choices=["announce", "withdraw"]),
             path=dict(required=False, type='str', default='')
         ),
         supports_check_mode=False)

--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -1,8 +1,3 @@
-import math
-import os
-import yaml
-import re
-import requests
 import time
 import logging
 import pytest

--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -40,7 +40,7 @@ def withdraw_and_announce_existing_routes(duthost, localhost, tbinfo):
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") == True)
-    time.sleep(CRM_POLLING_INTERVAL * 5)
+    time.sleep(CRM_POLLING_INTERVAL * 100)
     ipv4_route_used_before = get_crm_resources(duthost, "ipv4_route", "used")
     ipv6_route_used_before = get_crm_resources(duthost, "ipv6_route", "used")
     logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
@@ -52,6 +52,6 @@ def withdraw_and_announce_existing_routes(duthost, localhost, tbinfo):
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "outq") == True)
-    time.sleep(CRM_POLLING_INTERVAL * 5)
+    time.sleep(CRM_POLLING_INTERVAL * 100)
     logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
     logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))

--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -1,0 +1,62 @@
+import math
+import os
+import yaml
+import re
+import requests
+import time
+import logging
+import pytest
+
+from tests.common.utilities import wait_until
+from utils import get_crm_resources, check_queue_status
+
+CRM_POLLING_INTERVAL = 1
+CRM_DEFAULT_POLL_INTERVAL = 300
+MAX_WAIT_TIME = 120
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='module')
+def get_function_conpleteness_level(pytestconfig):
+    return pytestconfig.getoption("--completeness_level")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def set_polling_interval(duthost):
+    wait_time = 2
+    duthost.command("crm config polling interval {}".format(CRM_POLLING_INTERVAL))
+    logger.info("Waiting {} sec for CRM counters to become updated".format(wait_time))
+    time.sleep(wait_time)
+
+    yield
+
+    duthost.command("crm config polling interval {}".format(CRM_DEFAULT_POLL_INTERVAL))
+    logger.info("Waiting {} sec for CRM counters to become updated".format(wait_time))
+    time.sleep(wait_time)
+
+
+@pytest.fixture(scope='module')
+def withdraw_and_announce_existing_routes(duthost, localhost, tbinfo):
+    ptf_ip = tbinfo["ptf_ip"]
+    topo_name = tbinfo["topo"]["name"]
+
+    logger.info("withdraw existing ipv4 and ipv6 routes")
+    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw")
+
+    wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") == True)
+    time.sleep(CRM_POLLING_INTERVAL * 5)
+    ipv4_route_used_before = get_crm_resources(duthost, "ipv4_route", "used")
+    ipv6_route_used_before = get_crm_resources(duthost, "ipv6_route", "used")
+    logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
+    logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
+
+    yield ptf_ip, topo_name, ipv4_route_used_before, ipv6_route_used_before
+
+    logger.info("announce existing ipv4 and ipv6 routes")
+    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce")
+
+    wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "outq") == True)
+    time.sleep(CRM_POLLING_INTERVAL * 5)
+    logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
+    logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))

--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -37,7 +37,7 @@ def withdraw_and_announce_existing_routes(duthost, localhost, tbinfo):
     topo_name = tbinfo["topo"]["name"]
 
     logger.info("withdraw existing ipv4 and ipv6 routes")
-    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw")
+    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") == True)
     time.sleep(CRM_POLLING_INTERVAL * 5)
@@ -49,7 +49,7 @@ def withdraw_and_announce_existing_routes(duthost, localhost, tbinfo):
     yield ptf_ip, topo_name, ipv4_route_used_before, ipv6_route_used_before
 
     logger.info("announce existing ipv4 and ipv6 routes")
-    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce")
+    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "outq") == True)
     time.sleep(CRM_POLLING_INTERVAL * 5)

--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -51,7 +51,7 @@ def withdraw_and_announce_existing_routes(duthost, localhost, tbinfo):
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "outq") == True)
-    sleep_to_wait(CRM_POLLING_INTERVAL * 100)
+    sleep_to_wait(CRM_POLLING_INTERVAL * 5)
     logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
     logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
 

--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -1,9 +1,8 @@
-import time
 import logging
 import pytest
 
 from tests.common.utilities import wait_until
-from utils import get_crm_resources, check_queue_status
+from utils import get_crm_resources, check_queue_status, sleep_to_wait
 
 CRM_POLLING_INTERVAL = 1
 CRM_DEFAULT_POLL_INTERVAL = 300
@@ -40,18 +39,19 @@ def withdraw_and_announce_existing_routes(duthost, localhost, tbinfo):
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") == True)
-    time.sleep(CRM_POLLING_INTERVAL * 100)
+    sleep_to_wait(CRM_POLLING_INTERVAL * 100)
     ipv4_route_used_before = get_crm_resources(duthost, "ipv4_route", "used")
     ipv6_route_used_before = get_crm_resources(duthost, "ipv6_route", "used")
-    logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
-    logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
+    logger.info("ipv4 route used {}".format(ipv4_route_used_before))
+    logger.info("ipv6 route used {}".format(ipv6_route_used_before))
 
-    yield ptf_ip, topo_name, ipv4_route_used_before, ipv6_route_used_before
+    yield ipv4_route_used_before, ipv6_route_used_before
 
     logger.info("announce existing ipv4 and ipv6 routes")
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "outq") == True)
-    time.sleep(CRM_POLLING_INTERVAL * 100)
+    sleep_to_wait(CRM_POLLING_INTERVAL * 100)
     logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
     logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
+

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -62,4 +62,3 @@ def test_announce_withdraw_route(duthost, localhost, tbinfo, get_function_conple
                   "ipv4 route used after is not equal to it used before")
     pytest_assert(abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
                   "ipv6 route used after is not equal to it used before")
-

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+import math
+import os
+import yaml
+import re
+import requests
+import time
+import logging
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.plugins.test_completeness import CompletenessLevel
+from tests.common.utilities import wait_until
+from utils import get_crm_resources, check_queue_status
+
+ALLOW_ROUTES_CHANGE_NUMS = 10
+CRM_POLLING_INTERVAL = 1
+MAX_WAIT_TIME = 120
+
+pytestmark = [
+    pytest.mark.topology('t0')
+]
+
+logger = logging.getLogger(__name__)
+
+
+def announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name):
+    logger.info("announce ipv4 and ipv6 routes")
+    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce")
+
+    wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "outq") == True)
+
+    logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
+    logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
+    time.sleep(CRM_POLLING_INTERVAL * 5)
+    logger.info("withdraw ipv4 and ipv6 routes")
+    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw")
+
+    wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") == True)
+    time.sleep(CRM_POLLING_INTERVAL * 5)
+    logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
+    logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
+
+
+def test_announce_withdraw_route(duthost, localhost, tbinfo, get_function_conpleteness_level,
+                                 withdraw_and_announce_existing_routes):
+    normalized_level = get_function_conpleteness_level
+
+    ptf_ip, topo_name, ipv4_route_used_before, ipv6_route_used_before = withdraw_and_announce_existing_routes
+
+    loop_times = CompletenessLevel[normalized_level].value
+
+    while loop_times >= 0:
+        announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name)
+        loop_times -= 1
+
+    ipv4_route_used_after = get_crm_resources(duthost, "ipv4_route", "used")
+    ipv6_route_used_after = get_crm_resources(duthost, "ipv6_route", "used")
+
+    pytest_assert(abs(ipv4_route_used_after - ipv4_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
+                  "ipv4 route used after is not equal to it used before")
+    pytest_assert(abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
+                  "ipv6 route used after is not equal to it used before")
+

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -29,12 +29,12 @@ def announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name):
 
     logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
     logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
-    time.sleep(CRM_POLLING_INTERVAL * 5)
+    time.sleep(CRM_POLLING_INTERVAL * 100)
     logger.info("withdraw ipv4 and ipv6 routes")
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") == True)
-    time.sleep(CRM_POLLING_INTERVAL * 5)
+    time.sleep(CRM_POLLING_INTERVAL * 100)
     logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
     logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
 

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -18,16 +18,12 @@ ALLOW_ROUTES_CHANGE_NUMS = 10
 CRM_POLLING_INTERVAL = 1
 MAX_WAIT_TIME = 120
 
-pytestmark = [
-    pytest.mark.topology('t0')
-]
-
 logger = logging.getLogger(__name__)
 
 
 def announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name):
     logger.info("announce ipv4 and ipv6 routes")
-    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce")
+    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "outq") == True)
 
@@ -35,7 +31,7 @@ def announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name):
     logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
     time.sleep(CRM_POLLING_INTERVAL * 5)
     logger.info("withdraw ipv4 and ipv6 routes")
-    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw")
+    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") == True)
     time.sleep(CRM_POLLING_INTERVAL * 5)
@@ -46,6 +42,8 @@ def announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name):
 def test_announce_withdraw_route(duthost, localhost, tbinfo, get_function_conpleteness_level,
                                  withdraw_and_announce_existing_routes):
     normalized_level = get_function_conpleteness_level
+    if normalized_level is None:
+        normalized_level = "basic"
 
     ptf_ip, topo_name, ipv4_route_used_before, ipv6_route_used_before = withdraw_and_announce_existing_routes
 

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -51,7 +51,7 @@ def test_announce_withdraw_route(duthost, localhost, tbinfo, get_function_conple
 
     loop_times = LOOP_TIMES_LEVEL_MAP[normalized_level]
 
-    while loop_times >= 0:
+    while loop_times > 0:
         announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name)
         loop_times -= 1
 

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -27,13 +27,13 @@ def announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name):
 
     logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
     logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
-    sleep_to_wait(CRM_POLLING_INTERVAL * 100)
+    sleep_to_wait(CRM_POLLING_INTERVAL * 5)
 
     logger.info("withdraw ipv4 and ipv6 routes")
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") == True)
-    sleep_to_wait(CRM_POLLING_INTERVAL * 100)
+    sleep_to_wait(CRM_POLLING_INTERVAL * 5)
     logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
     logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
 
@@ -55,10 +55,12 @@ def test_announce_withdraw_route(duthost, localhost, tbinfo, get_function_conple
         announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name)
         loop_times -= 1
 
-        ipv4_route_used_after = get_crm_resources(duthost, "ipv4_route", "used")
-        ipv6_route_used_after = get_crm_resources(duthost, "ipv6_route", "used")
+    sleep_to_wait(CRM_POLLING_INTERVAL * 100)
 
-        pytest_assert(abs(ipv4_route_used_after - ipv4_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
-                  "ipv4 route used after is not equal to it used before")
-        pytest_assert(abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
-                  "ipv6 route used after is not equal to it used before")
+    ipv4_route_used_after = get_crm_resources(duthost, "ipv4_route", "used")
+    ipv6_route_used_after = get_crm_resources(duthost, "ipv6_route", "used")
+
+    pytest_assert(abs(ipv4_route_used_after - ipv4_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
+              "ipv4 route used after is not equal to it used before")
+    pytest_assert(abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
+              "ipv6 route used after is not equal to it used before")

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -5,16 +5,14 @@ import os
 import yaml
 import re
 import requests
-import time
 import logging
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.plugins.test_completeness import CompletenessLevel
 from tests.common.utilities import wait_until
-from utils import get_crm_resources, check_queue_status
+from utils import get_crm_resources, check_queue_status, sleep_to_wait, LOOP_TIMES_LEVEL_MAP
 
-ALLOW_ROUTES_CHANGE_NUMS = 10
+ALLOW_ROUTES_CHANGE_NUMS = 5
 CRM_POLLING_INTERVAL = 1
 MAX_WAIT_TIME = 120
 
@@ -29,34 +27,38 @@ def announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name):
 
     logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
     logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
-    time.sleep(CRM_POLLING_INTERVAL * 100)
+    sleep_to_wait(CRM_POLLING_INTERVAL * 100)
+
     logger.info("withdraw ipv4 and ipv6 routes")
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") == True)
-    time.sleep(CRM_POLLING_INTERVAL * 100)
+    sleep_to_wait(CRM_POLLING_INTERVAL * 100)
     logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
     logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
 
 
 def test_announce_withdraw_route(duthost, localhost, tbinfo, get_function_conpleteness_level,
                                  withdraw_and_announce_existing_routes):
+    ptf_ip = tbinfo["ptf_ip"]
+    topo_name = tbinfo["topo"]["name"]
+
     normalized_level = get_function_conpleteness_level
     if normalized_level is None:
         normalized_level = "basic"
 
-    ptf_ip, topo_name, ipv4_route_used_before, ipv6_route_used_before = withdraw_and_announce_existing_routes
+    ipv4_route_used_before, ipv6_route_used_before = withdraw_and_announce_existing_routes
 
-    loop_times = CompletenessLevel[normalized_level].value
+    loop_times = LOOP_TIMES_LEVEL_MAP[normalized_level]
 
     while loop_times >= 0:
         announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name)
         loop_times -= 1
 
-    ipv4_route_used_after = get_crm_resources(duthost, "ipv4_route", "used")
-    ipv6_route_used_after = get_crm_resources(duthost, "ipv6_route", "used")
+        ipv4_route_used_after = get_crm_resources(duthost, "ipv4_route", "used")
+        ipv6_route_used_after = get_crm_resources(duthost, "ipv6_route", "used")
 
-    pytest_assert(abs(ipv4_route_used_after - ipv4_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
+        pytest_assert(abs(ipv4_route_used_after - ipv4_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
                   "ipv4 route used after is not equal to it used before")
-    pytest_assert(abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
+        pytest_assert(abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
                   "ipv6 route used after is not equal to it used before")

--- a/tests/stress/utils.py
+++ b/tests/stress/utils.py
@@ -1,6 +1,5 @@
 import re
 
-TOPO_FILE_FOLDER = '../ansible/vars/'
 TOPO_FILENAME_TEMPLATE = 'topo_{}.yml'
 
 SHOW_BGP_SUMMARY_CMD = "show ip bgp summary"

--- a/tests/stress/utils.py
+++ b/tests/stress/utils.py
@@ -1,0 +1,19 @@
+import os
+import yaml
+import re
+
+TOPO_FILE_FOLDER = '../ansible/vars/'
+TOPO_FILENAME_TEMPLATE = 'topo_{}.yml'
+
+SHOW_BGP_SUMMARY_CMD = "show ip bgp summary"
+
+def get_crm_resources(duthost, resource, status):
+    return duthost.get_crm_resources().get("main_resources").get(resource).get(status)
+
+def check_queue_status(duthost, queue):
+    bgp_neighbors = duthost.show_and_parse(SHOW_BGP_SUMMARY_CMD)
+    bgp_neighbor_addr_regex = re.compile(r"^([0-9]{1,3}\.){3}[0-9]{1,3}")
+    for neighbor in bgp_neighbors:
+        if bgp_neighbor_addr_regex.match(neighbor["neighbhor"]) and int(neighbor[queue]) != 0 :
+            return False
+    return True

--- a/tests/stress/utils.py
+++ b/tests/stress/utils.py
@@ -1,5 +1,3 @@
-import os
-import yaml
 import re
 
 TOPO_FILE_FOLDER = '../ansible/vars/'

--- a/tests/stress/utils.py
+++ b/tests/stress/utils.py
@@ -1,8 +1,14 @@
 import re
 
 TOPO_FILENAME_TEMPLATE = 'topo_{}.yml'
-
 SHOW_BGP_SUMMARY_CMD = "show ip bgp summary"
+LOOP_TIMES_LEVEL_MAP = {
+    'debug': 1,
+    'basic': 10,
+    'confident': 50,
+    'thorough': 100,
+    'diagnose': 200
+}
 
 def get_crm_resources(duthost, resource, status):
     return duthost.get_crm_resources().get("main_resources").get(resource).get(status)
@@ -14,3 +20,8 @@ def check_queue_status(duthost, queue):
         if bgp_neighbor_addr_regex.match(neighbor["neighbhor"]) and int(neighbor[queue]) != 0 :
             return False
     return True
+
+def sleep_to_wait(seconds):
+    if seconds > 300:
+        seconds = 300
+    time.sleep(seconds)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

We have observed issues on multiple platform where some of the events were causing resource leak and eventually resulting in TABLE_FULL errors and crashes. This was impacting dataplane traffic.
This test is to simulate multiple route add/remove and check for the system stability.

Summary:
Fixes #4028

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

We have observed issues on multiple platform where some of the events were causing resource leak and eventually resulting in TABLE_FULL errors and crashes. This was impacting dataplane traffic.
This test is to simulate multiple route add/remove and check for the system stability.

#### How did you do it?

1. Modify the sonic-mgmt/ansible/library/announce_routes.py to support withdraw routes.
2. Add a test case to announce/withdraw routes repeatedly, and check the crm resource on sonic before and after I modify the routes and the test case support different completeness level(debug/basic/confident/thorough) to announce and withdraw routes servel times. 

#### How did you verify/test it?

1. I run the testbed_cli announce_route in order not to influence original function
2. I run the test case using ' pytest --inventory veos_vtb --host-pattern vlab-01 ../tests/stress/test_stress_routes.py --testbed vms-kvm-t0 --testbed_file vtestbed.csv --log-cli-level info --showlocals --assert plain --show-capture no -rav --completeness_level confident --skip_sanity --disable_loganalyzer'

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
