### PR TITLE
Skip everflow_per_interface test on Marvell platform

### DIFF
--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -89,6 +89,9 @@ def apply_acl_rule(request, rand_selected_dut, tbinfo, apply_mirror_session):
     ip_ver = request.param
     if "mellanox" == rand_selected_dut.facts["asic_type"] and ip_ver == "ipv6":
         pytest.skip("Match 'IN_PORTS' in EVERFLOWV6 is not supported on Mellanox platform")
+    # Skip on marvell platform
+    if "marvell" == rand_selected_dut.facts["asic_type"]:
+        pytest.skip("Match 'IN_PORTS' is not supported on Marvell platform")
     # Check existence of EVERFLOW
     table_name = EVERFLOW_TABLE_NAME[ip_ver]
     output = rand_selected_dut.shell('show acl table {}'.format(table_name))['stdout_lines']


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip everflow_per_interface test on Marvell platform since match ```IN_PORTS``` is not supported.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to skip everflow_per_interface test on Marvell platform.

#### How did you do it?
Check asic type in an autoused session, and skip the test if asic is ```Marvell```

#### How did you verify/test it?
Verified on a ```Nokia-7215``` device and confirmed test was skipped.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
