### PR TITLE
[TestbedProcessing] Fixed NameError for slot_num

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -549,7 +549,8 @@ def makeLab(data, devices, testbed, outfile):
                         except AttributeError:
                             print("\t\t" + host + " switch_type not found")
 
-                        try: #get slot_num                                                                                                                                                                                           slot_num = dev.get("slot_num")                                           
+                        try: #get slot_num
+                            slot_num = dev.get("slot_num")
                             if slot_num is not None:                                                 
                                entry += "\tslot_num=" + str( slot_num )                              
                         except AttributeError:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes `NameError: global name 'slot_num' is not defined` when running TestbedProcessing.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Running TestbedProcessing.py returns NameError for 'slot_num':
```
File "TestbedProcessing.py", line 864, in <module>
    main()
  File "TestbedProcessing.py", line 849, in main
    makeLab(device_groups, devices, testbed, args.basedir + lab_file)  # Generate lab in INI file format (LAB)
  File "TestbedProcessing.py", line 553, in makeLab
    if slot_num is not None:                                                 
NameError: global name 'slot_num' is not defined
```
#### How did you do it?
Moved slot_num definition to a new line
#### How did you verify/test it?
python TestbedProcessing.py -i <testbed_file>
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
