### PR TITLE
[test_reload] Increase restart time threshold

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -22,7 +22,7 @@ pytestmark = [
 
 CONTAINER_CHECK_INTERVAL_SECS = 1
 CONTAINER_STOP_THRESHOLD_SECS = 60
-CONTAINER_RESTART_THRESHOLD_SECS = 180
+CONTAINER_RESTART_THRESHOLD_SECS = 300
 CONTAINER_NAME_REGEX = (r"([a-zA-Z_-]+)(\d*)$")
 POST_CHECK_INTERVAL_SECS = 1
 POST_CHECK_THRESHOLD_SECS = 360
@@ -309,7 +309,7 @@ def check_all_critical_processes_status(duthost):
 
 def postcheck_critical_processes_status(duthost, container_autorestart_states, up_bgp_neighbors):
     """Restarts the containers which hit the restart limitation. Then post checks
-       to see whether all the critical processes are alive and 
+       to see whether all the critical processes are alive and
        expected BGP sessions are up after testing the autorestart feature.
 
     Args:
@@ -335,7 +335,7 @@ def postcheck_critical_processes_status(duthost, container_autorestart_states, u
         duthost.check_bgp_session_state, up_bgp_neighbors, "established"
     )
 
-    return critical_proceses and bgp_check
+    return critical_proceses, bgp_check
 
 
 def run_test_on_single_container(duthost, container_name, tbinfo):
@@ -409,9 +409,33 @@ def run_test_on_single_container(duthost, container_name, tbinfo):
         logger.info("Restore auto-restart state of container '{}' to 'disabled'".format(container_name))
         duthost.shell("sudo config feature autorestart {} disabled".format(feature_name))
 
-    if not postcheck_critical_processes_status(duthost, container_autorestart_states, up_bgp_neighbors):
+    critical_proceses, bgp_check = postcheck_critical_processes_status(
+        duthost, container_autorestart_states, up_bgp_neighbors
+    )
+    if not (critical_proceses and bgp_check):
         config_reload(duthost)
-        pytest.fail("Some post check failed after testing feature {}".format(container_name))
+        failed_check = "[Critical Process] " if not critical_proceses else ""
+        failed_check += "[BGP] " if not bgp_check else ""
+        processes_status = duthost.all_critical_process_status()
+        pstatus = [
+            {
+                k:{
+                    "status": v["status"],
+                    "exited_critical_process": processes["exited_critical_process"]
+                }
+            } for k, v in processes_status.items() if v[
+                "status"
+            ] is False and len(v["exited_critical_process"]) > 0
+        ]
+
+        pytest.fail(
+            ("{}check failed, testing feature {}, \nBGP:{}, \nNeighbors:{}"
+             "\nProcess status {}").format(
+                failed_check, container_name,
+                [{x: v['state']} for x, v in duthost.get_bgp_neighbors().items() if v['state'] != 'established'],
+                up_bgp_neighbors, pstatus
+            )
+        )
 
     logger.info("End of testing the container '{}'".format(container_name))
 

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -437,7 +437,6 @@ class MultiAsicSonicHost(object):
 
         for asic in self.asics:
             bgp_facts = asic.bgp_facts()['ansible_facts']
-            logging.info("bgp_facts: {}".format(bgp_facts))
             for k, v in bgp_facts['bgp_neighbors'].items():
                 if v['state'] == state:
                     if k.lower() in neigh_ips:

--- a/tests/ipfwd/test_nhop_count.py
+++ b/tests/ipfwd/test_nhop_count.py
@@ -252,6 +252,7 @@ def loganalyzer_ignore_regex_list():
         ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_SRC_IPV6:.*",
         ".*ERR syncd#syncd: :- processQuadEvent: attr: SAI_ACL_TABLE_ATTR_FIELD_TCP_FLAGS:.*",
         ".*ERR syncd#syncd: :- sendApiResponse: api SAI_COMMON_API_CREATE.*",
+        ".*ERR swss#orchagent: :- getResAvailableCounters: Failed to get availability for object_type.*",
         ".*brcm_sai_dnx_create_acl_table:.*",
     ]
     return ignore


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Increased restart time threshold. 

Summary:
On chassis platform reload and auto restart container tests are flaky, as it takes a little longer the services to come up due to interaction with chassis DB on supervisor.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Remove test flakiness on reload tests on chassis platform.

Minor changes:
 * Improve logging when the system readiness check fails.
 * Remove bgp_facts log from the common API as the logs become noisy. Let the test logic add the log.

#### How did you do it?
Increase reload time threshold.

#### How did you verify/test it?
Ran auto_restart_container tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
