### PR TITLE
[Loganalyzer]Fix loganalyzer python3 issue

### DIFF
--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -234,7 +234,7 @@ def combine_logs_and_save(directory, filenames, start_string, target_string, tar
             logger.debug("extract_log combine_logs from file {} create time {}, size {}".format(path, dt, sz))
             file = None
             if 'gz' in path:
-                file = gzip.GzipFile(path)
+                file = gzip.open(path, mode='rt')
             else:
                 file = open(path)
 


### PR DESCRIPTION
In python3 gzip.GzipFile supports opening files in binary mode. If you need to open a compressed file in text mode, use the gzip.open() function
In PR #4427, only partially fixed this issue.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix loganalyzer python3 issue
Fixes # (issue) In python3 gzip.GzipFile supports opening files in binary mode. If you need to open a compressed file in text mode, use the gzip.open() function

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
In python3 gzip.GzipFile supports opening files in binary mode. If you need to open a compressed file in text mode, use the gzip.open() function
In PR #4427, only partially fixed this issue.
#### How did you do it?
Change "file = gzip.GzipFile(path)" to  "file = gzip.open(path, mode='rt')"
#### How did you verify/test it?
run the script, and the test pass
py.test pfcwd/test_pfcwd_timer_accuracy.py --inventory="../ansible/inventory,../ansible/veos" --host-pattern arc-switch1038 --module-path                ../ansible/library/ --testbed arc-switch1038-t1-lag --testbed_file ../ansible/testbed.csv                --allow_recover  --session_id 5441009 --mars_key_id 0.7.1.1.3.1.1.4.4.1.1                --junit-xml junit_5441009_0.7.1.1.3.1.1.4.4.1.1.xml --assert plain --log-cli-level info --show-capture=no -ra --showlocals -v --clean-alluredir --alluredir=/tmp/allure-results --allure_server_addr="10.215.11.120" --allure_server_project_id=arc-switch1038-pfcwd-test-pfcwd-timer-accuracy-py --skip_sanity 

#### Any platform specific information?
No