### PR TITLE
[test_reboot] Check time passed before checking warmboot finalizer state

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -174,7 +174,12 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
 
     if reboot_type == 'warm':
         logger.info('waiting for warmboot-finalizer service to become activating on {}'.format(hostname))
-        finalizer_state = get_warmboot_finalizer_state(duthost)
+        # Check if finalizer state reaches "activating" before the "wait" period,
+        # the default wait is 90s since issue of warm-reboot).
+        # If the finalizer state is activating, however time passed is greater than "wait",
+        # then fail the testcase. Start with empty value to verify time passed before
+        # checking finalizer state for the first time.
+        finalizer_state = ''
         while finalizer_state != 'activating':
             dut_datetime_after_ssh = duthost.get_now_time()
             time_passed = float(dut_datetime_after_ssh.strftime("%s")) - float(dut_datetime.strftime("%s"))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix false negatives in test_reboot.py::test_warm_reboot when finalizer state is checked before checking time passed since warm-reboot.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

Fix false negatives in `test_reboot.py::test_warm_reboot`.

If more than 90s have passed since issue of warm-reboot, the test should fail, even if warmboot FINALIZER state has reached `activating`.

Without this change, if in the first attempt to check if FINALIZER state reaches `activating` passes, the time passed since reboot is not checked.

#### How did you do it?
The sequence of checks is now reverted - first check the time elapsed since issue of warm-reboot, then check the finalizer state. If elapsed time is greater than the wait (default 90s), and finalizer still reaches activating state, then fail the test.


#### How did you verify/test it?
With the fix, the false negative scenario is not seen. The test fails if elapsed time is greater than the wait period.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
