### PR TITLE
tests/scp: Improve SCP copy test to work both on old and new image

### DIFF
--- a/tests/scp/test_scp_copy.py
+++ b/tests/scp/test_scp_copy.py
@@ -44,8 +44,12 @@ def test_scp_copy(duthosts, rand_one_dut_hostname, ptfhost, setup_teardown, cred
     output = ptfhost.command("md5sum ./{}".format(TEST_FILE_NAME))["stdout"]
     orig_checksum = output.split()[0]
 
-    duthost.command("python3 perform_scp.py in {} /root/{} /home/admin {} {}"\
-        .format(ptf_ip, TEST_FILE_NAME, creds["ptf_host_user"], creds["ptf_host_pass"]))
+    python_version = "python3"
+    p3_pexp_exists = duthost.command("python3 -c 'import pexpect'", module_ignore_errors=True)["rc"]
+    if p3_pexp_exists!=0:
+        python_version = "python"
+    duthost.command("{} perform_scp.py in {} /root/{} /home/admin {} {}"\
+        .format(python_version, ptf_ip, TEST_FILE_NAME, creds["ptf_host_user"], creds["ptf_host_pass"]))
 
     # Validate file was received
     res = duthost.command("ls -ltr ./{}".format(TEST_FILE_NAME), module_ignore_errors=True)["rc"]
@@ -62,8 +66,8 @@ def test_scp_copy(duthosts, rand_one_dut_hostname, ptfhost, setup_teardown, cred
             .format(TEST_FILE_NAME, orig_checksum, TEST_FILE_NAME, new_checksum))
 
     # Use scp to copy the file into the PTF
-    duthost.command("python3 perform_scp.py out {} /home/admin/{} /root/{} {} {}"\
-            .format(ptf_ip, TEST_FILE_NAME, TEST_FILE_2_NAME, creds["ptf_host_user"], creds["ptf_host_pass"]))
+    duthost.command("{} perform_scp.py out {} /home/admin/{} /root/{} {} {}"\
+            .format(python_version, ptf_ip, TEST_FILE_NAME, TEST_FILE_2_NAME, creds["ptf_host_user"], creds["ptf_host_pass"]))
 
     # Validate that the file copied is now present in the PTF
     res = ptfhost.command("ls -ltr ./{}".format(TEST_FILE_2_NAME), module_ignore_errors=True)["rc"]


### PR DESCRIPTION


### tests/scp: Improve SCP copy test to work both on old and new image

* Use python2 to run perform scp on DUT for 2019 image.
* Use python3 to run perform scp on DUT for new images.

The test initially only worked on newer images but failed on the 201911 image.
The 201911 failure was brough up in [this issue](https://github.com/Azure/sonic-mgmt/issues/4480) and 
this PR tries to resolve the PR by making sure the test runs on both platforms. 

For further context, the failure occurred because pexpect library is not present in python3 but in python2 in the 201911 image.
I've run the test on both images in a t0 topology.

Summary:
Fixes # (https://github.com/Azure/sonic-mgmt/issues/4480)

### Type of change


- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Failure of test case in 201911 image.

#### How did you do it?
Used python2 for 201911 and python3 for newer images.

#### How did you verify/test it?
Tested change on both 201911 image and a fresh image in a t0 topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
Unchanged.
