### PR TITLE
[advance-reboot] Enable log_analyzer for sad cases and publish all logs

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -5,6 +5,7 @@ import json
 import logging
 import pytest
 import time
+import os
 
 from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from tests.common.platform.ssh_utils import prepare_testbed_ssh_keys as prepareTestbedSshKeys
@@ -76,6 +77,7 @@ class AdvancedReboot:
         self.creds = creds
         self.moduleIgnoreErrors = kwargs["allow_fail"] if "allow_fail" in kwargs else False
         self.allowMacJump = kwargs["allow_mac_jumping"] if "allow_mac_jumping" in kwargs else False
+        self.advanceboot_loganalyzer = kwargs["advanceboot_loganalyzer"] if "advanceboot_loganalyzer" in kwargs else None
         self.__dict__.update(kwargs)
         self.__extractTestParam()
         self.rebootData = {}
@@ -352,6 +354,17 @@ class AdvancedReboot:
         '''
         Fetch test logs from duthost and ptfhost after individual test run
         '''
+        if rebootOper:
+            dir_name = "{}_{}".format(self.request.node.name, rebootOper)
+        else:
+            dir_name = self.request.node.name
+        report_file_dir = os.path.realpath((os.path.join(os.path.dirname(__file__),\
+            "../../logs/platform_tests/")))
+        log_dir = os.path.join(report_file_dir, dir_name)
+        if not os.path.exists(log_dir):
+            os.makedirs(log_dir)
+        log_dir = log_dir + "/"
+
         if rebootOper is None:
             rebootLog = '/tmp/{0}.log'.format(self.rebootType)
             rebootReport = '/tmp/{0}-report.json'.format(self.rebootType)
@@ -381,15 +394,15 @@ class AdvancedReboot:
         logger.info('Fetching log files from ptf and dut hosts')
         logFiles = {
             self.ptfhost: [
-                {'src': rebootLog, 'dest': '/tmp/', 'flat': True, 'fail_on_missing': False},
-                {'src': rebootReport, 'dest': '/tmp/', 'flat': True, 'fail_on_missing': False},
-                {'src': capturePcap, 'dest': '/tmp/', 'flat': True, 'fail_on_missing': False},
-                {'src': filterPcap, 'dest': '/tmp/', 'flat': True, 'fail_on_missing': False},
+                {'src': rebootLog, 'dest': log_dir, 'flat': True, 'fail_on_missing': False},
+                {'src': rebootReport, 'dest': log_dir, 'flat': True, 'fail_on_missing': False},
+                {'src': capturePcap, 'dest': log_dir, 'flat': True, 'fail_on_missing': False},
+                {'src': filterPcap, 'dest': log_dir, 'flat': True, 'fail_on_missing': False},
             ],
             self.duthost: [
-                {'src': syslogFile, 'dest': '/tmp/', 'flat': True},
-                {'src': sairedisRec, 'dest': '/tmp/', 'flat': True},
-                {'src': swssRec, 'dest': '/tmp/', 'flat': True},
+                {'src': syslogFile, 'dest': log_dir, 'flat': True},
+                {'src': sairedisRec, 'dest': log_dir, 'flat': True},
+                {'src': swssRec, 'dest': log_dir, 'flat': True},
             ],
         }
         for host, logs in logFiles.items():
@@ -430,6 +443,8 @@ class AdvancedReboot:
         for rebootOper in self.rebootData['sadList']:
             count += 1
             try:
+                pre_reboot_analysis, post_reboot_analysis = self.advanceboot_loganalyzer
+                marker = pre_reboot_analysis()
                 self.__setupRebootOper(rebootOper)
                 result = self.__runPtfRunner(rebootOper)
                 self.__verifyRebootOper(rebootOper)
@@ -440,6 +455,7 @@ class AdvancedReboot:
                 self.__fetchTestLogs(rebootOper)
                 self.__clearArpAndFdbTables()
                 self.__revertRebootOper(rebootOper)
+                post_reboot_analysis(marker, reboot_oper=rebootOper)
             if len(self.rebootData['sadList']) > 1 and count != len(self.rebootData['sadList']):
                 time.sleep(TIME_BETWEEN_SUCCESSIVE_TEST_OPER)
         pytest_assert(len(failed_list) == 0,\

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -330,7 +330,8 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
     """
     duthost = duthosts[rand_one_dut_hostname]
     test_name = request.node.name
-    if "warm" in test_name:
+    if "warm" in test_name or\
+        ("continuous" in test_name and request.config.getoption("--reboot_type") == "warm"):
         reboot_type = "warm"
     elif "fast" in test_name:
         reboot_type = "fast"
@@ -345,62 +346,75 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
 
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="test_advanced_reboot_{}".format(test_name),
                     additional_files={'/var/log/swss/sairedis.rec': 'recording on: /var/log/swss/sairedis.rec', '/var/log/frr/bgpd.log': ''})
-    marker = loganalyzer.init()
-    loganalyzer.load_common_config()
 
-    ignore_file = os.path.join(TEMPLATES_DIR, "ignore_boot_messages")
-    expect_file = os.path.join(TEMPLATES_DIR, "expect_boot_messages")
-    ignore_reg_exp = loganalyzer.parse_regexp_file(src=ignore_file)
-    expect_reg_exp = loganalyzer.parse_regexp_file(src=expect_file)
+    def pre_reboot_analysis():
+        marker = loganalyzer.init()
+        loganalyzer.load_common_config()
 
-    loganalyzer.ignore_regex.extend(ignore_reg_exp)
-    loganalyzer.expect_regex = []
-    loganalyzer.expect_regex.extend(expect_reg_exp)
-    loganalyzer.match_regex = []
+        ignore_file = os.path.join(TEMPLATES_DIR, "ignore_boot_messages")
+        expect_file = os.path.join(TEMPLATES_DIR, "expect_boot_messages")
+        ignore_reg_exp = loganalyzer.parse_regexp_file(src=ignore_file)
+        expect_reg_exp = loganalyzer.parse_regexp_file(src=expect_file)
 
-    yield
+        loganalyzer.ignore_regex.extend(ignore_reg_exp)
+        loganalyzer.expect_regex = []
+        loganalyzer.expect_regex.extend(expect_reg_exp)
+        loganalyzer.match_regex = []
+        return marker
 
-    result = loganalyzer.analyze(marker, fail=False)
-    analyze_result = {"time_span": dict(), "offset_from_kexec": dict()}
-    offset_from_kexec = dict()
+    def post_reboot_analysis(marker, reboot_oper=None):
+        result = loganalyzer.analyze(marker, fail=False)
+        analyze_result = {"time_span": dict(), "offset_from_kexec": dict()}
+        offset_from_kexec = dict()
 
-    for key, messages in result["expect_messages"].items():
-        if "syslog" in key:
-            get_kexec_time(duthost, messages, analyze_result)
-            analyze_log_file(duthost, messages, analyze_result, offset_from_kexec)
-        elif "bgpd.log" in key:
-            analyze_log_file(duthost, messages, analyze_result, offset_from_kexec)
-        elif "sairedis.rec" in key:
-            analyze_sairedis_rec(messages, analyze_result, offset_from_kexec)
+        for key, messages in result["expect_messages"].items():
+            if "syslog" in key:
+                get_kexec_time(duthost, messages, analyze_result)
+                analyze_log_file(duthost, messages, analyze_result, offset_from_kexec)
+            elif "bgpd.log" in key:
+                analyze_log_file(duthost, messages, analyze_result, offset_from_kexec)
+            elif "sairedis.rec" in key:
+                analyze_sairedis_rec(messages, analyze_result, offset_from_kexec)
 
-    for marker, time_data in analyze_result["offset_from_kexec"].items():
-        marker_start_time = time_data.get("timestamp", {}).get("Start")
-        reboot_start_time = analyze_result.get("reboot_time", {}).get("timestamp", {}).get("Start")
-        if reboot_start_time and reboot_start_time != "N/A" and marker_start_time:
-            time_data["time_taken"] = (_parse_timestamp(marker_start_time) -\
-                _parse_timestamp(reboot_start_time)).total_seconds()
+        for marker, time_data in analyze_result["offset_from_kexec"].items():
+            marker_start_time = time_data.get("timestamp", {}).get("Start")
+            reboot_start_time = analyze_result.get("reboot_time", {}).get("timestamp", {}).get("Start")
+            if reboot_start_time and reboot_start_time != "N/A" and marker_start_time:
+                time_data["time_taken"] = (_parse_timestamp(marker_start_time) -\
+                    _parse_timestamp(reboot_start_time)).total_seconds()
+            else:
+                time_data["time_taken"] = "N/A"
+
+        get_data_plane_report(analyze_result, reboot_type)
+        result_summary = get_report_summary(analyze_result, reboot_type)
+        logging.info(json.dumps(analyze_result, indent=4))
+        logging.info(json.dumps(result_summary, indent=4))
+        if not isinstance(reboot_oper, str):
+            reboot_oper = type(reboot_oper).__name__
+        if reboot_oper:
+            report_file_name = request.node.name + "_" + reboot_oper + "_report.json"
+            summary_file_name = request.node.name + "_" + reboot_oper + "_summary.json"
         else:
-            time_data["time_taken"] = "N/A"
+            report_file_name = request.node.name + "_report.json"
+            summary_file_name = request.node.name + "_summary.json"
 
-    get_data_plane_report(analyze_result, reboot_type)
-    result_summary = get_report_summary(analyze_result, reboot_type)
-    logging.info(json.dumps(analyze_result, indent=4))
-    logging.info(json.dumps(result_summary, indent=4))
-    report_file_name = request.node.name + "_report.json"
-    summary_file_name = request.node.name + "_summary.json"
-    report_file_dir = os.path.realpath((os.path.join(os.path.dirname(__file__),\
-        "../logs/platform_tests/")))
-    report_file_path = report_file_dir + "/" + report_file_name
-    summary_file_path = report_file_dir + "/" + summary_file_name
-    if not os.path.exists(report_file_dir):
-        os.makedirs(report_file_dir)
-    with open(report_file_path, 'w') as fp:
-        json.dump(analyze_result, fp, indent=4)
-    with open(summary_file_path, 'w') as fp:
-        json.dump(result_summary, fp, indent=4)
 
-    # After generating timing data report, do some checks on the timing data
-    verify_mac_jumping(test_name, analyze_result)
+        report_file_dir = os.path.realpath((os.path.join(os.path.dirname(__file__),\
+            "../logs/platform_tests/")))
+        report_file_path = report_file_dir + "/" + report_file_name
+        summary_file_path = report_file_dir + "/" + summary_file_name
+        if not os.path.exists(report_file_dir):
+            os.makedirs(report_file_dir)
+        with open(report_file_path, 'w') as fp:
+            json.dump(analyze_result, fp, indent=4)
+        with open(summary_file_path, 'w') as fp:
+            json.dump(result_summary, fp, indent=4)
+
+        # After generating timing data report, do some checks on the timing data
+        verify_mac_jumping(test_name, analyze_result)
+
+    yield pre_reboot_analysis, post_reboot_analysis
+
 
 @pytest.fixture()
 def advanceboot_neighbor_restore(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -31,7 +31,8 @@ def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
-    advancedReboot = get_advanced_reboot(rebootType='fast-reboot')
+    advancedReboot = get_advanced_reboot(rebootType='fast-reboot',\
+        advanceboot_loganalyzer=advanceboot_loganalyzer)
     advancedReboot.runRebootTestcase()
 
 
@@ -44,7 +45,8 @@ def test_warm_reboot(request, get_advanced_reboot, verify_dut_health,
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
-    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot',\
+        advanceboot_loganalyzer=advanceboot_loganalyzer)
     advancedReboot.runRebootTestcase()
 
 
@@ -63,8 +65,11 @@ def test_warm_reboot_mac_jump(request, get_advanced_reboot, verify_dut_health,
     If for some reason SAI is not adhering to this requirement, any MAC learn events
     generated during warm reboot will cause META checker failure resulting to Orchagent crash.
     '''
-    advancedReboot = get_advanced_reboot(rebootType='warm-reboot', allow_mac_jumping=True)
+    marker, post_reboot_analysis = advanceboot_loganalyzer
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot', allow_mac_jumping=True,\
+        advanceboot_loganalyzer=advanceboot_loganalyzer)
     advancedReboot.runRebootTestcase()
+    post_reboot_analysis(marker)
 
 
 ### Testcases to verify abruptly failed reboot procedure ###
@@ -98,7 +103,7 @@ def test_cancelled_warm_reboot(request, add_fail_step_to_reboot, verify_dut_heal
 
 
 ### Tetcases to verify reboot procedure with SAD cases ###
-def test_warm_reboot_sad(request, get_advanced_reboot, verify_dut_health,
+def test_warm_reboot_sad(request, get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,
                          backup_and_restore_config_db, advanceboot_neighbor_restore,
                          duthost, fanouthosts, nbrhosts):
     '''
@@ -107,7 +112,8 @@ def test_warm_reboot_sad(request, get_advanced_reboot, verify_dut_health,
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
-    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot',\
+        advanceboot_loganalyzer=advanceboot_loganalyzer)
     prebootList = [
         'neigh_bgp_down',               # Shutdown single BGP session on remote device (VM) before reboot DUT
         'dut_bgp_down',                 # Shutdown single BGP session on DUT brefore rebooting it
@@ -128,7 +134,7 @@ def test_warm_reboot_sad(request, get_advanced_reboot, verify_dut_health,
     )
 
 
-def test_warm_reboot_multi_sad(request, get_advanced_reboot, verify_dut_health,
+def test_warm_reboot_multi_sad(request, get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,
                                backup_and_restore_config_db, advanceboot_neighbor_restore,
                                duthost, fanouthosts, nbrhosts):
     '''
@@ -137,7 +143,8 @@ def test_warm_reboot_multi_sad(request, get_advanced_reboot, verify_dut_health,
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
-    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot',\
+        advanceboot_loganalyzer=advanceboot_loganalyzer)
     lagMemberCnt = advancedReboot.getlagMemberCnt()
     prebootList = [
         'neigh_bgp_down:2',             # Shutdown single BGP session on 2 remote devices (VMs) before reboot DUT
@@ -165,7 +172,7 @@ def test_warm_reboot_multi_sad(request, get_advanced_reboot, verify_dut_health,
     )
 
 
-def test_warm_reboot_multi_sad_inboot(request, get_advanced_reboot, verify_dut_health,
+def test_warm_reboot_multi_sad_inboot(request, get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,
     backup_and_restore_config_db):
     '''
     Warm reboot with multi sad path (during boot)
@@ -175,7 +182,8 @@ def test_warm_reboot_multi_sad_inboot(request, get_advanced_reboot, verify_dut_h
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
-    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot',\
+        advanceboot_loganalyzer=advanceboot_loganalyzer)
     inbootList = [
         'routing_del:50',               # Delete 50 routes IPv4/IPv6 each (100 total) from each BGP session
         'routing_add:50',               # Add 50 routes IPv4/IPv6 each (100 total) from each BGP session
@@ -186,7 +194,7 @@ def test_warm_reboot_multi_sad_inboot(request, get_advanced_reboot, verify_dut_h
     )
 
 
-def test_warm_reboot_sad_bgp(request, get_advanced_reboot, verify_dut_health,
+def test_warm_reboot_sad_bgp(request, get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,
     backup_and_restore_config_db, advanceboot_neighbor_restore):
     '''
     Warm reboot with sad (bgp)
@@ -194,7 +202,8 @@ def test_warm_reboot_sad_bgp(request, get_advanced_reboot, verify_dut_health,
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
-    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot',\
+        advanceboot_loganalyzer=advanceboot_loganalyzer)
     prebootList = [
         'neigh_bgp_down:2',             # Shutdown single BGP session on 2 remote devices (VMs) before reboot DUT
         'dut_bgp_down:3',               # Shutdown 3 BGP sessions on DUT brefore rebooting it
@@ -205,7 +214,7 @@ def test_warm_reboot_sad_bgp(request, get_advanced_reboot, verify_dut_health,
     )
 
 
-def test_warm_reboot_sad_lag_member(request, get_advanced_reboot, verify_dut_health,
+def test_warm_reboot_sad_lag_member(request, get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,
                                     backup_and_restore_config_db, advanceboot_neighbor_restore,
                                     duthost, fanouthosts, nbrhosts):
     '''
@@ -214,7 +223,8 @@ def test_warm_reboot_sad_lag_member(request, get_advanced_reboot, verify_dut_hea
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
-    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot',\
+        advanceboot_loganalyzer=advanceboot_loganalyzer)
     lagMemberCnt = advancedReboot.getlagMemberCnt()
     prebootList = [
         # Shutdown 1 LAG member of 3 LAG sessions corresponding to 3 remote devices (VM)
@@ -236,7 +246,7 @@ def test_warm_reboot_sad_lag_member(request, get_advanced_reboot, verify_dut_hea
     )
 
 
-def test_warm_reboot_sad_lag(request, get_advanced_reboot, verify_dut_health,
+def test_warm_reboot_sad_lag(request, get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,
     backup_and_restore_config_db, advanceboot_neighbor_restore):
     '''
     Warm reboot with sad path (lag)
@@ -244,7 +254,8 @@ def test_warm_reboot_sad_lag(request, get_advanced_reboot, verify_dut_health,
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
-    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot',\
+        advanceboot_loganalyzer=advanceboot_loganalyzer)
     prebootList = [
         'dut_lag_down:2',               # Shutdown 2 LAG sessions on DUT brefore rebooting it
         'neigh_lag_down:3',             # Shutdown 1 LAG session on 3 remote devices (VMs) before reboot DUT
@@ -255,7 +266,7 @@ def test_warm_reboot_sad_lag(request, get_advanced_reboot, verify_dut_health,
     )
 
 
-def test_warm_reboot_sad_vlan_port(request, get_advanced_reboot, verify_dut_health,
+def test_warm_reboot_sad_vlan_port(request, get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,
                                    backup_and_restore_config_db, duthost, fanouthosts):
     '''
     Warm reboot with sad path (vlan port)
@@ -263,7 +274,8 @@ def test_warm_reboot_sad_vlan_port(request, get_advanced_reboot, verify_dut_heal
     @param request: Spytest commandline argument
     @param get_advanced_reboot: advanced reboot test fixture
     '''
-    advancedReboot = get_advanced_reboot(rebootType='warm-reboot')
+    advancedReboot = get_advanced_reboot(rebootType='warm-reboot',\
+        advanceboot_loganalyzer=advanceboot_loganalyzer)
     prebootList = [
         DutVlanMemberDown(duthost, PhyPropsPortSelector(duthost, 4)),                # Shutdown 4 vlan ports (interfaces) on DUT
         NeighVlanMemberDown(duthost, fanouthosts, PhyPropsPortSelector(duthost, 4)), # Shutdown 4 vlan ports (interfaces) on fanout


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Enable log-analyzer for SAD cases in test_advance_reboot. Also collect all the logs (including loganalyzer reboot-timing-data) for debugging purposes.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Two improvements:
1. Presently log_analyzer is enabled only for non-SAD cases. To provide better visibility about timing data and failure analysis for SAD cases, enable log_analyzer for every case in test_advance_reboot.
2. Collect all the logs for SAD cases and store them in logs folder. This folder will be later published as an artifact for the nightly run. 

Both of these enhancements will allow faster debugging and failure analysis.

#### How did you do it?

Since every SAD case itself has a list of subcases within, `advanceboot_loganalyzer` fixture is now modified.
There are two parts - log_analyzer setup before subcase, and log_analyzer analysis after subcase.
These two parts are now two inner functions that are called by subcases.

The logs (syslog, sairedis, loag_analyzer reboot-time report) are now published in logs directory (previously they remianed in /tmp/). Bringing out these logs in artifacts during nightly.

#### How did you verify/test it?
Tested on a physical testbed and every SAD case produced reboot-timing data report.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
