### PR TITLE
Use sudo to execute sonic_installer command on ptf script

### DIFF
--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -439,7 +439,7 @@ class SadOper(SadPath):
                 if key == 'v4':
                     cmd = "show ip bgp neighbors"
                 else:
-                    cmd = "show ip bgp neighbors" if "201811" in stdout[0] else "show ipv6 bgp neighbors"
+                    cmd = "show ip bgp neighbors" if (len(stdout) > 0 and "201811" in stdout[0]) else "show ipv6 bgp neighbors"
                 stdout, stderr, return_code = self.dut_connection.execCommand(cmd+' %s' % self.neigh_bgps[vm][key])
                 if return_code == 0:
                     for line in stdout:

--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -435,7 +435,7 @@ class SadOper(SadPath):
                 if key not in ['v4', 'v6']:
                     continue
                 self.log.append('Verifying if the DUT side BGP peer %s is %s' % (self.neigh_bgps[vm][key], states))
-                stdout, _, _ = self.dut_connection.execCommand('sonic_installer list | grep Current | cut -f2 -d " "')
+                stdout, _, _ = self.dut_connection.execCommand('sudo sonic_installer list | grep Current | cut -f2 -d " "')
                 if key == 'v4':
                     cmd = "show ip bgp neighbors"
                 else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add `sudo` to execute commands on DUT from ptf scripts.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
