### PR TITLE
[test_system_health] Skip unsupported releases for service checker testcase

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -6,7 +6,7 @@ import random
 import time
 from pkg_resources import parse_version
 from tests.common import config_reload
-from tests.common.utilities import wait_until
+from tests.common.utilities import skip_release, wait_until
 from tests.common.helpers.assertions import pytest_require
 from tests.platform_tests.thermal_control_test_helper import disable_thermal_policy
 from device_mocker import device_mocker_factory
@@ -98,6 +98,7 @@ def test_service_checker(duthosts, enum_rand_one_per_hwsku_hostname):
 @pytest.mark.disable_loganalyzer
 def test_service_checker_with_process_exit(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    skip_release(duthost, ["201811", "201911", "202012", "202106"])
     wait_system_health_boot_up(duthost)
     with ConfigFileContext(duthost, os.path.join(FILES_DIR, IGNORE_DEVICE_CHECK_CONFIG_FILE)):
         processes_status = duthost.all_critical_process_status()


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Skip the new testcase "test_service_checker_with_process_exit" added as part of #4562 on releases < 202111

Summary:
Fixes #4732

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

#### How did you do it?
Added the skip_release check before the start of the testcase

#### How did you verify/test it?
Verified that the testcase gets skipped on 202012 release
