### PR TITLE
Fix Snmp_default_route testcase for VOQ Chassis

### DIFF
--- a/tests/snmp/test_snmp_default_route.py
+++ b/tests/snmp/test_snmp_default_route.py
@@ -28,7 +28,7 @@ def test_snmp_default_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
             ip, interface = line.split('via')
             ip = ip.strip("*, ")
             interface = interface.strip("*, ")
-            if interface != "eth0":
+            if interface != "eth0" and 'Ethernet-IB' not in interface and 'Ethernet-BP' not in interface:
                 dut_result_nexthops.append(ip)
 
     # If show ip route 0.0.0.0/0 has route only via eth0,


### PR DESCRIPTION

### Description of PR


Summary:
Fixes # (issue)

### Type of change



- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach

#### What is the motivation for this PR?
In T2 topology for a VOQ Chassis, if the linecard learns the default route from eBGP, an snmp entry is created in the  ipCidrRouteTable
But if the linecard learns the default route through an in-band port (example a linecard connecting to only T1 VM's), there will not be any entry created in the snmp ipCidrRouteTable. 

This is per SONiC design as defined in the following code in rfc4292.py
```
    if (ifn in port_table and
       multi_asic.PORT_ROLE in port_table[ifn] and
       port_table[ifn][multi_asic.PORT_ROLE] == multi_asic.INTERNAL_PORT):
          continue
``` 
Thus, the test case fails.

#### How did you do it?
Added a condition to check if the output from "show ip route " command has internal inband or backplane  port in it, and if so don't add it to list of nexthops to check.

#### How did you verify/test it?
ran test_snmp_default_route on VOQ Chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->