### PR TITLE
[Vrf] Disable swss warm_boot flag after test_vrf_swss_warm_reboot

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -519,6 +519,15 @@ def ptf_test_port_map(tbinfo, duthosts, mg_facts, ptfhost, rand_one_dut_hostname
         }
     ptfhost.copy(content=json.dumps(ptf_test_port_map), dest=PTF_TEST_PORT_MAP)
 
+@pytest.fixture()
+def disable_swss_warm_boot_flag(duthosts, rand_one_dut_hostname):
+    yield
+
+    duthost = duthosts[rand_one_dut_hostname]
+    swss_flag = duthost.shell("sonic-db-cli STATE_DB HGET 'WARM_RESTART_ENABLE_TABLE|swss' 'enable'")['stdout']
+    if swss_flag == 'true':
+        duthost.shell("config warm_restart disable swss")
+
 # tests
 class TestVrfCreateAndBind():
     def test_vrf_in_kernel(self, duthosts, rand_one_dut_hostname, cfg_facts):
@@ -1007,6 +1016,7 @@ class TestVrfWarmReboot():
         #FIXME Might need cold reboot if test failed?
         pass
 
+    @pytest.mark.usefixtures('disable_swss_warm_boot_flag')
     def test_vrf_swss_warm_reboot(self, duthosts, rand_one_dut_hostname, cfg_facts, partial_ptf_runner):
         duthost = duthosts[rand_one_dut_hostname]
         # enable swss warm-reboot


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: After PR - [1460](https://github.com/Azure/sonic-utilities/pull/1460
) additional check was added to ensure, that before issuing an warm_reboot there are no warm_reboot flags set. `test_vrf_swss_warm_reboot` enables warm_boot flag for swss by using cmd -` config warm_restart enable swss`, but after restart of swss, next test case fails to make warm_reboot of system due to this flag is still set. 

**Error message:** 
`Warm restart flag for swss is set. Please check if a warm restart for swss is in progress.`



Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Disable swss warm_boot flag after **test_vrf_swss_warm_reboot**.
#### How did you do it?

#### How did you verify/test it?
Run `vrf/test_vrf.py::TestVrfWarmReboot`, `test_vrf_system_warm_reboot` gets executed. 
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.48366-dirty-20211103.084953
Distribution: Debian 10.11
Kernel: 4.19.0-12-2-amd64
Build commit: 689c10109
Build date: Wed Nov  3 15:37:52 UTC 2021
Built by: AzDevOps@sonic-build-workers-000UT4
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
