### PR TITLE
Skip `test_acl_outer_vlan` on testbeds under SONiC leaf-fanout

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -581,6 +581,19 @@ class AclVlanOuterTest_Base(object):
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, TYPE_COMBINE_UNTAGGED, ACTION_DROP)
 
+@pytest.fixture(scope='module', autouse=True)
+def skip_sonic_leaf_fanout(fanouthosts):
+    """
+    The test set can't run on testbeds connected to sonic leaf-fanout for below reasons:
+    1. The Ingress test will generate QinQ packet for testing. However, the QinQ packet will be dropped by sonic
+    leaf-fanout because dot1q-tunnel is not supported. Hence we skip the test on testbeds running sonic leaf-fanout
+    2. The Egress test will populate ARP table by ping command, and the egressed ICMP packets will be tagged with test
+    vlan id (100 or 200), which will be dropped by sonic leaf-fanout.
+    """
+    for fanouthost in fanouthosts.values():
+        if fanouthost.get_fanout_os() == 'sonic':
+            pytest.skip("Not supporteds on SONiC leaf-fanout")
+            
 class TestAclVlanOuter_Ingress(AclVlanOuterTest_Base):
     """
     Verify ACL rule matching outer vlan id in ingress


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip `test_acl_outer_vlan` on testbeds under SONiC leaf-fanout.

The test set ```test_acl_outer_vlan``` can't run on testbeds under SONiC leaf-fanout for below reasons
1. The Ingress test will generate QinQ packet for testing. However, the QinQ packet will be dropped by sonic
    leaf-fanout because dot1q-tunnel is not supported. Hence we skip the test on testbeds running sonic leaf-fanout
2. The Egress test will populate ARP table by ping command, and the egressed ICMP packets will be tagged with test
    vlan id (100 or 200), which will be dropped by sonic leaf-fanout.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to skip `test_acl_outer_vlan` on testbeds under SONiC leaf-fanout.

#### How did you do it?
Add an autoused class level fixture to check the os of leaf-fanout, and skip the test if the leaf-fanout is running SONiC.

#### How did you verify/test it?
Verified on a testbed under a SONiC leaf-fanout, and test is skipped.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
