### PR TITLE
[EVERFLOW] Implement EVERFLOW test on T0 topo

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -1,10 +1,12 @@
 """Utilities for testing the Everflow feature in SONiC."""
+from collections import defaultdict
 import os
 import logging
 import random
 import time
 import ipaddr
 import binascii
+import ptf
 import pytest
 import yaml
 
@@ -14,6 +16,7 @@ import ptf.packet as packet
 from abc import abstractmethod
 from ptf.mask import Mask
 from tests.common.helpers.assertions import pytest_assert
+import json
 
 # TODO: Add suport for CONFIGLET mode
 CONFIG_MODE_CLI = "cli"
@@ -34,6 +37,14 @@ STABILITY_BUFFER = 0.05 #50msec
 
 OUTER_HEADER_SIZE = 38
 
+# This IP is hardcoded into ACL rule
+TARGET_SERVER_IP = "192.168.0.2"
+# This IP is used as server ip
+DEFAULT_SERVER_IP = "192.168.0.3"
+VLAN_BASE_MAC_PATTERN = "72060001{:04}"
+DOWN_STREAM = "downstream"
+UP_STREAM = "upstream"
+
 @pytest.fixture(scope="module")
 def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
     """
@@ -48,12 +59,21 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
 
     """
     duthost = duthosts[rand_one_dut_hostname]
+    topo = tbinfo['topo']['name']
 
+    # {namespace: [server ports]}
+    server_ports_namespace_map = defaultdict(list)
+    # {namespace: [T1 ports]}
+    t1_ports_namespace_map = defaultdict(list)
     # { namespace : [tor ports] }
     tor_ports_namespace_map = defaultdict(list)
     # { namespace : [spine ports] }
     spine_ports_namespace_map = defaultdict(list)
 
+    # { set of namespace server ports belong }
+    server_ports_namespace = set()
+    # { set of namespace t1 ports belong}
+    t1_ports_namespace = set()
     # { set of namespace tor ports belongs }
     tor_ports_namespace = set()
     # { set of namespace spine ports belongs }
@@ -65,31 +85,49 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
     switch_capability_facts = duthost.switch_capabilities_facts()["ansible_facts"]
 
     # Get the list of T0/T2 ports
-    # TODO: The ACL tests do something really similar, I imagine we could refactor this bit.
     for dut_port, neigh in mg_facts["minigraph_neighbors"].items():
-        if "T0" in neigh["name"]:
-            # Add Tor ports to namespace
-            tor_ports_namespace_map[neigh['namespace']].append(dut_port)
-            tor_ports_namespace.add(neigh['namespace'])
-        elif "T2" in neigh["name"]:
-            # Add Spine ports to namespace
-            spine_ports_namespace_map[neigh['namespace']].append(dut_port)
-            spine_ports_namespace.add(neigh['namespace'])
+        if "t1" in topo:
+            # Get the list of T0/T2 ports
+            if "t0" in neigh["name"].lower():
+                # Add Tor ports to namespace
+                tor_ports_namespace_map[neigh['namespace']].append(dut_port)
+                tor_ports_namespace.add(neigh['namespace'])
+            elif "t2" in neigh["name"].lower():
+                # Add Spine ports to namespace
+                spine_ports_namespace_map[neigh['namespace']].append(dut_port)
+                spine_ports_namespace.add(neigh['namespace'])
+        elif "t0" in topo:
+            # Get the list of Server/T1 ports
+            if "server" in neigh["name"].lower():
+                # Add Server ports to namespace
+                server_ports_namespace_map[neigh['namespace']].append(dut_port)
+                server_ports_namespace.add(neigh['namespace'])
+            elif "t1" in neigh["name"].lower():
+                # Add T1 ports to namespace
+                t1_ports_namespace_map[neigh['namespace']].append(dut_port)
+                t1_ports_namespace.add(neigh['namespace'])
+        else:
+            # Todo: Support dualtor testbed
+            pytest.skip("Unsupported topo")
 
-    # Set of TOR ports only Namespace 
-    tor_only_namespace = tor_ports_namespace.difference(spine_ports_namespace)
-    # Set of Spine ports only Namespace 
-    spine_only_namespace = spine_ports_namespace.difference(tor_ports_namespace)
- 
-    # Randomly choose from TOR_only Namespace if present else just use first one 
-    tor_namespace = random.choice(tuple(tor_only_namespace)) if tor_only_namespace else tuple(tor_ports_namespace)[0]
-    # Randomly choose from Spine_only Namespace if present else just use first one 
-    spine_namespace = random.choice(tuple(spine_only_namespace)) if spine_only_namespace else tuple(spine_ports_namespace)[0]
+    if 't1' in topo:
+        # Set of TOR ports only Namespace 
+        tor_only_namespace = tor_ports_namespace.difference(spine_ports_namespace)
+        # Set of Spine ports only Namespace 
+        spine_only_namespace = spine_ports_namespace.difference(tor_ports_namespace)
+        # Randomly choose from TOR_only Namespace if present else just use first one 
+        tor_namespace = random.choice(tuple(tor_only_namespace)) if tor_only_namespace else tuple(tor_ports_namespace)[0]
+        # Randomly choose from Spine_only Namespace if present else just use first one 
+        spine_namespace = random.choice(tuple(spine_only_namespace)) if spine_only_namespace else tuple(spine_ports_namespace)[0]
+        tor_ports = tor_ports_namespace_map[tor_namespace]
+        spine_ports = spine_ports_namespace_map[spine_namespace]
 
-    # Get the corresponding namespace ports
-    tor_ports = tor_ports_namespace_map[tor_namespace]
-    spine_ports = spine_ports_namespace_map[spine_namespace]
-         
+    else:
+        # Use the default namespace for Server and T1
+        server_namespace = tuple(server_ports_namespace)[0]
+        t1_namespace = tuple(t1_ports_namespace)[0]
+        server_ports = server_ports_namespace_map[server_namespace]
+        t1_ports = t1_ports_namespace_map[t1_namespace]
 
     switch_capabilities = switch_capability_facts["switch_capabilities"]["switch"]
 
@@ -120,11 +158,13 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
             if port not in out_port_list and port not in out_port_exclude_list and len(out_port_list) < 4:
                 ptf_port_id = str(mg_facts["minigraph_ptf_indices"][port])
                 out_port_list.append(port)
-                out_port_lag_name.append("Not Applicable")
+                if out_port_lag_name != None:
+                    out_port_lag_name.append("Not Applicable")
 
                 for portchannelinfo in mg_facts["minigraph_portchannels"].items():
                     if port in portchannelinfo[1]["members"]:
-                        out_port_lag_name[-1] = portchannelinfo[0]
+                        if out_port_lag_name != None:
+                            out_port_lag_name[-1] = portchannelinfo[0]
                         for lag_member in portchannelinfo[1]["members"]:
                             if port == lag_member:
                                 continue
@@ -132,26 +172,9 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
                             out_port_exclude_list.append(lag_member)
 
                 out_port_ptf_id_list.append(ptf_port_id)
-
-    tor_dest_ports = []
-    tor_dest_ports_ptf_id = []
-    tor_dest_lag_name = []
-    get_port_info(tor_ports, tor_dest_ports, tor_dest_ports_ptf_id, tor_dest_lag_name)
-
-    spine_dest_ports = []
-    spine_dest_ports_ptf_id = []
-    spine_dest_lag_name = []
-    get_port_info(spine_ports, spine_dest_ports, spine_dest_ports_ptf_id, spine_dest_lag_name)
-
-    # TODO: Some of this can probably be tailored to the specific set of test cases (e.g.
-    # we don't need spine v. tor info to check match types).
-    #
-    # Also given how much info is here it probably makes sense to make a data object/named
-    # tuple to help with the typing.
+    
     setup_information = {
         "router_mac": duthost.facts["router_mac"],
-        "tor_ports": tor_ports,
-        "spine_ports": spine_ports,
         "test_mirror_v4": test_mirror_v4,
         "test_mirror_v6": test_mirror_v6,
         "ingress": {
@@ -161,24 +184,6 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
         "egress": {
             "ingress": test_ingress_mirror_on_egress_acl,
             "egress": test_egress_mirror_on_egress_acl
-        },
-        "tor": {
-            "src_port": spine_ports[0],
-            "src_port_lag_name":spine_dest_lag_name[0],
-            "src_port_ptf_id": str(mg_facts["minigraph_ptf_indices"][spine_ports[0]]),
-            "dest_port": tor_dest_ports,
-            "dest_port_ptf_id": tor_dest_ports_ptf_id,
-            "dest_port_lag_name": tor_dest_lag_name,
-            "namespace": tor_namespace
-        },
-        "spine": {
-            "src_port": tor_ports[0],
-            "src_port_lag_name":tor_dest_lag_name[0],
-            "src_port_ptf_id": str(mg_facts["minigraph_ptf_indices"][tor_ports[0]]),
-            "dest_port": spine_dest_ports,
-            "dest_port_ptf_id": spine_dest_ports_ptf_id,
-            "dest_port_lag_name": spine_dest_lag_name,
-            "namespace": spine_namespace
         },
         "port_index_map": {
             k: v
@@ -192,6 +197,86 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
            if k in mg_facts["minigraph_ports"]
         }
     }
+
+    if 't0' in topo:
+        # Downstream traffic (T0 -> Server)
+        server_dest_ports = []
+        server_dest_ports_ptf_id = []
+        get_port_info(server_ports, server_dest_ports, server_dest_ports_ptf_id, None)
+
+        # Upstream traffic (Server -> T0)
+        t1_dest_ports = []
+        t1_dest_ports_ptf_id = []
+        t1_dest_lag_name = []
+        get_port_info(t1_ports, t1_dest_ports, t1_dest_ports_ptf_id, t1_dest_lag_name)
+
+        setup_information.update(
+            {
+                "topo": "t0",
+                "server_ports": server_ports,
+                "server_dest_ports_ptf_id": server_dest_ports_ptf_id,
+                "t1_ports": t1_ports,
+                DOWN_STREAM: {
+                    "src_port": t1_ports[0],
+                    "src_port_lag_name":t1_dest_lag_name[0],
+                    "src_port_ptf_id": str(mg_facts["minigraph_ptf_indices"][t1_ports[0]]),
+                    # Downstream traffic ingress from the first portchannel,
+                    # and mirror packet egress from other portchannels
+                    "dest_port": t1_ports[2:] if len(t1_dest_ports_ptf_id[0].split(',')) == 2 else t1_ports[1:],
+                    "dest_port_ptf_id": t1_dest_ports_ptf_id[1:],
+                    "dest_port_lag_name": t1_dest_lag_name[1:],
+                    "namespace": server_namespace
+                },
+                UP_STREAM: {
+                    "src_port": server_ports[0],
+                    "src_port_lag_name":"Not Applicable",
+                    "src_port_ptf_id": str(mg_facts["minigraph_ptf_indices"][server_ports[0]]),
+                    "dest_port": t1_dest_ports,
+                    "dest_port_ptf_id": t1_dest_ports_ptf_id,
+                    "dest_port_lag_name": t1_dest_lag_name,
+                    "namespace": t1_namespace
+                },
+            }
+        )
+    elif 't1' in topo:
+        # Downstream traffic (T1 -> T0)
+        tor_dest_ports = []
+        tor_dest_ports_ptf_id = []
+        tor_dest_lag_name = []
+        get_port_info(tor_ports, tor_dest_ports, tor_dest_ports_ptf_id, tor_dest_lag_name)
+        
+        # Upstream traffic (T0 -> T1)
+        spine_dest_ports = []
+        spine_dest_ports_ptf_id = []
+        spine_dest_lag_name = []
+        get_port_info(spine_ports, spine_dest_ports, spine_dest_ports_ptf_id, spine_dest_lag_name)
+
+        setup_information.update(
+            {
+                "topo": "t1",
+                "tor_ports": tor_ports,
+                "spine_ports": spine_ports,
+                DOWN_STREAM: {
+                    "src_port": spine_ports[0],
+                    "src_port_lag_name":spine_dest_lag_name[0],
+                    "src_port_ptf_id": str(mg_facts["minigraph_ptf_indices"][spine_ports[0]]),
+                    "dest_port": tor_dest_ports,
+                    "dest_port_ptf_id": tor_dest_ports_ptf_id,
+                    "dest_port_lag_name": tor_dest_lag_name,
+                    "namespace": tor_namespace
+                    },
+                UP_STREAM: {
+                    "src_port": tor_ports[0],
+                    "src_port_lag_name":tor_dest_lag_name[0],
+                    "src_port_ptf_id": str(mg_facts["minigraph_ptf_indices"][tor_ports[0]]),
+                    "dest_port": spine_dest_ports,
+                    "dest_port_ptf_id": spine_dest_ports_ptf_id,
+                    "dest_port_lag_name": spine_dest_lag_name,
+                    "namespace": spine_namespace
+                }
+            }
+        )
+
     # Disable BGP so that we don't keep on bouncing back mirror packets
     # If we send TTL=1 packet we don't need this but in multi-asic TTL > 1
     duthost.command("sudo config bgp shutdown all")
@@ -221,7 +306,6 @@ def add_route(duthost, prefix, nexthop, namespace):
     duthost.shell(duthost.get_vtysh_cmd_for_namespace("vtysh -c \"configure terminal\" -c \"ip route {} {}\"".format(prefix, nexthop), namespace))
 
 
-
 # TODO: This should be refactored to some common area of sonic-mgmt.
 def remove_route(duthost, prefix, nexthop, namespace):
     """
@@ -236,6 +320,46 @@ def remove_route(duthost, prefix, nexthop, namespace):
     """
     duthost.shell(duthost.get_vtysh_cmd_for_namespace("vtysh -c \"configure terminal\" -c \"no ip route {} {}\"".format(prefix, nexthop), namespace))
 
+@pytest.fixture(scope='module', autouse=True)
+def setup_arp_responder(duthost, ptfhost, setup_info):
+    if setup_info['topo'] != 't0':
+        yield
+        return
+    ip_list = [TARGET_SERVER_IP, DEFAULT_SERVER_IP]
+    port_list = setup_info["server_dest_ports_ptf_id"][0:2]
+    arp_responder_cfg = {}
+    for i, ip in enumerate(ip_list):
+        iface_name = "eth{}".format(port_list[i])
+        mac = VLAN_BASE_MAC_PATTERN.format(i)
+        arp_responder_cfg[iface_name] = {ip: mac}
+
+    CFG_FILE = '/tmp/arp_responder.json'
+    with open(CFG_FILE, 'w') as file:
+        json.dump(arp_responder_cfg, file)
+
+    ptfhost.copy(src=CFG_FILE, dest=CFG_FILE)
+
+    extra_vars = {
+            'arp_responder_args': '--conf {}'.format(CFG_FILE)
+        }
+
+    ptfhost.host.options['variable_manager'].extra_vars.update(extra_vars)
+    ptfhost.template(src='templates/arp_responder.conf.j2', dest='/etc/supervisor/conf.d/arp_responder.conf')
+
+    ptfhost.command('supervisorctl reread')
+    ptfhost.command('supervisorctl update')
+
+    ptfhost.command('supervisorctl start arp_responder')
+    time.sleep(10)
+    for ip in ip_list:
+        duthost.shell("ping -c 1 {}".format(ip), module_ignore_errors=True)
+
+    yield
+
+    ptfhost.command('supervisorctl stop arp_responder')
+    ptfhost.file(path='/tmp/arp_responder.json', state="absent")
+    duthost.command('sonic-clear arp')
+
 
 # TODO: This should be refactored to some common area of sonic-mgmt.
 def get_neighbor_info(duthost, dest_port, tbinfo, resolved=True):
@@ -246,7 +370,6 @@ def get_neighbor_info(duthost, dest_port, tbinfo, resolved=True):
         duthost: DUT fixture
         dest_port: The port for which to gather the neighbor information
         resolved: Whether to return a resolved route or not
-
     """
     if not resolved:
         return "20.20.20.100"
@@ -278,6 +401,17 @@ class BaseEverflowTest(object):
     Contains common methods for setting up the mirror session and describing the
     mirror and ACL stage for the tests.
     """
+    @pytest.fixture(scope="class", autouse=True)
+    def skip_on_dualtor(self, tbinfo):
+        """
+        Skip dualtor topo for now
+        """
+        if 'dualtor' in tbinfo['topo']['name']:
+            pytest.skip("Dualtor testbed is not supported yet")
+        
+        self.is_t0 = False
+        if 't0' in tbinfo['topo']['name']:
+            self.is_t0 = True
 
     @pytest.fixture(scope="class", params=[CONFIG_MODE_CLI])
     def config_method(self, request):

--- a/tests/everflow/files/ipv4_test_rules.yaml
+++ b/tests/everflow/files/ipv4_test_rules.yaml
@@ -7,6 +7,10 @@
       destination-ip-address: "30.0.0.10/32"
 
 - qualifiers:
+    ip:
+      destination-ip-address: "192.168.0.2/32"
+
+- qualifiers:
     transport:
       source-port: "4661"
 

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -1,18 +1,20 @@
 """Test cases to support the Everflow Mirroring feature in SONiC."""
+from collections import defaultdict
 import logging
 import time
+import ptf
 import pytest
 
 import ptf.testutils as testutils
 import everflow_test_utilities as everflow_utils
 
 from tests.ptf_runner import ptf_runner
-from everflow_test_utilities import BaseEverflowTest
-
+from everflow_test_utilities import TARGET_SERVER_IP, BaseEverflowTest, DOWN_STREAM, UP_STREAM, DEFAULT_SERVER_IP
 # Module-level fixtures
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa: F401, E501 lgtm[py/unused-import] pylint: disable=import-error
 from tests.common.fixtures.ptfhost_utils import copy_acstests_directory   # noqa: F401, E501 lgtm[py/unused-import] pylint: disable=import-error
-from everflow_test_utilities import setup_info, EVERFLOW_DSCP_RULES       # noqa: F401, E501 lgtm[py/unused-import] pylint: disable=import-error
+from everflow_test_utilities import setup_info, setup_arp_responder, EVERFLOW_DSCP_RULES       # noqa: F401, E501 lgtm[py/unused-import] pylint: disable=import-error
+from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py # noqa: F401, E501 lgtm[py/unused-import] pylint: disable=import-error
 
 pytestmark = [
     pytest.mark.topology("t1")
@@ -70,14 +72,14 @@ class EverflowIPv4Tests(BaseEverflowTest):
     DEFAULT_DST_IP = "30.0.0.1"
     MIRROR_POLICER_UNSUPPORTED_ASIC_LIST = ["th3"]
 
-    @pytest.fixture(params=["tor", "spine"])
+    @pytest.fixture(params=[DOWN_STREAM, UP_STREAM])
     def dest_port_type(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, tbinfo, request):
         """
         This fixture parametrize  dest_port_type and can perform action based
         on that. As of now cleanup is being done here.
         """
         duthost = duthosts[rand_one_dut_hostname]
-
+        
         duthost.shell(duthost.get_vtysh_cmd_for_namespace("vtysh -c \"config\" -c \"router bgp\" -c \"address-family ipv4\" -c \"redistribute static\"",setup_info[request.param]["namespace"]))
         yield request.param
         
@@ -120,7 +122,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             setup_mirror_session,
             duthost,
             rx_port_ptf_id,
-            [tx_port_ptf_id]
+            [tx_port_ptf_id],
+            dest_port_type
         )
 
         # Add a (better) unresolved route to the mirror session destination IP
@@ -135,7 +138,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             setup_mirror_session,
             duthost,
             rx_port_ptf_id,
-            [tx_port_ptf_id]
+            [tx_port_ptf_id],
+            dest_port_type
         )
 
         # Remove the unresolved route
@@ -155,7 +159,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             setup_mirror_session,
             duthost,
             rx_port_ptf_id,
-            [tx_port_ptf_id]
+            [tx_port_ptf_id],
+            dest_port_type
         )
 
         # Remove the better route.
@@ -170,7 +175,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             setup_mirror_session,
             duthost,
             rx_port_ptf_id,
-            [tx_port_ptf_id]
+            [tx_port_ptf_id],
+            dest_port_type
         )
         duthost.shell(duthost.get_vtysh_cmd_for_namespace("vtysh -c \"configure terminal\" -c \"ip nht resolve-via-default\"", setup_info[dest_port_type]["namespace"]))
 
@@ -192,7 +198,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             setup_mirror_session,
             duthost,
             rx_port_ptf_id,
-            [tx_port_ptf_id]
+            [tx_port_ptf_id],
+            dest_port_type
         )
 
         # Update the MAC on the neighbor interface for the route we installed
@@ -210,7 +217,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
                 setup_mirror_session,
                 duthost,
                 rx_port_ptf_id,
-                [tx_port_ptf_id]
+                [tx_port_ptf_id],
+                dest_port_type
             )
 
         finally:
@@ -225,7 +233,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             setup_mirror_session,
             duthost,
             rx_port_ptf_id,
-            [tx_port_ptf_id]
+            [tx_port_ptf_id],
+            dest_port_type
         )
     
     def test_everflow_remove_unused_ecmp_next_hop(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
@@ -254,7 +263,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             setup_mirror_session,
             duthost,
             rx_port_ptf_id,
-            tx_port_ptf_ids
+            tx_port_ptf_ids,
+            dest_port_type
         )
 
         # Remaining Scenario not applicable for this topology
@@ -276,6 +286,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             duthost,
             rx_port_ptf_id,
             [tx_port_ptf_id],
+            dest_port_type,
             expect_recv=False,
             valid_across_namespace=False
         )
@@ -292,6 +303,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             duthost,
             rx_port_ptf_id,
             [tx_port_ptf_id],
+            dest_port_type,
             expect_recv=False,
             valid_across_namespace=False
         )
@@ -303,7 +315,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             setup_mirror_session,
             duthost,
             rx_port_ptf_id,
-            tx_port_ptf_ids
+            tx_port_ptf_ids,
+            dest_port_type
         )
 
     def test_everflow_remove_used_ecmp_next_hop(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
@@ -329,7 +342,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             setup_mirror_session,
             duthost,
             rx_port_ptf_id,
-            [tx_port_ptf_id]
+            [tx_port_ptf_id],
+            dest_port_type
         )
 
         # Add two new ECMP next hops
@@ -350,6 +364,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             duthost,
             rx_port_ptf_id,
             [tx_port_ptf_id],
+            dest_port_type,
             valid_across_namespace=False
         )
 
@@ -365,6 +380,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             duthost,
             rx_port_ptf_id,
             tx_port_ptf_ids,
+            dest_port_type,
             expect_recv=False,
             valid_across_namespace=False
         )
@@ -381,6 +397,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             duthost,
             rx_port_ptf_id,
             [tx_port_ptf_id],
+            dest_port_type,
             expect_recv=False
         )
 
@@ -391,7 +408,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             setup_mirror_session,
             duthost,
             rx_port_ptf_id,
-            tx_port_ptf_ids
+            tx_port_ptf_ids,
+            dest_port_type
         )
     
     def test_everflow_dscp_with_policer(
@@ -421,15 +439,19 @@ class EverflowIPv4Tests(BaseEverflowTest):
             vendorAsic = "{0}_{1}_hwskus".format(vendor, asic)
             if vendorAsic in hostvars.keys() and duthost.facts['hwsku'] in hostvars[vendorAsic]:
                 pytest.skip("Skipping test since mirror policing is not supported on {0} {1} platforms".format(vendor,asic))
-
-        default_tarffic_port_type = "tor" if dest_port_type == "spine" else "spine"
+        if setup_info['topo'] == 't0':
+            default_tarffic_port_type = dest_port_type
+            # Use the second portchannel as missor session nexthop
+            tx_port = setup_info[dest_port_type]["dest_port"][1]
+        else:
+            default_tarffic_port_type = DOWN_STREAM if dest_port_type == UP_STREAM else UP_STREAM
+            tx_port = setup_info[dest_port_type]["dest_port"][0]
         default_traffic_tx_port = setup_info[default_tarffic_port_type]["dest_port"][0]
         default_traffic_peer_ip = everflow_utils.get_neighbor_info(duthost, default_traffic_tx_port, tbinfo)
         everflow_utils.add_route(duthost, self.DEFAULT_DST_IP + "/32", default_traffic_peer_ip, setup_info[default_tarffic_port_type]["namespace"])
         time.sleep(15)
 
         # Add explicit route for the mirror session
-        tx_port = setup_info[dest_port_type]["dest_port"][0]
         peer_ip = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
         everflow_utils.add_route(duthost, policer_mirror_session["session_prefixes"][0], peer_ip, setup_info[dest_port_type]["namespace"])
         time.sleep(15)
@@ -440,9 +462,15 @@ class EverflowIPv4Tests(BaseEverflowTest):
             table_type = "MIRROR_DSCP"
             rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
             tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
-            bind_interface = setup_info[dest_port_type]["src_port"]
-            if setup_info[dest_port_type]["src_port_lag_name"] != "Not Applicable":
-                bind_interface = setup_info[dest_port_type]["src_port_lag_name"]
+            if setup_info['topo'] == 't0' and self.acl_stage() == "egress":
+                # For T0 upstream, the EVERFLOW_DSCP table is binded to one of portchannels
+                bind_interface = setup_info[dest_port_type]["dest_port_lag_name"][0]
+                mirror_port_id = setup_info[dest_port_type]["dest_port_ptf_id"][1]
+            else:
+                bind_interface = setup_info[dest_port_type]["src_port"]
+                mirror_port_id = tx_port_ptf_id
+                if setup_info[dest_port_type]["src_port_lag_name"] != "Not Applicable":
+                    bind_interface = setup_info[dest_port_type]["src_port_lag_name"]
 
             # Temp change for multi-asic to create acl table in host and namespace
             # Will be removed once CLI is command is enahnced to work across all namespaces.
@@ -465,7 +493,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                expect_receive=True,
                                test_name="everflow_policer_test.EverflowPolicerTest",
                                src_port=rx_port_ptf_id,
-                               dst_mirror_ports=tx_port_ptf_id,
+                               dst_mirror_ports=mirror_port_id,
                                dst_ports=tx_port_ptf_id,
                                meter_type="packets",
                                cir="100",
@@ -481,21 +509,27 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_utils.remove_route(duthost, policer_mirror_session["session_prefixes"][0], peer_ip, setup_info[dest_port_type]["namespace"])
             everflow_utils.remove_route(duthost, self.DEFAULT_DST_IP + "/32", default_traffic_peer_ip, setup_info[default_tarffic_port_type]["namespace"])
 
-    def _run_everflow_test_scenarios(self, ptfadapter, setup, mirror_session, duthost, rx_port, tx_ports, expect_recv=True, valid_across_namespace=True):
+    def _run_everflow_test_scenarios(self, ptfadapter, setup, mirror_session, duthost, rx_port, tx_ports, direction, expect_recv=True, valid_across_namespace=True):
         # FIXME: In the ptf_runner version of these tests, LAGs were passed down to the tests as comma-separated strings of
         # LAG member port IDs (e.g. portchannel0001 -> "2,3"). Because the DSCP test is still using ptf_runner we will preserve
         # this for now, but we should try to make the format a little more friendly once the DSCP test also gets converted.
         tx_port_ids = self._get_tx_port_id_list(tx_ports)
+        target_ip = "30.0.0.10"
+        default_ip = self.DEFAULT_DST_IP
+        if 't0' == setup['topo'] and direction == DOWN_STREAM:
+            target_ip = TARGET_SERVER_IP
+            default_ip = DEFAULT_SERVER_IP
+
         pkt_dict = {
-            "(src ip)": self._base_tcp_packet(ptfadapter, setup, src_ip="20.0.0.10"),
-            "(dst ip)": self._base_tcp_packet(ptfadapter, setup, dst_ip="30.0.0.10"),
-            "(l4 src port)": self._base_tcp_packet(ptfadapter, setup, sport=0x1235),
-            "(l4 dst port)": self._base_tcp_packet(ptfadapter, setup, dport=0x1235),
-            "(ip protocol)": self._base_tcp_packet(ptfadapter, setup, ip_protocol=0x7E),
-            "(tcp flags)": self._base_tcp_packet(ptfadapter, setup, flags=0x12),
-            "(l4 src range)": self._base_tcp_packet(ptfadapter, setup, sport=4675),
-            "(l4 dst range)": self._base_tcp_packet(ptfadapter, setup, dport=4675),
-            "(dscp)": self._base_tcp_packet(ptfadapter, setup, dscp=51)
+            "(src ip)": self._base_tcp_packet(ptfadapter, setup, src_ip="20.0.0.10", dst_ip=default_ip),
+            "(dst ip)": self._base_tcp_packet(ptfadapter, setup, dst_ip=target_ip),
+            "(l4 src port)": self._base_tcp_packet(ptfadapter, setup, sport=0x1235, dst_ip=default_ip),
+            "(l4 dst port)": self._base_tcp_packet(ptfadapter, setup, dport=0x1235, dst_ip=default_ip),
+            "(ip protocol)": self._base_tcp_packet(ptfadapter, setup, ip_protocol=0x7E, dst_ip=default_ip),
+            "(tcp flags)": self._base_tcp_packet(ptfadapter, setup, flags=0x12, dst_ip=default_ip),
+            "(l4 src range)": self._base_tcp_packet(ptfadapter, setup, sport=4675, dst_ip=default_ip),
+            "(l4 dst range)": self._base_tcp_packet(ptfadapter, setup, dport=4675, dst_ip=default_ip),
+            "(dscp)": self._base_tcp_packet(ptfadapter, setup, dscp=51, dst_ip=default_ip)
         }
 
         for description, pkt in pkt_dict.items():


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This test is to implement EVERFLOW test on T0 topo.
The current everflow test set is only running on `T1` topo. This PR enable the test on T0 topo by adding setup and updating test code.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This test is to implement EVERFLOW test on T0 topo.

#### How did you do it?
1. Add setup for T0 testbed.
2. Update test code.

#### How did you verify/test it?
Verified on Mellanox 4600c, T0 topo
```
collected 40 items                                                                                                                                                                                       

everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_basic_forwarding[cli-downstream] PASSED                                                                    [  2%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_basic_forwarding[cli-upstream]  ^HPASSED                                                                      [  5%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_neighbor_mac_change[cli-downstream] PASSED                                                                 [  7%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_neighbor_mac_change[cli-upstream] PASSED                                                                   [ 10%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream] PASSED                                                         [ 12%] ^H
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream] PASSED                                                           [ 15%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream] PASSED                                                           [ 17%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream] PASSED                                                             [ 20%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer[cli-downstream]  ^HPASSED                                                                   [ 22%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer[cli-upstream] PASSED                                                                     [ 25%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_basic_forwarding[cli-downstream] SKIPPED                                                                    [ 27%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_basic_forwarding[cli-upstream] SKIPPED                                                                      [ 30%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_neighbor_mac_change[cli-downstream] SKIPPED                                                                 [ 32%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_neighbor_mac_change[cli-upstream] SKIPPED                                                                   [ 35%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream] SKIPPED                                                         [ 37%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream] SKIPPED                                                           [ 40%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream] SKIPPED                                                           [ 42%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream] SKIPPED                                                             [ 45%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_dscp_with_policer[cli-downstream] SKIPPED                                                                   [ 47%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_dscp_with_policer[cli-upstream] SKIPPED                                                                     [ 50%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_basic_forwarding[cli-downstream] SKIPPED                                                                    [ 52%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_basic_forwarding[cli-upstream] SKIPPED                                                                      [ 55%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_neighbor_mac_change[cli-downstream] SKIPPED                                                                 [ 57%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_neighbor_mac_change[cli-upstream] SKIPPED                                                                   [ 60%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream] SKIPPED                                                         [ 62%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream] SKIPPED                                                           [ 65%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream] SKIPPED                                                           [ 67%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream] SKIPPED                                                             [ 70%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_dscp_with_policer[cli-downstream] SKIPPED                                                                   [ 72%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_dscp_with_policer[cli-upstream] SKIPPED                                                                     [ 75%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_basic_forwarding[cli-downstream] PASSED                                                                      [ 77%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_basic_forwarding[cli-upstream]  ^HPASSED                                                                        [ 80%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_neighbor_mac_change[cli-downstream] PASSED                                                                   [ 82%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_neighbor_mac_change[cli-upstream] PASSED                                                                     [ 85%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-downstream] PASSED                                                           [ 87%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_unused_ecmp_next_hop[cli-upstream]  ^HPASSED                                                             [ 90%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-downstream] PASSED                                                             [ 92%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_remove_used_ecmp_next_hop[cli-upstream] PASSED                                                               [ 95%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_dscp_with_policer[cli-downstream]  ^HPASSED                                                                     [ 97%]
everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_dscp_with_policer[cli-upstream] PASSED                                                                       [100%]

========================================================================== 20 passed, 20 skipped, 1 warnings in 2054.11 seconds ==========================================================================
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
