### PR TITLE
[test_decap]: Skip decap subtest case for cisco-8000 due to unsupported DSCP Pipe mode

### DIFF
--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -33,6 +33,9 @@ def ttl_dscp_params(duthost, supported_ttl_dscp_params):
     if "uniform" in supported_ttl_dscp_params.values() and ("201811" in duthost.os_version or "201911" in duthost.os_version):
         pytest.skip('uniform ttl/dscp mode is available from 202012. Current version is %s' % duthost.os_version)
 
+    if supported_ttl_dscp_params['dscp'] == 'pipe' and duthost.facts['asic_type'] in ['cisco-8000']:
+        pytest.skip('dscp pipe mode is currently not supported for Cisco 8000 platform')
+
     return supported_ttl_dscp_params
 
 


### PR DESCRIPTION
### Description of PR
Currently on cisco-8000 platforms, we only support uniform mode for DSCP. The subtests which are under “test_decap.py” are validating functionality using the DSCP Pipe mode and hence need to be skipped.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
dscp pipe mode is currently not supported for Cisco 8000 platform

#### How did you do it?
Skip these tests for cisco-8000

#### How did you verify/test it?
Ran on a cisco-8000 device and verified tests are skipped instead of failing

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
