### PR TITLE
Fix issue of parsing DUT_NAME from vtestbed.csv

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -42,7 +42,7 @@ function get_dut_from_testbed_file() {
                 show_help_and_exit 4
             fi
             IFS=',' read -ra ARRAY <<< "$LINE"
-            DUT_NAME=${ARRAY[9]}
+            DUT_NAME=${ARRAY[9]//[\[\] ]/}
         elif [[ $TESTBED_FILE == *.yaml ]];
         then
             content=$(python -c "from __future__ import print_function; import yaml; print('+'.join(str(tb) for tb in yaml.safe_load(open('$TESTBED_FILE')) if '$TESTBED_NAME'==tb['conf-name']))")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
When we use run_tests.sh to run a test on VS setup and do not support DUT_NAME via the -d argument, test will fail
with error like `Failed: One of the specified DUTs ['[vlab-01]'] does not belong to the testbed vms-kvm-t0`.
The issue only happen if testbed file `vtestbed.csv` is used. The problem is with parsing DUT_NAME from
`vtestbed.csv` file. Currently the code in run_tests.sh parses DUT_NAME as something like `'[vlab-01]'` and feed it
to pytest command.

#### How did you do it?
This PR fixed the issue of parsing DUT_NAME by removing the extra `[` and `]`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
