### PR TITLE
Fixed logic for remove vlan interface

### DIFF
--- a/ansible/roles/vm_set/library/vlan_port.py
+++ b/ansible/roles/vm_set/library/vlan_port.py
@@ -65,7 +65,7 @@ class VlanPort(object):
     def destroy_vlan_port(self, vlan_port):
         if VlanPort.iface_exists(vlan_port):
             VlanPort.iface_down(vlan_port)
-            VlanPort.cmd('vconfig rem %s' % vlan_port)
+            VlanPort.cmd('ip link del %s' % vlan_port)
 
         return
 
@@ -104,7 +104,10 @@ class VlanPort(object):
 
     @staticmethod
     def iface_exists(iface_name):
-        iface = VlanPort.ifconfig("ifconfig -a %s" % iface_name)
+        try:
+            iface = VlanPort.ifconfig("ifconfig -a %s" % iface_name)
+        except Exception:
+            iface = None
         return bool(iface)
 
     @staticmethod


### PR DESCRIPTION
Signed-off-by: Petro Pikh petrop@nvidia.com

### Description of PR

Previous logic failed when interface does not exist
Now we check if interface exist - then remove, if does not exist - just pass
Changed cmd for remove vlan iterfac from "vconfig rem" to "ip link del" - somehow vconfig sometimes can not remove iface

Summary: Fixed logic for remove vlan interface
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Previous logic failed when interface does not exist
Now we check if interface exist - then remove, if does not exist - just pass

#### How did you do it?
Added try/except block

#### How did you verify/test it?
Executed add/remove topo

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
