### PR TITLE
[restart-ptf] Check ptf ports only if ptf exists

### DIFF
--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -31,6 +31,8 @@
       name: ptf_{{ vm_set_name }}
     register: ptf_docker_info
 
+  - debug: var=ptf_docker_info
+
   - name: Flush ptf network info log
     shell: |
       date > /tmp/ptf_network_{{ vm_set_name }}.log
@@ -40,6 +42,7 @@
       echo "before deleting" >> /tmp/ptf_network_{{ vm_set_name }}.log
       ls /proc/{{ ptf_docker_info.container.State.Pid }}/net/vlan/ >> /tmp/ptf_network_{{ vm_set_name }}.log
       echo "-----------------------------" >> /tmp/ptf_network_{{ vm_set_name }}.log
+    when: ptf_docker_info.exists
 
   - name: Remove ptf container ptf_{{ vm_set_name }}
     docker_container:
@@ -61,6 +64,7 @@
       echo "Before recreating" >> /tmp/ptf_network_{{ vm_set_name }}.log
       ls /proc/{{ ptf_docker_info.container.State.Pid }}/net/vlan/ >> /tmp/ptf_network_{{ vm_set_name }}.log
       echo "-----------------------------" >> /tmp/ptf_network_{{ vm_set_name }}.log
+    when: ptf_docker_info.exists
 
   - name: Create ptf container ptf_{{ vm_set_name }}
     docker_container:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4292

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Nightly pipelines complains errors about the task `Collect ptf network info before deletin` because the ptf might be not exists so the ptf port check will fail.

#### How did you do it?
Only check ptf ports only if the ptf exists.

#### How did you verify/test it?
Run `restart-ptf`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
