### PR TITLE
Re-united pytest topology mark's character

### DIFF
--- a/tests/acl/null_route/test_null_route_helper.py
+++ b/tests/acl/null_route/test_null_route_helper.py
@@ -16,7 +16,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyze
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("t0"),
+    pytest.mark.topology('t0'),
     pytest.mark.disable_loganalyzer,  # Disable automatic loganalyzer, since we use it for the test
 ]
 

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.acl,
     pytest.mark.disable_loganalyzer,  # Disable automatic loganalyzer, since we use it for the test
-    pytest.mark.topology("any"),
+    pytest.mark.topology('any'),
     pytest.mark.usefixtures('backup_and_restore_config_db_on_duts')
 ]
 

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -16,7 +16,7 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 
 
 pytestmark = [
-    pytest.mark.topology("any"),
+    pytest.mark.topology('any'),
 ]
 
 PEER_COUNT = 2

--- a/tests/configlet/test_add_rack.py
+++ b/tests/configlet/test_add_rack.py
@@ -54,7 +54,7 @@ from common import *
 #
 
 pytestmark = [
-        pytest.mark.topology("t1")
+        pytest.mark.topology('t1')
         ]
 
 ORIG_DB_SUB_DIR = "orig"

--- a/tests/console/test_console_availability.py
+++ b/tests/console/test_console_availability.py
@@ -5,7 +5,7 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
-    pytest.mark.topology("any"),
+    pytest.mark.topology('any'),
     pytest.mark.device_type("vs")
 ]
 

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -35,7 +35,7 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 
 pytestmark = [
-    pytest.mark.topology("t1", "t2")
+    pytest.mark.topology('t1', 't2')
 ]
 
 _COPPTestParameters = namedtuple("_COPPTestParameters",

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -17,7 +17,7 @@ from tests.common.fixtures.duthost_utils import disable_fdb_aging
 
 
 pytestmark = [
-    pytest.mark.topology("any")
+    pytest.mark.topology('any')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/dhcp_relay/test_dhcp_pkt_fwd.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_fwd.py
@@ -11,7 +11,7 @@ from ptf.mask import Mask
 from socket import INADDR_ANY
 
 pytestmark = [
-    pytest.mark.topology("t1")
+    pytest.mark.topology('t1')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -15,7 +15,7 @@ from tests.common.helpers.drop_counters.drop_counters import verify_drop_counter
 from .drop_packets import *  # FIXME
 
 pytestmark = [
-    pytest.mark.topology("any")
+    pytest.mark.topology('any')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -28,7 +28,7 @@ from tests.common.utilities import dump_scapy_packet_show_output
 
 
 pytestmark = [
-    pytest.mark.topology("t0")
+    pytest.mark.topology('t0')
 ]
 
 

--- a/tests/dualtor/test_orch_stress.py
+++ b/tests/dualtor/test_orch_stress.py
@@ -29,7 +29,7 @@ from tests.common.dualtor.dual_tor_utils import tor_mux_intfs
 from tests.common.dualtor.dual_tor_mock import *
 
 pytestmark = [
-    pytest.mark.topology("t0")
+    pytest.mark.topology('t0')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/dualtor/test_orchagent_slb.py
+++ b/tests/dualtor/test_orchagent_slb.py
@@ -22,7 +22,7 @@ from tests.common.utilities import is_ipv4_address
 
 
 pytestmark = [
-    pytest.mark.topology("dualtor")
+    pytest.mark.topology('dualtor')
 ]
 
 

--- a/tests/dualtor/test_tor_ecn.py
+++ b/tests/dualtor/test_tor_ecn.py
@@ -31,7 +31,7 @@ from tests.common.utilities import dump_scapy_packet_show_output
 from tests.common.dualtor.tunnel_traffic_utils import derive_queue_id_from_dscp
 
 pytestmark = [
-    pytest.mark.topology("t0")
+    pytest.mark.topology('t0')
 ]
 
 @contextlib.contextmanager

--- a/tests/dualtor_io/test_heartbeat_failure.py
+++ b/tests/dualtor_io/test_heartbeat_failure.py
@@ -11,7 +11,7 @@ from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_ser
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 
 pytestmark = [
-    pytest.mark.topology("dualtor")
+    pytest.mark.topology('dualtor')
 ]
 
 

--- a/tests/dualtor_io/test_link_drop.py
+++ b/tests/dualtor_io/test_link_drop.py
@@ -18,7 +18,7 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory         
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 
 pytestmark = [
-    pytest.mark.topology("dualtor")
+    pytest.mark.topology('dualtor')
 ]
 
 def _set_drop_factory(set_drop_func, direction, tor_mux_intfs):

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -9,7 +9,7 @@ from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_ser
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 
 pytestmark = [
-    pytest.mark.topology("dualtor")
+    pytest.mark.topology('dualtor')
 ]
 
 

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -9,7 +9,7 @@ from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_ser
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC, CONFIG_RELOAD_ALLOWED_DISRUPTION_SEC
 
 pytestmark = [
-    pytest.mark.topology("dualtor")
+    pytest.mark.topology('dualtor')
 ]
 
 

--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -10,7 +10,7 @@ from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 
 pytestmark = [
-    pytest.mark.topology("dualtor")
+    pytest.mark.topology('dualtor')
 ]
 
 '''

--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -13,7 +13,7 @@ from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("dualtor")
+    pytest.mark.topology('dualtor')
 ]
 
 

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -9,7 +9,7 @@ from everflow_test_utilities import BaseEverflowTest
 from everflow_test_utilities import setup_info  # noqa: F401, E501 lgtm[py/unused-import] pylint: disable=import-error
 
 pytestmark = [
-    pytest.mark.topology("t1")
+    pytest.mark.topology('t1')
 ]
 
 EVERFLOW_V6_RULES = "ipv6_test_rules.yaml"

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -13,7 +13,7 @@ from tests.common.helpers.assertions import pytest_require, pytest_assert
 from everflow_test_utilities import setup_info, EVERFLOW_DSCP_RULES       # noqa: F401, E501 lgtm[py/unused-import] pylint: disable=import-error
 
 pytestmark = [
-    pytest.mark.topology("any")
+    pytest.mark.topology('any')
 ]
 
 EVERFLOW_TABLE_NAME = {

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -15,7 +15,7 @@ from tests.common.fixtures.ptfhost_utils import copy_acstests_directory   # noqa
 from everflow_test_utilities import setup_info, EVERFLOW_DSCP_RULES       # noqa: F401, E501 lgtm[py/unused-import] pylint: disable=import-error
 
 pytestmark = [
-    pytest.mark.topology("t1")
+    pytest.mark.topology('t1')
 ]
 
 

--- a/tests/http/test_http_copy.py
+++ b/tests/http/test_http_copy.py
@@ -5,7 +5,7 @@ from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology("any"),
+    pytest.mark.topology('any'),
     pytest.mark.device_type("vs"),
 ]
 

--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -12,7 +12,7 @@ from pkg_resources import parse_version
 from tests.common.devices.ptf import PTFHost
 
 pytestmark = [
-    pytest.mark.topology("any")
+    pytest.mark.topology('any')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/pfc/test_unknown_mac.py
+++ b/tests/pfc/test_unknown_mac.py
@@ -21,7 +21,7 @@ from tests.common.utilities import get_intf_by_sub_intf
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology("t0")]
+pytestmark = [pytest.mark.topology('t0')]
 
 TEST_PKT_CNT = 10
 

--- a/tests/platform_tests/test_port_toggle.py
+++ b/tests/platform_tests/test_port_toggle.py
@@ -8,7 +8,7 @@ from tests.common import port_toggle
 
 
 pytestmark = [
-    pytest.mark.topology("any")
+    pytest.mark.topology('any')
 ]
 
 

--- a/tests/sai_qualify/sai_infra.py
+++ b/tests/sai_qualify/sai_infra.py
@@ -20,7 +20,7 @@ from community_cases import *
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("ptf")
+    pytest.mark.topology('ptf')
 ]
 
 TEST_INTERFACE_PARAMS = "--interface '0@eth0' --interface '1@eth1' --interface '2@eth2' \

--- a/tests/scp/test_scp_copy.py
+++ b/tests/scp/test_scp_copy.py
@@ -3,7 +3,7 @@ from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology("any"),
+    pytest.mark.topology('any'),
     pytest.mark.device_type("vs"),
 ]
 

--- a/tests/ssh/test_ssh_stress.py
+++ b/tests/ssh/test_ssh_stress.py
@@ -8,7 +8,7 @@ from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology("any"),
+    pytest.mark.topology('any'),
     pytest.mark.device_type("vs"),
 ]
 

--- a/tests/sub_port_interfaces/test_show_subinterface.py
+++ b/tests/sub_port_interfaces/test_show_subinterface.py
@@ -7,7 +7,7 @@ from tests.common.utilities import wait_until
 
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1")
+    pytest.mark.topology('t0', 't1')
 ]
 
 

--- a/tests/sub_port_interfaces/test_sub_port_l2_forwarding.py
+++ b/tests/sub_port_interfaces/test_sub_port_l2_forwarding.py
@@ -13,7 +13,7 @@ from tests.common.helpers.assertions import pytest_assert
 
 
 pytestmark = [
-    pytest.mark.topology("t0")
+    pytest.mark.topology('t0')
 ]
 
 

--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -8,7 +8,7 @@ from scapy.all import rdpcap
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("any")
+    pytest.mark.topology('any')
 ]
 
 DUT_PCAP_FILEPATH = "/tmp/test_syslog_tcpdump.pcap"

--- a/tests/vlan/test_host_vlan.py
+++ b/tests/vlan/test_host_vlan.py
@@ -16,7 +16,7 @@ from tests.common.utilities import skip_version
 
 
 pytestmark = [
-    pytest.mark.topology("t0")
+    pytest.mark.topology('t0')
 ]
 
 DUT_VLAN_INTF_MAC = "00:00:11:22:33:44"

--- a/tests/vxlan/test_vnet_route_leak.py
+++ b/tests/vxlan/test_vnet_route_leak.py
@@ -12,7 +12,7 @@ from tests.common.config_reload import config_reload
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("t0"),
+    pytest.mark.topology('t0'),
     pytest.mark.asic("mellanox")
 ]
 

--- a/tests/vxlan/test_vnet_vxlan.py
+++ b/tests/vxlan/test_vnet_vxlan.py
@@ -15,7 +15,7 @@ from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("t0"),
+    pytest.mark.topology('t0'),
     pytest.mark.sanity_check(post_check=True),
     pytest.mark.asic("mellanox")
 ]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Our test scripts are not unified on the characters of pytest.mark.topology.
This PR is to change the pytest topology marks' character from " " to ' '

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Standardize the character of topology marks in test scripts.
#### How did you do it?
change the character of pytest topology marks from " " to ' '
#### How did you verify/test it?
Run tests
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
