### PR TITLE
Skip unsupported platform API test on Mellanox platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -130,6 +130,24 @@ platform_tests/api/test_psu.py::TestPsuApi::test_led:
     conditions:
       - "asic_type in ['mellanox']"
 
+platform_tests/api/test_psu.py::TestPsuApi::test_fans:
+  skip:
+    reason: "Unsupported platform API"
+    conditions:
+      - "asic_type in ['mellanox']"
+
+platform_tests/api/test_psu.py::TestPsuApi::test_get_serial:
+  skip:
+    reason: "Unsupported platform API"
+    conditions:
+      - "asic_type in ['mellanox']"
+
+platform_tests/api/test_psu.py::TestPsuApi::test_get_model:
+  skip:
+    reason: "Unsupported platform API"
+    conditions:
+      - "asic_type in ['mellanox']"
+
 platform_tests/api/test_psu_fans.py::TestPsuFans::test_get_model:
   skip:
     reason: "Unsupported platform API"


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip test cases ```TestPsuApi::test_fans``` , ```TestPsuApi::test_get_serial``` and ```TestPsuApi::test_get_model``` that depend on unsupported API on ```Mellanox```.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to skip test cases that depend on unsupported API on ```Mellanox```.

#### How did you do it?
Add the unsupported test cases into ```tests_mark_conditions.yaml```.

#### How did you verify/test it?
Verified by running the test cases that are expected to be skipped.

#### Any platform specific information?
Only for ```Mellanox```.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
