### PR TITLE
Fix vlan config index error

### DIFF
--- a/ansible/library/vlan_config.py
+++ b/ansible/library/vlan_config.py
@@ -52,7 +52,7 @@ def main():
             vlan_configs[vlan]['tag'] = vlan_param['tag']
             vlan_configs[vlan]['prefix'] = vlan_param['prefix']
             vlan_configs[vlan]['prefix_v6'] = vlan_param['prefix_v6']
-            vlan_configs[vlan]['intfs'] = [port_alias[i] for i in vlan_param['intfs']]
+            vlan_configs[vlan]['intfs'] = [port_alias[i] for i in range(vlan_param['intfs'][0])]
             vlan_configs[vlan]['portchannels'] = vlan_param.get('portchannels', [])
 
             if 'mac' in vlan_param:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix ansible vlan_config index error
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
vlan_param['infts'] returns a list containing a single integer denoting the number of intfs, and this value is used incorrectly as an index into a list that contains the corresponding number of elements (e.g. vlan_param['intfs'] would return [4] when port_alias is a list of 4 elements, and 4 would be used to index into port_alias). This results in sonic-mgmt crashing before tests are ran.

#### How did you do it?
Change logic to generate the correct indices based on vlan_param['infts']

#### How did you verify/test it?
Ran sonic-mgmt on Arista platform successfully

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
