### PR TITLE
[qos]: Change autorestart and mux enable order

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -741,10 +741,6 @@ class QosSaiBase(QosBase):
 
         yield
 
-        enable_container_autorestart(duthost, testcase="test_qos_sai", feature_list=feature_list)
-        if 'dualtor' in tbinfo['topo']['name']:
-            enable_container_autorestart(duthost_lower, testcase="test_qos_sai", feature_list=feature_list)
-
         for service in services:
             updateDockerService(duthost, action="start", **service)
 
@@ -761,6 +757,11 @@ class QosSaiBase(QosBase):
            duthost.shell('sudo config feature state mux enabled')
            duthost_lower.shell('sudo config feature state mux enabled')
            logger.info("Start mux container for dual ToR testbed")
+
+        enable_container_autorestart(duthost, testcase="test_qos_sai", feature_list=feature_list)
+        if 'dualtor' in tbinfo['topo']['name']:
+            enable_container_autorestart(duthost_lower, testcase="test_qos_sai", feature_list=feature_list)
+
 
     @pytest.fixture(autouse=True)
     def updateLoganalyzerExceptions(self, rand_one_dut_hostname, loganalyzer):


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Previously, container autorestart was enabled after qos tests before also enabling the mux feature on dual ToR testbeds. This would cause a `config save` to be performed while the mux feature was still disabled, making the testbed unhealthy after any subsequent config reloads.

#### How did you do it?
Re-enable container autorestart only after the mux feature has been re-enabled, so that the `config save` is performed with the mux feature enabled.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
