### PR TITLE
[sanity]: Print mux status and config

### DIFF
--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -166,7 +166,7 @@ def run_test(duthosts, activehost, ptfhost, ptfadapter, action,
 
 
 def cleanup(ptfadapter, duthosts_list):
-    print_logs(duthosts_list)
+    print_logs(duthosts_list, print_dual_tor_logs=True)
     # cleanup torIO
     ptfadapter.dataplane.flush()
     for duthost in duthosts_list:

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -86,11 +86,16 @@ def _update_check_items(old_items, new_items, supported_items):
     return updated_items
 
 
-def print_logs(duthosts):
+def print_logs(duthosts, print_dual_tor_logs=False):
     for dut in duthosts:
         logger.info("Run commands to print logs")
 
         cmds = constants.PRINT_LOGS.values()
+
+        if print_dual_tor_logs is False:
+            cmds.remove(constants.PRINT_LOGS['mux_status'])
+            cmds.remove(constants.PRINT_LOGS['mux_config'])
+
         results = dut.shell_cmds(cmds=cmds, module_ignore_errors=True, verbose=False)['results']
         outputs = []
         for res in results:
@@ -220,8 +225,8 @@ def sanity_check(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
         # Dynamically attach selected check fixtures to node
         for item in set(pre_check_items):
             request.fixturenames.append(_item2fixture(item))
-
-        print_logs(duthosts)
+        dual_tor = 'dualtor' in tbinfo['topo']['name']
+        print_logs(duthosts, print_dual_tor_logs=dual_tor)
 
         check_results = do_checks(request, pre_check_items, stage=STAGE_PRE_TEST)
         logger.debug("Pre-test sanity check results:\n%s" % json.dumps(check_results, indent=4, default=fallback_serializer))

--- a/tests/common/plugins/sanity_check/constants.py
+++ b/tests/common/plugins/sanity_check/constants.py
@@ -8,7 +8,9 @@ PRINT_LOGS = {
     "neigh": "ip neigh",
     "bgpv4": "show ip bgp summary",
     "bgpv6": "show ipv6 bgp summary",
-    "routes": "ip route | wc -l"
+    "routes": "ip route | wc -l",
+    "mux_status": "show mux status",
+    "mux_config": "show mux config",
 }
 
 # Check items for testbed infrastructure that are not 


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Diagnosing dual ToR IO test failures can be difficult if the initial state of the testbed is unknown

#### How did you do it?
Add commands to print the mux status and mux config when printing logs during the sanity check. Also add checks to avoid printing mux logs on non dual ToR testbeds.

#### How did you verify/test it?
Run a test on a dual ToR testbed. Verify that mux logs are printed during the sanity check.
Run a test on a non dual ToR testbed. Verify that no mux logs are printed during the sanity check and no other errors occur.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
