### PR TITLE
[test_host_vlan.py]Replace config reload method

### DIFF
--- a/tests/vlan/test_host_vlan.py
+++ b/tests/vlan/test_host_vlan.py
@@ -73,8 +73,10 @@ def setup_host_vlan_intf_mac(duthosts, rand_one_dut_hostname, testbed_params, ve
     wait_until(10, 2, 2, lambda: duthost.get_dut_iface_mac(vlan_intf["attachto"]) == DUT_VLAN_INTF_MAC)
 
     yield
-
-    config_reload(duthost)
+    
+    DUT_HOST_MAC = duthost.get_dut_iface_mac('eth0')
+    duthost.shell('redis-cli -n 4 hmset "VLAN|%s" mac %s' % (vlan_intf["attachto"], DUT_HOST_MAC))
+    wait_until(10, 2, 2, lambda: duthost.get_dut_iface_mac(vlan_intf["attachto"]) == DUT_HOST_MAC)
 
 
 def test_host_vlan_no_floodling(

--- a/tests/vlan/test_host_vlan.py
+++ b/tests/vlan/test_host_vlan.py
@@ -68,14 +68,14 @@ def verify_host_port_vlan_membership(duthosts, rand_one_dut_hostname, testbed_pa
 def setup_host_vlan_intf_mac(duthosts, rand_one_dut_hostname, testbed_params, verify_host_port_vlan_membership):
     vlan_intf, _ = testbed_params
     duthost = duthosts[rand_one_dut_hostname]
+    dut_vlan_mac = duthost.get_dut_iface_mac('%s' % vlan_intf["attachto"])
     duthost.shell('redis-cli -n 4 hmset "VLAN|%s" mac %s' % (vlan_intf["attachto"], DUT_VLAN_INTF_MAC))
     wait_until(10, 2, 2, lambda: duthost.get_dut_iface_mac(vlan_intf["attachto"]) == DUT_VLAN_INTF_MAC)
 
     yield
     
-    DUT_HOST_MAC = duthost.get_dut_iface_mac('eth0')
-    duthost.shell('redis-cli -n 4 hmset "VLAN|%s" mac %s' % (vlan_intf["attachto"], DUT_HOST_MAC))
-    wait_until(10, 2, 2, lambda: duthost.get_dut_iface_mac(vlan_intf["attachto"]) == DUT_HOST_MAC)
+    duthost.shell('redis-cli -n 4 hmset "VLAN|%s" mac %s' % (vlan_intf["attachto"], dut_vlan_mac))
+    wait_until(10, 2, 2, lambda: duthost.get_dut_iface_mac(vlan_intf["attachto"]) == dut_vlan_mac)
 
 
 def test_host_vlan_no_floodling(

--- a/tests/vlan/test_host_vlan.py
+++ b/tests/vlan/test_host_vlan.py
@@ -7,7 +7,6 @@ import tempfile
 from scapy.all import sniff
 from ptf import testutils
 
-from tests.common.config_reload import config_reload
 from tests.common.dualtor.mux_simulator_control import mux_server_url                                   # lgtm[py/unused-import]
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # lgtm[py/unused-import]
 from tests.common.utilities import is_ipv4_address


### PR DESCRIPTION
replace config reload

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The config reload took a too long time.
========================== 1 passed in 338.26 seconds ==========================

After replace config reload by changing mac to its origin, time saved.
========================== 1 passed in 72.34 seconds ===========================

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Reduce test teardown time.
#### How did you do it?
Remove config reload by changing the mac back to origin.
#### How did you verify/test it?
Run test_host_vlan.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
