### PR TITLE
Fix for test_voq_end_to_end_ping in a T2 topology

### DIFF
--- a/tests/voq/test_voq_disrupts.py
+++ b/tests/voq/test_voq_disrupts.py
@@ -105,7 +105,7 @@ def check_intfs_and_nbrs(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
             dump_and_verify_neighbors_on_asic(duthosts, host, asic, neighs, nbrhosts, all_cfg_facts, nbr_macs)
 
 
-def check_ip_fwd(duthosts, all_cfg_facts, nbrhosts):
+def check_ip_fwd(duthosts, all_cfg_facts, nbrhosts, tbinfo):
     """
     Checks basic IP connectivity through the voq system.
 
@@ -117,7 +117,7 @@ def check_ip_fwd(duthosts, all_cfg_facts, nbrhosts):
     for porttype in ["ethernet", "portchannel"]:
         for version in [4, 6]:
 
-            ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, port_type_a=porttype, version=version)
+            ports = pick_ports(duthosts, all_cfg_facts, nbrhosts, tbinfo, port_type_a=porttype, version=version)
 
             for ttl, size in [(2, 64), (1, 1450)]:
                 # local interfaces


### PR DESCRIPTION




<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
PR# 4497 changed the ASN numbers for a T2 chassis. The ASN's for all T3 VM's are the same,
while the ASN's for the T1 VM's are incremented.

This made the voq_end_to_end_ping test cases fail. This test picks VM's A,B,C,D for pings based on:

```
                          ---------- DUT ----------
                          |--- LC1 ---|--- LC2 ---|
    VM01T3   -------------|A          |          C|------------- VM02T1
                          |         F0|F1         |
    VM02T3   -------------|B     LB1  |   LB2    D|------------- VM01T1
                          |-----------|-----------|

```
In the test, from VM01T3 we would ping the loopback address of every other VMs.

With the ASN change, both VM01T3 and VM02T3 are in the same ASN (65200), while the DUT is in ASN 65100.

Route for loopback address of VM02T3 is advertised to LC1, which advertises it to VM01T3 with AS PATH 65100,65200.
But, since VM01T3 is also in ASN 65200, it doesn't install the route with LC1 port A as the next hop.

Thus, ping from VM01T3 to loopback address of VM02T3 fails.

#### How did you do it?
Fix is to pick VM's A,B,C,D for pings based on:

```
                          ---------- DUT ----------
                          |--- LC1 ---|--- LC2 ---|
    VM01T1   -------------|A          |          C|------------- VM02T3
                          |         F0|F1         |
    VM02T1   -------------|B     LB1  |   LB2    D|------------- VM01T3
                          |-----------|-----------|
```
With this we make VM01T1 ping everybody other VM who are in a different ASN's.

#### How did you verify/test it?
Ran tests in voq/test_voq_ipfwd.py  against a T2 chassis 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
