### PR TITLE
test_add_rack - made configlet config file to be generated dynamically

### DIFF
--- a/tests/configlet/test_add_rack.py
+++ b/tests/configlet/test_add_rack.py
@@ -61,8 +61,7 @@ ORIG_DB_SUB_DIR = "orig"
 CLET_DB_SUB_DIR = "clet"
 FILES_SUB_DIR = "files"
 
-base_dir    = "logs/configlet"
-data_dir    = "{}/AddRack".format(base_dir)
+data_dir    = "logs/configlet/AddRack"
 orig_db_dir = "{}/{}".format(data_dir, ORIG_DB_SUB_DIR)
 clet_db_dir = "{}/{}".format(data_dir, CLET_DB_SUB_DIR)
 files_dir   = "{}/{}".format(data_dir, FILES_SUB_DIR)
@@ -79,13 +78,10 @@ def do_pause(secs, msg):
 
 def init(duthost, duthost_name):
     global init_data
-
-    if not os.path.exists(base_dir):
-        os.mkdir(base_dir)
-
-    for i in [ data_dir, orig_db_dir, clet_db_dir, files_dir ]:
-        if not os.path.exists(i):
-            os.mkdir(i)
+    import shutil
+    shutil.rmtree(data_dir)
+    for i in [ orig_db_dir, clet_db_dir, files_dir ]:
+        os.makedirs(i)
 
     init_data["files_dir"] = files_dir 
     init_data["data_dir"] = data_dir
@@ -211,8 +207,8 @@ def test_add_rack(configure_dut, tbinfo, duthosts, rand_one_dut_hostname):
     download_sonic_files(duthost, files_dir)
 
     # Create minigraph w/o a T0 & configlet, apply & take dump
-    files_create.do_run(is_mlnx = duthost.facts["asic_type"] == "mellanox",
-            is_storage_backend = 'backend' in tbinfo['topo']['name'])
+
+    files_create.do_run(is_storage_backend = 'backend' in tbinfo['topo']['name'])
 
     # Ensure BGP session is up before we apply stripped minigraph
     chk_bgp_session(duthost, tor_data["ip"]["remote"], "pre-clet test")

--- a/tests/configlet/util/configlet.py
+++ b/tests/configlet/util/configlet.py
@@ -167,97 +167,70 @@ def get_device_info():
     return ret
 
 
-def get_port_related_data(is_mlnx, is_storage_backend):
+def get_cable_len(ifname):
+    return {ifname: config_db_data_orig['CABLE_LENGTH']['AZURE'][ifname]}
+
+def get_pg_profile(ifname):
+    def target_if_pg_only(key):
+        return ifname in key
+    res = {}
+    pgs = config_db_data_orig['BUFFER_PG']
+    for pg in filter(target_if_pg_only, pgs):
+        res[pg] = pgs[pg]
+    return res
+
+def get_queue_cfg(ifname):
+    def target_if_queue_only(key):
+        return ifname in key
+    res = {}
+    queues = config_db_data_orig['QUEUE']
+    for key in filter(target_if_queue_only, queues):
+        res[key] = queues[key]
+    return res
+
+def get_queue_profile(ifname):
+    def target_if_queue_only(key):
+        return ifname in key 
+    res = {}
+    queues = config_db_data_orig['BUFFER_QUEUE']
+    for key in filter(target_if_queue_only, queues):
+        q_range = key[key.rindex('|')+1:]
+        res[ifname + '|' + q_range] = queues[key]
+    return res
+
+def get_qos_map(ifname):
+    return {ifname: config_db_data_orig['PORT_QOS_MAP'][ifname]}
+    
+def get_pfcwd_config(ifname):
+    pfc_wd = {}
+    pfc_time = get_pfc_time()
+    if pfc_time:
+            # "PFC_WD"
+            pfc_wd[ifname] = {
+                    "action": "drop",
+                    "detection_time": pfc_time,
+                    "restoration_time": pfc_time }
+    return pfc_wd
+
+def get_port_qos_config():
     ret = []
     cable = {}
     queue = {}
     buffer_pg = {}
     buffer_q = {}
-    buffer_port_ingress = {}
-    buffer_port_egress = {}
     qos = {}
-    pfc_wd = {}
-    pfc_time = get_pfc_time()
+    pfc_wd = {}    
     
     log_debug("is_version_2019_higher={}".format(is_version_2019_higher()))
 
     for local_port in sonic_local_ports:
-        # Hard coded as 300m per discussion with Neetha
+        cable.update(get_cable_len(local_port))
+        buffer_pg.update(get_pg_profile(local_port))
+        queue.update(get_queue_cfg(local_port))
+        buffer_q.update(get_queue_profile(local_port))
+        qos.update(get_qos_map(local_port))
+        pfc_wd.update(get_pfcwd_config(local_port))
 
-        #  "CABLE_LENGTH"
-        cable[local_port] = "300m"
-
-        # "BUFFER_PG"
-        buffer_pg["{}|0".format(local_port)] = {
-                "profile": "[BUFFER_PROFILE|ingress_lossy_profile]" }
-
-        # "QUEUE"
-        for i in range(3):
-            queue["{}|{}".format(local_port, i)] = {
-                    "scheduler": "[SCHEDULER|scheduler.0]"}
-
-        for i in range(3, 5):
-            queue["{}|{}".format(local_port, i)] = {
-                    "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]",
-                    "scheduler": "[SCHEDULER|scheduler.1]"}
-        
-        for i in range(5,7):
-            queue["{}|{}".format(local_port, i)] = {
-                    "scheduler": "[SCHEDULER|scheduler.0]"}
-
-        # "BUFFER_QUEUE"
-        lossy_profile = "[BUFFER_PROFILE|{}]".format(
-                    "q_lossy_profile" if is_mlnx else "egress_lossy_profile")
-
-        buffer_q["{}|0-2".format(local_port)] = {"profile": lossy_profile}
-
-        buffer_q["{}|3-4".format(local_port)] = {
-                "profile": "[BUFFER_PROFILE|egress_lossless_profile]" }
-
-        buffer_q["{}|5-6".format(local_port)] = {"profile": lossy_profile}
-
-        if is_mlnx:
-            # "BUFFER_PORT_INGRESS_PROFILE_LIST"
-            if is_version_2019_higher():
-                buffer_port_ingress[local_port] = {
-                        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile]"
-                        }
-            else:
-                buffer_port_ingress[local_port] = {
-                        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-                        }
-            # "BUFFER_PORT_EGRESS_PROFILE_LIST"
-            buffer_port_egress[local_port] = {
-                    "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-                    }
-            ret.append({ "BUFFER_PORT_INGRESS_PROFILE_LIST": buffer_port_ingress })
-            ret.append({ "BUFFER_PORT_EGRESS_PROFILE_LIST": buffer_port_egress })
-
-        # "PORT_QOS_MAP"
-        qos[local_port] = {
-                "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-                "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]",
-                "pfc_enable": "3,4",
-                "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]"
-                }
-
-        if is_storage_backend:
-            qos[local_port]["dot1p_to_tc_map"] = "[DOT1P_TO_TC_MAP|AZURE]"
-        else:
-            qos[local_port]["dscp_to_tc_map"]  = "[DSCP_TO_TC_MAP|AZURE]"
-
-        if is_mlnx:
-            qos[local_port]["pfc_to_pg_map"] = "[PFC_PRIORITY_TO_PRIORITY_GROUP_MAP|AZURE]"
-
-        if pfc_time:
-            # "PFC_WD"
-            pfc_wd[local_port] = {
-                    "action": "drop",
-                    "detection_time": pfc_time,
-                    "restoration_time": pfc_time }
-
-
-        
     ret.append({ "CABLE_LENGTH": { "AZURE": cable } })
     ret.append({ "QUEUE": queue })
     ret.append({ "BUFFER_PG": buffer_pg })
@@ -267,7 +240,7 @@ def get_port_related_data(is_mlnx, is_storage_backend):
         ret.append({ "PFC_WD": pfc_wd })
 
     return ret
-         
+
 
 def get_bgp_neighbor():
     bgp = {}
@@ -301,7 +274,7 @@ def write_out(lst, tmpdir):
     managed_files["configlet"] = fpath
 
 
-def main(tmpdir, is_mlnx, is_storage_backend):
+def main(tmpdir, is_storage_backend):
     global sonic_local_ports
     ret = []
 
@@ -315,21 +288,7 @@ def main(tmpdir, is_mlnx, is_storage_backend):
         ret += get_vlan_sub_interface()
     ret += get_acl()
     ret += get_device_info()
-    ret += get_port_related_data(is_mlnx, is_storage_backend)
+    ret += get_port_qos_config()
     ret += get_bgp_neighbor()
 
     write_out(ret, tmpdir)
-
-    return 0
-
-
-
-    
-    
-
-
-
-
-
-
-

--- a/tests/configlet/util/files_create.py
+++ b/tests/configlet/util/files_create.py
@@ -10,11 +10,11 @@ import strip
 import configlet
 
 
-def do_run(is_mlnx, is_storage_backend):
+def do_run(is_storage_backend):
     init_global_data()
 
     strip.main(init_data["files_dir"])
-    configlet.main(init_data["files_dir"], is_mlnx, is_storage_backend)
+    configlet.main(init_data["files_dir"], is_storage_backend)
 
     log_info("Managed files: {}".format(json.dumps(managed_files, indent=4)))
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: test_add_rack - made configlet config file to be generated dynamically
Fixes # (issue)
- made configlet config file to be generated dynamically

test_add_rack tests configlet by restoring previously removed one T0 config using a prepared configlet file.
The prepared config is applied then and the final DUT config is analyzed on presence of the applied config.

Part of the aforementioned config related to QoS is generated with hardcoded values what results in maintenance difficulties because QoS config may vary for different platforms. This PR resolves the issue by generating QoS config dynamically based on configdb info


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Adapt the test to work with no change for any platform
#### How did you do it?
Replaced hardcoded QoS info for configlet file
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t1,any configlet/test_add_rack.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
