### PR TITLE
[adv-reboot] Fix 201811 compatibility issues in BGP and interface cfg

### DIFF
--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -435,10 +435,11 @@ class SadOper(SadPath):
                 if key not in ['v4', 'v6']:
                     continue
                 self.log.append('Verifying if the DUT side BGP peer %s is %s' % (self.neigh_bgps[vm][key], states))
+                stdout, _, _ = self.dut_connection.execCommand('sonic_installer list | grep Current | cut -f2 -d " "')
                 if key == 'v4':
                     cmd = "show ip bgp neighbors"
                 else:
-                    cmd = "show ipv6 bgp neighbors"
+                    cmd = "show ip bgp neighbors" if "201811" in stdout[0] else "show ipv6 bgp neighbors"
                 stdout, stderr, return_code = self.dut_connection.execCommand(cmd+' %s' % self.neigh_bgps[vm][key])
                 if return_code == 0:
                     for line in stdout:

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -806,6 +806,8 @@ class SonicHost(AnsibleHostBase):
                 ifnames (list): the interface names to shutdown
         """
         image_info = self.get_image_info()
+        # 201811 image does not support multiple interfaces shutdown
+        # Change the batch shutdown call to individual call here
         if "201811" in image_info.get("current"):
             for ifname in ifnames:
                 self.shutdown(ifname)
@@ -832,12 +834,15 @@ class SonicHost(AnsibleHostBase):
                 ifnames (list): the interface names to bring up
         """
         image_info = self.get_image_info()
+        # 201811 image does not support multiple interfaces startup
+        # Change the batch startup call to individual call here
         if "201811" in image_info.get("current"):
             for ifname in ifnames:
                 self.no_shutdown(ifname)
             return
-        intf_str = ','.join(ifnames)
-        return self.no_shutdown(intf_str)
+        else:
+            intf_str = ','.join(ifnames)
+            return self.no_shutdown(intf_str)
 
     def get_ip_route_info(self, dstip, ns=""):
         """

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -805,8 +805,14 @@ class SonicHost(AnsibleHostBase):
             Args:
                 ifnames (list): the interface names to shutdown
         """
-        intf_str = ','.join(ifnames)
-        return self.shutdown(intf_str)
+        image_info = self.get_image_info()
+        if "201811" in image_info.get("current"):
+            for ifname in ifnames:
+                self.shutdown(ifname)
+            return
+        else:
+            intf_str = ','.join(ifnames)
+            return self.shutdown(intf_str)
 
     def no_shutdown(self, ifname):
         """
@@ -825,6 +831,11 @@ class SonicHost(AnsibleHostBase):
             Args:
                 ifnames (list): the interface names to bring up
         """
+        image_info = self.get_image_info()
+        if "201811" in image_info.get("current"):
+            for ifname in ifnames:
+                self.no_shutdown(ifname)
+            return
         intf_str = ','.join(ifnames)
         return self.no_shutdown(intf_str)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix advance-reboot upgrade path issues where interface and BGP config commands are different between 201811 and newer images.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix issue where `show ipv6 bgp neighbor <neighbor>` command does not work on 201811 image. In 201811 image, the command is still `show ip bgp neighbor <neighbor>`

Interface config in 201811 fails when all the ports are provided together (comma separated). In 201811 images, interface needs to be individually startup/shutdown.
```
2021-12-05T20:07:59.9750429Z         "module_args": {
2021-12-05T20:07:59.9752802Z             "_raw_params": "sudo config interface startup Ethernet120,Ethernet116,Ethernet112", 
2021-12-05T20:07:59.9755183Z             "_uses_shell": false, 
2021-12-05T20:07:59.9757324Z             "argv": null, 
2021-12-05T20:07:59.9759408Z             "chdir": null, 
2021-12-05T20:07:59.9761491Z             "creates": null, 
2021-12-05T20:07:59.9763394Z             "executable": null, 
2021-12-05T20:07:59.9765433Z             "removes": null, 
2021-12-05T20:07:59.9767508Z             "stdin": null, 
2021-12-05T20:07:59.9770039Z             "stdin_add_newline": true, 
2021-12-05T20:07:59.9772335Z             "strip_empty_ends": true, 
2021-12-05T20:07:59.9774518Z             "warn": true
2021-12-05T20:07:59.9776642Z         }
2021-12-05T20:07:59.9778641Z     }, 
2021-12-05T20:07:59.9789449Z     "msg": "non-zero return code", 
2021-12-05T20:07:59.9791904Z     "rc": 2, 
2021-12-05T20:07:59.9794422Z     "start": "2021-12-05 20:07:59.227092", 
2021-12-05T20:07:59.9797235Z     "stderr": "Usage: config interface startup [OPTIONS] <interface_name>\n\nError: Interface name is invalid. Please enter a valid interface name!!", 
2021-12-05T20:07:59.9800103Z     "stderr_lines": [
2021-12-05T20:07:59.9802547Z         "Usage: config interface startup [OPTIONS] <interface_name>", 
2021-12-05T20:07:59.9804898Z         "", 
2021-12-05T20:07:59.9807198Z         "Error: Interface name is invalid. Please enter a valid interface name!!"
2021-12-05T20:07:59.9809960Z     ], 
```


#### How did you do it?
Check the current image version, and use the respective command for the current image.

#### How did you verify/test it?
Tested on a physical DUT.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
