### PR TITLE
[storage_backend] fix test_link_flap test case failure which is caused by port config wrongly overwriting

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -476,8 +476,15 @@ def fanouthosts(ansible_adhoc, conn_graph_facts, creds, duthosts):
 
                 # Add port name to fanout port mapping port if dut_port is alias.
                 if dut_port in mg_facts['minigraph_port_alias_to_name_map']:
-                    fanout.add_port_map(encode_dut_port_name(
-                       dut_host, mg_facts['minigraph_port_alias_to_name_map'][dut_port]), fanout_port)
+                    mapped_port = mg_facts['minigraph_port_alias_to_name_map'][dut_port]
+                    # only add the mapped port which isn't in device_conn ports to avoid overwriting port map wrongly,
+                    # it happens when an interface has the same name with another alias, for example:
+                    # Interface     Alias
+                    # --------------------
+                    # Ethernet108   Ethernet32
+                    # Ethernet32    Ethernet13/1
+                    if mapped_port not in value.keys():
+                        fanout.add_port_map(encode_dut_port_name(dut_host, mapped_port), fanout_port)
 
                 if dut_host not in fanout.dut_hostnames:
                     fanout.dut_hostnames.append(dut_host)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4731

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix the issue brought by https://github.com/Azure/sonic-mgmt/pull/4508
fix test_link_flap test case failure
#### How did you do it?
Avoid overwriting port map wrongly
#### How did you verify/test it?
Run test_link_flap on physical t0 backend topology and all of them passed.
