### PR TITLE
[conn_graph_facts] get port list from lab_connection_graph.xml

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -446,14 +446,11 @@ def find_graph(hostnames, part=False):
     return lab_graph
 
 
-def get_port_name_list(hwsku):
-    # Create a map of SONiC port name to physical port index
-    # Start by creating a list of all port names
-    port_alias_to_name_map, _ = get_port_alias_to_name_map(hwsku)
+def get_port_name_list(device_link):
+    port_name_list = []
+    for port in device_link:
+        port_name_list.append(port)
 
-    # Create a map of SONiC port name to physical port index
-    # Start by creating a list of all port names
-    port_name_list = port_alias_to_name_map.values()
     # Sort the list in natural order, because SONiC port names, when
     # sorted in natural sort order, match the phyical port index order
     port_name_list_sorted = natsorted(port_name_list)
@@ -493,7 +490,7 @@ def build_results(lab_graph, hostnames, ignore_error=False):
             else:
                 device_vlan_map_list[hostname] = {}
 
-                port_name_list_sorted = get_port_name_list(dev['HwSku'])
+                port_name_list_sorted = get_port_name_list(device_conn[hostname])
                 logging.debug("For %s with hwsku %s, port_name_list is %s" % (hostname, dev['HwSku'], port_name_list_sorted))
                 for a_host_vlan in host_vlan["VlanList"]:
                     # Get the corresponding port for this vlan from the port vlan list for this hostname


### PR DESCRIPTION
Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Get port list from lab_connection_graph.xml.
Next action: Get get_port_alias_to_name_map() from port_config.ini or platform.json in DUT.
Then we don't need to write hard code in get_port_alias_to_name_map()

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Get port list from lab_connection_graph.xml.
Next action: Get get_port_alias_to_name_map() from port_config.ini or platform.json in DUT.
Then we don't need to write hard code in get_port_alias_to_name_map()

#### How did you do it?
Get port list from lab_connection_graph.xml.

#### How did you verify/test it?
Add topology

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
