### PR TITLE
[anvance_reboot] Add copy of sniffer script to ptf_runner_reboot.yml file.

### DIFF
--- a/ansible/roles/test/tasks/ptf_runner_reboot.yml
+++ b/ansible/roles/test/tasks/ptf_runner_reboot.yml
@@ -36,6 +36,10 @@
       delegate_to: "{{ ptf_host }}"
       when: item and item != 'None'
 
+    - name: Copy sniffer script to the PTF container
+      copy: src=../tests/scripts/dual_tor_sniffer.py dest=/root/ptftests/advanced_reboot_sniffer.py
+      delegate_to: "{{ ptf_host }}"
+
     - name: Update supervisor configuration
       include_tasks: "roles/test/tasks/common_tasks/update_supervisor.yml"
       vars:


### PR DESCRIPTION
Add copy of sniffer script to ptf_runner_reboot.yml file.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add copy of sniffer script to ptf_runner_reboot.yml file.
Fixes # (issue) When run the advance reboot with ansible, the ansible/roles/test/tasks/ptf_runner_reboot.yml is not copied to the ptf docker.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
When run the advance reboot with ansible, the ansible/roles/test/tasks/ptf_runner_reboot.yml is not copied to the ptf docker. 
#### How did you do it?
Add copy sniffer script to the PTF container:
_name: Copy sniffer script to the PTF container
      copy: src=../tests/scripts/dual_tor_sniffer.py dest=/root/ptftests/advanced_reboot_sniffer.py
      delegate_to: "{{ ptf_host }}"_
#### How did you verify/test it?
Run the reboot with ansiable, and the advance_reboot can pass.
#### Any platform specific information?
No
