### PR TITLE
Improve `test_acl` on E1031 Haliburton

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -262,7 +262,8 @@ def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname, i
     def populate_arp_table():
         duthost.command("sonic-clear fdb all")
         duthost.command("sonic-clear arp")
-
+        # Wait some time to ensure the async call of clear is completed
+        time.sleep(20)
         for addr in addr_list:
             duthost.command("ping {} -c 3".format(addr), module_ignore_errors=True)
 
@@ -938,6 +939,9 @@ class TestAclWithReboot(TestBasicAcl):
         """
         dut.command("config save -y")
         reboot(dut, localhost, wait=240)
+        # We need some additional delay on e1031
+        if dut.facts["platform"] == "x86_64-cel_e1031-r0":
+            time.sleep(240)
         populate_vlan_arp_entries()
 
 


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to stabilize ```test_acl``` on E1031 box. Changes include
1. Add a delay after ```sonic-clear fdb``` and ```sonic-clear arp``` to ensure the call is completed before populating ARP
2. Add addition delay (240 seconds) afte reboot to eusure system is fully initialized.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to stabilize ```test_acl``` on E1031 box.

#### How did you do it?
1. Add a delay after ```sonic-clear fdb``` and ```sonic-clear arp``` to ensure the call is completed before populating ARP
2. Add addition delay (240 seconds) afte reboot to eusure system is fully initialized.

#### How did you verify/test it?
Verified by running on E1031
```
collected 800 items                                                                                                                                                                                   

acl/test_acl.py::TestBasicAcl::test_ingress_unmatched_blocked[ipv4-ingress-downlink->uplink] PASSED                                                                                             [  0%]
acl/test_acl.py::TestBasicAcl::test_ingress_unmatched_blocked[ipv4-ingress-uplink->downlink] PASSED                                                                                             [  0%]
acl/test_acl.py::TestBasicAcl::test_egress_unmatched_forwarded[ipv4-ingress-downlink->uplink] SKIPPED                                                                                           [  0%]
acl/test_acl.py::TestBasicAcl::test_egress_unmatched_forwarded[ipv4-ingress-uplink->downlink] SKIPPED                                                                                           [  0%]
acl/test_acl.py::TestBasicAcl::test_source_ip_match_forwarded[ipv4-ingress-downlink->uplink] PASSED                                                                                             [  0%]
acl/test_acl.py::TestBasicAcl::test_source_ip_match_forwarded[ipv4-ingress-uplink->downlink] PASSED                                                                                             [  0%]
acl/test_acl.py::TestBasicAcl::test_rules_priority_forwarded[ipv4-ingress-downlink->uplink] PASSED                                                                                              [  0%]
acl/test_acl.py::TestBasicAcl::test_rules_priority_forwarded[ipv4-ingress-uplink->downlink] PASSED                                                                                              [  1%]
acl/test_acl.py::TestBasicAcl::test_rules_priority_dropped[ipv4-ingress-downlink->uplink] PASSED                                                                                                [  1%]
acl/test_acl.py::TestBasicAcl::test_rules_priority_dropped[ipv4-ingress-uplink->downlink] PASSED                                                                                                [  1%]
acl/test_acl.py::TestBasicAcl::test_dest_ip_match_forwarded[ipv4-ingress-downlink->uplink] PASSED                                                                                               [  1%]
acl/test_acl.py::TestBasicAcl::test_dest_ip_match_forwarded[ipv4-ingress-uplink->downlink] PASSED                                                                                               [  1%]
acl/test_acl.py::TestBasicAcl::test_dest_ip_match_dropped[ipv4-ingress-downlink->uplink] PASSED                                                                                                 [  1%]
acl/test_acl.py::TestBasicAcl::test_dest_ip_match_dropped[ipv4-ingress-uplink->downlink] PASSED                                                                                                 [  1%]
acl/test_acl.py::TestBasicAcl::test_source_ip_match_dropped[ipv4-ingress-downlink->uplink] PASSED                                                                                               [  1%]
acl/test_acl.py::TestBasicAcl::test_source_ip_match_dropped[ipv4-ingress-uplink->downlink] PASSED                                                                                               [  2%]
acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_forwarded[ipv4-ingress-downlink->uplink] PASSED                                                                                         [  2%]
acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_forwarded[ipv4-ingress-uplink->downlink] PASSED                                                                                         [  2%]
acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_dropped[ipv4-ingress-downlink->uplink] PASSED                                                                                           [  2%]
acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_dropped[ipv4-ingress-uplink->downlink] PASSED                                                                                           [  2%]
acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_dropped[ipv4-ingress-downlink->uplink] PASSED                                                                                          [  2%]
acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_dropped[ipv4-ingress-uplink->downlink] PASSED                                                                                          [  2%]
acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_forwarded[ipv4-ingress-downlink->uplink] PASSED                                                                                        [  2%]
acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_forwarded[ipv4-ingress-uplink->downlink] PASSED                                                                                        [  3%]
......
acl/test_acl.py::TestAclWithPortToggle::test_ip_proto_match_dropped[ipv6-ingress-uplink->downlink] SKIPPED                                                                                      [ 99%]
acl/test_acl.py::TestAclWithPortToggle::test_tcp_flags_match_dropped[ipv6-ingress-downlink->uplink] SKIPPED                                                                                     [ 99%]
acl/test_acl.py::TestAclWithPortToggle::test_tcp_flags_match_dropped[ipv6-ingress-uplink->downlink] SKIPPED                                                                                     [ 99%]
acl/test_acl.py::TestAclWithPortToggle::test_icmp_match_forwarded[ipv6-ingress-downlink->uplink] SKIPPED                                                                                        [ 99%]
acl/test_acl.py::TestAclWithPortToggle::test_icmp_match_forwarded[ipv6-ingress-uplink->downlink] SKIPPED                                                                                        [100%]


-------------------------------------------------------------------------- generated xml file: /data/sonic-mgmt/tests/tr.xml --------------------------------------------------------------------------
======================================================================= 192 passed, 608 skipped, 1 warnings in 1671.27 seconds ========================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
