### PR TITLE
[Test Report] Optimize the test report to include xfail results

### DIFF
--- a/test_reporting/kusto/flat_views.kql
+++ b/test_reporting/kusto/flat_views.kql
@@ -5,8 +5,8 @@
 {
     TestReportMetadata
     | join kind=innerunique TestReportSummary on ReportId
-    | project Timestamp, OSVersion, HardwareSku, TotalCasesRun, Successes=(TotalCasesRun - Failures - Skipped),
-              Failures, Errors, Skipped, TestbedName, TrackingId, TotalRuntime,
+    | project Timestamp, OSVersion, HardwareSku, TotalCasesRun, Successes=(TotalCasesRun - Failures - Skipped - Xfails),
+              Failures, Errors, Skipped, Xfails, TestbedName, TrackingId, TotalRuntime,
               AsicType, Platform, Topology, ReportId, UploadTimestamp
     | sort by Timestamp desc
 }

--- a/test_reporting/kusto/setup.kql
+++ b/test_reporting/kusto/setup.kql
@@ -55,13 +55,14 @@
 # 2. Add a JSON mapping for the table                                         #
 ###############################################################################
 .create table TestReportSummary (ReportId: string, TotalCasesRun: int, Failures: int,
-                                 Errors: int, Skipped: int, TotalRuntime: double)
+                                 Errors: int, Skipped: int, Xfails: int, TotalRuntime: double)
 
 .create table TestReportSummary ingestion json mapping 'FlatSummaryMappingV1' '[{"column":"ReportId","Properties":{"path":"$.id"}},
                                                                                 {"column":"TotalCasesRun","Properties":{"path":"$.tests"}},
                                                                                 {"column":"Failures","Properties":{"path":"$.failures"}},
                                                                                 {"column":"Errors","Properties":{"path":"$.errors"}},
                                                                                 {"column":"Skipped","Properties":{"path":"$.skipped"}},
+                                                                                {"column":"Xfails","Properties":{"path":"$.xfails"}},
                                                                                 {"column":"TotalRuntime","Properties":{"path":"$.time"}}]'
 
 ###############################################################################

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -299,6 +299,8 @@ def pytest_collection_modifyitems(session, config, items):
                     if mark_name == 'xfail':
                         strict = mark_details.get('strict', False)
                         mark = getattr(pytest.mark, mark_name)(reason=reason, strict=strict)
+                        # To generate xfail property in the report xml file
+                        item.user_properties.append(('xfail', strict))
                     else:
                         mark = getattr(pytest.mark, mark_name)(reason=reason)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Optimize the test report to include xfail results
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
By adding xfail marker, can't tell a real success or a xfail success, this PR is to optimize the test report function to include xfail results.
#### How did you do it?
Add 4 new result types to test case result, xfail_success, xfail_failure, xfail_error, xfail_skipped. And add one new filed xfails in test report summary.
#### How did you verify/test it?
Run test to generate test report to have different combinations of xfail cases.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
