### PR TITLE
port autoneg tests: fixed false positives

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1093,7 +1093,7 @@ def pytest_generate_tests(metafunc):
     if "enum_dut_portname" in metafunc.fixturenames:
         metafunc.parametrize("enum_dut_portname", generate_port_lists(metafunc, "all_ports"))
     if "enum_dut_portname_module_fixture" in metafunc.fixturenames:
-        metafunc.parametrize("enum_dut_portname_module_fixture", generate_port_lists(metafunc, "all_ports"), scope="module")
+        metafunc.parametrize("enum_dut_portname_module_fixture", generate_port_lists(metafunc, "all_ports"), scope="module", indirect=True)
     if "enum_dut_portname_oper_up" in metafunc.fixturenames:
         metafunc.parametrize("enum_dut_portname_oper_up", generate_port_lists(metafunc, "oper_up_ports"))
     if "enum_dut_portname_admin_up" in metafunc.fixturenames:

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -271,23 +271,15 @@ def test_auto_negotiation_dut_advertises_each_speed(enum_dut_portname_module_fix
     logger.info('Start test for DUT port {} and fanout port {}'.format(dut_port, fanout_port))
     # Enable auto negotiation on fanout port
     success = fanout.set_auto_negotiation_mode(fanout_port, True)
-    if not success:
-        # Fanout does not support set auto negotiation mode for this port
-        logger.info('Ignore port {} due to fanout port {} does not support setting auto-neg mode'.format(dut_port, fanout_port))
-        return
+    pytest_require(success, 'Failed to set port autoneg on fanout port {}'.format(fanout_port))
 
     # Advertise all supported speeds in fanout port
     success = fanout.set_speed(fanout_port, None)
-    if not success:
-        # Fanout does not support set advertise speeds for this port
-        logger.info('Ignore port {} due to fanout port {} does not support setting advertised speeds'.format(dut_port, fanout_port))
-        return
+    pytest_require(success, 'Failed to advertise speed on fanout port {}, speed {}'.format(fanout_port, speed))
 
     logger.info('Trying to get a common supported speed set among dut port, fanout port and cable')
     supported_speeds = get_supported_speeds_for_port(duthost, dut_port, fanout, fanout_port)
-    if not supported_speeds:
-        logger.warn('Ignore test for port {} due to cannot get supported speed for it'.format(dut_port))
-        return
+    pytest_require(supported_speeds, 'Ignore test for port {} due to cannot get supported speed for it'.format(dut_port))
 
     logger.info('Run test based on supported speeds: {}'.format(supported_speeds))
     duthost.shell('config interface autoneg {} enabled'.format(dut_port))
@@ -322,23 +314,16 @@ def test_auto_negotiation_fanout_advertises_each_speed(enum_dut_portname_module_
 
     logger.info('Trying to get a common supported speed set among dut port, fanout port and cable')
     supported_speeds = get_supported_speeds_for_port(duthost, dut_port, fanout, fanout_port)
-    if not supported_speeds:
-        logger.warn('Ignore test for port {} due to cannot get supported speed for it'.format(dut_port))
-        return
+    pytest_require(supported_speeds, 'Ignore test for port {} due to cannot get supported speed for it'.format(dut_port))
 
     logger.info('Run test based on supported speeds: {}'.format(supported_speeds))
     success = fanout.set_auto_negotiation_mode(fanout_port, True)
-    if not success:
-        # Fanout does not support set auto negotiation mode for this port
-        logger.info('Ignore port {} due to fanout port {} does not support setting auto-neg mode'.format(dut_port, fanout_port))
-        return
-
+    pytest_require(success, 'Failed to set port autoneg on fanout port {}'.format(fanout_port))
+    
     for speed in supported_speeds:
         success = fanout.set_speed(fanout_port, speed)
-        if not success:
-            # Fanout does not support set advertise speeds for this port
-            logger.info('Ignore port {} due to fanout port {} does not support setting advertised speeds'.format(dut_port, fanout_port))
-            continue
+        pytest_require(success, 'Failed to advertised speeds on fanout port {}, speed {}'.format(fanout_port, speed))
+
         logger.info('Wait until the port status is up, expected speed: {}'.format(speed))
         wait_result = wait_until(SINGLE_PORT_WAIT_TIME, 
                                 PORT_STATUS_CHECK_INTERVAL, 
@@ -364,24 +349,18 @@ def test_force_speed(enum_dut_portname_module_fixture):
     logger.info('Start test for DUT port {} and fanout port {}'.format(dut_port, fanout_port))
     # Disable auto negotiation on fanout port
     success = fanout.set_auto_negotiation_mode(fanout_port, False)
-    if not success:
-        # Fanout does not support set auto negotiation mode for this port
-        logger.info('Ignore port {} due to fanout port {} does not support setting auto-neg mode'.format(dut_port, fanout_port))
-        return
+    pytest_require(success, 'Failed to set port autoneg on fanout port {}'.format(fanout_port))
 
     logger.info('Trying to get a common supported speeds set among dut port, fanout port and cable')
     supported_speeds = get_supported_speeds_for_port(duthost, dut_port, fanout, fanout_port)
-    if not supported_speeds:
-        logger.warn('Ignore test for port {} due to cannot get supported speed for it'.format(dut_port))
-        return
+    pytest_require(supported_speeds, 'Ignore test for port {} due to cannot get supported speed for it'.format(dut_port))
 
     logger.info('Run test based on supported speeds: {}'.format(supported_speeds))
     duthost.shell('config interface autoneg {} disabled'.format(dut_port))
     for speed in supported_speeds:
         success = fanout.set_speed(fanout_port, speed)
-        if not success:
-            logger.info('Skip speed {} because fanout does not support it'.format(speed))
-            continue
+        pytest_require(success, 'Failed to speed on fanout port {}, speed {}'.format(fanout_port, speed))
+
         duthost.shell('config interface speed {} {}'.format(dut_port, speed))
         logger.info('Wait until the port status is up, expected speed: {}'.format(speed))
         wait_result = wait_until(SINGLE_PORT_WAIT_TIME, 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: port autoneg tests - fixed false positives
Fixes # (issue)
- fixed false positives
Port autoneg tests make additional checks before actually executing the test scenario, but if checks fail the test stops execution via `return` statement rather than `pytest.skip` so tests which in fact did not even run look as passed

- refactored code limiting interfaces set test runs with

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix false positives
#### How did you do it?
Used pytest skip
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
