### PR TITLE
[test_techsupport]: Adding GRE ERSPAN type-2 for Cisco platform

### DIFF
--- a/ansible/roles/test/tasks/everflow_testbed/apply_config/acl_rule_persistent.json.j2
+++ b/ansible/roles/test/tasks/everflow_testbed/apply_config/acl_rule_persistent.json.j2
@@ -76,7 +76,7 @@
                                 },
                                 "l2": {
                                     "config": {
-                                        "ethertype": "4660"
+                                        "ethertype": "2048"
                                     }
                                 }
                             },

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -191,6 +191,8 @@ def gre_version(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         SESSION_INFO['gre'] = 0x8949  # Mellanox specific
     elif asic_type in ["barefoot"]:
         SESSION_INFO['gre'] = 0x22EB  # barefoot specific
+    elif asic_type in ["cisco-8000"]:
+        SESSION_INFO['gre'] = 0x88BE  # ERSPAN type-2
     else:
         SESSION_INFO['gre'] = 0x6558
 


### PR DESCRIPTION
### Description of PR
Adding GRE ERSPAN type-2 for Cisco platform and changing invalid Ether type(4660)  to valid IPv4 Ether type(2048)

Summary:
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Cisco-8000 platforms supports only GRE protocol type ERSPAN type-2(0x88be). The testcase is setting the
GRE protocol type as Trans Ether Bridging(0x6558) in mirror encapsulation header which results in invalid param and mirror session not getting created. This results in mirror session creation and removal failure. Hence there is no required mirror session removal log message in syslog which causes test case failure.

#### How did you do it?
Added GRE ERSPAN type-2 for Cisco platform and changed the ethertype.

#### How did you verify/test it?
Verified on cisco-8000 platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
