### PR TITLE
Skip get fan serial number test cases for Cisco platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -7,6 +7,30 @@ drop_packets/test_drop_counters.py::test_loopback_filter:
   skip:
     reason: "SONiC can't enable loop-back filter feature"
 
+platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_serial:
+  #Fan tray serial numbers cannot be retrieved through software in cisco platform
+  #there is no fan tray idprom
+  skip:
+    reason: "Retrieving fan tray serial number is not supported in Cisco 8000 platform"
+    conditions:
+       - asic_type=="cisco-8000"
+
+platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_serial:
+  #Fan tray serial numbers cannot be retrieved through software in cisco platform
+  #there is no fan tray idprom
+  skip:
+    reason: "Retrieving fan tray serial number is not supported in Cisco 8000 platform"
+    conditions:
+       - asic_type=="cisco-8000"
+
+platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_serial:
+  #Fan tray serial numbers cannot be retrieved through software in cisco platform
+  #there is no fan tray idprom
+  skip:
+    reason: "Retrieving fan tray serial number is not supported in Cisco 8000 platform"
+    conditions:
+       - asic_type=="cisco-8000"
+
 ntp/test_ntp.py::test_ntp_long_jump_disabled:
   # Due to NTP code bug, long jump will still happen after disable it.
   # Set xfail flag for this test case


### PR DESCRIPTION
### Description of PR
Skip test_get_serial for Cisco Platform in the following scripts
platform_tests/api/test_chassis_fans.py
platform_tests/api/test_fan_drawer.py
platform_tests/api/test_fan_drawer_fans.py

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
There is no fan tray idprom, hence Fan tray (and thus their fan) serial numbers cannot be retrieved through software on Cisco Platform

#### How did you do it?
Skip these tests for cisco-8000 platform

#### How did you verify/test it?
Verified on cisco-8000 platform.

#### Any platform specific information?
Cisco-8000 platform

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
