### PR TITLE
Skip removing EGRESS ACL table on Broadcom

### DIFF
--- a/tests/acl/templates/acltb_test_rules_outer_vlan.j2
+++ b/tests/acl/templates/acltb_test_rules_outer_vlan.j2
@@ -1,7 +1,7 @@
 {
     "ACL_RULE": {
         "{{ table_name }}|rule_1": {
-            "priority": "1003",
+            "PRIORITY": "1003",
             "VLAN_ID": "{{ vlan_id }}",
             "PACKET_ACTION": "{{ action }}"
         }

--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -666,6 +666,7 @@ class TestAclVlanOuter_Egress(AclVlanOuterTest_Base):
 
     def pre_running_hook(self, duthost, ptfhost, ip_version, vlan_setup_info):
         # Skip on broadcom platforms
+        self.testing_acl_table_created = False
         pytest_require(duthost.facts["asic_type"] not in ("broadcom"),
                     "Egress ACLs are not currently supported on \"{}\" ASICs".format(duthost.facts["asic_type"]))
         # Skip IPV6 EGRESS test since arp_responder doesn't support yet
@@ -673,6 +674,7 @@ class TestAclVlanOuter_Egress(AclVlanOuterTest_Base):
                     "IPV6 EGRESS test not supported")
 
         self._setup_acl_table(duthost, EGRESS, ip_version, vlan_setup_info[1])
+        self.testing_acl_table_created = True
         ip_list = self._setup_arp_responder(ptfhost, vlan_setup_info)
         # Populate ARP table on DUT
         cmds = []
@@ -681,7 +683,7 @@ class TestAclVlanOuter_Egress(AclVlanOuterTest_Base):
         duthost.shell_cmds(cmds=cmds, module_ignore_errors=True)
 
     def post_running_hook(self, duthost, ptfhost, ip_version):
-        if ip_version == IPV4:
+        if self.testing_acl_table_created:
             self._remove_acl_table(duthost, EGRESS, ip_version)
         self._teardown_arp_responder(ptfhost)
     


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix a code bug in ```test_acl_outer_vlan.py```.
EGRESS ACL test will be skipped on ```Broadcom``` platform since it's not supported yet. However, the setup of ACL table is skipped but the teardown is nor due to a code bug.

The `priority` in `acltb_test_rules_outer_vlan.j2` is also changed to upper case to be compatible with `2019` image.
This PR is to fix that.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix a code bug in ```test_acl_outer_vlan.py```.

#### How did you do it?
Skip the teardown of EGRESS ACL table if it's not created.
 
#### How did you verify/test it?
Verified on Broadcom platform. Test can be skipped now.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
