### PR TITLE
deprecate skip_version, use skip_release instead

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -26,15 +26,6 @@ logger = logging.getLogger(__name__)
 cache = FactsCache()
 
 
-def skip_version(duthost, version_list):
-    """
-    @summary: Skip current test if any given version keywords are in os_version
-    @param duthost: The DUT
-    @param version_list: A list of incompatible versions
-    """
-    if any(version in duthost.os_version for version in version_list):
-        pytest.skip("DUT has version {} and test does not support {}".format(duthost.os_version, ", ".join(version_list)))
-
 def skip_release(duthost, release_list):
     """
     @summary: Skip current test if any given release keywords are in os_version, match sonic_release.

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -11,7 +11,7 @@ from tests.common.helpers.platform_api import chassis, module
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts
 from tests.common.utilities import get_inventory_files
 from tests.common.utilities import get_host_visible_vars
-from tests.common.utilities import skip_version
+from tests.common.utilities import skip_release
 from tests.common.platform.interface_utils import get_physical_port_indices
 
 from platform_api_test_base import PlatformApiTestBase
@@ -150,7 +150,7 @@ class TestChassisApi(PlatformApiTestBase):
 
     def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        skip_version(duthost, ["201811", "201911", "202012"])
+        skip_release(duthost, ["201811", "201911", "202012"])
         revision = chassis.get_revision(platform_api_conn)
         pytest_assert(revision is not None, "Unable to retrieve chassis serial number")
         pytest_assert(isinstance(revision, STRING_TYPE), "Chassis serial number appears incorrect")

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -5,7 +5,7 @@ import yaml
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import chassis, psu
-from tests.common.utilities import skip_version
+from tests.common.utilities import skip_release
 from tests.platform_tests.cli.util import get_skip_mod_list
 from platform_api_test_base import PlatformApiTestBase
 from tests.common.utilities import skip_release_for_platform
@@ -120,7 +120,7 @@ class TestPsuApi(PlatformApiTestBase):
 
     def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        skip_version(duthost, ["201811", "201911", "202012"])
+        skip_release(duthost, ["201811", "201911", "202012"])
         for i in range(self.num_psus):
             revision = psu.get_revision(platform_api_conn, i)
             if self.expect(revision is not None, "Unable to retrieve PSU {} serial number".format(i)):

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import sfp
-from tests.common.utilities import skip_version
+from tests.common.utilities import skip_release
 from tests.common.utilities import skip_release_for_platform
 from tests.common.platform.interface_utils import get_physical_port_indices
 from tests.common.utilities import wait_until
@@ -551,7 +551,7 @@ class TestSfpApi(PlatformApiTestBase):
 
     def test_get_error_description(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         """This function tests get_error_description() API (supported on 202106 and above)"""
-        skip_version(duthosts[enum_rand_one_per_hwsku_hostname], ["201811", "201911", "202012"])
+        skip_release(duthosts[enum_rand_one_per_hwsku_hostname], ["201811", "201911", "202012"])
 
         for i in self.sfp_setup["sfp_test_port_indices"]:
             error_description = sfp.get_error_description(platform_api_conn, i)

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -14,7 +14,7 @@ import pytest
 from util import parse_eeprom
 from util import parse_output
 from util import get_dev_conn
-from tests.common.utilities import skip_version
+from tests.common.utilities import skip_release
 
 cmd_sfp_presence = "sudo sfputil show presence"
 cmd_sfp_eeprom = "sudo sfputil show eeprom"
@@ -53,7 +53,7 @@ def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_h
     @param: cmd_sfp_error_status: fixture representing the command used to test
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    skip_version(duthost, ["201811", "201911", "202012"])
+    skip_release(duthost, ["201811", "201911", "202012"])
     portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
 
     logging.info("Check output of '{}'".format(cmd_sfp_error_status))

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -16,7 +16,7 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.helpers.dut_ports import decode_dut_port_name
 from tests.common.utilities import wait_until
 from tests.platform_tests.link_flap.link_flap_utils import build_test_candidates
-from tests.common.utilities import skip_version
+from tests.common.utilities import skip_release
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -48,7 +48,7 @@ def check_image_version(duthost):
     Returns:
         None.
     """
-    skip_version(duthost, ["201811", "201911", "202012"])
+    skip_release(duthost, ["201811", "201911", "202012"])
 
 @pytest.fixture(scope='module', autouse=True)
 def recover_ports(duthosts, fanouthosts):

--- a/tests/vlan/test_host_vlan.py
+++ b/tests/vlan/test_host_vlan.py
@@ -11,7 +11,7 @@ from tests.common.dualtor.mux_simulator_control import mux_server_url           
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # lgtm[py/unused-import]
 from tests.common.utilities import is_ipv4_address
 from tests.common.utilities import wait_until
-from tests.common.utilities import skip_version
+from tests.common.utilities import skip_release
 
 
 pytestmark = [
@@ -42,7 +42,7 @@ def log_icmp_updates(duthost, iface, save_path):
 @pytest.fixture(scope="module")
 def testbed_params(duthosts, rand_one_dut_hostname, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
-    skip_version(duthost, ["201811", "201911"])
+    skip_release(duthost, ["201811", "201911"])
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     vlan_intf_name = mg_facts["minigraph_vlans"].keys()[0]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Introduced in #4736, deprecate skip_version, use skip_release instead.

#### How did you do it?
change to skip_release, remove skip_version

#### How did you verify/test it?
run test_dhcp_relay.py to verify 
dhcp_relay/test_dhcp_relay.py::test_interface_binding SKIPPED                                                                                                       [  9%]

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
