### PR TITLE
[Issue]Fix issue that some options added in the pytest is meaningless

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -521,6 +521,7 @@ def get_intf_by_sub_intf(sub_intf, vlan_id=None):
         return sub_intf[:-len(vlan_suffix)]
     return sub_intf
 
+
 def check_qos_db_fv_reference_with_table(duthost):
     """
     @summary: Check qos db field value refrence with table name or not.
@@ -531,3 +532,13 @@ def check_qos_db_fv_reference_with_table(duthost):
         logger.info("DUT release {} exits in release list {}, QOS db field value refered to table names".format(duthost.sonic_release, ", ".join(release_list)))
         return True
     return False
+
+
+def str2bool(str):
+    """
+    This is used as a type when add option for pytest
+    :param str: The input string value
+    :return: False if value is 0 or false, else True
+    """
+    return str.lower() not in ["0", "false"]
+

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -540,5 +540,4 @@ def str2bool(str):
     :param str: The input string value
     :return: False if value is 0 or false, else True
     """
-    return str.lower() not in ["0", "false"]
-
+    return str.lower() not in ["0", "false", "no"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ from tests.common.helpers.dut_utils import is_supervisor_node, is_frontend_node
 from tests.common.cache import FactsCache
 
 from tests.common.connections.console_host import ConsoleHost
+from tests.common.utilities import str2bool
 
 
 logger = logging.getLogger(__name__)
@@ -97,7 +98,7 @@ def pytest_addoption(parser):
                     help="Change default loops delay")
     parser.addoption("--logs_since", action="store", type=int,
                     help="number of minutes for show techsupport command")
-    parser.addoption("--collect_techsupport", action="store", default=True, type=bool,
+    parser.addoption("--collect_techsupport", action="store", default=True, type=str2bool,
                     help="Enable/Disable tech support collection. Default is enabled (True)")
 
     ############################

--- a/tests/ixia/ecn/args/ecn_args.py
+++ b/tests/ixia/ecn/args/ecn_args.py
@@ -1,3 +1,6 @@
+from tests.common.utilities import str2bool
+
+
 def add_ecn_args(parser):
     """
     Add arguments required for ECN test cases
@@ -12,7 +15,7 @@ def add_ecn_args(parser):
     ecn_group.addoption(
         "--disable_ecn_test",
         action="store",
-        type=bool,
+        type=str2bool,
         default=True,
         help="Control execution of ECN tests",
     )

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -7,6 +7,7 @@ from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # lg
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
 from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from .files.pfcwd_helper import TrafficPorts, set_pfc_timers, select_test_ports
+from tests.common.utilities import str2bool
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ def pytest_addoption(parser):
                      help='Warm reboot needs to be enabled or not')
     parser.addoption('--restore-time', action='store', type=int, default=3000,
                      help='PFC WD storm restore interval')
-    parser.addoption('--fake-storm', action='store', type=bool, default=True,
+    parser.addoption('--fake-storm', action='store', type=str2bool, default=True,
                      help='Fake storm for most ports instead of using pfc gen')
     parser.addoption('--two-queues', action='store_true', default=True,
                      help='Run test with sending traffic to both queues [3, 4]')

--- a/tests/platform_tests/args/advanced_reboot_args.py
+++ b/tests/platform_tests/args/advanced_reboot_args.py
@@ -1,4 +1,5 @@
 import pytest
+from tests.common.utilities import str2bool
 
 
 def add_advanced_reboot_args(parser):
@@ -31,7 +32,7 @@ def add_advanced_reboot_args(parser):
     parser.addoption(
         "--stay_in_target_image",
         action="store",
-        type=bool,
+        type=str2bool,
         default=True,
         help="Stay in target image after reboot",
     )

--- a/tests/qos/args/qos_sai_args.py
+++ b/tests/qos/args/qos_sai_args.py
@@ -1,4 +1,6 @@
 # QoS-SAI Args file
+from tests.common.utilities import str2bool
+
 
 def add_qos_sai_args(parser):
     """
@@ -15,7 +17,7 @@ def add_qos_sai_args(parser):
     qos_group.addoption(
         "--disable_test",
         action="store",
-        type=bool,
+        type=str2bool,
         default=True,
         help="Control execution of buffer watermark experimental tests",
     )
@@ -23,7 +25,7 @@ def add_qos_sai_args(parser):
     qos_group.addoption(
         "--qos_swap_syncd",
         action="store",
-        type=bool,
+        type=str2bool,
         default=True,
         help="Swap syncd container with syncd-rpc container",
     )

--- a/tests/snappi/ecn/ecn_args/ecn_args.py
+++ b/tests/snappi/ecn/ecn_args/ecn_args.py
@@ -1,3 +1,6 @@
+from tests.common.utilities import str2bool
+
+
 def add_ecn_args(parser):
     """
     Add arguments required for ECN test cases
@@ -12,7 +15,7 @@ def add_ecn_args(parser):
     ecn_group.addoption(
         "--disable_ecn_snappi_test",
         action="store",
-        type=bool,
+        type=str2bool,
         default=True,
         help="Control execution of ECN tests",
     )


### PR DESCRIPTION
When addoption in the pytest, if set the type to be true, and the default value as True, then the option is meaningless, since there is no chance for user to specify the value as False, this commit is to fix such kind of issue, and keep backward compatiblity

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Some option added in the pytest us meaningless
Fixes # (issue) When addoption in the pytest, if set the type to be true, and the default value as True, then the option is meaningless, since there is no chance for user to specify the value as False, this commit is to fix such kind of issue, and keep backward compatiblity, and give user posibility to specify False for the option

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911

### Approach
#### What is the motivation for this PR?
When addoption in the pytest, if set the type to be true, and the default value as True, then the option is meaningless, since there is no chance for user to specify the value as False, this commit is to fix such kind of issue, and keep backward compatiblity, and give user posibility to specify False for the option
#### How did you do it?
Define a str2bool function, and specify type of the option added to this function name
#### How did you verify/test it?
Run the qos related testcase and check that the value of option "--qos_swap_syncd" can be specified as False
py.test qos/test_qos_sai.py --inventory="../ansible/inventory,../ansible/veos" --host-pattern mtbc-sonic-03-2700 --module-path ../ansible/library/ --testbed mtbc-sonic-03-2700-ptf32 --testbed_file ../ansible/testbed.csv --allow_recover --session_id 5402255 --mars_key_id 0.7.1.1.1.1.1.3.1.1.1 --junit-xml junit_5402255_0.7.1.1.1.1.1.3.1.1.1.xml --assert plain --log-cli-level info --show-capture=no -ra --showlocals -k="not testQosSaiDwrr and not testQosSaiDwrrWeightChange" --clean-alluredir --alluredir=/tmp/allure-results --allure_server_addr="10.215.11.120" --qos_swap_syncd=False --allure_server_project_id=mtbc-sonic-03-2700-qos-test-qos-sai-py
#### Any platform specific information?
No
