### PR TITLE
Make GCU syslog's test independent from previous test

### DIFF
--- a/tests/generic_config_updater/test_syslog.py
+++ b/tests/generic_config_updater/test_syslog.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 SYSLOG_DUMMY_IPV4_SERVER    = "10.0.0.5"
 SYSLOG_DUMMY_IPV6_SERVER    = "cc98:2008::1"
-SETUP_ENV_CP                = "test_setup"
+SETUP_ENV_CP                = "test_setup_checkpoint"
 CONFIG_CLEANUP              = "config_cleanup"
 CONFIG_ADD_DEFAULT          = "config_add_default"
 
@@ -139,6 +139,7 @@ def setup_env(duthosts, rand_one_dut_hostname, cfg_facts, init_syslog_config, or
             "Syslog servers are not rollback_or_reload to initial config setup"
         )
     finally:
+        delete_checkpoint(duthost, SETUP_ENV_CP)
         delete_checkpoint(duthost)
 
 def expect_res_success_syslog(duthost, expected_content_list, unexpected_content_list):

--- a/tests/generic_config_updater/test_syslog.py
+++ b/tests/generic_config_updater/test_syslog.py
@@ -364,13 +364,6 @@ def syslog_server_add_to_max(duthost):
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         expect_op_success(duthost,output)
 
-        status = duthost.get_service_props('rsyslog-config')["ActiveState"]
-        logger.info("rsyslog-config status {}".format(status))
-        pytest_assert(
-            duthost.get_service_props('rsyslog-config')["ActiveState"] == "active",
-            "rsyslog-config service is not active"
-        )
-
         expected_content_list = ["[{}]".format(syslog_server) for syslog_server in syslog_servers]
         expect_res_success_syslog(duthost, expected_content_list, [])
     finally:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Make GCU syslog test independent from previous test
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To avoid testing on one test case that is dependent on the previous test.

#### How did you do it?
Setup prerequisite environment for each test

#### How did you verify/test it?
Run test of sonic-mgmt/tests/generic_config_updater/test_syslog.py on KVM

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
