### PR TITLE
Improved cleanup logic in test tests/ecmp/test_fghng.py

### DIFF
--- a/tests/ecmp/test_fgnhg.py
+++ b/tests/ecmp/test_fgnhg.py
@@ -578,7 +578,7 @@ def fg_ecmp_to_regular_ecmp_transitions(ptfhost, duthost, router_mac, net_ports,
 
 def cleanup(duthost, ptfhost):
     logger.info("Start cleanup")
-    ptfhost.command('rm /tmp/fg_ecmp_persist_map.json')
+    ptfhost.command('rm -f /tmp/fg_ecmp_persist_map.json')
     config_reload(duthost)
 
 


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>


### Description of PR
Old logic expects that file exist and did remove by cmd: rm
In case when file does not exist - it fail with exception
New logic doing remove by cmd: rm -f
This will pass in any case

Summary: Improved cleanup logic in test tests/ecmp/test_fghng.py
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
In case when file does not exist, cmd "rm" failed.

#### How did you do it?
Changed remove file command from "rm" to "rm -f"

#### How did you verify/test it?
Executed test: tests/ecmp/test_fghng.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
