### PR TITLE
Fix `recover_server` script for veos

### DIFF
--- a/ansible/recover_server.py
+++ b/ansible/recover_server.py
@@ -89,16 +89,16 @@ class Task(object):
 class TaskStartTopoVMs(Task):
     """Task start-topo-vms."""
 
-    def __init__(self, tbname, passfile, log_save_dir, tbfile=None, vmfile=None, dry_run=False):
-        Task.__init__(self, tbname + '_start_topo_vms', log_save_dir=log_save_dir, tbfile=tbfile, vmfile=vmfile, dry_run=dry_run)
+    def __init__(self, tbname, passfile, log_save_dir, tbfile=None, vmfile=None, vmtype=None, dry_run=False):
+        Task.__init__(self, tbname + '_start_topo_vms', log_save_dir=log_save_dir, tbfile=tbfile, vmfile=vmfile, vmtype=vmtype, dry_run=dry_run)
         self.args.extend(('start-topo-vms', tbname, passfile))
         self.tbname = tbname
 
 class TaskStartVMs(Task):
     """Task start-vm"""
 
-    def __init__(self, server, passfile, log_save_dir, tbfile=None, vmfile=None, dry_run=False):
-        Task.__init__(self, server + '_start_vms', log_save_dir=log_save_dir, tbfile=tbfile, vmfile=vmfile, dry_run=dry_run)
+    def __init__(self, server, passfile, log_save_dir, tbfile=None, vmfile=None, vmtype=None, dry_run=False):
+        Task.__init__(self, server + '_start_vms', log_save_dir=log_save_dir, tbfile=tbfile, vmfile=vmfile, vmtype=vmtype, dry_run=dry_run)
         self.args.extend(('start-vms', server, passfile))
 
 class TaskAddTopo(Task):
@@ -153,7 +153,7 @@ class Job(object):
         elif jobname == 'start-vms':
             server = kwargs['server']
             self.tasks = [
-                TaskStartVMs(server, passfile, log_save_dir, tbfile=tbfile, vmfile=vmfile, dry_run=self.dry_run)
+                TaskStartVMs(server, passfile, log_save_dir, tbfile=tbfile, vmfile=vmfile, vmtype=vmtype, dry_run=self.dry_run)
             ]
             self.ignore_errors = False
         elif jobname == 'init_testbed':
@@ -279,6 +279,7 @@ def do_jobs(testbeds, passfile, tbfile=None, vmfile=None, vmtype=None, skip_clea
                     passfile=passfile,
                     tbfile=tbfile,
                     vmfile=vmfile,
+                    vmtype=vmtype,
                     log_save_dir=log_save_dir_per_server,
                     dry_run=dry_run
                 )


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix `recover_server` script.
Task `start-vms` or `start-topo-vms` is not running when `vmtype=veos`. The reason is the option `-k` is not passed into `testbed-cli.sh`. This PR will address the issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix a bug in `recover_server` script when vmtype is veos.

#### How did you do it?
The issue is fixed by passing  `-k` option to `testbed-cli.sh`.

#### How did you verify/test it?
Verified by running `recover_server` script.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
