### PR TITLE
[upgrade path] Fix ptftest failure: add preboot_files to the param list

### DIFF
--- a/tests/upgrade_path/upgrade_helpers.py
+++ b/tests/upgrade_path/upgrade_helpers.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 TMP_VLAN_PORTCHANNEL_FILE = '/tmp/portchannel_interfaces.json'
 TMP_VLAN_FILE = '/tmp/vlan_interfaces.json'
 TMP_PORTS_FILE = '/tmp/ports.json'
+TMP_PEER_INFO_FILE = "/tmp/peer_dev_info.json"
+TMP_PEER_PORT_INFO_FILE = "/tmp/neigh_port_info.json"
 
 
 def pytest_runtest_setup(item):
@@ -62,6 +64,16 @@ def prepare_ptf(ptfhost, duthost, tbinfo):
         file.write(json.dumps(mg_facts['minigraph_ptf_indices']))
     ptfhost.copy(src=TMP_PORTS_FILE,
                  dest=TMP_PORTS_FILE)
+
+    with open(TMP_PEER_INFO_FILE, "w") as file:
+        file.write(json.dumps(mg_facts['minigraph_devices']))
+    ptfhost.copy(src=TMP_PEER_INFO_FILE,
+                 dest=TMP_PEER_INFO_FILE)
+
+    with open(TMP_PEER_PORT_INFO_FILE, "w") as file:
+        file.write(json.dumps(mg_facts['minigraph_neighbors']))
+    ptfhost.copy(src=TMP_PEER_PORT_INFO_FILE,
+                 dest=TMP_PEER_PORT_INFO_FILE)
 
     arp_responder_conf = Template(open("../ansible/roles/test/templates/arp_responder.conf.j2").read())
     ptfhost.copy(content=arp_responder_conf.render(arp_responder_args="-e"),
@@ -207,6 +219,7 @@ def ptf_params(duthosts, rand_one_dut_hostname, creds, tbinfo):
         "lo_v6_prefix": lo_v6_prefix,
         "arista_vms": vm_hosts,
         "setup_fdb_before_test": True,
-        "target_version": "Unknown"
+        "target_version": "Unknown",
+        "preboot_files" : "peer_dev_info,neigh_port_info"
     }
     return ptf_params


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: After fixing advance-reboot sad cases in https://github.com/Azure/sonic-mgmt/pull/4758, upgrade path cases have regressed. Update the param list for upgrade path cases same as in test_advanced_reboot.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix test_upgrade_path regression where ptftest fails as it is expecting list of preboot files as modified in https://github.com/Azure/sonic-mgmt/pull/4758

#### How did you do it?

#### How did you verify/test it?

Tested in physical testbed, and the test works well with the fix.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
