### PR TITLE
disabled mac learning on arista fanouts

### DIFF
--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -43,6 +43,7 @@ interface {{ intf }}
    spanning-tree portfast
    speed forced 100gfull
    error-correction encoding reed-solomon
+   no switchport mac address learning
    no shutdown
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "40000" %}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
@@ -50,6 +51,7 @@ interface {{ intf }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 40gfull
+   no switchport mac address learning
    no shutdown
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "50000" %}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
@@ -58,6 +60,7 @@ interface {{ intf }}
    spanning-tree portfast
    speed forced 50gfull
    no error-correction encoding
+   no switchport mac address learning
    no shutdown
 {% set intf =  'Ethernet' + i|string + '/3'  %}
 interface {{ intf }}
@@ -68,6 +71,7 @@ interface {{ intf }}
    spanning-tree portfast
    speed forced 50gfull
    no error-correction encoding
+   no switchport mac address learning
    no shutdown
 {%         else %}
    shutdown
@@ -79,6 +83,7 @@ interface {{ intf }}
    spanning-tree portfast
    speed forced 10gfull
    no error-correction encoding
+   no switchport mac address learning
    no shutdown
 {%         for j in range(2,5) %}
 {% set intf =  'Ethernet' + i|string + '/' + j|string %}
@@ -90,6 +95,7 @@ interface {{ intf }}
    spanning-tree portfast
    speed forced 10gfull
    no error-correction encoding
+   no switchport mac address learning
    no shutdown
 {%             else %}
    shutdown
@@ -105,6 +111,7 @@ interface {{ intf }}
    switchport trunk allowed vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    spanning-tree portfast
    speed force 40gfull
+   no switchport mac address learning
    no shutdown
 {% else %}
    shutdown

--- a/ansible/roles/fanout/templates/arista_7260_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260_deploy.j2
@@ -41,11 +41,13 @@ interface {{ intf }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 40gfull
+   no switchport mac address learning
    no shutdown
 {% elif intf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][intf]['mode'] == 'Trunk' %}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport mode trunk
    switchport trunk allowed vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
+   no switchport mac address learning
    no shutdown
 {% else %}
    shutdown


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: disabled mac learning on arista fanouts
Fixes # (issue)

Mac learning feature on fanout is redundant for testbed setups so it was disabled
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Disable mac learning for server-switch connection since vlan per port is enough for them to communicate
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
