### PR TITLE
Implement test case to verify dest MAC won't refresh FDB

### DIFF
--- a/ansible/roles/test/files/ptftests/fdb_mac_expire_test.py
+++ b/ansible/roles/test/files/ptftests/fdb_mac_expire_test.py
@@ -7,6 +7,11 @@ import ptf.dataplane as dataplane
 from ptf import config
 from ptf.base_tests import BaseTest
 from ptf.testutils import *
+import datetime
+import time
+
+DISABLE_REFRESH = "disable_refresh"
+REFRESH_DEST_MAC = "refresh_with_dest_mac"
 
 class FdbMacExpireTest(BaseTest):
     def __init__(self):
@@ -18,6 +23,9 @@ class FdbMacExpireTest(BaseTest):
         self.router_mac = self.test_params['router_mac']
         self.dummy_mac_prefix = self.test_params['dummy_mac_prefix']
         self.fdb_info = self.test_params['fdb_info']
+        self.refresh_type = self.test_params.get('refresh_type', DISABLE_REFRESH)
+        self.aging_time = self.test_params.get('aging_time', 0)
+        self.mac_table = []
     #--------------------------------------------------------------------------
     def populateFdb(self):
         self.fdb = fdb.Fdb(self.fdb_info)
@@ -30,8 +38,24 @@ class FdbMacExpireTest(BaseTest):
                                         eth_src=mac,
                                         eth_type=0x1234)
                 send(self, member, pkt)
+                # Save the MAC table for possible refresh
+                self.mac_table.append((member, mac))
+    
+    def refreshFdbWithInvalidPackets(self):
+        # Keep sending packets with Dest MAC address equals to router MAC for aging_time
+        # The FDB is not supposed to be refreshed on DUT
+        t1 = t0 = datetime.datetime.now()
+        while (t1 - t0).seconds < self.aging_time:
+            for member, mac in self.mac_table:
+                pkt = simple_eth_packet(eth_dst=mac, eth_type=0x1234)
+                send(self, member, pkt)
+            time.sleep(5)
+            t1 = datetime.datetime.now()
+            
     #--------------------------------------------------------------------------
     def runTest(self):
         self.populateFdb()
+        if self.refresh_type == REFRESH_DEST_MAC:
+            self.refreshFdbWithInvalidPackets()
 	return
     #--------------------------------------------------------------------------

--- a/tests/fdb/test_fdb_mac_expire.py
+++ b/tests/fdb/test_fdb_mac_expire.py
@@ -11,6 +11,8 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
+DISABLE_REFRESH = "disable_refresh"
+REFRESH_DEST_MAC = "refresh_with_dest_mac"
 class TestFdbMacExpire:
     """
         TestFdbMacExpire Verifies FDb aging timer is respected
@@ -201,7 +203,8 @@ class TestFdbMacExpire:
             self.__loadSwssConfig(duthost)
         self.__deleteTmpSwitchConfig(duthost)
 
-    def testFdbMacExpire(self, request, tbinfo, rand_selected_dut, ptfhost):
+    @pytest.mark.parametrize("refresh_type", [DISABLE_REFRESH, REFRESH_DEST_MAC])
+    def testFdbMacExpire(self, request, tbinfo, rand_selected_dut, ptfhost, refresh_type):
         """
             TestFdbMacExpire Verifies FDb aging timer is respected
 
@@ -230,6 +233,8 @@ class TestFdbMacExpire:
             "router_mac": rand_selected_dut.facts["router_mac"],
             "fdb_info": self.FDB_INFO_FILE,
             "dummy_mac_prefix": self.DUMMY_MAC_PREFIX,
+            "refresh_type":  refresh_type,
+            "aging_time": fdbAgingTime
         }
         self.__runPtfTest(ptfhost, "fdb_mac_expire_test.FdbMacExpireTest", testParams)
 


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4281
This PR is to add a test case to verify MAC aging will ignore dest MAC in packets.
 
### Type of  change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to add a test case to verify MAC aging will ignore dest MAC in packets.

#### How did you do it?
The new tese case is implemented based on current ```test_fdb_mac_expire```. 
To verify the dest MAC in packets won't refresh FDB on DUT, the test script on ptf keeps sending packets whose dest MAC equals to testing MAC for aging time (60 seconds in default), and then we will verify the FDB will get aged on DUT in next aging time.

#### How did you verify/test it?
Verified on SN4600c, all passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
The test case is supposed to run on T0 testbed.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
