### PR TITLE
[link_flap] Check presence of PORTCHANNEL before checking portchannel status

### DIFF
--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -85,9 +85,10 @@ class TestContLinkFlap(object):
 
         config_facts = duthost.get_running_config_facts()
 
-        for portchannel in config_facts['PORTCHANNEL'].keys():
-            pytest_assert(check_portchannel_status(duthost, portchannel, "up", verbose=True),
-                          "Fail: dut interface {}: link operational down".format(portchannel))
+        if config_facts and 'PORTCHANNEL' in config_facts:
+            for portchannel in config_facts['PORTCHANNEL'].keys():
+                pytest_assert(check_portchannel_status(duthost, portchannel, "up", verbose=True),
+                              "Fail: dut interface {}: link operational down".format(portchannel))
 
         # Make Sure all ipv4/ipv6 routes are relearned with jitter of ~5
         if not wait_until(120, 2, 0, check_bgp_routes, duthost, start_time_ipv4_route_counts, start_time_ipv6_route_counts):


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Due to changes made in #4602, continuous link flap test fails on backend topologies since they do not have any portchannels. This PR addresses that by checking for the presence of portchannels before attempting to check their status

Summary:
Fixes #4682

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

#### How did you verify/test it?
Verified that the test passes on backend T1 with the change