### PR TITLE
[platform api] fixed false positive scenarios

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -269,6 +269,9 @@ class TestChassisApi(PlatformApiTestBase):
             num_components = int(chassis.get_num_components(platform_api_conn))
         except:
             pytest.fail("num_components is not an integer")
+        else:
+            if num_components == 0:
+                pytest.skip("No components found on device")
 
         if duthost.facts.get("chassis"):
             expected_num_components = len(duthost.facts.get("chassis").get('components'))
@@ -290,6 +293,9 @@ class TestChassisApi(PlatformApiTestBase):
             num_modules = int(chassis.get_num_modules(platform_api_conn))
         except:
             pytest.fail("num_modules is not an integer")
+        else:
+            if num_modules == 0:
+                pytest.skip("No modules found on device")
 
         module_list = chassis.get_all_modules(platform_api_conn)
         pytest_assert(module_list is not None, "Failed to retrieve modules")
@@ -309,6 +315,9 @@ class TestChassisApi(PlatformApiTestBase):
             num_fans = int(chassis.get_num_fans(platform_api_conn))
         except:
             pytest.fail("num_fans is not an integer")
+        else:
+            if num_fans == 0:
+                pytest.skip("No fans found on device")
 
         if duthost.facts.get("chassis"):
             expected_num_fans = len(duthost.facts.get("chassis").get('fans'))
@@ -331,6 +340,9 @@ class TestChassisApi(PlatformApiTestBase):
             num_fan_drawers = int(chassis.get_num_fan_drawers(platform_api_conn))
         except:
             pytest.fail("num_fan_drawers is not an integer")
+        else:
+            if num_fan_drawers == 0:
+                pytest.skip("No fan drawers found on device")
 
         if duthost.facts.get("chassis"):
             expected_num_fan_drawers = len(duthost.facts.get("chassis").get('fan_drawers'))
@@ -353,6 +365,9 @@ class TestChassisApi(PlatformApiTestBase):
             num_psus = int(chassis.get_num_psus(platform_api_conn))
         except:
             pytest.fail("num_psus is not an integer")
+        else:
+            if num_psus == 0:
+                pytest.skip("No psus found on device")
 
         if duthost.facts.get("chassis"):
             expected_num_psus = len(duthost.facts.get("chassis").get('psus'))
@@ -375,6 +390,9 @@ class TestChassisApi(PlatformApiTestBase):
             num_thermals = int(chassis.get_num_thermals(platform_api_conn))
         except:
             pytest.fail("num_thermals is not an integer")
+        else:
+            if num_thermals == 0:
+                pytest.skip("No thermals found on device")
 
         if duthost.facts.get("chassis"):
             expected_num_thermals = len(duthost.facts.get("chassis").get('thermals'))
@@ -399,6 +417,9 @@ class TestChassisApi(PlatformApiTestBase):
             num_sfps = int(chassis.get_num_sfps(platform_api_conn))
         except:
             pytest.fail("num_sfps is not an integer")
+        else:
+            if num_sfps == 0:
+                pytest.skip("No sfps found on device")
 
         list_sfps = physical_port_indices
 

--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -54,6 +54,9 @@ class TestChassisFans(PlatformApiTestBase):
                 self.num_fans = int(chassis.get_num_fans(platform_api_conn))
             except:
                 pytest.fail("num_fans is not an integer")
+            else:
+                if self.num_fans == 0:
+                    pytest.skip("No fans found on device")
 
     #
     # Helper functions

--- a/tests/platform_tests/api/test_component.py
+++ b/tests/platform_tests/api/test_component.py
@@ -50,6 +50,9 @@ class TestComponentApi(PlatformApiTestBase):
                 self.num_components = int(chassis.get_num_components(platform_api_conn))
             except:
                 pytest.fail("num_components is not an integer")
+            else:
+                if self.num_components == 0:
+                    pytest.skip("No components found on device")
 
     #
     # Helper functions
@@ -73,8 +76,6 @@ class TestComponentApi(PlatformApiTestBase):
 
     def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        if self.num_components == 0:
-            pytest.skip("No components found on device")
 
         for i in range(self.num_components):
             name = component.get_name(platform_api_conn, i)
@@ -84,8 +85,6 @@ class TestComponentApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_components == 0:
-            pytest.skip("No components found on device")
 
         for i in range(self.num_components):
             presence = component.get_presence(platform_api_conn, i)
@@ -96,8 +95,6 @@ class TestComponentApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_components == 0:
-            pytest.skip("No components found on device")
 
         for i in range(self.num_components):
             model = component.get_model(platform_api_conn, i)
@@ -106,8 +103,6 @@ class TestComponentApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_components == 0:
-            pytest.skip("No components found on device")
 
         for i in range(self.num_components):
             serial = component.get_serial(platform_api_conn, i)
@@ -116,8 +111,6 @@ class TestComponentApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_components == 0:
-            pytest.skip("No components found on device")
 
         for i in range(self.num_components):
             status = component.get_status(platform_api_conn, i)
@@ -145,8 +138,6 @@ class TestComponentApi(PlatformApiTestBase):
 
 
     def test_get_description(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_components == 0:
-            pytest.skip("No components found on device")
 
         for i in range(self.num_components):
             description = component.get_description(platform_api_conn, i)
@@ -155,8 +146,6 @@ class TestComponentApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_firmware_version(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_components == 0:
-            pytest.skip("No components found on device")
 
         for i in range(self.num_components):
             fw_version = component.get_firmware_version(platform_api_conn, i)
@@ -167,9 +156,6 @@ class TestComponentApi(PlatformApiTestBase):
     def test_get_available_firmware_version(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["nokia"])
-
-        if self.num_components == 0:
-            pytest.skip("No components found on device")
 
         for i in range(self.num_components):
             for image in image_list:
@@ -182,9 +168,6 @@ class TestComponentApi(PlatformApiTestBase):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["nokia"])
 
-        if self.num_components == 0:
-            pytest.skip("No components found on device")
-
         for i in range(self.num_components):
             for image in image_list:
                 notif = component.get_firmware_update_notification(platform_api_conn, i, image)
@@ -194,9 +177,6 @@ class TestComponentApi(PlatformApiTestBase):
     def test_install_firmware(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["nokia"])
-
-        if self.num_components == 0:
-            pytest.skip("No components found on device")
 
         for i in range(self.num_components):
             for image in image_list:
@@ -209,9 +189,6 @@ class TestComponentApi(PlatformApiTestBase):
     def test_update_firmware(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["nokia"])
-
-        if self.num_components == 0:
-            pytest.skip("No components found on device")
 
         for i in range(self.num_components):
             for image in image_list:

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -49,6 +49,9 @@ class TestFanDrawerApi(PlatformApiTestBase):
                 self.num_fan_drawers = int(chassis.get_num_fan_drawers(platform_api_conn))
             except:
                 pytest.fail("num_fan_drawers is not an integer")
+            else:
+                if self.num_fan_drawers == 0:
+                    pytest.skip("No fan drawers found on device")
 
     #
     # Helper functions

--- a/tests/platform_tests/api/test_fan_drawer_fans.py
+++ b/tests/platform_tests/api/test_fan_drawer_fans.py
@@ -54,6 +54,9 @@ class TestFanDrawerFans(PlatformApiTestBase):
                 self.num_fan_drawers = chassis.get_num_fan_drawers(platform_api_conn)
             except:
                 pytest.fail("num_fans is not an integer")
+            else:
+                if self.num_fan_drawers == 0:
+                    pytest.skip("No fan drawers found on device")
 
     #
     # Helper functions

--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -72,6 +72,9 @@ class TestModuleApi(PlatformApiTestBase):
                 self.num_modules = int(chassis.get_num_modules(platform_api_conn))
             except:
                 pytest.fail("num_modules is not an integer")
+            else:
+                if self.num_modules == 0:
+                    pytest.skip("No modules found on device")
 
     #
     # Functions to test methods inherited from DeviceBase class
@@ -82,8 +85,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.skip_mod_list = get_skip_mod_list(duthost)
 
     def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         for i in range(self.num_modules):
             name = module.get_name(platform_api_conn, i)
@@ -92,8 +93,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         for i in range(self.num_modules):
             presence = module.get_presence(platform_api_conn, i)
@@ -107,8 +106,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         for i in range(self.num_modules):
             model = module.get_model(platform_api_conn, i)
@@ -117,8 +114,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         for i in range(self.num_modules):
             serial = module.get_serial(platform_api_conn, i)
@@ -127,8 +122,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         for i in range(self.num_modules):
             status = module.get_status(platform_api_conn, i)
@@ -156,8 +149,6 @@ class TestModuleApi(PlatformApiTestBase):
     #
 
     def test_get_base_mac(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         # Ensure the base MAC address of each module is sane
         # TODO: Add expected base MAC address for each module to inventory file and compare against it
@@ -199,9 +190,6 @@ class TestModuleApi(PlatformApiTestBase):
             ONIE_TLVINFO_TYPE_CODE_CRC32
         ]
 
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
-
         # TODO: Add expected system EEPROM info for each module to inventory file and compare against it
         for i in range(self.num_modules):
             syseeprom_info_dict = module.get_system_eeprom_info(platform_api_conn, i)
@@ -231,8 +219,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_components(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         # TODO: Ensure the number of components and that the returned list is correct for this platform
         for mod_idx in range(self.num_modules):
@@ -253,8 +239,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         # TODO: Ensure the number of fans and that the returned list is correct for this platform
         for mod_idx in range(self.num_modules):
@@ -275,8 +259,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_psus(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         # TODO: Ensure the number of PSUs and that the returned list is correct for this platform
         for mod_idx in range(self.num_modules):
@@ -297,8 +279,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_thermals(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         # TODO: Ensure the number of thermals and that the returned list is correct for this platform
         for mod_idx in range(self.num_modules):
@@ -319,8 +299,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_sfps(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         # TODO: Ensure the number of SFPs and that the returned list is correct for this platform
         for mod_idx in range(self.num_modules):
@@ -341,8 +319,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_description(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         for i in range(self.num_modules):
             description = module.get_description(platform_api_conn, i)
@@ -351,8 +327,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_slot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         for i in range(self.num_modules):
             slot_id = module.get_slot(platform_api_conn, i)
@@ -361,8 +335,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_type(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         for i in range(self.num_modules):
             mod_type = module.get_type(platform_api_conn, i)
@@ -372,8 +344,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_maximum_consumed_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         for i in range(self.num_modules):
             mod_max_con_power = module.get_maximum_consumed_power(platform_api_conn, i)
@@ -383,8 +353,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_midplane_ip(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         for i in range(self.num_modules):
             module_type = module.get_type(platform_api_conn, i)
@@ -395,8 +363,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_is_midplane_reachable(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         for i in range(self.num_modules):
             module_type = module.get_type(platform_api_conn, i)
@@ -407,8 +373,6 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_oper_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        if self.num_modules == 0:
-            pytest.skip("No modules found on device")
 
         for i in range(self.num_modules):
             status = module.get_oper_status(platform_api_conn, i)

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -48,6 +48,9 @@ class TestPsuApi(PlatformApiTestBase):
                 self.num_psus = int(chassis.get_num_psus(platform_api_conn))
             except:
                 pytest.fail("num_psus is not an integer")
+            else:
+                if self.num_psus == 0:
+                    pytest.skip("No psus found on device")
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         self.psu_skip_list = get_skip_mod_list(duthost, ['psus'])

--- a/tests/platform_tests/api/test_psu_fans.py
+++ b/tests/platform_tests/api/test_psu_fans.py
@@ -54,6 +54,9 @@ class TestPsuFans(PlatformApiTestBase):
                 self.num_psus = chassis.get_num_psus(platform_api_conn)
             except:
                 pytest.fail("num_fans is not an integer")
+            else:
+                if self.num_psus == 0:
+                    pytest.skip("No psus found on device")
 
     #
     # Helper functions

--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -46,6 +46,9 @@ class TestThermalApi(PlatformApiTestBase):
                 self.num_thermals = int(chassis.get_num_thermals(platform_api_conn))
             except:
                 pytest.fail("num_thermals is not an integer")
+            else:
+                if self.num_thermals == 0:
+                    pytest.skip("No thermals found on device")
 
     #
     # Helper functions


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. When run platform API cases we are facing situation when API returns 0 for key components of the tests. If API not implemented and returns for ,example, num_modules = 0 we do have false - positive scenario for cases which do not have checking for 0. Also if that happens all cases are marked as passed but TC duration equals to 0. 
2. Remove code duplication for component and modules API
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
1. Avoid false positive scenarios for API cases.
2. Remove code duplication. 
#### How did you do it?
Added else section to try/except module to check if api does not return 0 value for tested API.
#### How did you verify/test it?
Run API test suite. APIs which were not implemented and returned 0 have been skipped. 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
