### PR TITLE
[log filename refine] add action type and vm_set_name to vm_topology log filename

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -137,8 +137,13 @@ SUB_INTERFACE_SEPARATOR = '.'
 SUB_INTERFACE_VLAN_ID = '10'
 
 
-config_module_logging('vm_topology')
-
+def construct_log_filename(cmd, vm_set_name):
+    log_filename = 'vm_topology'
+    if cmd:
+        log_filename += '_' + cmd
+    if vm_set_name:
+        log_filename += '_' + vm_set_name
+    return log_filename
 
 def adaptive_name(template, host, index):
     """
@@ -1209,10 +1214,13 @@ def main():
         supports_check_mode=False)
 
     cmd = module.params['cmd']
+    vm_set_name = module.params['vm_set_name']
     vm_names = module.params['vm_names']
     fp_mtu = module.params['fp_mtu']
     max_fp_num = module.params['max_fp_num']
     vm_properties = module.params['vm_properties']
+
+    config_module_logging(construct_log_filename(cmd, vm_set_name))
 
     if cmd == 'bind_keysight_api_server_ip':
         vm_names = []


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Refine the filename of vm_topology.py module to be easier identified between different runs.

#### How did you do it?
Add vm_set_name and cmd to log filename.
#### How did you verify/test it?
Rerun add-topo, remove-topo, and restart-ptf, all of them went well.

/tmp$ ls|grep vm_topo              
vm_topology_2021-11-29T03:16:36.255083.log (old)
vm_topology_2021-11-29T03:17:03.194976.log (old)
vm_topology_bind_vms20-2_2021-11-29T07:44:15.935972.log (new)
vm_topology_create_2021-11-29T07:43:52.758181.log (new)
vm_topology_destroy_2021-11-29T07:40:58.813069.log (new)
vm_topology_renumber_vms20-2_2021-11-29T08:09:14.360649.log (new)
vm_topology_unbind_vms20-2_2021-11-29T07:40:28.707791.log (new)

