### PR TITLE
Skip Sub Port tunnel cases for cisco-8000 due to unsupported DSCP Pipe mode

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -464,3 +464,9 @@ platform_tests/api/test_thermal.py::TestThermalApi::test_set_high_threshold:
     reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox']"
+
+sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports:
+  skip:
+    reason: "Cisco 8000 platform does not support DSCP PIPE Mode for IPinIP Tunnels"
+    conditions:
+      - "asic_type=='cisco-8000'"


### PR DESCRIPTION
### Description of PR
Currently on cisco-8000 platforms, we only support uniform mode for DSCP. The subtests which are under “test_tunneling_between_sub_ports” are validating functionality using the DSCP Pipe mode and hence need to
be skipped.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
DSCP Pipe mode support for IPinIP tunnels is currently unavailable

#### How did you do it?
Skip these tests for cisco-8000

#### How did you verify/test it?
Ran on a cisco-8000 device and verified tests are skipped instead of failing

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
