### PR TITLE
[Platform API]: Skip test cases based on additional capabilities fields in platform.json

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -491,6 +491,14 @@ class TestChassisApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_thermal_manager(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        thermal_manager_available = True
+        if duthost.facts.get("chassis"):
+            thermal_manager_available = duthost.facts.get("chassis").get("thermal_manager", True)
+
+        if not thermal_manager_available:
+            pytest.skip("skipped as thermal manager is not available")
+
         thermal_mgr = chassis.get_thermal_manager(platform_api_conn)
         pytest_assert(thermal_mgr is not None, "Failed to retrieve thermal manager")
 

--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -266,6 +266,12 @@ class TestChassisFans(PlatformApiTestBase):
         fans_skipped = 0
 
         for i in range(self.num_fans):
+            led_available = self.get_fan_facts(duthost, i, True, "status_led", "available")
+            if not led_available:
+                logger.info("test_set_fans_led: Skipping chassis fan {} (LED not available)".format(i))
+                fans_skipped += 1
+                continue
+
             led_controllable = self.get_fan_facts(duthost, i, True, "status_led", "controllable")
             if not led_controllable:
                 logger.info("test_set_fans_led: Skipping chassis fan {} (LED not controllable)".format(i))
@@ -287,6 +293,6 @@ class TestChassisFans(PlatformApiTestBase):
                             color, color_actual, i))
 
         if fans_skipped == self.num_fans:
-            pytest.skip("skipped as all chassis fans' LED is not controllable")
+            pytest.skip("skipped as all chassis fans' LED is not available/controllable")
 
         self.assert_expectations()

--- a/tests/platform_tests/api/test_fan_drawer_fans.py
+++ b/tests/platform_tests/api/test_fan_drawer_fans.py
@@ -342,6 +342,12 @@ class TestFanDrawerFans(PlatformApiTestBase):
             fans_skipped = 0
 
             for i in range(num_fans):
+                led_available = self.get_fan_facts(duthost, j, i, True, "status_led", "available")
+                if not led_available:
+                    logger.info("test_set_fans_led: Skipping fandrawer {} fan {} (LED not available)".format(j, i))
+                    fans_skipped += 1
+                    continue
+
                 led_controllable = self.get_fan_facts(duthost, j, i, True, "status_led", "controllable")
                 led_supported_colors = self.get_fan_facts(duthost, j, i, None, "status_led", "colors")
 
@@ -381,6 +387,6 @@ class TestFanDrawerFans(PlatformApiTestBase):
                 fan_drawers_skipped += 1
 
         if fan_drawers_skipped == self.num_fan_drawers:
-            pytest.skip("skipped as all fandrawer fans' LED is not controllable/no supported colors")
+            pytest.skip("skipped as all fandrawer fans' LED is not available/controllable/no supported colors")
 
         self.assert_expectations()

--- a/tests/platform_tests/api/test_psu_fans.py
+++ b/tests/platform_tests/api/test_psu_fans.py
@@ -324,6 +324,12 @@ class TestPsuFans(PlatformApiTestBase):
             fans_skipped = 0
 
             for i in range(num_fans):
+                led_available = self.get_fan_facts(duthost, j, i, True, "status_led", "available")
+                if not led_available:
+                    logger.info("test_set_fans_led: Skipping PSU {} fan {} (LED not available)".format(j, i))
+                    fans_skipped += 1
+                    continue
+
                 led_controllable = self.get_fan_facts(duthost, j, i, True, "status_led", "controllable")
                 if not led_controllable:
                     logger.info("test_set_fans_led: Skipping PSU {} fan {} (LED not controllable)".format(j, i))
@@ -348,6 +354,6 @@ class TestPsuFans(PlatformApiTestBase):
                 psus_skipped += 1
 
         if psus_skipped == self.num_psus:
-            pytest.skip("skipped as all PSU fans' LED is not controllable")
+            pytest.skip("skipped as all PSU fans' LED is not available/controllable")
 
         self.assert_expectations()

--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -159,7 +159,16 @@ class TestThermalApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_minimum_recorded(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        thermals_skipped = 0
+
         for i in range(self.num_thermals):
+            record_supported = self.get_thermal_facts(duthost, i, True, "minimum-recorded")
+            if not record_supported:
+                logger.info("test_get_minimum_recorded: Skipping thermal {} (not supported)".format(i))
+                thermals_skipped += 1
+                continue
+
             temperature = thermal.get_minimum_recorded(platform_api_conn, i)
 
             if self.expect(temperature is not None, "Unable to retrieve Thermal {} temperature".format(i)):
@@ -167,16 +176,31 @@ class TestThermalApi(PlatformApiTestBase):
                     self.expect(temperature > 0 and temperature <= 100,
                                 "Thermal {} temperature {} reading is not within range".format(i, temperature))
 
+        if thermals_skipped == self.num_thermals:
+            pytest.skip("skipped as all chassis thermals' minimum-recorded is not supported")
+
         self.assert_expectations()
 
     def test_get_maximum_recorded(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        thermals_skipped = 0
+
         for i in range(self.num_thermals):
+            record_supported = self.get_thermal_facts(duthost, i, True, "maximum-recorded")
+            if not record_supported:
+                logger.info("test_get_maximum_recorded: Skipping thermal {} (not supported)".format(i))
+                thermals_skipped += 1
+                continue
+
             temperature = thermal.get_maximum_recorded(platform_api_conn, i)
 
             if self.expect(temperature is not None, "Unable to retrieve Thermal {} temperature".format(i)):
                 if self.expect(isinstance(temperature, float), "Thermal {} temperature appears incorrect".format(i)):
                     self.expect(temperature > 0 and temperature <= 100,
                                 "Thermal {} temperature {} reading is not within range".format(i, temperature))
+
+        if thermals_skipped == self.num_thermals:
+            pytest.skip("skipped as all chassis thermals' maximum-recorded is not supported")
 
         self.assert_expectations()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Skip test cases for a given platform based on the capabilities fields in platform.json

Test cases modified:

    - Chassis: test_get_thermal_manager
    - Chassis Fans: test_set_fans_led
    - FanDrawer Fans: test_set_fans_led
    - PSU Fans: test_set_fans_led
    - Thermal: test_get_maximum_recorded, test_get_minimum_recorded

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

To skip test cases on a given platform based on the capabilities provided in platform.json 

#### How did you do it?

Use chassis facts available in duthosts to get the required parameters for the test case.

#### How did you verify/test it?

- Run the test cases with the existing platform.json and observe no change in behavior.
- Run the test cases with platform.json consisting of the capabilities fields and observe that the appropriate test cases are skipped.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
