### PR TITLE
Re-add the import:mock_server_base_ip_addr of test_acl.py

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -20,6 +20,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyze
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py, run_garp_service, change_mac_addresses
 from tests.common.utilities import wait_until
+from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Add from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The PR https://github.com/Azure/sonic-mgmt/pull/4634 removed unused imports in test_acl.py. 
But when running test_acl.py, an error happened:

/var/AzDevOps/sonic-mgmt-master/tests/common/fixtures/ptfhost_utils.py:227

file /var/AzDevOps/sonic-mgmt-master/tests/acl/test_acl.py, line 668
      def test_ingress_unmatched_blocked(self, setup, direction, ptfadapter, ip_version, stage):
file /var/AzDevOps/sonic-mgmt-master/tests/common/fixtures/ptfhost_utils.py, line 227
  @pytest.fixture(scope='module', autouse=True)
  def run_garp_service(duthost, ptfhost, tbinfo, change_mac_addresses, request):
**_E       fixture 'mock_server_base_ip_addr' not found_**


Summary:
Fixes #4653

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Re-add the necessary import.
#### How did you do it?
This change to re-add it.
#### How did you verify/test it?
Run test-acl.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
