### PR TITLE
[ptf]: Retry to check the ptf_nn_agent status

### DIFF
--- a/tests/common/plugins/ptfadapter/__init__.py
+++ b/tests/common/plugins/ptfadapter/__init__.py
@@ -1,6 +1,7 @@
 """This module provides ptfadapter fixture to be used by tests to send/receive traffic via PTF ports"""
 import os
 import pytest
+import time
 
 from ptfadapter import PtfTestAdapter
 import ptf.testutils
@@ -199,8 +200,10 @@ def nbr_ptfadapter(request, nbrhosts, nbr_device_numbers, ptfadapter):
                 host.shell('docker run -dt --network=host --rm --name ptf -v /tmp/ptf_nn_agent.conf:/etc/supervisor/conf.d/ptf_nn_agent.conf docker-ptf')
 
                 #Maybe the threads in this docker are not ready and may return None
-                if "RUNNING" in host.shell('docker exec ptf supervisorctl status ptf_nn_agent')["stdout_lines"][0]:
-                    return ptf_nn_port
+                for j in range(MAX_RETRY_TIME):
+                    time.sleep(1)
+                    if "RUNNING" in host.shell('docker exec ptf supervisorctl status ptf_nn_agent', module_ignore_errors = True)["stdout_lines"][0]:
+                        return ptf_nn_port
             return None
 
         ptf_nn_agent_port = start_ptf_nn_agent()


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Because `docker run -d` is an async command which doesn't guarantee when the container starts. So, the following command `docker exec ptf` maybe fail due to ptf inexistence.

#### How did you do it?
Retry and wait a second for ptf container starting.

#### How did you verify/test it?
Azp status

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
