### PR TITLE
Increase the value of ```netdev_max_backlog``` in restart-ptf task.

### DIFF
--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -1,3 +1,9 @@
+# Increase netdev_max_backlog to mitigate the packet drop issue
+# Ref https://www.kernel.org/doc/Documentation/sysctl/net.txt
+- name: Increase netdev_max_backlog
+  shell: echo 65535 > /proc/sys/net/core/netdev_max_backlog
+  become: yes
+
 - name: set "PTF" container type, by default
   set_fact:
     container_type: "PTF"


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
We were seeing packet drop in the veth pair which is used to transmit packet across vmhost and ptf container.
To mitigate the issue, we increase the value of ```netdev_max_backlog``` from ```1000``` to ```65535```.
Reference: https://www.kernel.org/doc/Documentation/sysctl/net.txt

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Thisi PR is to increase the value of ```netdev_max_backlog``` in restart-ptf task.

#### How did you do it?
Run a shell command to set the value.

#### How did you verify/test it?
Verified by running ```test_fib``` and ```test_decap```. The test cases can consistently pass now.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
