### PR TITLE
Ignore psu's in psu_skip_list in test_master_led

### DIFF
--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -393,6 +393,9 @@ class TestPsuApi(PlatformApiTestBase):
             pytest.skip("No psus found on device skipping for device {}".format(duthost))
 
         for psu_id in range(self.num_psus):
+            name = psu.get_name(platform_api_conn, psu_id)
+            if name in self.psu_skip_list:
+                continue
             for index, led_type in enumerate(LED_COLOR_TYPES):
                 led_type_result = False
                 for color in led_type:


### PR DESCRIPTION




<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

PR#[4545 ](https://github.com/Azure/sonic-mgmt/pull/4545)introduced a change in test_master_led to loop through all the PSU's. However, there could be DUTs where all the PSU's are not present. 

This test fails when checking a PSU that is not present in the DUT.

#### How did you do it?
Check if the PSU is present in skip_psu_list and if so, then skip checking led on that PSU

#### How did you verify/test it?
Tested against a DUT where not all PSU's are present, and also a DUT where all PSU's are present.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
