### PR TITLE
[sanity_check] optimize the bgp check

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -203,7 +203,7 @@ def check_bgp(duthosts):
             for asic_index, a_asic_facts in enumerate(bgp_facts):
                 a_asic_result = False
                 a_asic_neighbors = a_asic_facts['ansible_facts']['bgp_neighbors']
-                if a_asic_neighbors is not None:
+                if a_asic_neighbors is not None and len(a_asic_neighbors) > 0:
                     down_neighbors = [k for k, v in a_asic_neighbors.items()
                                       if v['state'] != 'established']
                     if down_neighbors:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The pretest check will check the status of BGP neighbor , it will fail the check if any neighbor goes down. 
When the system is just up, during the time that the BGP configuration is not loaded, there is no BGP neighbor information in the system yet, BGP neighbor check will pass even there is no BGP connection at all, it may lead to failure of later test cases. 

In this PR, to check the BGP neighbor quantity, if it is zero, it means that the BGP container doesn't work yet, fail the check. 

Besides this change, there are several other things we need to tackle later. 
1. Current pre check sequence is based on the name sequence of check function, need to execute the test based on pre defined sequence, like the service and critical process check should be executed before BGP check. 
2. Optimize the bgp_facts to support multi-asic.
3. Further optimize BGP check by comparing the bgp facts and config facts, fail the check for any mismatch.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run test to verify the sanity check
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
