### PR TITLE
Fail early if loading conditional marks failed

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -61,6 +61,7 @@ def load_conditions(session):
             return yaml.safe_load(f)
     except Exception as e:
         logger.error('Failed to load {}, exception: {}'.format(conditions_file, repr(e)), exc_info=True)
+        pytest.fail('Loading conditions file "{}" failed. Possibly invalid yaml file.'.format(conditions_file))
 
     return None
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
PR #4575 introduced indention issue to file `tests_mark_conditions.yaml`.
However, the issue was not caught by PR testing. Since file
`test_mark_conditions.yaml` has been widely used now, any broken
change to it should be caught in PR testing as early as possible.

#### How did you do it?
This change updated the conditional mark plugin to fail early if loading
mark conditions file failed.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
