### PR TITLE
Enable VS setup to run MTU test for size 9114

### DIFF
--- a/ansible/roles/vm_set/templates/sonic.xml.j2
+++ b/ansible/roles/vm_set/templates/sonic.xml.j2
@@ -46,6 +46,7 @@
     <interface type='ethernet' >
         <target dev='{{ dut_name }}-{{ i + 1 }}' />
         <model type='e1000' />
+        <mtu size='{{ fp_mtu_size }}' />
     </interface>
 {% endfor %}
     <controller type='usb' index='0'/>

--- a/tests/ipfwd/test_mtu.py
+++ b/tests/ipfwd/test_mtu.py
@@ -8,7 +8,8 @@ from tests.ptf_runner import ptf_runner
 from datetime import datetime
 
 pytestmark = [
-    pytest.mark.topology('t1', 't2')
+    pytest.mark.topology('t1', 't2'),
+    pytest.mark.device_type('vs')
 ]
 
 @pytest.mark.parametrize("mtu", [1514,9114])

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -199,6 +199,7 @@ test_t1_lag() {
     bgp/test_bgp_update_timer.py \
     bgp/test_traffic_shift.py \
     http/test_http_copy.py \
+    ipfwd/test_mtu.py \
     lldp/test_lldp.py \
     route/test_default_route.py \
     platform_tests/test_cpu_memory_usage.py \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
If MTU size is 9114, the MTU test would fail on VS setup. The reason is that MTU of the
SONiC KVM interfaces were set to 1500 by default.

#### How did you do it?
This change added `<mtu size={{ fp_mtu_size }}` to the interfaces in the XML template
 for deploying KVM based SONiC DUT. Default fp_mtu_size is defined to 9216. With
 this change, `tests/ipfwd/test_mtu.py` can pass on KVM setup running t1-lag
 topology. This PR also added this script to KVM test.

#### How did you verify/test it?
Tested `add-topo`, `refresh-dut` using the `testbed-cli.sh` tool.
Tested run `test_mtu.py` on vms-kvm-t1-lag VS setup.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
