### PR TITLE
[testbed-cli.sh] Skip start/stop VMs if vm_type is ceos

### DIFF
--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -163,6 +163,10 @@ function read_file
 
 function start_vms
 {
+  if [[ $vm_type == ceos ]]; then
+    echo "VM type is ceos. No need to run start-vms. Please specify VM type using the -k option. Example: -k veos"
+    exit
+  fi
   server=$1
   passwd=$2
   shift
@@ -175,6 +179,10 @@ function start_vms
 
 function stop_vms
 {
+  if [[ $vm_type == ceos ]]; then
+    echo "VM type is ceos. No need to run stop-vms. Please specify VM type using the -k option. Example: -k veos"
+    exit
+  fi
   server=$1
   passwd=$2
   shift
@@ -186,6 +194,10 @@ function stop_vms
 
 function start_topo_vms
 {
+  if [[ $vm_type == ceos ]]; then
+    echo "VM type is ceos. No need to run start-topo-vms. Please specify VM type using the -k option. Example: -k veos"
+    exit
+  fi
   testbed_name=$1
   passwd=$2
   shift
@@ -199,6 +211,10 @@ function start_topo_vms
 
 function stop_topo_vms
 {
+  if [[ $vm_type == ceos ]]; then
+    echo "VM type is ceos. No need to run stop-topo-vms. Please specify VM type using the -k option. Example: -k veos"
+    exit
+  fi
   testbed_name=$1
   passwd=$2
   shift


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
If VM type of testbed is cEOS, then it is unnecessary to run the steps of adding or remoing VMs.
The cEOS dockers containers as VMs are created/destroyed during add-topo and remove-topo
steps.

#### How did you do it?
This change added code in functions start_vms/stop_vms/start_topo_vms/stop_topo_vms to check
vm_type. If vm_type is ceos, then just print a help message and exit.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
