### PR TITLE
Skip the "show platform ssdhealth" test for non-SSD platform

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -313,6 +313,11 @@ def test_show_platform_ssdhealth(duthosts, enum_supervisor_dut_hostname):
     @summary: Verify output of `show platform ssdhealth`
     """
     duthost = duthosts[enum_supervisor_dut_hostname]
+    cmd = "cat /sys/block/sda/queue/rotational"
+    ssdcheck_output_lines = duthost.command(cmd)["stdout_lines"]
+    if '0' not in ssdcheck_output_lines:
+       pytest.skip("Disk type is not SSD")
+
     cmd = " ".join([CMD_SHOW_PLATFORM, "ssdhealth"])
 
     logging.info("Verifying output of '{}' on ''{}'...".format(cmd, duthost.hostname))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Skip the "show platform ssdhealth" test for non-SSD platform
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://github.com/Azure/sonic-buildimage/issues/9407

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
With recent ssd platform api changes, ssdhealth check fails on some specific platform.
Since the platform doesn't have SSD.

#### How did you do it?
Skip the show platform ssdhealth for any platform with other type of disk.

#### How did you verify/test it?
Run pytest tests/platform_tests/cli/test_show_platform.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
