### PR TITLE
[sfp-refactor] Fix is_xcvr_optical for QSFP28/CMIS

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -161,6 +161,10 @@ class TestSfpApi(PlatformApiTestBase):
                 compliance_code = spec_compliance_dict.get("10/40G Ethernet Compliance Code")
                 if compliance_code == "40GBASE-CR4":
                    return False
+                if compliance_code == "Extended":
+                    extended_code = spec_compliance_dict.get("Extended Specification Compliance")
+                    if "CR" in extended_code:
+                        return False
         return True
 
     def is_xcvr_resettable(self, xcvr_info_dict):

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -33,7 +33,7 @@ pytestmark = [
 def setup(request, duthosts, enum_rand_one_per_hwsku_hostname, xcvr_skip_list, conn_graph_facts):
     sfp_setup = {}
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    
+
     if duthost.is_supervisor_node():
         pytest.skip("skipping for supervisor node")
 
@@ -41,7 +41,7 @@ def setup(request, duthosts, enum_rand_one_per_hwsku_hostname, xcvr_skip_list, c
     physical_intfs = conn_graph_facts["device_conn"][duthost.hostname]
 
     physical_port_index_map = get_physical_port_indices(duthost, physical_intfs)
-  
+
     sfp_port_indices = set([physical_port_index_map[intf] \
         for intf in physical_port_index_map.keys()])
     sfp_setup["sfp_port_indices"] = sorted(sfp_port_indices)
@@ -148,8 +148,9 @@ class TestSfpApi(PlatformApiTestBase):
     def is_xcvr_optical(self, xcvr_info_dict):
         """Returns True if transceiver is optical, False if copper (DAC)"""
         #For QSFP-DD specification compliance will return type as passive or active
-        if xcvr_info_dict["type_abbrv_name"] == "QSFP-DD" or xcvr_info_dict["type_abbrv_name"] == "OSFP-8X":
-            if xcvr_info_dict["specification_compliance"] == "passive_copper_media_interface":
+        if xcvr_info_dict["type_abbrv_name"] == "QSFP-DD" or xcvr_info_dict["type_abbrv_name"] == "OSFP-8X" \
+        or xcvr_info_dict["type_abbrv_name"] == "QSFP+C":
+            if xcvr_info_dict["specification_compliance"] == "Passive Copper Cable":
                return False
         else:
             spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add additional check in is_xcvr_optical for passive QSFP28 cables. Also fix check for CMIS cables.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Passive QSFP28 cables may use an extended specification compliance code but this is not currently checked for in is_xcvr_optical, which results in some test cases inadvertently running and failing instead of being skipped.

Update check for CMIS cables to enable support for CMIS QSFP cables and address change in specification_compliance value introduced in https://github.com/Azure/sonic-platform-common/pull/228

#### How did you do it?
Updated is_xcvr_optical to check for the extended specification compliance code. Based on SFF-8024 Table 4-4, this change assumes that passive cables have "CR" in the code description.

#### How did you verify/test it?
Ran sonic-mgmt test suite on Arista platfrom with QSFP28 passive cables/CMIS QSFP cables to verify.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
