### PR TITLE
Adjust the value of netdev_max_backlog regarding to 100G NIC

### DIFF
--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -1,7 +1,7 @@
 # Increase netdev_max_backlog to mitigate the packet drop issue
 # Ref https://www.kernel.org/doc/Documentation/sysctl/net.txt
 - name: Increase netdev_max_backlog
-  shell: echo 65535 > /proc/sys/net/core/netdev_max_backlog
+  shell: echo 250000 > /proc/sys/net/core/netdev_max_backlog
   become: yes
 
 - name: set "PTF" container type, by default


### PR DESCRIPTION
Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
65535 is not enough to get all the packets on 100G NIC. 
#### How did you do it?
Adjust to 250000 which is from the NIC vendor's guide.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
