### PR TITLE
Fix a typo in TestbedProcessiing

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -549,9 +549,10 @@ def makeLab(data, devices, testbed, outfile):
                         except AttributeError:
                             print("\t\t" + host + " switch_type not found")
 
-                        try: #get slot_num                                                                                                                                                                                           slot_num = dev.get("slot_num")                                           
-                            if slot_num is not None:                                                 
-                               entry += "\tslot_num=" + str( slot_num )                              
+                        try: #get slot_num
+                            slot_num = dev.get("slot_num")
+                            if slot_num is not None:
+                               entry += "\tslot_num=" + str( slot_num )
                         except AttributeError:
                             print("\t\t" + host + " slot_num not found")
 


### PR DESCRIPTION
Fix a typo in TestbedProcessiing that accidentally comments out the following statement:

num = dev.get("slot_num") 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
