### PR TITLE
[Mellanox] Rename SN2201 platform prefix

### DIFF
--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -10,7 +10,7 @@ PSU_CAPABILITIES = [
     ['psu{}_curr', 'psu{}_curr_in', 'psu{}_power', 'psu{}_power_in', 'psu{}_volt', 'psu{}_volt_out2']
 ]
 SWITCH_MODELS = {
-    "x86_64-mlnx_msn2201-r0": {
+    "x86_64-nvidia_sn2201-r0": {
         "chip_type": "spectrum1",
         "reboot": {
             "cold_reboot": True,
@@ -23,7 +23,8 @@ SWITCH_MODELS = {
         },
         "psus": {
             "number": 2,
-            "hot_swappable": True
+            "hot_swappable": True,
+            "capabilities": PSU_CAPABILITIES[0]
         },
         "cpu_pack": {
             "number": 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Rename SN2201 platform prefix

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix name for SN2201 platform
#### How did you do it?
Change the platform name for SN2201 from x86_64-mlnx_sn2201-r0 to x86_64-nvidia_sn2201-r0, and add "capabilities": PSU_CAPABILITIES[0] for  this platform
#### How did you verify/test it?
Run platform related test case on this platform 
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
