### PR TITLE
[NAT] Fixed typo in 'iptables_output' variable

### DIFF
--- a/tests/nat/test_dynamic_nat.py
+++ b/tests/nat/test_dynamic_nat.py
@@ -646,7 +646,7 @@ class TestDynamicNat(object):
                                                                                                   portrange)]
                          }
         pytest_assert(iptables_rules == iptables_output,
-                      "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_ouput, iptables_rules))
+                      "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_output, iptables_rules))
         # Enable outer interface
         dut_interface_control(duthost, "enable", setup_data["config_portchannels"][ifname_to_disable]['members'][0])
         # Send traffic
@@ -941,7 +941,7 @@ class TestDynamicNat(object):
                           "postrouting": []
                          }
         pytest_assert(iptables_rules == iptables_output,
-                      "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_ouput, iptables_rules))
+                      "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_output, iptables_rules))
 
         # Prepare and add configuration json file
         nat_session = {
@@ -963,7 +963,7 @@ class TestDynamicNat(object):
                                                                                                   port_range)]
                          }
         pytest_assert(iptables_rules == iptables_output,
-                      "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_ouput, iptables_rules))
+                      "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_output, iptables_rules))
         # Check traffic. Zone 1 is not configured, not NAT translations expected
         generate_and_verify_not_translated_traffic(ptfadapter, setup_info, interface_type, direction, protocol_type, nat_type)
 
@@ -981,7 +981,7 @@ class TestDynamicNat(object):
                                                                                                   port_range)]
                          }
         pytest_assert(iptables_rules == iptables_output,
-                      "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_ouput, iptables_rules))
+                      "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_output, iptables_rules))
 
         # Perform TCP handshake (host-tor -> leaf-tor)
         perform_handshake(ptfhost, setup_data, protocol_type, direction,
@@ -1030,7 +1030,7 @@ class TestDynamicNat(object):
                                                                                                   portrange)]
                          }
         pytest_assert(iptables_rules == iptables_output,
-                      "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_ouput, iptables_rules))
+                      "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_output, iptables_rules))
         # Send TCP/UDP traffic and check
         generate_and_verify_traffic(duthost, ptfadapter, setup_data, interface_type, direction, protocol_type, nat_type=nat_type)
 
@@ -1045,7 +1045,7 @@ class TestDynamicNat(object):
                           "postrouting": []
                          }
         pytest_assert(iptables_rules == iptables_output,
-                      "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_ouput, iptables_rules))
+                      "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_output, iptables_rules))
         wait_timeout(protocol_type)
         # Send TCP/UDP traffic and check without NAT
         generate_and_verify_not_translated_traffic(ptfadapter, setup_info, interface_type, direction, protocol_type, nat_type)
@@ -1067,7 +1067,7 @@ class TestDynamicNat(object):
                                                                                                          portrange)]
                          }
         pytest_assert(iptables_rules == iptables_output,
-                      "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_ouput, iptables_rules))
+                      "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_output, iptables_rules))
 
         # Perform TCP handshake (host-tor -> leaf-tor)
         perform_handshake(ptfhost, setup_info, protocol_type, direction,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixed typo in 'iptables_output' variable that used in asserts "Unexpected iptables output for nat table"
By now we have issue [sonic-swss-1835](https://github.com/Azure/sonic-swss/issues/1835) which activates these asserts.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix incorrect test behavior.
```
pytest_assert(iptables_rules == iptables_output,
>                     "Unexpected iptables output for nat table. \n Got:\n{}\n Expected:\n{}".format(iptables_ouput, iptables_rules))
E       NameError: global name 'iptables_ouput' is not defined
```
#### How did you do it?
Replace "iptables_ouput" on "iptables_output".
#### How did you verify/test it?
Run test with changes and saw the expected result.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
