### PR TITLE
Skip extra lines while parsing tabulate content

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1171,6 +1171,10 @@ Totals               6450                 6449
             headers.append(header_line[left:right].strip().lower())
 
         for content_line in content_lines:
+            # When an empty line is encountered while parsing the tabulate content, it is highly possible that the
+            # tabulate content has been drained. The empty line and rest of the lines should not be parsed.
+            if len(content_line) == 0:
+                break
             item = {}
             for idx, (left, right) in enumerate(positions):
                 k = headers[idx]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Some SONiC cli commands output extra lines after the tabulate content, for example:

```
admin@vlab-01:~$ show ip bgp summary

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 6425
RIB entries 12807, using 2458944 bytes of memory
Peers 4, using 87264 KiB of memory
Peer groups 4, using 256 bytes of memory

Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600     397168     397119         0      0       0  01w6d16h             6400  ARISTA01T1
10.0.0.59      4  64600     397168     397119         0      0       0  01w6d16h             6400  ARISTA02T1
10.0.0.61      4  64600     397169     397119         0      0       0  01w6d16h             6400  ARISTA03T1
10.0.0.63      4  64600     397169     397119         0      0       0  01w6d16h             6400  ARISTA04T1

Total number of neighbors 4
```

In the above example output, there is an extra empty line and an extra line for total number neighbors
after the tabulate content.
The extra lines after the tabulate content are also parsed by the helper method `show_and_parse`.
In the parsed output, we may see content like below for `show ip bgp summary`:
```
[
    ...
    {
        "outq": "",
        "state/pfxrcd": "",
        "msgsent": "",
        "neighborname": "",
        "neighbhor": "",
        "inq": "",
        "up/down": "",
        "as": "",
        "v": "",
        "msgrcvd": "",
        "tblver": ""
    },
    {
        "outq": "",
        "state/pfxrcd": "",
        "msgsent": "",
        "neighborname": "",
        "neighbhor": "Total numbe",
        "inq": "",
        "up/down": "",
        "as": "ighbo",
        "v": "of",
        "msgrcvd": "4",
        "tblver": ""
    }
]
```

#### How did you do it?
This change added an extra check of line length while parsing the tabulate content. If an empty line is encountered,
skip parsing rest of the lines because it is highly possible that the tabulate has been drained already. Rest of the
lines do not need to be parsed.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
