### PR TITLE
[radv] Check radv O and M flags

### DIFF
--- a/tests/radv/test_radv_flag.py
+++ b/tests/radv/test_radv_flag.py
@@ -1,0 +1,28 @@
+import pytest
+
+pytestmark = [
+    pytest.mark.topology('t0'),
+    pytest.mark.device_type('vs')
+]
+
+RADV_CONF_FILE = '/etc/radvd.conf'
+
+
+def test_radv_managed_flag(duthosts, rand_one_dut_hostname):
+
+    duthost = duthost = duthosts[rand_one_dut_hostname]
+    cmd = "grep -q 'AdvManagedFlag on' {}; echo $?".format(RADV_CONF_FILE)
+    output = duthost.shell("docker exec radv {}".format(cmd))["stdout"]
+
+    assert(output == '0')
+
+
+
+def test_radv_other_flag(duthosts, rand_one_dut_hostname):
+
+    duthost = duthost = duthosts[rand_one_dut_hostname]
+    cmd = "grep -q 'AdvOtherConfigFlag off' {}; echo $?".format(RADV_CONF_FILE)
+    output = duthost.shell("docker exec radv {}".format(cmd))["stdout"]
+
+    assert(output == '0')
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add radv flag tests
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Radv is configured to use DHCPv6 instead of SLAAC. Test for the correct radv flag

#### How did you do it?
Check M flag is on and O flag is off.
M flag indicates client will use DHCPv6 server to retrieve ipv6 address.
O flag is set to off to ensure only DHCPv6 will be used.

#### How did you verify/test it?
Run tests on vs testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
