### PR TITLE
downgrade exception to warning

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -36,6 +36,7 @@ def xcvr_skip_list(duthosts):
         hwsku = dut.facts['hwsku']
         f_path = os.path.join('/usr/share/sonic/device', platform, hwsku, 'hwsku.json')
         intf_skip_list[dut.hostname] = []
+        dut.has_sku = True
         try:
             out = dut.command("cat {}".format(f_path))
             hwsku_info = json.loads(out["stdout"])
@@ -45,6 +46,7 @@ def xcvr_skip_list(duthosts):
 
         except Exception:
             # hwsku.json does not exist will return empty skip list
+            dut.has_sku = False
             logging.debug(
                 "hwsku.json absent or port_type for interfaces not included for hwsku {}".format(hwsku))
 

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -94,26 +94,17 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type =
         logging.info("Wait {} seconds for all the transceivers to be detected".format(MAX_WAIT_TIME_FOR_INTERFACES))
         result = wait_until(MAX_WAIT_TIME_FOR_INTERFACES, 20, 0, check_all_interface_information, dut, interfaces,
                             xcvr_skip_list)
-        if dut.has_sku:
-            assert result, "Not all transceivers are detected or interfaces are up in {} seconds".format(
-                MAX_WAIT_TIME_FOR_INTERFACES)
-        else:
-            if not result:
-                logging.warn("Not all transceivers are detected or interfaces are up in {} seconds, but the required hwsku.json is not present either".format(MAX_WAIT_TIME_FOR_INTERFACES))
-
+        if not dut.has_sku:
+            pytest.xfail("hwsku.json is needed for interface checking to pass, and it is not provided.")
+        assert result, "Not all transceivers are detected or interfaces are up in {} seconds".format(
+            MAX_WAIT_TIME_FOR_INTERFACES)
 
         logging.info("Check transceiver status")
-        try:
-            for asic_index in dut.get_frontend_asic_ids():
-                # Get the interfaces pertaining to that asic
-                interface_list = get_port_map(dut, asic_index)
-                interfaces_per_asic = {k:v for k, v in interface_list.items() if k in interfaces}
-                check_transceiver_basic(dut, asic_index, interfaces_per_asic, xcvr_skip_list)
-        except AssertionError as ae:
-            if dut.has_sku:
-                raise ae
-            else:
-                logging.warn("Error in checking transceiver status {}".format(ae))
+        for asic_index in dut.get_frontend_asic_ids():
+            # Get the interfaces pertaining to that asic
+            interface_list = get_port_map(dut, asic_index)
+            interfaces_per_asic = {k:v for k, v in interface_list.items() if k in interfaces}
+            check_transceiver_basic(dut, asic_index, interfaces_per_asic, xcvr_skip_list)
 
         logging.info("Check pmon daemon status")
         assert check_pmon_daemon_status(dut), "Not all pmon daemons running."


### PR DESCRIPTION
When hwsku.json is not available, some tests will always fail. Downgrade
them from exception to warning.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
When hwsku.json is not available, some tests will always fail. Downgrade them from exception to warning.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Option --skip-absent-sfp has been effectively removed in a previous commit, and the process has been automated by reading a file hwsku.json. Since hwsku.json is not mandatory and could be missing, in which case some tests will always fail without producing reliable result, some checks will be skipped and when failed, reduced from an exception to a warning, if hwsku.json is not available. Currently when hwsku.json is missing, some tests always fail and error messages not related to the real cause are reported.

#### How did you do it?
Check for hwsku.json before throwing some exceptions. If exists, throw as usual, otherwise reduce to a warning.

#### How did you verify/test it?
Run tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
