### PR TITLE
[SFP-refactor]Fix vendor revision key issue

### DIFF
--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -78,7 +78,7 @@ def check_transceiver_details(dut, asic_index, interfaces, xcvr_skip_list):
     """
     asichost = dut.asic_instance(asic_index)
     logging.info("Check detailed transceiver information of each connected port")
-    expected_fields = ["type", "hardware_rev", "serial", "manufacturer", "model"]
+    expected_fields = ["type", "vendor_rev", "serial", "manufacturer", "model"]
     for intf in interfaces:
         if intf not in xcvr_skip_list[dut.hostname]:
             cmd = 'redis-cli -n 6 hgetall "TRANSCEIVER_INFO|%s"' % intf

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -79,7 +79,7 @@ class TestSfpApi(PlatformApiTestBase):
         'type',
         'manufacturer',
         'model',
-        'hardware_rev',
+        'vendor_rev',
         'serial',
         'vendor_oui',
         'vendor_date',

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -259,6 +259,9 @@ class TestSfpApi(PlatformApiTestBase):
 
                     unexpected_keys = set(actual_keys) - set(self.EXPECTED_XCVR_INFO_KEYS + self.NEWLY_ADDED_XCVR_INFO_KEYS)
                     for key in unexpected_keys:
+                        #hardware_rev is applicable only for QSFP-DD
+                        if key == 'hardware_rev' and info_dict["type_abbrv_name"] == "QSFP-DD":
+                            continue
                         self.expect(False, "Transceiver {} info contains unexpected field '{}'".format(i, key))
         self.assert_expectations()
 

--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -511,7 +511,7 @@ def test_transceiver_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physi
         assert transceiver_snmp_fact['entPhysClass'] == PHYSICAL_CLASS_PORT
         assert transceiver_snmp_fact['entPhyParentRelPos'] == -1
         assert transceiver_snmp_fact['entPhysName'] == name
-        assert transceiver_snmp_fact['entPhysHwVer'] == transceiver_info['hardware_rev']
+        assert transceiver_snmp_fact['entPhysHwVer'] == transceiver_info['vendor_rev']
         assert transceiver_snmp_fact['entPhysFwVer'] == ''
         assert transceiver_snmp_fact['entPhysSwVer'] == ''
         assert transceiver_snmp_fact['entPhysSerialNum'] == transceiver_info['serial']


### PR DESCRIPTION
### Description of PR
With new SFP refactor, hardware revision key won't be returned for the media except CMIS 
Summary:
Fixes # https://github.com/Azure/sonic-platform-common/issues/250

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
sonic-mgmt test case may fail with the integration of new SFP refactor
#### How did you do it?
Check the expected list of keys in test_sfp.py
#### How did you verify/test it?
Verified in DellEMC Z9332f platform.
After fix:
sfputil show eeprom -p Ethernet80
Ethernet80: SFP EEPROM detected
Application Advertisement: N/A
Connector: No separable connector
Encoding: Unspecified
Extended Identifier: Power Class 1 Module (1.5W max. Power consumption), No CLEI code present in Page 02h, No CDR in TX, No CDR in RX
Extended RateSelect Compliance: QSFP+ Rate Select Version 1
Identifier: QSFP+ or later with SFF-8636 or SFF-8436
Length Cable Assembly(m): 1.0
Nominal Bit Rate(100Mbs): 103
Specification compliance:
10/40G Ethernet Compliance Code: 40GBASE-CR4
Fibre Channel Link Length: Medium (M)
Fibre Channel Speed: Unknown
Fibre Channel Transmission Media: Twin Axial Pair (TW)
Fibre Channel Transmitter Technology: Unknown
Gigabit Ethernet Compliant Codes: Unknown
SAS/SATA Compliance Codes: Unknown
SONET Compliance Codes: Unknown
Vendor Date Code(YYYY-MM-DD Lot): 2019-01-09
Vendor Name: Amphenol
Vendor OUI: 78-a7-14
Vendor PN: 616750000
Vendor Rev: C
Vendor SN: CN01M31V9172909
root@sonic-10431:~#
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
