### PR TITLE
[platform_test/api] Enhance SFP power_override API test

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -177,6 +177,12 @@ class TestSfpApi(PlatformApiTestBase):
             return False
         return True
 
+    def is_xcvr_support_power_override(self, xcvr_info_dict):
+        """Returns True if transceiver supports power override, False if not supported"""
+        xcvr_type = xcvr_info_dict["type_abbrv_name"]
+        is_valid_xcvr_type = "QSFP" in xcvr_type and xcvr_type != "QSFP-DD"
+        return self.is_xcvr_optical(xcvr_info_dict) and is_valid_xcvr_type
+
     #
     # Functions to test methods inherited from DeviceBase class
     #
@@ -523,7 +529,7 @@ class TestSfpApi(PlatformApiTestBase):
             if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
                 continue
 
-            if not self.is_xcvr_optical(info_dict):
+            if not self.is_xcvr_support_power_override(info_dict):
                 logger.warning("test_power_override: Skipping transceiver {} (not applicable for this transceiver type)".format(i))
                 continue
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Enhance SFP test_power_override test case to check for xcvr support

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The power override API is currently only applicable to QSFP-type modules but the corresponding test case does not reflect this.

#### How did you do it?
 Added a check, `is_xcvr_support_power_override`, to skip testing if power override is not applicable to the xcvr.

#### How did you verify/test it?
Ran test on Arista platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
