### PR TITLE
Improve the error message when non-exist testbed name is provided to run_tests.sh

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -37,11 +37,19 @@ function get_dut_from_testbed_file() {
         if [[ $TESTBED_FILE == *.csv ]];
         then
             LINE=`cat $TESTBED_FILE | grep "^$TESTBED_NAME"`
+            if [[ -z ${LINE} ]]; then
+                echo "Unable to find testbed '$TESTBED_NAME' in testbed file '$TESTBED_FILE'"
+                show_help_and_exit 4
+            fi
             IFS=',' read -ra ARRAY <<< "$LINE"
             DUT_NAME=${ARRAY[9]}
         elif [[ $TESTBED_FILE == *.yaml ]];
         then
             content=$(python -c "from __future__ import print_function; import yaml; print('+'.join(str(tb) for tb in yaml.safe_load(open('$TESTBED_FILE')) if '$TESTBED_NAME'==tb['conf-name']))")
+            if [[ -z ${content} ]]; then
+                echo "Unable to find testbed '$TESTBED_NAME' in testbed file '$TESTBED_FILE'"
+                show_help_and_exit 4
+            fi
             IFS=$'+' read -r -a tb_lines <<< $content
             tb_line=${tb_lines[0]}
             DUT_NAME=$(python -c "from __future__ import print_function; tb=eval(\"$tb_line\"); print(\",\".join(tb[\"dut\"]))")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The error message of run_tests.sh is confusing if:
* non-exist testbed name is provided
* Yaml format testbed file is used.

For example:
```
$ ./run_tests.sh -i veos_vtb -n 'vms-kvm-xxx' -c ./dhcp_relay/test_dhcp_relay.py -f vtestbed.yaml
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 0

    ^
SyntaxError: unexpected EOF while parsing
DUT name (-d) is not set..
Usage ./run_tests.sh [options]
    options with (*) must be provided
    -h -?          : get this help
    ...
```

#### How did you do it?
This change added checking testbed name existence and improved the error message

#### How did you verify/test it?
With this change, the error message is like below:

```
$ ./run_tests.sh -i veos_vtb -n 'vms-kvm-xxx' -c ./dhcp_relay/test_dhcp_relay.py -f vtestbed.yaml
Unable to find testbed 'vms-kvm-xxx' in testbed file 'vtestbed.yaml'
Usage ./run_tests.sh [options]
    options with (*) must be provided
    -h -?          : get this help
    ...
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
