### PR TITLE
Add ignore err msg for the test_turn_on_off_psu_and_check_psustatus

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -53,7 +53,10 @@ SKIP_ERROR_LOG_COMMON = ['.*ERR syncd#syncd:.*SAI_API_QUEUE:_brcm_sai_cosq_stat_
 SKIP_ERROR_LOG_SHOW_PLATFORM_TEMP = ['.*ERR pmon#thermalctld.*int\(\) argument must be a string.* or a number.*',
                                      '.*ERR pmon#thermalctld.*invalid literal for int\(\) with base 10.*']
 
-SKIP_ERROR_LOG_PSU_ABSENCE = ['.*Error getting sensor data: dps460.*Kernel interface error.*']
+SKIP_ERROR_LOG_PSU_ABSENCE = ['.*Error getting sensor data: dps460.*Kernel interface error.*',
+                              '.*ERR pmon#psud:.*Fail to read model number: No key PN_VPD_FIELD in.*',
+                              '.*ERR pmon#psud:.*Fail to read serial number: No key SN_VPD_FIELD in.*',
+                              '.*ERR pmon#psud:.*Fail to read revision: No key REV_VPD_FIELD in.*']
 
 SKIP_ERROR_LOG_SHOW_PLATFORM_TEMP.extend(SKIP_ERROR_LOG_COMMON)
 SKIP_ERROR_LOG_PSU_ABSENCE.extend(SKIP_ERROR_LOG_COMMON)


### PR DESCRIPTION
The code added in https://github.com/Azure/sonic-buildimage/pull/9040 will introduce timing err msg, the test case need to be aligned with adding ingnore for  the err msg since it is a functional issue.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add ignore err msg for the test_turn_on_off_psu_and_check_psustatus
Fixes # (issue) test_turn_on_off_psu_and_check_psustatus failed from time to time due to the err msg in the syslog.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Make the test_turn_on_off_psu_and_check_psustatus pass,  currently the test case failed due to err msg in the syslog:

 _LogAnalyzerError: {'match_messages': {'/tmp/syslog.r-tigon-15.2021-11-09-18:29:27': ['Nov  9 18:29:02.843342 r-tigon-15 ERR pmon#psud: Fail to read model number: No key PN_VPD_FIELD in VPD /var/run/hw-management/eeprom/psu1_vpd\n', 'Nov  9 18:29:02.843403 r-tigon-15 ERR pmon#psud: Fail to read serial number: No key SN_VPD_FIELD in VPD /var/run/hw-management/eeprom/psu1_vpd\n', 'Nov  9 18:29:02.843438 r-tigon-15 ERR pmon#psud: Fail to read revision: No key REV_VPD_FIELD in VPD /var/run/hw-management/eeprom/psu1_vpd\n']}, 'total': {'expected_match': 0, 'expected_missing_match': 0, 'match': 3}, 'match_files': {'/tmp/syslog.r-tigon-15.2021-11-09-18:29:27': {'expected_match': 0, 'match': 3}}, 'expect_messages': {'/tmp/syslog.r-tigon-15.2021-11-09-18:29:27': []}, 'unused_expected_regexp': []}_
#### How did you do it?
Add the err msg which should be ignored to the ignore list:
SKIP_ERROR_LOG_PSU_ABSENCE = ['.*Error getting sensor data: dps460.*Kernel interface error.*',
                              **'.*ERR pmon#psud:.*Fail to read model number: No key PN_VPD_FIELD in.*',
                              '.*ERR pmon#psud:.*Fail to read serial number: No key SN_VPD_FIELD in.*',
                              '.*ERR pmon#psud:.*Fail to read revision: No key REV_VPD_FIELD in.*'**]
#### How did you verify/test it?
Run the test case, and test case pass
py.test platform_tests/test_platform_info.py --inventory="../ansible/inventory,../ansible/veos" --host-pattern r-tigon-15 --module-path                ../ansible/library/ --testbed r-tigon-15-ptf-any --testbed_file ../ansible/testbed.csv                --allow_recover  --session_id 5356417 --mars_key_id 0.10.1.1.1.1.1.3.2.1.1                --junit-xml junit_5356417_0.10.1.1.1.1.1.3.2.1.1.xml --assert plain --log-cli-level debug --show-capture=no -ra --showlocals -k="test_thermal_control_psu_absence" --clean-alluredir --alluredir=/tmp/allure-results --allure_server_addr="10.215.11.120" --allure_server_project_id=r-tigon-15-platform-tests-test-platform-info-py
#### Any platform specific information?
No
