### PR TITLE
Skip dest link local and loopback ip drop counter test for cisco platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -522,12 +522,12 @@ sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_be
       
 drop_packets/test_drop_counters.py::test_dst_ip_link_local:
   skip:
-    reason: "Cisco 8000 platform does not drop DIP linklocal packets"
+    reason: "Cisco 8000 platform does not drop DIP linklocal packets in 202012 version"
     conditions:
-      - "asic_type=='cisco-8000'"
+      - "asic_type=='cisco-8000' and release in ['202012']"
 
 drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr:
   skip:
-    reason: "Cisco 8000 platform does not drop DIP loopback packets"
+    reason: "Cisco 8000 platform does not drop DIP loopback packets in 202012 version"
     conditions:
-      - "asic_type=='cisco-8000'"
+      - "asic_type=='cisco-8000' and release in ['202012']"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -519,3 +519,15 @@ sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_be
     reason: "Cisco 8000 platform does not support DSCP PIPE Mode for IPinIP Tunnels"
     conditions:
       - "asic_type=='cisco-8000'"
+      
+drop_packets/test_drop_counters.py::test_dst_ip_link_local:
+  skip:
+    reason: "Cisco 8000 platform does not drop DIP linklocal packets"
+    conditions:
+      - "asic_type=='cisco-8000'"
+
+drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr:
+  skip:
+    reason: "Cisco 8000 platform does not drop DIP loopback packets"
+    conditions:
+      - "asic_type=='cisco-8000'"


### PR DESCRIPTION

### Description of PR
The following packets will not be dropped by Cisco-8000 platforms:
 Destination ip as link local [test_dst_ip_link_local]
 Destination ip as loopback [test_dst_ip_is_loopback_addr]


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Cisco 8000 platform does not drop DIP linklocal packets and DIP loopback packets
#### How did you do it?
For these test cases, require the ASIC type be non cisco-8000.
#### How did you verify/test it?
Ran on a cisco-8000 device and verified tests are skipped instead of failing
==================================== short test summary info =====================================
SKIPPED [3] drop_packets/drop_packets.py: Cisco 8000 platform does not drop DIP linklocal packets
SKIPPED [3] drop_packets/drop_packets.py: Cisco 8000 platform does not drop DIP loopback packets
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
