### PR TITLE
[vlan_port] Restrict regex pattern to filter port with specified vlan id

### DIFF
--- a/ansible/roles/vm_set/library/vlan_port.py
+++ b/ansible/roles/vm_set/library/vlan_port.py
@@ -109,13 +109,19 @@ class VlanPort(object):
 
     @staticmethod
     def log_show_vlan_intf(port, vlan_id):
-        cmdline = "cat /proc/net/vlan/config | grep %s" % vlan_id
+        cmdline = "cat /proc/net/vlan/config | grep -E '\|[[:space:]]*%s[[:space:]]*\|'" % vlan_id
         out = VlanPort.cmd(cmdline, ignore_error=True)
-        if out:
-            vlan_intf, vlan_id, port = out.strip().split("|")
-            logging.debug("Port %s has vlan interface %s with vlan id %s" % (port, vlan_intf, vlan_id))
-        else:
+        lines = out.splitlines()
+        if len(lines) == 0:
             logging.debug("Port %s doesn't has vlan interface with vlan id %s" % (port, vlan_id))
+        elif len(lines) == 1:
+            try:
+                vlan_intf, vlan_id, port = lines[0].strip().split("|")
+                logging.debug("Port %s has vlan interface %s with vlan id %s" % (port, vlan_intf, vlan_id))
+            except Exception:
+                logging.warn("Unexpected output:\n%s", out)
+        else:
+            logging.warn("Unexpected output:\n%s", out)
 
     @staticmethod
     def iface_updown(iface_name, state, pid):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix the regex pattern to filter out vlan port with specified vlan id
the issue is because the server might have vlan ports that contains the digits of the specified vlan id.
```
$ cat /proc/net/vlan/config | grep 215
enp59s0f1.2150 | 2150 | enp59s0f1
enp59s0f1.2152 | 2152 | enp59s0f1
enp59s0f1.215 | 215 | enp59s0f1
enp59s0f1.2151 | 2151 | enp59s0f1
```

#### How did you do it?
restrict the regex pattern to filter out only the second column.

#### How did you verify/test it?
run `restart-ptf`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
