### PR TITLE
[advance-reboot] Fix sad case: don't send traffic through down lag interfaces

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -278,9 +278,13 @@ class ReloadTest(BaseTest):
                     ports_in_vlan.append(self.port_indices[ifname])
             ports_per_vlan[vlan] = ports_in_vlan
 
+        active_portchannels = list()
+        for neighbor_info in list(self.vm_dut_map.values()):
+            active_portchannels.append(neighbor_info["dut_portchannel"])
+
         pc_ifaces = []
         for pc in portchannel_content.values():
-            if not pc['name'] in pc_in_vlan:
+            if not pc['name'] in pc_in_vlan and pc['name'] in active_portchannels:
                 pc_ifaces.extend([self.port_indices[member] for member in pc['members']])
 
         return ports_per_vlan, pc_ifaces
@@ -532,12 +536,12 @@ class ReloadTest(BaseTest):
         self.fails['dut'] = set()
         self.port_indices = self.read_port_indices()
         self.vlan_ip_range = ast.literal_eval(self.test_params['vlan_ip_range'])
+        self.build_peer_mapping()
         self.ports_per_vlan, self.portchannel_ports = self.read_vlan_portchannel_ports()
         self.vlan_ports = []
         for ports in self.ports_per_vlan.values():
             self.vlan_ports += ports
         if self.sad_oper:
-            self.build_peer_mapping()
             self.test_params['vlan_if_port'] = self.build_vlan_if_port_mapping()
 
         self.default_ip_range = self.test_params['default_ip_range']

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -518,7 +518,8 @@ class AdvancedReboot:
             "vnet_pkts" : self.vnetPkts,
             "bgp_v4_v6_time_diff": self.bgpV4V6TimeDiff,
             "asic_type": self.duthost.facts["asic_type"],
-            "allow_mac_jumping": self.allowMacJump
+            "allow_mac_jumping": self.allowMacJump,
+            "preboot_files" : self.prebootFiles
         }
 
         if not isinstance(rebootOper, SadOperation):
@@ -529,7 +530,6 @@ class AdvancedReboot:
             # presence of routing in reboot operation indicates it is during reboot operation (inboot)
             inbootOper = rebootOper if rebootOper is not None and 'routing' in rebootOper else None
             params.update({
-                "preboot_files" : self.prebootFiles,
                 "preboot_oper" : prebootOper,
                 "inboot_oper" : inbootOper,
             })

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -446,7 +446,8 @@ class AdvancedReboot:
             "Advanced-reboot failure. Failed cases: {}".format(failed_list))
         return result
 
-    def runRebootTestcase(self, prebootList=None, inbootList=None, prebootFiles=None):
+    def runRebootTestcase(self, prebootList=None, inbootList=None,
+        prebootFiles='peer_dev_info,neigh_port_info'):
         '''
         This method validates and prepares test bed for reboot test case. It runs the reboot test case using provided
         test arguments

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -124,8 +124,7 @@ def test_warm_reboot_sad(request, get_advanced_reboot, verify_dut_health,
     ]
 
     advancedReboot.runRebootTestcase(
-        prebootList=prebootList,
-        prebootFiles='peer_dev_info,neigh_port_info'
+        prebootList=prebootList
     )
 
 
@@ -162,8 +161,7 @@ def test_warm_reboot_multi_sad(request, get_advanced_reboot, verify_dut_health,
     ] if advancedReboot.getTestbedType() in ['t0-64', 't0-116', 't0-64-32'] else [])
 
     advancedReboot.runRebootTestcase(
-        prebootList=prebootList,
-        prebootFiles='peer_dev_info,neigh_port_info'
+        prebootList=prebootList
     )
 
 
@@ -184,8 +182,7 @@ def test_warm_reboot_multi_sad_inboot(request, get_advanced_reboot, verify_dut_h
     ]
 
     advancedReboot.runRebootTestcase(
-        inbootList=inbootList,
-        prebootFiles='peer_dev_info,neigh_port_info'
+        inbootList=inbootList
     )
 
 
@@ -204,8 +201,7 @@ def test_warm_reboot_sad_bgp(request, get_advanced_reboot, verify_dut_health,
     ]
 
     advancedReboot.runRebootTestcase(
-        prebootList=prebootList,
-        prebootFiles='peer_dev_info,neigh_port_info'
+        prebootList=prebootList
     )
 
 
@@ -236,8 +232,7 @@ def test_warm_reboot_sad_lag_member(request, get_advanced_reboot, verify_dut_hea
     ] if advancedReboot.getTestbedType() in ['t0-64', 't0-116', 't0-64-32'] else [])
 
     advancedReboot.runRebootTestcase(
-        prebootList=prebootList,
-        prebootFiles='peer_dev_info,neigh_port_info'
+        prebootList=prebootList
     )
 
 
@@ -256,8 +251,7 @@ def test_warm_reboot_sad_lag(request, get_advanced_reboot, verify_dut_health,
     ]
 
     advancedReboot.runRebootTestcase(
-        prebootList=prebootList,
-        prebootFiles='peer_dev_info,neigh_port_info'
+        prebootList=prebootList
     )
 
 
@@ -276,6 +270,5 @@ def test_warm_reboot_sad_vlan_port(request, get_advanced_reboot, verify_dut_heal
     ]
 
     advancedReboot.runRebootTestcase(
-        prebootList=prebootList,
-        prebootFiles='peer_dev_info,neigh_port_info'
+        prebootList=prebootList
     )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix sad case: don't send traffic through down lag interfaces
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix advance-reboot SAD cases in testcase `test_warm_reboot_multi_sad`.
The failures observed were:
```
        "AssertionError: ", 
        "", 
        "Something went wrong. Please check output below:", 
        "", 
        "FAILED:dut:Control plane didn't come up within warm up timeout", 
        "FAILED:dut:DUT is not ready for test", 
        "", 
        "", 
        "----------------------------------------------------------------------", 
        "Ran 1 test in 350.481s", 
        "", 
        "FAILED (failures=1)"
```

The cause for failure was when incorrect participating member interfaces in a LAG are selected.
This issue supposedly started after https://github.com/Azure/sonic-mgmt/pull/3853
As part of PR 3853, some of the SAD case handling was moved out of ptf-tests. Due to this, the port selection for some cases is not done on ptf scripts.
Specifically, presently the traffic is sent through even the LAGs which are brought down. This leads to part of the downstream traffic always being dropped - ultimately leading to warm-up failure.

#### How did you do it?
Select the right set of ports for test, and send I/O via these selected ports.

#### How did you verify/test it?
Tested on a physical testbed with the fix and the issue was not seen.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
