### PR TITLE
Fix the issue of standby_side field always be "lower_tor" in response of mux simulator

### DIFF
--- a/ansible/roles/vm_set/files/mux_simulator.py
+++ b/ansible/roles/vm_set/files/mux_simulator.py
@@ -172,12 +172,12 @@ class Mux(object):
 
         self._init_ports()
 
-        # If the mux does not have valid ports attahed, it is invalid
+        # If the mux does not have valid ports attached, it is invalid
         if not self._get_ports():
             self.isvalid = False
             return
 
-        # Initilize the flows configured on the mux bridge
+        # Initialize the flows configured on the mux bridge
         self._init_flows()
         self._get_flows()
 
@@ -248,12 +248,13 @@ class Mux(object):
             tor_ports[1]: LOWER_TOR
         }
 
+        self.info('Sides map: {}'.format(self.sides, indent=2))
         return True
 
     def _active_standby_state_helper(self, active_side):
         if active_side is None:
             active_side = random.choice([UPPER_TOR, LOWER_TOR])
-        standby_side = LOWER_TOR if active_side == UPPER_TOR else LOWER_TOR
+        standby_side = LOWER_TOR if active_side == UPPER_TOR else UPPER_TOR
 
         self.active_side = active_side
         self.active_port = self.ports[active_side]
@@ -323,7 +324,7 @@ class Mux(object):
 
     @property
     def status(self):
-        """Property for statu of the mux bridge.
+        """Property for status of the mux bridge.
 
         Status of the mux bridge is maintained in instance attributes. This property is to gather the attributes and
         return them in a dict.
@@ -364,7 +365,7 @@ class Mux(object):
     def set_active_side(self, new_active_side):
         """Set the active side of the mux bridge to the specified side.
 
-        If the specified side is same as the current active side of bridge, no config change is reuqired. Otherwise,
+        If the specified side is same as the current active side of bridge, no config change is required. Otherwise,
         this method will run ovs-ofctl command to remove flow and add a new flow to switch active side. All the
         related instance attributes are updated after open flow rules are changed.
         """


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Because of a logic error, the "standby_side" field in the returned mux status will always be "lower_tor".
Originally the standby_side is determined by:

    standby_side = LOWER_TOR if active_side == UPPER_TOR else LOWER_TOR

When "active_side" is not UPPER_TOR, then it must be LOWER_TOR. In this case, the "standby_side" variable
is set with value LOWER_TOR which is same as value of the "active_side" variable.

#### How did you do it?

Fortunately the "standby_side" field is not used by any test or by the simulated y_cable driver, this
issue didn't cause trouble. Anyway, this logic error need to be fixed. The fix is simple, just update
the original code to below:

    standby_side = LOWER_TOR if active_side == UPPER_TOR else UPPER_TOR

#### How did you verify/test it?
Tested toggle mux simulator and check consistency of active_side/standby_side in the response.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
