### PR TITLE
[Sensors] Check stderr is not None before decode

### DIFF
--- a/ansible/library/sensors_facts.py
+++ b/ansible/library/sensors_facts.py
@@ -107,7 +107,8 @@ class SensorsModule(object):
             process = subprocess.Popen(['sensors', '-A', '-u'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
             self.stdout, stderr = process.communicate()
             self.stdout = self.stdout.decode('utf-8')
-            stderr = stderr.decode('utf-8')
+            if stderr is not None:
+                stderr = stderr.decode('utf-8')
             ret_code = process.returncode
         except Exception as e:
             self.module.fail_json(msg=str(e))

--- a/ansible/library/sensors_facts.py
+++ b/ansible/library/sensors_facts.py
@@ -104,11 +104,10 @@ class SensorsModule(object):
             Collect sensors by reading output of 'sensors' utility
         '''
         try:
-            process = subprocess.Popen(['sensors', '-A', '-u'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+            process = subprocess.Popen(['sensors', '-A', '-u'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             self.stdout, stderr = process.communicate()
             self.stdout = self.stdout.decode('utf-8')
-            if stderr is not None:
-                stderr = stderr.decode('utf-8')
+            stderr = stderr.decode('utf-8')
             ret_code = process.returncode
         except Exception as e:
             self.module.fail_json(msg=str(e))

--- a/ansible/library/sonic_release.py
+++ b/ansible/library/sonic_release.py
@@ -32,15 +32,16 @@ def main():
                 stdout=subprocess.PIPE, stdin=subprocess.PIPE)
         self.stdout, stderr = process.communicate()
         self.stdout = self.stdout.decode('utf-8')
-        stderr = stderr.decode('utf-8')
+        if stderr is not None:
+            stderr = stderr.decode('utf-8')
         ret_code = process.returncode
     except Exception as e:
         module.fail_json(msg=str(e))
     else:
         if ret_code != 0:
-             module.fail_json(msg=stderr)
+            module.fail_json(msg=stderr)
         else:
-             sonic_release = self.stdout.split('.')[0].strip()
+            sonic_release = self.stdout.split('.')[0].strip()
     """
     Check for QOS DB format for Field Value refered with tables or not.
     """

--- a/ansible/library/sonic_release.py
+++ b/ansible/library/sonic_release.py
@@ -29,11 +29,10 @@ def main():
     sonic_qos_db_fv_reference_with_table = false
     try:
         process = subprocess.Popen(['sonic-cfggen', '-y', '/etc/sonic/sonic_version.yml', '-v', 'release'],
-                stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         self.stdout, stderr = process.communicate()
         self.stdout = self.stdout.decode('utf-8')
-        if stderr is not None:
-            stderr = stderr.decode('utf-8')
+        stderr = stderr.decode('utf-8')
         ret_code = process.returncode
     except Exception as e:
         module.fail_json(msg=str(e))


### PR DESCRIPTION
What is the motivation for this PR?
If running "sensors" succeed, the stderr is None. It will throw out an exception if we decode a None object.

How did you do it?
Check stderr string is not None before decode.

How did you verify/test it?
Run test_sensors.py

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
