### PR TITLE
[advance-reboot] New testcase - warm reboot with MAC jumping

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -43,10 +43,6 @@ class AdvancedReboot:
             "Please set rebootType var."
         )
 
-        sonic_hwsku = duthost.sonichost.facts["hwsku"]
-        if "SN3800" in sonic_hwsku and kwargs['rebootType'] == 'fast-reboot':
-            pytest.skip("Not supported on Mellanox 3800")
-
         if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
             # Fast and Warm-reboot procedure now test if "docker exec" works.
             # The timeout for check_docker_exec test is 1s. This timeout is good
@@ -596,7 +592,7 @@ class AdvancedReboot:
             self.__restorePrevImage()
 
 @pytest.fixture
-def get_advanced_reboot(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, localhost, tbinfo, creds):
+def get_advanced_reboot(request, duthosts, rand_one_dut_hostname, ptfhost, localhost, tbinfo, creds):
     '''
     Pytest test fixture that provides access to AdvancedReboot test fixture
         @param request: pytest request object
@@ -605,7 +601,7 @@ def get_advanced_reboot(request, duthosts, enum_rand_one_per_hwsku_frontend_host
         @param localhost: Localhost for interacting with localhost through ansible
         @param tbinfo: fixture provides information about testbed
     '''
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_hostname]
     instances = []
 
     def get_advanced_reboot(**kwargs):

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -302,8 +302,7 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
     """
     duthost = duthosts[rand_one_dut_hostname]
     test_name = request.node.name
-    if "warm" in test_name or\
-        ("continuous" in test_name and request.config.getoption("--reboot_type") == "warm"):
+    if "warm" in test_name:
         reboot_type = "warm"
     elif "fast" in test_name:
         reboot_type = "fast"
@@ -373,7 +372,6 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
         json.dump(result_summary, fp, indent=4)
 
     # After generating timing data report, do some checks on the timing data
-
     verify_mac_jumping(test_name, analyze_result)
 
 @pytest.fixture()

--- a/tests/platform_tests/reboot_timing_constants.py
+++ b/tests/platform_tests/reboot_timing_constants.py
@@ -41,6 +41,8 @@ OTHER_PATTERNS = {
     "BRCM": {
         "SYNCD_CREATE_SWITCH|Start": re.compile(r'.*syncd#syncd.*performWarmRestart: switches defined in warm restart.*'),
         "SYNCD_CREATE_SWITCH|End": re.compile(r'.*syncd#syncd.*performWarmRestartSingleSwitch: Warm boot: create switch VID.*'),
+        "FDB_EVENT_OTHER_MAC_EXPIRY|Start": re.compile(r".* INFO syncd#syncd.*SAI_API_FDB.*fdbEvent: 0 for mac (?!00-06-07-08-09-0A).*"),
+        "FDB_EVENT_SCAPY_MAC_EXPIRY|Start": re.compile(r".* INFO syncd#syncd.*SAI_API_FDB.*fdbEvent: 0 for mac 00-06-07-08-09-0A.*")
     },
     "MLNX": {
         "SYNCD_CREATE_SWITCH|Start": re.compile(r'.*syncd.*mlnx_sai_switch.*mlnx_create_switch: Create switch.*INIT_SWITCH=true.*'),

--- a/tests/platform_tests/templates/expect_boot_messages
+++ b/tests/platform_tests/templates/expect_boot_messages
@@ -19,6 +19,7 @@ r, ".* NOTICE syncd#syncd.*performWarmRestart: switches defined in warm restart.
 r, ".* NOTICE syncd#syncd.*performWarmRestartSingleSwitch: Warm boot: create switch VID.*"
 r, ".* NOTICE bgp#fpmsyncd.*main: Warm-Restart timer started.*.*"
 r, ".* NOTICE bgp#fpmsyncd.*main: Warm-Restart reconciliation processed..*"
+r, ".* INFO syncd#syncd.*SAI_API_FDB:_brcm_sai_fdb_event_cb.*fdbEvent: 0 for mac.*"
 
 # sairedis.rec messages
 r, ".*\|c\|SAI_OBJECT_TYPE_SWITCH.*"

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -31,6 +31,7 @@ def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
+
     advancedReboot = get_advanced_reboot(rebootType='fast-reboot')
     advancedReboot.runRebootTestcase()
 
@@ -45,6 +46,25 @@ def test_warm_reboot(request, get_advanced_reboot, verify_dut_health,
     @param get_advanced_reboot: advanced reboot test fixture
     '''
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    advancedReboot.runRebootTestcase()
+
+
+def test_warm_reboot_mac_jump(request, get_advanced_reboot, verify_dut_health,
+    advanceboot_loganalyzer, capture_interface_counters):
+    '''
+    Warm reboot testcase with one MAC address (00-06-07-08-09-0A) jumping from
+    all VLAN ports.
+    Part of the warm reboot handling is to ensure there are no MAC events reported
+    while warm reboot is in progress. So at the beginning of warm reboot SONIC
+    instructs SAI to disable MAC learning on all the ports.
+    When the warm reboot completes, SAI is communicated again for each port to enable
+    MAC learning. To ensure that this is properly handled by SAI, this test case
+    purposely generates new MAC learn events or MAC move events during warm reboot
+    and the expected results is to only see those MAC move events after warm reboot competed.
+    If for some reason SAI is not adhering to this requirement, any MAC learn events
+    generated during warm reboot will cause META checker failure resulting to Orchagent crash.
+    '''
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot', allow_mac_jumping=True)
     advancedReboot.runRebootTestcase()
 
 

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -31,7 +31,6 @@ def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
-
     advancedReboot = get_advanced_reboot(rebootType='fast-reboot')
     advancedReboot.runRebootTestcase()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: New warm reboot testcase with MAC jumping across vlan ports. This is to verify SAI behavior and catch image issues where META checker will fail resulting to Orchagent crash.
Fix https://github.com/Azure/sonic-mgmt/issues/4213

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

Part of the warm reboot handling is to ensure there are no MAC events reported while warm reboot is in progress. So at the beginning of warm reboot SONIC instructs SAI to disable MAC learning on all the ports. When the warm reboot completes, SAI is communicated again for each port to enable MAC learning.
To ensure that this is properly handled by SAI, we need to have new test case that purposely generate New MAC learn events or MAC move events during warm reboot and the expected results is to only see those MAC move events after warm reboot competed.
If for some reason SAI is not adhering to this requirement, any MAC learn events generated during warm reboot will cause META checker failure resulting to Orchagent crash.

#### How did you do it?
Added an option in the advance-reboot setup to enable MAC jumping from VLAN ports.

In the verification path, this test detects all the FDB expiry events. Among all such events verify if ONLY `00-06-07-08-09-0A` MAC address makes jumps (learns and expires) from different ports.

The test detects other addresses also that are expired. But these events happen after warmboot is done. Hence this is expected.
Also added a check to verify if ANY other address expires before warm reboot completes.

#### How did you verify/test it?
Tested on a physical testbed.
```
14:38:04 conftest.verify_mac_jumping              L0274 INFO   | MAC jumping is allowed. Jump count for expected mac: 680, unexpected MAC: 536
14:38:04 conftest.verify_mac_jumping              L0281 INFO   | Mac expiry for other address started at Nov 11 14:34:11.077374 and Warmboot finished at Nov 11 14:28:23.069926
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
