### PR TITLE
Fix fib test for T2 topo

### DIFF
--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -114,7 +114,10 @@ class HashTest(BaseTest):
         ports = list(set(self.src_ports) - set(exp_port_list))
         filtered_ports = []
         for port in ports:
-            active_dut_index = self.ptf_test_port_map[str(port)]['target_dut']
+            if self.single_fib:
+                active_dut_index = 0
+            else:
+                active_dut_index = self.ptf_test_port_map[str(port)]['target_dut']
             next_hop = self.fibs[active_dut_index][dst_ip]
             possible_exp_port_list = next_hop.get_next_hop_list()
             if possible_exp_port_list == exp_port_list:


### PR DESCRIPTION
- Upate ptf hash_test to honor single_fib setting for T2 topo.
- Fix get_t2_fib_info() to handle routes pointing to system neighbor or LAG.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
