### PR TITLE
Fix test_bgp_update_timer failure caused by scapy upgrade in sonic-mg docker image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ stages:
   - job:
     pool: sonictest
     displayName: "kvmtest-t0"
-    timeoutInMinutes: 330
+    timeoutInMinutes: 400
 
     steps:
     - template: .azure-pipelines/run-test-template.yml

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -152,12 +152,41 @@ def test_bgp_update_timer(common_setup_teardown, constants, duthosts, rand_one_d
         if not (packet[IP].src == src_ip and packet[IP].dst == dst_ip):
             return False
         subnet = ipaddress.ip_network(route["prefix"].decode())
-        _route = (subnet.prefixlen, str(subnet.network_address))
+
+        # New scapy (version 2.4.5) uses a different way to represent and dissect BGP messages. Below logic is to
+        # address the compatibility issue of scapy versions.
+        if hasattr(bgp, 'BGPNLRI_IPv4'):
+            _route = bgp.BGPNLRI_IPv4(prefix=str(subnet))
+        else:
+            _route = (subnet.prefixlen, str(subnet.network_address))
         bgp_fields = packet[bgp.BGPUpdate].fields
         if action == "announce":
-            return bgp_fields["tp_len"] > 0 and _route in bgp_fields["nlri"]
+            # New scapy (version 2.4.5) uses a different way to represent and dissect BGP messages. Below logic is to
+            # address the compatibility issue of scapy versions.
+            path_attr_valid = False
+            if "tp_len" in bgp_fields:
+                path_attr_valid = bgp_fields['tp_len'] > 0
+            elif "path_attr_len" in bgp_fields:
+                path_attr_valid = bgp_fields["path_attr_len"] > 0
+            return path_attr_valid and _route in bgp_fields["nlri"]
         elif action == "withdraw":
-            return bgp_fields["withdrawn_len"] > 0 and _route in bgp_fields["withdrawn"]
+            # New scapy (version 2.4.5) uses a different way to represent and dissect BGP messages. Below logic is to
+            # address the compatibility issue of scapy versions.
+            withdrawn_len_valid = False
+            if "withdrawn_len" in bgp_fields:
+                withdrawn_len_valid = bgp_fields["withdrawn_len"] > 0
+            elif "withdrawn_routes_len" in bgp_fields:
+                withdrawn_len_valid = bgp_fields["withdrawn_routes_len"] > 0
+
+            # New scapy (version 2.4.5) uses a different way to represent and dissect BGP messages. Below logic is to
+            # address the compatibility issue of scapy versions.
+            withdrawn_route_valid = False
+            if "withdrawn" in bgp_fields:
+                withdrawn_route_valid = _route in bgp_fields["withdrawn"]
+            elif "withdrawn_routes" in bgp_fields:
+                withdrawn_route_valid = _route in bgp_fields["withdrawn_routes"]
+
+            return withdrawn_len_valid and withdrawn_route_valid
         else:
             return False
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The scapy package in sonic-mgmt docker image was upgraded in PR https://github.com/Azure/sonic-buildimage/pull/8554.
The new version of scapy uses a different way to represent and dissect BGP messages. This caused the failure of
test_bgp_update_time.py.

#### How did you do it?
This PR is to address the compatibility issue of scapy. The test_bgp_update_timer.py script was updated to be
be compatible with both old and new scapy versions.

#### How did you verify/test it?
Run `bgp/test_bgp_update_timer.py` using both old and new sonic-mgmt docker image.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
