### PR TITLE
Fixes to minigraph generation for linecards in a VoQ Chassis

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -235,6 +235,17 @@
       - "ports"
     when: front_panel_asic_ifnames != []
 
+  - block:
+      - name: Create new dictionary for my slot
+        set_fact:
+          new_asic_topo_config : "{{ new_asic_topo_config | default( { slot_num  : asic_topo_config.slot0 }) }}"
+
+      - name: set asic_topo_config to new dictionary
+        set_fact:
+          asic_topo_config: "{{ new_asic_topo_config }}"
+
+    when: switch_type is defined and switch_type == 'voq' and slot_num is defined and asic_topo_config|length > 0
+
   - name: create minigraph file in ansible minigraph folder
     template: src=templates/minigraph_template.j2
               dest=minigraph/{{ inventory_hostname}}.{{ topo }}.xml

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -84,6 +84,8 @@ class ParseTestbedTopoinfo():
 
     def parse_topo_defintion(self, topo_definition, po_map, dut_num, neigh_type='VMs'):
         vmconfig = dict()
+        if topo_definition['topology'][neigh_type] is None:
+            return vmconfig
         for vm in topo_definition['topology'][neigh_type]:
             vmconfig[vm] = dict()
             vmconfig[vm]['intfs'] = [[] for i in range(dut_num)]
@@ -105,7 +107,6 @@ class ParseTestbedTopoinfo():
                 for asic_intf in topo_definition['topology'][neigh_type][vm]['asic_intfs']:
                     vmconfig[vm]['asic_intfs'][dut_index].append(asic_intf)
 
- 
             # physical interface
             if 'configuration' in topo_definition:
                 if 'interfaces' in topo_definition['configuration'][vm]:

--- a/ansible/templates/minigraph_cpg.j2
+++ b/ansible/templates/minigraph_cpg.j2
@@ -1,4 +1,4 @@
-   <CpgDec>
+  <CpgDec>
 {% if card_type is not defined or card_type != 'supervisor' %}
     <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     <PeeringSessions>
@@ -216,6 +216,21 @@
           </BGPPeer>
 {% endif %}
 {% endfor %}
+{% if switch_type is defined and switch_type == 'voq' %}
+{% set asic_id = asic.split('ASIC')[1]|int %}
+{% for a_linecard in all_loopback4096 %}
+{% for idx in range(all_loopback4096[a_linecard]|length) %}
+{% if loopback4096_ip[asic_id] != all_loopback4096[a_linecard][idx] %}
+          <BGPPeer>
+            <Address>{{ all_inbands[a_linecard][idx] }}</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% else %}
 {% for neigh_asic in  asic_config['neigh_asic'] %}
 {% if neigh_asic in asic_config['neigh_asic'] and asic_config['neigh_asic'][neigh_asic]['peer_ipv4'][0] %}
           <BGPPeer>
@@ -226,56 +241,28 @@
           </BGPPeer>
 {% endif %}
 {% endfor %}
+{% endif %}
         </a:Peers>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
 {% endfor %}
+{% endif %}
 {% if switch_type is defined and (switch_type == 'voq' or switch_type == 'chassis-packet') %}
 {% for a_linecard in all_loopback4096 %}
 {% if a_linecard != inventory_hostname %}
 {% for idx in range(all_loopback4096[a_linecard]|length) %}
       <a:BGPRouterDeclaration>
         <a:ASN>{{ vm_topo_config['dut_asn'] }}</a:ASN>
+{% if switch_type == 'voq' %}
+        <a:Hostname>{{ chassis_ibgp_peers[all_inbands[a_linecard][idx].split('/')[0]] }}</a:Hostname>
+{% else %}
         <a:Hostname>{{ chassis_ibgp_peers[all_loopback4096[a_linecard][idx].split('/')[0]] }}</a:Hostname>
+{% endif %}
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
 {% endfor %}
 {% endif %}
 {% endfor %}
-{% if num_asics > 1 %}
-{% for asic_id in range(num_asics) %}
-{% set asic_name = "ASIC" + asic_id|string %}
-      <a:BGPRouterDeclaration>
-        <a:ASN>{{ vm_topo_config['dut_asn'] }}</a:ASN>
-        <a:Hostname>{{ asic_name }}</a:Hostname>
-        <a:Peers>
-{% for index in range( vms_number) %}
-{% if vms[index] in vm_asic_ifnames and vm_asic_ifnames[vms[index]][0].split('-')[1] == asic_name %}
-          <BGPPeer>
-            <Address>{{ vm_topo_config['vm'][vms[index]]['peer_ipv4'][dut_index|int] }}</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-{% endif %}
-{% endfor %}
-{% for a_linecard in all_loopback4096 %}
-{% for idx in range(all_loopback4096[a_linecard]|length) %}
-{% if loopback4096_ip[asic_id] != all_loopback4096[a_linecard][idx] %}
-          <BGPPeer>
-            <Address>{{ all_loopback4096[a_linecard][idx] }}</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-{% endif %}
-{% endfor %}
-{% endfor %}
-        </a:Peers>
-      </a:BGPRouterDeclaration>
-{% endfor %}
-{% endif %}
-{% endif %}
 {% endif %}
     </Routers>
 {% endif %}

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -108,7 +108,7 @@
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
 {% set port_channel_intf=';'.join(intf_names[vms[index]])  %}
         <PortChannel>
-          <Name>PortChannel{{ ((index+1)|string).zfill(2) }}</Name>
+          <Name>PortChannel{{ ((index+1)|string).zfill(4) }}</Name>
           <AttachTo>{{ port_channel_intf }}</AttachTo>
           <SubInterface/>
         </PortChannel>
@@ -171,7 +171,7 @@
         <IPInterface>
           <Name i:nil="true"/>
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
-          <AttachTo>PortChannel{{ ((index+1) |string).zfill(2) }}</AttachTo>
+          <AttachTo>PortChannel{{ ((index+1) |string).zfill(4) }}</AttachTo>
 {% else %}
           <AttachTo>{{ port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
@@ -180,7 +180,7 @@
         <IPInterface>
           <Name i:Name="true"/>
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
-          <AttachTo>PortChannel{{ ((index+1) |string).zfill(2) }}</AttachTo>
+          <AttachTo>PortChannel{{ ((index+1) |string).zfill(4) }}</AttachTo>
 {% else %}
           <AttachTo>{{ port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
@@ -242,7 +242,7 @@
 {%- set acl_intfs = [] -%}
 {%- for index in range(vms_number) %}
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
-{% set a_intf = 'PortChannel' + ((index+1) |string).zfill(2) %}
+{% set a_intf = 'PortChannel' + ((index+1) |string).zfill(4) %}
 {{- acl_intfs.append(a_intf) -}}
 {% endif %}
 {% endfor %}

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -108,7 +108,7 @@
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
 {% set port_channel_intf=';'.join(intf_names[vms[index]])  %}
         <PortChannel>
-          <Name>PortChannel{{ ((index+1)|string).zfill(4) }}</Name>
+          <Name>PortChannel{{ ((index+1)|string).zfill(2) }}</Name>
           <AttachTo>{{ port_channel_intf }}</AttachTo>
           <SubInterface/>
         </PortChannel>
@@ -171,7 +171,7 @@
         <IPInterface>
           <Name i:nil="true"/>
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
-          <AttachTo>PortChannel{{ ((index+1) |string).zfill(4) }}</AttachTo>
+          <AttachTo>PortChannel{{ ((index+1) |string).zfill(2) }}</AttachTo>
 {% else %}
           <AttachTo>{{ port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
@@ -180,7 +180,7 @@
         <IPInterface>
           <Name i:Name="true"/>
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
-          <AttachTo>PortChannel{{ ((index+1) |string).zfill(4) }}</AttachTo>
+          <AttachTo>PortChannel{{ ((index+1) |string).zfill(2) }}</AttachTo>
 {% else %}
           <AttachTo>{{ port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
@@ -242,7 +242,7 @@
 {%- set acl_intfs = [] -%}
 {%- for index in range(vms_number) %}
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
-{% set a_intf = 'PortChannel' + ((index+1) |string).zfill(4) %}
+{% set a_intf = 'PortChannel' + ((index+1) |string).zfill(2) %}
 {{- acl_intfs.append(a_intf) -}}
 {% endif %}
 {% endfor %}

--- a/ansible/vars/topo_Nokia-IXR7250E-36x400G.yml
+++ b/ansible/vars/topo_Nokia-IXR7250E-36x400G.yml
@@ -1,0 +1,16 @@
+slot0:
+    ASIC0:
+      topology:
+        NEIGH_ASIC:
+      configuration_properties:
+        common:
+          asic_type: FrontEnd 
+      configuration:
+
+    ASIC1:
+      topology:
+        NEIGH_ASIC:
+      configuration_properties:
+        common:
+          asic_type: FrontEnd
+      configuration:


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
PR# [4479 ](https://github.com/Azure/sonic-mgmt/pull/4479)added support for minigraph generation for packet based chassis.

However, this broke the generated minigraph for linecards in a VoQ chassis.

There were two issues in the minigraph generated with this PR:

- In Cpg
    - Missing BGPRouterDeclaration section for remote asics - <remote_linecard>-ASIC<#>
    - For multi-asic linecard, missing BGPRouterDeclaraion section for my asics - ASIC<#>
- In Dpg, we are missing the DeviceDataPlaneInfo for my asics in a multi-asic linecard
    - This is generated in template_dpg_asic, which is dependent on asic_topo_config.
      For voq_chassis, asic_topo_config is empty dictionary - as the iBGP connections depend on the what linecards are present in the chassis, and also what asics are on each linecard.

#### How did you do it?
To fix the above issues:
- create an almost empty asic topology file for our multi-asic linecard with slot0.
- In config_sonic_basedon_testbed.yml, when dealing with voq switch_type, before running through the Jinja2 templates,
  change slot0 in the asic_topo_config to the slot_num that is defined in the inventory.

Below is the asic topology for a multi-asic linecard Nokia_IXR7250e_36x400G card (in vars/topo_Nokia_IXR7250e_36x400G.yml) that is added:

```
slot0:
    ASIC0:
      topology:
        NEIGH_ASIC:
      configuration_properties:
        common:
          asic_type: FrontEnd
      configuration:

    ASIC1:
      topology:
        NEIGH_ASIC:
      configuration_properties:
        common:
          asic_type: FrontEnd
      configuration:
```
#### How did you verify/test it?
Generated minigraph for single and multi-asic linecards in a VoQ chassis and validated with:
- loading minigraph on the linecards
- Running iface_naming mode and test_interfaces on the linecards that exercise minigraph_facts on host and asic level.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
