### PR TITLE
Improve sanity check to have expected check sequence

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -17,7 +17,7 @@ MONIT_STABILIZE_MAX_TIME = 500
 OMEM_THRESHOLD_BYTES=10485760 # 10MB
 cache = FactsCache()
 
-__all__ = [
+CHECK_ITEMS = [
     'check_services',
     'check_interfaces',
     'check_bgp',
@@ -26,6 +26,8 @@ __all__ = [
     'check_processes',
     'check_mux_simulator',
     'check_secureboot']
+
+__all__ = CHECK_ITEMS
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Currently the sanity check plugin uses `inspect.getmembers` to find out the check items defined in
`checks.py`. The problem is that sequence of the check items found from `checks.py` is not guaranteed
and can cause subtle issue.

The bgp check will check if all BGP sessions are UP. If the DUT was just reloaded and BGP is the first
check item, there is a chance that BGP check will fail. PR https://github.com/Azure/sonic-mgmt/pull/4757
is to address such issue.

A more reliable fix is to have a guaranteed check sequence. The service check item has logic to wait
some time if the DUT was just rebooted or reloaded. With guaranteed check sequence, we can make the
service check always the first sanity check item.

#### How did you do it?
This PR added a list `CHECK_ITEMS` in file `checks.py`. The sanity check plugin runs check items
defined in the list from top to bottom. This can ensure the default sanity check sequence.

When the check sequence needs to be updated, we can update the `CHECK_ITEMS` list. Or use the sanity
check options `--check_items` and `--post_check_items` to affect the default check items.
Please refer to `README.md` of the sanity check plugin for how to use the options.

#### How did you verify/test it?
Run a test with sanity check enabled.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
