### PR TITLE
skip_release DUTs that don't support apply-patch feature

### DIFF
--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -1,8 +1,8 @@
 import pytest
 
-from tests.common.utilities import skip_version
+from tests.common.utilities import skip_release
 
-@pytest.fixture(autouse=True, scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def check_image_version(duthost):
     """Skips this test if the SONiC image installed on DUT is older than 202106
 
@@ -12,5 +12,5 @@ def check_image_version(duthost):
     Returns:
         None.
     """
-    skip_version(duthost, ["201811", "201911", "202012"])
+    skip_release(duthost, ["201811", "201911", "202012"])
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Use robust skip_release instead of skip_version
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
robust skip test
#### How did you do it?
change to skip_release
#### How did you verify/test it?
Verify on DUT
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc1_apply_empty[clean_setup] SKIPPED [  6%]
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc2_rm_on_empty[clean_setup] SKIPPED [ 12%]
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc3_rm_nonexist[clean_setup] SKIPPED [ 18%]
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc4_add_exist[clean_setup] SKIPPED [ 25%]
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc5_rm[clean_setup] SKIPPED [ 31%]
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc6_add[clean_setup] SKIPPED [ 37%]
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc7_add_rm[clean_setup] SKIPPED [ 43%]
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc7_replace[clean_setup] SKIPPED [ 50%]
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc1_apply_empty[default_setup] SKIPPED [ 56%]
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc2_rm_on_empty[default_setup] SKIPPED [ 62%]
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc3_rm_nonexist[default_setup] SKIPPED [ 68%]
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc4_add_exist[default_setup] SKIPPED [ 75%]
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc5_rm[default_setup] SKIPPED [ 81%]
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc6_add[default_setup] SKIPPED [ 87%]
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc7_add_rm[default_setup] SKIPPED [ 93%]
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc7_replace[default_setup] SKIPPED [100%]
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
