### PR TITLE
Fixed wait_until method call - added default delay argument

### DIFF
--- a/tests/platform_tests/mellanox/test_thermal_control.py
+++ b/tests/platform_tests/mellanox/test_thermal_control.py
@@ -50,6 +50,7 @@ def test_dynamic_minimum_table(duthosts, rand_one_dut_hostname, mocker_factory):
         mocker.mock_min_table(temperature, trust_state)
         assert wait_until(THERMAL_CONTROL_TEST_WAIT_TIME,
                         THERMAL_CONTROL_TEST_CHECK_INTERVAL,
+                        0,
                         check_cooling_level_larger_than_minimum,
                         duthost,
                         expect_minimum_cooling_level), \
@@ -62,6 +63,7 @@ def test_dynamic_minimum_table(duthosts, rand_one_dut_hostname, mocker_factory):
         mocker.mock_min_table(temperature, not trust_state)
         assert wait_until(THERMAL_CONTROL_TEST_WAIT_TIME,
                         THERMAL_CONTROL_TEST_CHECK_INTERVAL,
+                        0,
                         check_cooling_level_larger_than_minimum,
                         duthost,
                         expect_minimum_cooling_level), \
@@ -70,6 +72,7 @@ def test_dynamic_minimum_table(duthosts, rand_one_dut_hostname, mocker_factory):
         # minimum table is not defined yet, check that the default cooling level is 6
         assert wait_until(THERMAL_CONTROL_TEST_WAIT_TIME,
                         THERMAL_CONTROL_TEST_CHECK_INTERVAL,
+                        0,
                         check_cooling_level_larger_than_minimum,
                         duthost,
                         6), \


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Fixed wait_until method call - added default delay argument
Few days ago logic in method wait_until  modified and now we need to provide delay argument.
If not provide it - we will see error:
```
AttributeError: '<class 'tests.common.devices.sonic.SonicHost'>' object has no attribute '__name__'
```

Summary: Fixed wait_until method call - added default delay argument
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix AttributeError: '<class 'tests.common.devices.sonic.SonicHost'>' object has no attribute '__name__'

#### How did you do it?
Added default default delay argument when call wait_untill method

#### How did you verify/test it?
executed test platform_tests/mellanox/test_thermal_control.py::test_dynamic_minimum_table

#### Any platform specific information?
mellanox/nvidia

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
