### PR TITLE
Add "testbed-cli.sh config-y-cable" for injecting y-cable to dualtor

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -21,11 +21,11 @@
 # -e testbed_name=vms1-1     - the testbed name specified in testbed.csv file
 #                              (if you give 'testbed_name' option, will use info from testbed and ignore topo and vm_base options)
 # -e vm_file=veos            - the virtual machine file name
-# -e deploy=True             - if deploy the newly generated minigraph to the targent DUT, default is false if not defined
-# -e save=True               - if save the newly generated minigraph to the targent DUT as starup-config, default is false if not defined
+# -e deploy=True             - if deploy the newly generated minigraph to the target DUT, default is false if not defined
+# -e save=True               - if save the newly generated minigraph to the target DUT as startup-config, default is false if not defined
 #
 # After minigraph.xml is generated, the playbook will replace the original minigraph file under ansible/minigraph/ with the newly generated minigraph file for the SONiC device.
-# The playbook will based on deploy=True or False to deside if load the SONiC device with new minigraph or not.
+# The playbook will based on deploy=True or False to decide if load the SONiC device with new minigraph or not.
 # If deploy=true, the playbook will apply the newly generated minigraph to the SONiC switch
 # If save=true, the playbook will save the newly generated minigraph to SONiC switch as startup-config
 #
@@ -97,7 +97,7 @@
     delegate_to: localhost
     when: deploy is not defined or deploy|bool == false
 
-  - name: find and generate fabric ASIC infomation
+  - name: find and generate fabric ASIC information
     fabric_info:
       num_fabric_asic: "{{ num_fabric_asics | default(0) }}"
       asics_host_basepfx: "{{ asics_host_ip | default(None) }}"
@@ -122,7 +122,7 @@
     when: hostvars[item]['voq_inband_ipv6'] is defined
     loop: "{{ ansible_play_batch }}"
 
-  - name: set all Loopback4096 information for iBGP chassis 
+  - name: set all Loopback4096 information for iBGP chassis
     set_fact:
       all_loopback4096: "{{ all_loopback4096 | default( {} ) | combine( { item : hostvars[item]['loopback4096_ip']}) }}"
     when: hostvars[item]['loopback4096_ip'] is defined
@@ -166,6 +166,12 @@
     delegate_to: localhost
     when: "'dualtor' in topo or 'cable' in topo"
 
+  - name: generate y_cable simulator driver
+    include_tasks: dualtor/config_simulated_y_cable.yml
+    vars:
+      restart_pmon: no
+    when: "'dualtor' in topo"
+
   - name: set default vm file path
     set_fact:
       vm_file: veos
@@ -175,7 +181,7 @@
       VM_topo: "{% if 'ptf' in topo %}False{% else %}True{% endif %}"
       remote_dut: "{{ ansible_ssh_host }}"
 
-  - name: gather testbed VM informations
+  - name: gather testbed VM information
     testbed_vm_info: base_vm={{ testbed_facts['vm_base'] }} topo={{ testbed_facts['topo'] }} vm_file={{ vm_file }}
     delegate_to: localhost
     when: "(VM_topo | bool) and ('cable' not in topo)"
@@ -227,7 +233,7 @@
     with_subelements:
       - "{{ interface_to_vms }}"
       - "ports"
-    when: front_panel_asic_ifnames != [] 
+    when: front_panel_asic_ifnames != []
 
   - name: create minigraph file in ansible minigraph folder
     template: src=templates/minigraph_template.j2
@@ -275,7 +281,7 @@
       set_fact:
         subject_server: "{{ telemetry_certs['subject_server'] }}"
       when: telemetry_certs['subject_server'] is defined
-    
+
     - name: read client subject
       set_fact:
         subject_client: "{{ telemetry_certs['subject_client'] }}"
@@ -290,7 +296,7 @@
         dsmsroot_key: "{{ dsmsroot_key_t }}"
         cert_subject: "{{ subject_server }}"
         root_subject: "{{ subject_client }}"
-    
+
     when: deploy is defined and deploy|bool == true
 
   - block:
@@ -330,7 +336,7 @@
     when: deploy is defined and deploy|bool == true
 
   - block:
-      - name: saved original minigraph file in SONiC DUT(ignore errors when file doesnot exist)
+      - name: saved original minigraph file in SONiC DUT(ignore errors when file does not exist)
         shell: mv /etc/sonic/minigraph.xml /etc/sonic/minigraph.xml.orig
         become: true
         ignore_errors: true

--- a/ansible/config_y_cable.yml
+++ b/ansible/config_y_cable.yml
@@ -1,0 +1,21 @@
+
+- hosts: sonic
+  gather_facts: no
+  tasks:
+
+  - name: Gathering testbed information
+    test_facts: testbed_name="{{ testbed_name }}" testbed_file="{{ testbed_file }}"
+    delegate_to: localhost
+
+  - fail: msg="The DUT you are trying to run test does not belongs to this testbed"
+    when: inventory_hostname not in testbed_facts['duts']
+
+  - name: set testbed_type
+    set_fact:
+      topo: "{{ testbed_facts['topo'] }}"
+
+  - name: config simulated y_cable
+    include_tasks: dualtor/config_simulated_y_cable.yml
+    vars:
+      restart_pmon: yes
+    when: "'dualtor' in topo"

--- a/ansible/dualtor/config_simulated_y_cable.yml
+++ b/ansible/dualtor/config_simulated_y_cable.yml
@@ -1,0 +1,68 @@
+
+- fail: msg="There must be two duts in this testbed"
+  when: "testbed_facts['duts']|length != 2"
+
+- fail: msg="The type of testbed must be dualtor"
+  when: "'dualtor' not in testbed_facts['topo']"
+
+- fail: msg="The DUT you are trying to run test does not belongs to this testbed"
+  when: inventory_hostname not in testbed_facts['duts']
+
+- name: Initialize variable restart_pmon
+  set_fact:
+    restart_pmon: yes
+  when: restart_pmon is not defined and restart_pmon|bool == true
+
+- name: Get host server address
+  vmhost_server_info: vmhost_server_name={{ testbed_facts['server'] }} vm_file={{ vm_file }}
+  delegate_to: localhost
+
+- name: Set y cable simulator server address
+  set_fact:
+    mux_simulator_server: "{{ vmhost_server_address }}"
+
+- name: Set default y cable simulator server port
+  set_fact:
+    mux_simulator_port: "{{ mux_simulator_http_port[testbed_name] }}"
+  when: mux_simulator_port is not defined
+
+- name: Set default dut index
+  set_fact:
+    dut_index: "{{ testbed_facts['duts_map'][inventory_hostname]|int }}"
+
+- name: Set other variables required by y_cable driver
+  set_fact:
+    duts_map: "{{ testbed_facts['duts_map'] }}"
+    dut_name: "{{ inventory_hostname }}"
+    vm_set_name: "{{ testbed_facts['group-name'] }}"
+    dut_side: "{% if dut_index|int == 0 %}upper_tor{% else %}lower_tor{% endif %}"
+
+# Legacy - inject simulated y cable driver
+- block:
+  - name: Generate y_cable_simulator driver to DUTs
+    template: src=dualtor/y_cable_simulator_client.j2
+              dest=/tmp/y_cable_simulator_client.py
+    become: true
+
+  - name: Copy y_cable_simulator to pmon container in DUTs
+    shell: docker cp /tmp/y_cable_simulator_client.py pmon:/usr/lib/python3/dist-packages
+
+# New - inject mux simulator config
+# Below step is required after these PRs are merged:
+# * https://github.com/Azure/sonic-platform-common/pull/213
+# * https://github.com/Azure/sonic-platform-daemons/pull/197
+# For the simulated y_cable driver to work, basic configuration information of the mux simulator is required.
+# When /etc/sonic/mux_simulator.json file is found on DUT, xcvrd will try to load simulated y_cable driver.
+# File /etc/sonic/mux_simulator.json can co-exist with the 'y_cable_simulator_client.py' file injected above.
+# Process xcvrd will determine which one to load or use.
+- name: Generate mux simulator configuration for DUTs
+  template: src=dualtor/mux_simulator.json.j2
+            dest=/etc/sonic/mux_simulator.json
+  become: true
+
+- name: Restart the pmon service
+  service:
+    name: pmon
+    state: restarted
+  become: true
+  when: restart_pmon|bool == true

--- a/ansible/dualtor/mux_simulator.json.j2
+++ b/ansible/dualtor/mux_simulator.json.j2
@@ -1,0 +1,6 @@
+{
+    "server_ip": "{{ mux_simulator_server }}",
+    "server_port": "{{ mux_simulator_port }}",
+    "vm_set": "{{ vm_set_name }}",
+    "side": "{{ dut_side }}"
+}

--- a/ansible/dualtor/y_cable_simulator_client.j2
+++ b/ansible/dualtor/y_cable_simulator_client.j2
@@ -10,7 +10,7 @@ from sonic_py_common.interface import backplane_prefix
 
 DUTS_MAP = {{ duts_map }}
 
-VM_SET = "{{ group_name }}"
+VM_SET = "{{ vm_set_name }}"
 
 DUT_NAME = "{{ dut_name }}"
 

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -14,6 +14,7 @@ function usage
   echo "    $0 [options] config-vm <testbed-name> <vm-name> <vault-password-file>"
   echo "    $0 [options] announce-routes <testbed-name> <vault-password-file>"
   echo "    $0 [options] (gen-mg | deploy-mg | test-mg) <testbed-name> <inventory> <vault-password-file>"
+  echo "    $0 [options] (config-y-cable) <testbed-name> <inventory> <vault-password-file>"
   echo "    $0 [options] (create-master | destroy-master) <k8s-server-name> <vault-password-file>"
   echo "    $0 [options] restart-ptf <testbed-name> <vault-password-file>"
   echo
@@ -62,6 +63,7 @@ function usage
   echo "        -e enable_data_plane_acl=true"
   echo "        -e enable_data_plane_acl=false"
   echo "        by default, data acl is enabled"
+  echo "To config simulated y-cable driver for DUT in specified testbed: $0 config-y-cable 'testbed-name' 'inventory' ~/.password"
   echo "To create Kubernetes master on a server: $0 -m k8s_ubuntu create-master 'k8s-server-name'  ~/.password"
   echo "To destroy Kubernetes master on a server: $0 -m k8s_ubuntu destroy-master 'k8s-server-name' ~/.password"
   echo "To restart ptf of specified testbed: $0 restart-ptf 'testbed-name' ~/.password"
@@ -468,6 +470,24 @@ function test_minigraph
   echo Done
 }
 
+function config_y_cable
+{
+  testbed_name=$1
+  inventory=$2
+  passfile=$3
+  shift
+  shift
+  shift
+
+  echo "Config y-cable on testbed '$testbed_name'"
+
+  read_file $testbed_name
+
+  ansible-playbook -i "$inventory" config_y_cable.yml --vault-password-file="$passfile" -l "$duts" -e testbed_name="$testbed_name" -e testbed_file=$tbfile -e vm_file=$vmfile $@
+
+  echo Done
+}
+
 function config_vm
 {
   echo "Configure VM $2"
@@ -601,6 +621,8 @@ case "${subcmd}" in
   deploy-mg)   deploy_minigraph $@
                ;;
   test-mg)     test_minigraph $@
+               ;;
+  config-y-cable) config_y_cable $@
                ;;
   cleanup-vmhost) cleanup_vmhost $@
                ;;


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
PR #2981 moved injecting y-cable driver to dualtor DUTs from deploy-mg to a test case in test_pretest.py.
This caused an chicken and egg problem. Initially without simulated y-cable driver or mux configuration
in dualtor DUTs, the mux status is "unknown". When we run the test_pretest.py script to inject simulated
y-cable driver or mux configuration, sanity check is performed by default. One of the check item is to
check the mux simulator. Before simulated y-cable is injected/configured on dualtor DUTs, the muxcable
status on DUTs would be "unknown" and mux simulator sanity check would fail after PR #4640 was merged.
Then test_pretest would not be able to inject simulated y-cable driver or configuration.

#### How did you do it?
This change:
* Deprecated test case test_inject_y_cable_simulator_client in test_pretest.py.
* Added back injecting simulated y-cable driver and configuration in "testbed-cli.sh deploy-mg".
* Added extra light weighted tool "testbed-cli.sh config-y-cable" just for injecting simulated y-cable
  driver or mux configuration.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
