### PR TITLE
[VLAN]: Replace members field of VLAN table

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -183,12 +183,13 @@ def utils_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tb
                 break
         else:
             continue
-        for port in v['members']:
-            if k in vlan_members and port in vlan_members[k]:
-                if 'tagging_mode' not in vlan_members[k][port]:
-                    continue
-                mode = vlan_members[k][port]['tagging_mode']
-                config_ports_vlan[port].append({'vlanid':int(vlanid), 'ip':ip, 'tagging_mode':mode})
+        if k not in vlan_members:
+            continue
+        for port in vlan_members[k]:
+            if 'tagging_mode' not in vlan_members[k][port]:
+                continue
+            mode = vlan_members[k][port]['tagging_mode']
+            config_ports_vlan[port].append({'vlanid':int(vlanid), 'ip':ip, 'tagging_mode':mode})
 
     if config_portchannels:
         for po in config_portchannels:


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
“members” field of VLAN table is deprecated, and sonic-mgmt should not use this field.

#### How did you do it?
Use VLAN_MEMBERS table instead.

#### How did you verify/test it?
Run test_vlan with t0 topology and t0-56-po2vlan topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
