### PR TITLE
Reduce unnecessary logs in sanity check

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -269,7 +269,6 @@ def pytest_collection_modifyitems(session, config, items):
     if not conditions:
         logger.debug('No mark condition is defined')
         return
-    logger.debug('Predefined mark conditions\n{}'.format(json.dumps(conditions, indent=2)))
 
     basic_facts = config.cache.get('BASIC_FACTS', None)
     if not basic_facts:

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -1,4 +1,3 @@
-from _typeshed import OpenTextModeReading
 import re
 import json
 import logging

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -266,7 +266,6 @@ def _is_db_omem_over_threshold(command_output):
         if m:
             omem = int(m.group(1))
             total_omem += omem
-    logger.debug(json.dumps(command_output, indent=4))
     logger.debug('total_omen={}, OMEM_THRESHOLD_BYTES={}'.format(total_omem, OMEM_THRESHOLD_BYTES))
     if total_omem > OMEM_THRESHOLD_BYTES:
         result = True


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Some logs in sanity check may occupy multiple pages. These logs are not necessary for troubleshooting.
It would be better to reduce them to make the test log more concise and relevant.

#### How did you do it?
* Reduce logging of content of conditional marks
The conditional marks are defined in yaml file committed in git repository. It's unnecessary to log them
again. If anything is wrong, we can simply check the file in git repository for its content.

* Reduce logging of redis db memory checking command output
The redis db checking will log the full output of redis db cli "client list". This log may occupy multiple
pages. Since this db memory check is pretty stable and never showed issue. It should be safe to
reduce this log too.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
