### PR TITLE
Removed optional field "Vendor Extension" from expected fields list for syseeprom output

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -151,7 +151,6 @@ def test_show_platform_syseeprom(duthosts, enum_rand_one_per_hwsku_hostname, dut
             "Device Version",
             "MAC Addresses",
             "Manufacturer",
-            "Vendor Extension",
             "ONIE Version",
             "CRC-32"]
 


### PR DESCRIPTION
Removed optional field "Vendor Extension" from expected fields list for syseeprom output

Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Some platform may not have "Vendor Extension" in output for cmd: ```show platform syseeprom```
This filed optional.

Summary: Removed optional field "Vendor Extension" from expected fields list for syseeprom output
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Some platform may not have "Vendor Extension" in output for cmd: ```show platform syseeprom```

#### How did you do it?
Removed optional field from list of expected fields

#### How did you verify/test it?
Executed platform test: platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
