### PR TITLE
[tests] remove --skip-absent-sfp

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,16 +129,6 @@ def pytest_addoption(parser):
     parser.addoption("--testnum", action="store", default=None, type=str)
 
     ############################
-    # platform sfp api options #
-    ############################
-    # Allow user to skip the absent sfp modules. User can use it like below:
-    # "--skip-absent-sfp=True"
-    # If this option is not specified, False will be used by default.
-    parser.addoption("--skip-absent-sfp", action="store", type=bool, default=False,
-        help="Skip test on absent SFP",
-    )
-
-    ############################
     # upgrade_path options     #
     ############################
     parser.addoption("--upgrade_type", default="warm",
@@ -488,7 +478,7 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds, duthosts):
                 if dut_port in mg_facts['minigraph_port_alias_to_name_map']:
                     fanout.add_port_map(encode_dut_port_name(
                        dut_host, mg_facts['minigraph_port_alias_to_name_map'][dut_port]), fanout_port)
- 
+
                 if dut_host not in fanout.dut_hostnames:
                     fanout.dut_hostnames.append(dut_host)
     except:


### PR DESCRIPTION
This option has already been removed in a previous commit. This is just
the remaining of what's left that no longer serves any function.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Remove option that is no longer handled.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
