### PR TITLE
Stabilize testQosSaiPgSharedWatermark by increasing the wartermark range

### DIFF
--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -1820,7 +1820,7 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         if hwsku == 'DellEMC-Z9332f-O32' or hwsku == 'DellEMC-Z9332f-M-O16C64':
             margin = 10
         else:
-            margin = 2
+            margin = 3
 
         # Get a snapshot of counter values
         xmit_counters_base, queue_counters_base = sai_thrift_read_port_counters(self.client, port_list[dst_port_id])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When run test we meet the following error:
```
"stderr_lines": [ 

E                   "ptftests/remote.py:42: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.", 

E                   "  constants = yaml.load(fd)", 

E                   "sai_qos_tests.PGSharedWatermarkTest ... router_mac: 1c:34:da:bf:b7:00", 

E                   "dst_port_id: 0, src_port_id: 1 src_port_vlan: None", 

E                   "actual dst_port_id: 0", 

E                   "Init pkts num sent: 0, min: 0, actual watermark value to start: 144", 

E                   "pkts num to send: 3, total pkts: 9, pg shared: 161514", 

E                   "lower bound: 1296, actual value: 1296, upper bound (+2): 1584", 

E                   "pkts num to send: 13459, total pkts: 40386, pg shared: 161514", 

E                   "lower bound: 5815584, actual value: 5815584, upper bound (+2): 5815872", 

E                   "pkts num to send: 13459, total pkts: 80763, pg shared: 161514", 

E                   "lower bound: 11629872, actual value: 11629872, upper bound (+2): 11630160", 

E                   "pkts num to send: 13459, total pkts: 121140, pg shared: 161514", 

E                   "lower bound: 17444160, actual value: 17444160, upper bound (+2): 17444448", 

E                   "pkts num to send: 13458, total pkts: 161514, pg shared: 161514", 

E                   "lower bound: 23258016, actual value: 23258016, upper bound (+2): 23258304", 

E                   "exceeded pkts num sent: 13459, expected watermark: 23258448, actual value: 23258880", 

E                   "FAIL", 

E                   "", 

E                   "======================================================================", 

E                   "FAIL: sai_qos_tests.PGSharedWatermarkTest", 

E                   "----------------------------------------------------------------------", 

E                   "Traceback (most recent call last):", 

E                   "  File \"saitests/sai_qos_tests.py\", line 1906, in runTest", 

E                   "    assert(pg_shared_wm_res[pg] <= (expected_wm + margin + cell_occupancy) * cell_size)", 

E                   "AssertionError", 

E                   "", 

E                   "----------------------------------------------------------------------", 

E                   "Ran 1 test in 77.146s", 

E                   "", 

E                   "FAILED (failures=1)", 

E                   "No handlers could be found for logger \"dataplane\"" 

E               ], 
```
In order to stabilize the testQosSaiPgSharedWatermark, according to the experience value, increase margin from 2 to 3.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Stabilize the testQosSaiPgSharedWatermark.

#### How did you do it?
According to the experience value, increase margin from 2 to 3.

#### How did you verify/test it?
run the test of testQosSaiPgSharedWatermark

#### Any platform specific information?
no

#### Supported testbed topology if it's a new test case?
ptf32 

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
