### PR TITLE
Cleanup cache for asics as well in the cleanup_cache_for_session fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1149,9 +1149,15 @@ def cleanup_cache_for_session(request):
     This fixture is not automatically applied, if you want to use it, you have to add a call to it in your tests.
     """
     tbname, tbinfo = get_tbinfo(request)
+    inv_files = get_inventory_files(request)
     cache.cleanup(zone=tbname)
     for a_dut in tbinfo['duts']:
         cache.cleanup(zone=a_dut)
+    inv_data = get_host_visible_vars(inv_files, a_dut)
+    if 'num_asics' in inv_data and inv_data['num_asics'] > 1:
+            for asic_id in range(inv_data['num_asics']):
+                cache.cleanup(zone="{}-asic{}".format(a_dut, asic_id))
+
 
 def get_l2_info(dut):
     """


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
In the cache collected for a multi-asic DUT, there is cache data for asics that
is stored as well, under the <dutName>-asic<asic_id> directory.
This data is not cleaned up as part of cleanup_cache_for_session fixture.
#### How did you do it?
To cleanup the asic specific data, We get the num_asics from the inventory file
(since at this time we don't have the SonicHost object for the DUT),
and if that is more than one, then we pass <dutName>-asic<asic_id> as the zone
parameter to cache.cleanup

#### How did you verify/test it?
Ran fixture against a multi-asic DUT and validated that the cache data is cleaned up.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
