### PR TITLE
[test_add_rack]: Check if directory exists before creating it

### DIFF
--- a/tests/configlet/test_add_rack.py
+++ b/tests/configlet/test_add_rack.py
@@ -84,7 +84,8 @@ def init(duthost, duthost_name):
         os.mkdir(base_dir)
 
     for i in [ data_dir, orig_db_dir, clet_db_dir, files_dir ]:
-        os.mkdir(i)
+        if not os.path.exists(i):
+            os.mkdir(i)
 
     init_data["files_dir"] = files_dir 
     init_data["data_dir"] = data_dir


### PR DESCRIPTION
### Description of PR
Configlet/test_add_rack.py fails because test doesn't clean up directories that it created during the test run. when run again, test tries to make the same directory again and fails stating that the directory already exists. The test check if the base_dir is present but doesn't verify if the subsequent directories are present or not. It is a simple fix to verify if the subsequent directories are present or not and then proceed to create them.

Summary:
Fixes #4762  

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To fix test_add_rack.py testcase.

#### How did you do it?
Check if the directory exists before creating it.

#### How did you verify/test it?
Test case passes after making the change

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
