### PR TITLE
[dualtor_io]: Reduce performance expectations

### DIFF
--- a/tests/common/devices/duthosts.py
+++ b/tests/common/devices/duthosts.py
@@ -111,6 +111,9 @@ class DutHosts(object):
         """
         return getattr(self.nodes, attr)
 
+    def __repr__(self):
+        return self.nodes.__repr__()
+
     def config_facts(self, *module_args, **complex_args):
         result = {}
         for node in self.nodes:

--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -196,7 +196,7 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo):
     arp_setup(ptfhost)
     
     def t1_to_server_io_test(activehost, tor_vlan_port=None,
-                            delay=0, allowed_disruption=0, action=None, verify=False, send_interval=None,
+                            delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.01,
                             stop_after=None):
         """
         Helper method for `send_t1_to_server_with_action`.
@@ -261,7 +261,7 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo):
     arp_setup(ptfhost)
 
     def server_to_t1_io_test(activehost, tor_vlan_port=None,
-                            delay=0, allowed_disruption=0, action=None, verify=False, send_interval=None,
+                            delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.01,
                             stop_after=None):
         """
         Helper method for `send_server_to_t1_with_action`.

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 class DualTorIO:
     def __init__(self, activehost, standbyhost, ptfhost, ptfadapter, tbinfo,
-                io_ready, tor_vlan_port=None, send_interval=None):
+                io_ready, tor_vlan_port=None, send_interval=0.01):
         self.tor_pc_intf = None
         self.tor_vlan_intf = tor_vlan_port
         self.duthost = activehost
@@ -91,6 +91,7 @@ class DualTorIO:
         else:
             self.send_interval = send_interval
         # How many packets to be sent by sender thread
+        logger.info("Using send interval {}".format(self.send_interval))
         self.packets_to_send = min(int(self.time_to_listen /
             (self.send_interval + 0.0015)), 45000)
         self.packets_sent_per_server = dict()

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1084,3 +1084,21 @@ def remove_static_routes(standby_tor, active_tor_loopback_ip):
     """
     logger.info("Removing dual ToR peer switch static route")
     standby_tor.shell('ip route del {}/32'.format(active_tor_loopback_ip), module_ignore_errors=True)
+
+
+def increase_linkmgrd_probe_interval(duthosts, tbinfo):
+    '''
+    Increase the interval at which linkmgrd sends ICMP heartbeats to the server/PTF
+    '''
+    if 'dualtor' not in tbinfo['topo']['name']:
+        return
+
+    probe_interval_ms = 1000
+
+    logger.info("Increase linkmgrd probe interval on {} to {}ms".format(duthosts, probe_interval_ms))
+
+    cmds = []
+    cmds.append('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
+                    .format(probe_interval_ms))
+    cmds.append("config save -y")
+    duthosts.shell_cmds(cmds=cmds)

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -12,6 +12,7 @@ from natsort import natsorted
 
 from tests.common import constants
 from tests.common.helpers.assertions import pytest_assert as pt_assert
+from tests.common.dualtor.dual_tor_utils import increase_linkmgrd_probe_interval
 
 logger = logging.getLogger(__name__)
 
@@ -191,14 +192,18 @@ def ptf_portmap_file(duthosts, rand_one_dut_hostname, ptfhost):
     yield "/root/{}".format(portMapFile.split('/')[-1])
 
 
-@pytest.fixture(scope="session", autouse=True)
-def run_icmp_responder(duthost, ptfhost, tbinfo):
+@pytest.fixture(scope="module", autouse=True)
+def run_icmp_responder(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     """Run icmp_responder.py over ptfhost."""
     # No vlan is avaliable on non-t0 testbed, so skip this fixture 
     if 't0' not in tbinfo['topo']['type']:
         logger.info("Not running on a T0 testbed, not starting ICMP responder")
         yield
         return
+
+    increase_linkmgrd_probe_interval(duthosts, tbinfo)
+
+    duthost = duthosts[rand_one_dut_hostname]
     logger.debug("Copy icmp_responder.py to ptfhost '{0}'".format(ptfhost.hostname))
     ptfhost.copy(src=os.path.join(SCRIPTS_SRC_DIR, ICMP_RESPONDER_PY), dest=OPT_DIR)
 

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -41,7 +41,7 @@ def test_normal_op_downstream_standby(upper_tor_host, lower_tor_host,
     Send downstream traffic to the standby ToR and confirm no disruption or
     switchover occurs
     """
-    send_t1_to_server_with_action(lower_tor_host, verify=True)
+    send_t1_to_server_with_action(lower_tor_host, verify=True, stop_after=60)
     verify_tor_states(expected_active_host=upper_tor_host,
                       expected_standby_host=lower_tor_host)
 

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -241,6 +241,24 @@ def test_update_saithrift_ptf(request, ptfhost):
     ptfhost.shell("dpkg -i {}".format(os.path.join("/root", pkg_name)))
     logging.info("Python saithrift package installed successfully")
 
+def test_increase_linkmgrd_probe_interval(duthosts, enum_dut_hostname, tbinfo):
+    '''
+    Increase the interval at which linkmgrd sends ICMP heartbeats to the server/PTF
+    '''
+    if 'dualtor' not in tbinfo['topo']['name']:
+        return
+
+    duthost = duthosts[enum_dut_hostname]
+    probe_interval_ms = 1000
+
+    logger.info("Increase linkmgrd probe interval on {} to {}ms".format(duthost, probe_interval_ms))
+
+    cmds = []
+    cmds.append('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
+                    .format(probe_interval_ms))
+    cmds.append("config save -y")
+    duthost.shell_cmds(cmds=cmds)
+
 def test_inject_y_cable_simulator_client(duthosts, enum_dut_hostname, tbinfo, vmhost):
     '''
     Inject the Y cable simulator client to both ToRs in a dualtor testbed

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -241,24 +241,6 @@ def test_update_saithrift_ptf(request, ptfhost):
     ptfhost.shell("dpkg -i {}".format(os.path.join("/root", pkg_name)))
     logging.info("Python saithrift package installed successfully")
 
-def test_increase_linkmgrd_probe_interval(duthosts, enum_dut_hostname, tbinfo):
-    '''
-    Increase the interval at which linkmgrd sends ICMP heartbeats to the server/PTF
-    '''
-    if 'dualtor' not in tbinfo['topo']['name']:
-        return
-
-    duthost = duthosts[enum_dut_hostname]
-    probe_interval_ms = 1000
-
-    logger.info("Increase linkmgrd probe interval on {} to {}ms".format(duthost, probe_interval_ms))
-
-    cmds = []
-    cmds.append('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|LINK_PROBER" "interval_v4" "{}"'
-                    .format(probe_interval_ms))
-    cmds.append("config save -y")
-    duthost.shell_cmds(cmds=cmds)
-
 def test_inject_y_cable_simulator_client(duthosts, enum_dut_hostname, tbinfo, vmhost):
     '''
     Inject the Y cable simulator client to both ToRs in a dualtor testbed


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Dual ToR tests/testbeds currently operate at performance levels meant for physical mux cables. These levels of performance cannot always be achieved with the mux simulator, especially when lab servers are under heavy CPU load. Since these tests are only meant to ensure correctness and not performance, lowering the performance expectations will improve consistency.

#### How did you do it?
- Before the ICMP responder runs, configure the linkmgrd probe interval to 1s on all DUTs
    - This change is not reverted after fixture runs, as it should be appropriate for linkmgrd to operate at this reduced speed all the time with the ICMP responder
- Increase the default packet send interval for dual ToR tests from .0035s to .01s
- Exit test case `test_normal_op_downstream_standby` early to align with other test cases in this module where switchovers are not expected
- Add a `__repr__` method to the `Duthosts` class for improved logging

#### How did you verify/test it?
- Run a dualtor_io test with the server under high CPU load, check that no spontaneous switchovers occur. Verify that the linkmgrd probe interval was set to 1s

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
