### PR TITLE
[Reboot] Fixed logic which counts reboot time

### DIFF
--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -3,6 +3,7 @@ import json
 import logging
 
 from multiprocessing.pool import ThreadPool
+from datetime import datetime
 
 from tests.common.errors import RunAnsibleModuleFail
 
@@ -89,3 +90,14 @@ class AnsibleHostBase(object):
             raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
 
         return res
+
+    def get_up_time(self):
+        up_time_text = self.command("uptime -s")["stdout"]
+        return datetime.strptime(up_time_text, "%Y-%m-%d %H:%M:%S")
+
+    def get_now_time(self):
+        now_time_text = self.command('date +"%Y-%m-%d %H:%M:%S"')["stdout"]
+        return datetime.strptime(now_time_text, "%Y-%m-%d %H:%M:%S")
+
+    def get_uptime(self):
+        return self.get_now_time() - self.get_up_time()

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -745,18 +745,6 @@ class SonicHost(AnsibleHostBase):
 
         return namespace_ids, True
 
-
-    def get_up_time(self):
-        up_time_text = self.command("uptime -s")["stdout"]
-        return datetime.strptime(up_time_text, "%Y-%m-%d %H:%M:%S")
-
-    def get_now_time(self):
-        now_time_text = self.command('date +"%Y-%m-%d %H:%M:%S"')["stdout"]
-        return datetime.strptime(now_time_text, "%Y-%m-%d %H:%M:%S")
-
-    def get_uptime(self):
-        return self.get_now_time() - self.get_up_time()
-
     def get_networking_uptime(self):
         start_time = self.get_service_props("networking", props=["ExecMainStartTimestamp",])
         try:


### PR DESCRIPTION
[Reboot] Fixed logic which counts reboot time

Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Old logic started to count device downtime before execute reboot cmd(it may take some time)
New logic started to count device downtime since SSH connection dropped(device really unreachable)

Summary: [Reboot] Fixed logic which counts reboot time
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Sometimes reboot tests may fail, due to reboot time longer than expected(it can happen when reboot cmd took more time and device still reachable).
New logic start count downtime since device unreachable(really rebooted)

#### How did you do it?
See code

#### How did you verify/test it?
Executed tests which use reboot logic: warm-reboot, reboot
For example:  sflow.test_sflow.TestReboot#testWarmreboot

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 

