### PR TITLE
[arp]: Use unicast arp packst to verify arp table

### DIFF
--- a/tests/arp/test_tagged_arp.py
+++ b/tests/arp/test_tagged_arp.py
@@ -18,7 +18,7 @@ from tests.common.helpers.assertions import pytest_require
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 't0-56-po2vlan')
+    pytest.mark.topology('t0')
 ]
 
 PTF_PORT_MAPPING_MODE = "use_orig_interface"
@@ -71,10 +71,10 @@ def setup_arp(duthosts, rand_one_dut_hostname, cfg_facts):
         arp_cleanup(duthost)
 
 
-def build_arp_packet(vlan_id, neighbor_mac, neighbor_ip):
+def build_arp_packet(vlan_id, neighbor_mac, dst_mac, neighbor_ip):
 
     pkt = testutils.simple_arp_packet(pktlen=60 if vlan_id == 0 else 64,
-            eth_dst='ff:ff:ff:ff:ff:ff',
+            eth_dst=dst_mac,
             eth_src=neighbor_mac,
             vlan_vid=vlan_id,
             arp_op=2,
@@ -82,56 +82,6 @@ def build_arp_packet(vlan_id, neighbor_mac, neighbor_ip):
             ip_snd=neighbor_ip,
             ip_tgt=neighbor_ip)
     return pkt
-
-
-def verify_packets_with_portchannel(test, pkt, ports=[], portchannel_ports=[], device_number=0, timeout=1):
-    for port in ports:
-        result = testutils.dp_poll(test, device_number=device_number, port_number=port,
-                                   timeout=timeout, exp_pkt=pkt)
-        if isinstance(result, test.dataplane.PollFailure):
-            test.fail("Expected packet was not received on device %d, port %r.\n%s"
-                    % (device_number, port, result.format()))
-
-    for port_group in portchannel_ports:
-        for port in port_group:
-            result = testutils.dp_poll(test, device_number=device_number, port_number=port,
-                                       timeout=timeout, exp_pkt=pkt)
-            if isinstance(result, test.dataplane.PollSuccess):
-                break
-        else:
-            test.fail("Expected packet was not received on device %d, ports %s.\n"
-                    % (device_number, str(port_group)))
-
-
-def verify_arp_packets(ptfadapter, vlan_ports_list, vlan_port, vlan_id, untagged_pkt, masked_tagged_pkt):
-    untagged_dst_ports = []
-    tagged_dst_ports = []
-    untagged_dst_pc_ports = []
-    tagged_dst_pc_ports = []
-    logger.info("Verify packets from ports " + str(vlan_port["port_index"][0]))
-    for port in vlan_ports_list:
-        if vlan_port["port_index"] == port["port_index"]:
-            # Skip src port
-            continue
-        if port["pvid"] == vlan_id:
-            if len(port["port_index"]) > 1:
-                untagged_dst_pc_ports.append(port["port_index"])
-            else:
-                untagged_dst_ports += port["port_index"]
-        elif vlan_id in map(int, port["permit_vlanid"]):
-            if len(port["port_index"]) > 1:
-                tagged_dst_pc_ports.append(port["port_index"])
-            else:
-                tagged_dst_ports += port["port_index"]
-
-    verify_packets_with_portchannel(test=ptfadapter,
-                                    pkt=untagged_pkt,
-                                    ports=untagged_dst_ports,
-                                    portchannel_ports=untagged_dst_pc_ports)
-    verify_packets_with_portchannel(test=ptfadapter,
-                                    pkt=masked_tagged_pkt,
-                                    ports=tagged_dst_ports,
-                                    portchannel_ports=tagged_dst_pc_ports)
 
 
 @pytest.mark.bsl
@@ -143,6 +93,7 @@ def test_tagged_arp_pkt(ptfadapter, vlan_ports_list, duthosts, rand_one_dut_host
     verify show arp command on DUT.
     """
     duthost = duthosts[rand_one_dut_hostname]
+    router_mac = duthost.facts['router_mac']
     for vlan_port in vlan_ports_list:
         port_index = vlan_port["port_index"][0]
         # Send GARP packets to switch to populate the arp table with dummy MACs for each port
@@ -157,40 +108,39 @@ def test_tagged_arp_pkt(ptfadapter, vlan_ports_list, duthosts, rand_one_dut_host
             # Perform ARP clean up
             arp_cleanup(duthost)
             for i in range(DUMMY_ARP_COUNT):
-                pkt = build_arp_packet(permit_vlanid, dummy_macs[i], dummy_ips[i])
-                exp_untagged_pkt = build_arp_packet(0, dummy_macs[i], dummy_ips[i])
-                # vlan priority attached to packets is determined by the port, so we ignore it here
-                exp_tagged_pkt = Mask(pkt)
-                exp_tagged_pkt.set_do_not_care_scapy(scapy.Dot1Q, "prio")
+                pkt = build_arp_packet(permit_vlanid, dummy_macs[i], router_mac, dummy_ips[i])
                 logger.info("Send tagged({}) packet from {} ...".format(permit_vlanid, port_index))
                 testutils.send(ptfadapter, port_index, pkt)
-                verify_arp_packets(ptfadapter, vlan_ports_list, vlan_port, permit_vlanid, exp_untagged_pkt, exp_tagged_pkt)
 
-            res = duthost.command('show arp')
-            assert res['rc'] == 0
-            logger.info('"show arp" output on DUT:\n{}'.format(pprint.pformat(res['stdout_lines'])))
+            try:
+                res = duthost.command('show arp')
+                assert res['rc'] == 0
+                logger.info('"show arp" output on DUT:\n{}'.format(pprint.pformat(res['stdout_lines'])))
 
-            arp_cnt = 0
-            for l in res['stdout_lines']:
-                # Address MacAddress Iface Vlan
-                items = l.split()
-                if len(items) != 4:
-                    continue
-                # Vlan must be number
-                if not items[3].isdigit():
-                    continue
-                arp_cnt += 1
-                ip = items[0]
-                mac = items[1]
-                ifname = items[2]
-                vlan_id = int(items[3])
-                assert ip in dummy_ips
-                assert mac in dummy_macs
-                # 'show arp' command gets iface from FDB table,
-                # if 'show arp' command was earlier than FDB table update, ifname would be '-'
-                if ifname == '-':
-                    logger.info('Ignore unknown iface...')
-                else:
-                    assert ifname == vlan_port["dev"]
-                assert vlan_id == permit_vlanid
-            assert arp_cnt == DUMMY_ARP_COUNT
+                arp_cnt = 0
+                for l in res['stdout_lines']:
+                    # Address MacAddress Iface Vlan
+                    items = l.split()
+                    if len(items) != 4:
+                        continue
+                    # Vlan must be number
+                    if not items[3].isdigit():
+                        continue
+                    arp_cnt += 1
+                    ip = items[0]
+                    mac = items[1]
+                    ifname = items[2]
+                    vlan_id = int(items[3])
+                    assert ip in dummy_ips
+                    assert mac in dummy_macs
+                    # 'show arp' command gets iface from FDB table,
+                    # if 'show arp' command was earlier than FDB table update, ifname would be '-'
+                    if ifname == '-':
+                        logger.info('Ignore unknown iface...')
+                    else:
+                        assert ifname == vlan_port["dev"]
+                    assert vlan_id == permit_vlanid
+                assert arp_cnt == DUMMY_ARP_COUNT
+            except Exception as detail:
+                logger.error("Except: {}".format(detail))
+

--- a/tests/arp/test_tagged_arp.py
+++ b/tests/arp/test_tagged_arp.py
@@ -1,8 +1,6 @@
 
 import pytest
-import ptf.packet as scapy
 import ptf.testutils as testutils
-from ptf.mask import Mask
 
 import itertools
 import logging


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
test_tagged_arp test failed on t0-116 topology.

#### How did you do it?
Use unicast arp packet, and don't need to receive arp packet on PTF.

#### How did you verify/test it?
Run test with t0 topology and t0-116 topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
