### PR TITLE
[TestbedProcessing] Added serial, base_mac, model values to lab

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -563,6 +563,27 @@ def makeLab(data, devices, testbed, outfile):
                         except AttributeError:
                             print("\t\t" + host + " os not found")
 
+                        try: #get model
+                            model=dev.get("model")
+                            if model is not None:
+                                entry += "\tmodel=" + str( model )
+                        except AttributeError:
+                            print("\t\t" + host + " model not found")
+
+                        try: #get base_mac
+                            base_mac=dev.get("base_mac")
+                            if base_mac is not None:
+                                entry += "\tbase_mac=" + str( base_mac )
+                        except AttributeError:
+                            print("\t\t" + host + " base_mac not found")
+
+                        try: #get serial
+                            serial=dev.get("serial")
+                            if serial is not None:
+                                entry += "\tserial=" + str( serial )
+                        except AttributeError:
+                            print("\t\t" + host + " serial not found")
+
                     toWrite.write(entry + "\n")
                 toWrite.write("\n")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
When executing platform/api cases face issues when TC fails due to "Failed: Unable to get expected value for 'model' from inventory file"

model, base_mac, serial have to be stored in testbed-new.yaml and added to lab file (lab file generated using TestbedProcessing)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
API cases covers model, base_mac, serial passing
#### How did you do it?
Added ability to get model, base_mac, serial from testbed-new.yaml using TestbedProcessing script if available
#### How did you verify/test it?
API cases for model, base_mac, serial passed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
