### PR TITLE
[cache] Fixed logic which read cache from .pickle file

### DIFF
--- a/tests/common/cache/facts_cache.py
+++ b/tests/common/cache/facts_cache.py
@@ -84,7 +84,7 @@ class FactsCache(with_metaclass(Singleton, object)):
         else:
             facts_file = os.path.join(self._cache_location, '{}/{}.pickle'.format(zone, key))
             try:
-                with open(facts_file, 'b') as f:
+                with open(facts_file, 'rb') as f:
                     self._cache[zone][key] = pickle.load(f)
                     logger.debug('Loaded cached facts "{}.{}" from {}'.format(zone, key, facts_file))
                     return self._cache[zone][key]


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Fixed logic which read cache from .pickle file
Commit #4708 introduced errors during read cache file:
```
12:24:45 facts_cache.read                         L0093 INFO   | Load cache file "/root/mars/workspace/sonic-mgmt/tests/_cache/arc-switch1025/mg_facts.pickle" failed with exception: ValueError("mode string must begin with one of 'r', 'w', 'a' or 'U', not 'b'",)
```
Current commit is fix for ValueError issue

Summary: Fixed logic which read cache from .pickle file
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix error during read .pickle file

#### How did you do it?
Changed file open mode from "b" to "rb"

#### How did you verify/test it?
Executed pytest tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
