### PR TITLE
Fix decap test

### DIFF
--- a/ansible/roles/test/files/ptftests/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/IP_decap_test.py
@@ -97,6 +97,7 @@ class DecapPacketTest(BaseTest):
         self.dscp_mode = self.test_params.get('dscp_mode')
         self.ttl_mode = self.test_params.get('ttl_mode')
         self.ignore_ttl = self.test_params.get('ignore_ttl', False)
+        self.single_fib = self.test_params.get('single_fib_for_duts', False)
 
         # multi asic platforms have internal routing hops
         # this param will be used to set the correct ttl values for inner packet
@@ -424,7 +425,10 @@ class DecapPacketTest(BaseTest):
     def get_src_and_exp_ports(self, dst_ip):
         while True:
             src_port = int(random.choice(self.src_ports))
-            active_dut_index = int(self.ptf_test_port_map[str(src_port)]['target_dut'])
+            if self.single_fib:
+                active_dut_index = 0
+            else:
+                active_dut_index = int(self.ptf_test_port_map[str(src_port)]['target_dut'])
             next_hop = self.fibs[active_dut_index][dst_ip]
             exp_port_list = next_hop.get_next_hop_list()
             if src_port in exp_port_list:

--- a/tests/common/fixtures/fib_utils.py
+++ b/tests/common/fixtures/fib_utils.py
@@ -268,3 +268,12 @@ def fib_info_files_per_function(duthosts, ptfhost, duts_running_config_facts, du
         files.append(filename)
 
     return files
+
+
+@pytest.fixture(scope="module")
+def single_fib_for_duts(tbinfo):
+    # For a T2 topology, we are generating a single fib file across all asics, but have multiple frontend nodes (DUTS).
+    if tbinfo['topo']['type'] == "t2":
+        return True
+    return False
+ 

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -14,6 +14,7 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # lg
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import ptf_test_port_map
 from tests.common.fixtures.fib_utils import fib_info_files
+from tests.common.fixtures.fib_utils import single_fib_for_duts
 from tests.ptf_runner import ptf_runner
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.dualtor.mux_simulator_control import mux_server_url
@@ -90,12 +91,13 @@ def loopback_ips(duthosts, duts_running_config_facts):
 
 
 @pytest.fixture(scope='module')
-def setup_teardown(request, duthosts, duts_running_config_facts, ip_ver, loopback_ips, fib_info_files):
+def setup_teardown(request, duthosts, duts_running_config_facts, ip_ver, loopback_ips, fib_info_files, single_fib_for_duts):
 
     is_multi_asic = duthosts[0].sonichost.is_multi_asic
 
     setup_info = {
         "fib_info_files": fib_info_files[:3],  # Test at most 3 DUTs in case of multi-DUT
+        "single_fib_for_duts": single_fib_for_duts,
         "ignore_ttl": True if is_multi_asic else False,
         "max_internal_hops": 3 if is_multi_asic else 0,
         'router_macs': [duthost.facts['router_mac'] for duthost in duthosts]
@@ -200,6 +202,7 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, decap_config, mux_serv
                         "ignore_ttl": setup_info["ignore_ttl"],
                         "max_internal_hops": setup_info["max_internal_hops"],
                         "fib_info_files": setup_info["fib_info_files"],
+                        "single_fib_for_duts": setup_info["single_fib_for_duts"],
                         "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url)
                         },
                 qlen=PTFRUNNER_QLEN,

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -17,6 +17,7 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.utilities import is_ipv4_address
 
 from tests.common.fixtures.fib_utils import fib_info_files_per_function
+from tests.common.fixtures.fib_utils import single_fib_for_duts
 from tests.common.utilities import wait
 
 logger = logging.getLogger(__name__)
@@ -55,14 +56,6 @@ def ignore_ttl(duthosts):
     for duthost in duthosts:
         if duthost.sonichost.is_multi_asic:
             return True
-    return False
-
-
-@pytest.fixture(scope="module")
-def single_fib_for_duts(tbinfo):
-    # For a T2 topology, we are generating a single fib file across all asics, but have multiple frontend nodes (DUTS).
-    if tbinfo['topo']['type'] == "t2":
-        return True
     return False
 
 


### PR DESCRIPTION
- Move fixture single_fib_for_duts to common/fixtures/fib_utils.py.
- Fix test_decap to pass single_fib setting to ptf tests.
- Fix ptf test IP_decap_test to honor single_fib setting.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
