### PR TITLE
[auto restart] Refactor for better logging

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -99,10 +99,14 @@ def wait_until(timeout, interval, delay, condition, *args, **kwargs):
 
         try:
             check_result = condition(*args, **kwargs)
-        except Exception:
+        except Exception as e:
             exc_info = sys.exc_info()
             details = traceback.format_exception(*exc_info)
-            logger.error("Exception caught while checking %s:\n%s" % (condition.__name__, "".join(details)))
+            logger.error(
+                "Exception caught while checking {}:{}, error:{}".format(
+                    condition.__name__, "".join(details, e)
+                )
+            )
             check_result = False
 
         if check_result:

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -104,7 +104,7 @@ def wait_until(timeout, interval, delay, condition, *args, **kwargs):
             details = traceback.format_exception(*exc_info)
             logger.error(
                 "Exception caught while checking {}:{}, error:{}".format(
-                    condition.__name__, "".join(details, e)
+                    condition.__name__, "".join(details), e
                 )
             )
             check_result = False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
When the check fails the log message just says check failed for some reason. It's not clear from the log if the 'critical' process check failed or the 'bgp neighbors' check failed without going through lots of messages in the log.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Improve logging to root cause the failure

#### How did you do it?
Refactor the code

#### How did you verify/test it?
Ran the auto retstart test.

```
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collecting ... /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 15 items                                                                                                                                                                                                                                                             

autorestart/test_container_autorestart.py ..ss.s..s.s.s..                                                                                                                                                                                                                                                                                                            [100%]

============================================================================================================================================================================= warnings summary =============================================================================================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================================================================================================================================ 9 passed, 6 skipped, 1 warnings in 1982.07 seconds ============================================================================================================================================================

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
