### PR TITLE
[link_flap] Log neighbor's bgp info while error happened after link_flap

### DIFF
--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -14,7 +14,8 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common import port_toggle
 from tests.platform_tests.link_flap.link_flap_utils import build_test_candidates, toggle_one_link, check_orch_cpu_utilization, check_bgp_routes, check_portchannel_status
 from tests.common.utilities import wait_until
-
+from tests.common.devices.eos import EosHost
+from tests.common.devices.sonic import SonicHost
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -26,7 +27,7 @@ class TestContLinkFlap(object):
     TestContLinkFlap class for continuous link flap
     """
 
-    def test_cont_link_flap(self, request, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, bring_up_dut_interfaces, tbinfo):
+    def test_cont_link_flap(self, request, duthosts, nbrhosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, bring_up_dut_interfaces, tbinfo):
         """
         Validates that continuous link flap works as expected
 
@@ -91,7 +92,23 @@ class TestContLinkFlap(object):
         # Make Sure all ipv4/ipv6 routes are relearned with jitter of ~5
         if not wait_until(120, 2, 0, check_bgp_routes, duthost, start_time_ipv4_route_counts, start_time_ipv6_route_counts):
             endv4, endv6 = duthost.get_ip_route_summary()
-            pytest.fail("IP routes are not equal after link flap: before ipv4 {} ipv6 {}, after ipv4 {} ipv6 {}".format(sumv4, sumv6, endv4, endv6))
+            failmsg = []
+            failmsg.append(
+                "IP routes are not equal after link flap: before ipv4 {} ipv6 {}, after ipv4 {} ipv6 {}".format(sumv4,
+                                                                                                                sumv6,
+                                                                                                                endv4,
+                                                                                                                endv6))
+            nei_meta = config_facts.get('DEVICE_NEIGHBOR_METADATA', {})
+            for k in nei_meta.keys():
+                nbrhost = nbrhosts[k]['host']
+                if isinstance(nbrhost, EosHost):
+                    res = nbrhost.eos_command(commands=['show ip bgp sum'])
+                elif isinstance(nbrhost, SonicHost):
+                    res = nbrhost.eos_command('vtysh -c "show ip bgp sum"')
+                else:
+                    res = ""
+                failmsg.append(res['stdout'])
+            pytest.fail(str(failmsg))
 
         # Record memory status at end
         memory_output = duthost.shell("show system-memory")["stdout"]

--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -104,7 +104,7 @@ class TestContLinkFlap(object):
                 if isinstance(nbrhost, EosHost):
                     res = nbrhost.eos_command(commands=['show ip bgp sum'])
                 elif isinstance(nbrhost, SonicHost):
-                    res = nbrhost.eos_command('vtysh -c "show ip bgp sum"')
+                    res = nbrhost.command('vtysh -c "show ip bgp sum"')
                 else:
                     res = ""
                 failmsg.append(res['stdout'])


### PR DESCRIPTION
What is the motivation for this PR?
There is a flaky issue caused by the inconsistent bgp routes count after link flap.

How did you do it?
This PR is to log the neigbor's bgp info while error happened for debug purpose.

How did you verify/test it?
Run the cont link flap test case.

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
