### PR TITLE
[test_cont_warm_reboot] Fix regression - allow preboot ptf setup

### DIFF
--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -92,7 +92,7 @@ class ContinuousReboot:
 
     @handle_test_error
     def run_reboot_testcase(self):
-        result = self.advancedReboot.runRebootTest()
+        result = self.advancedReboot.runRebootTestcase()
         if result is not True:
             # Create a failure report
             error = result.get("stderr")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix test regression in test_cont_warm_reboot. This issue is caused due to a recent change in advanced-reboot.py PTF script, which expects preboot files as an argument.
Changing the caller from `runRebootTest` to `runRebootTestcase` makes sure that these files are passed to ptf.

```
2021-12-10T05:12:15.1797701Z ======================================================================
2021-12-10T05:12:15.1798154Z ERROR: advanced-reboot.ReloadTest
2021-12-10T05:12:15.1798619Z ----------------------------------------------------------------------
2021-12-10T05:12:15.1798983Z Traceback (most recent call last):
2021-12-10T05:12:15.1799430Z   File "ptftests/advanced-reboot.py", line 539, in setUp
2021-12-10T05:12:15.1799745Z     self.build_peer_mapping()
2021-12-10T05:12:15.1800522Z   File "ptftests/advanced-reboot.py", line 424, in build_peer_mapping
2021-12-10T05:12:15.1801007Z     for file in self.test_params['preboot_files'].split(','):
2021-12-10T05:12:15.1801879Z AttributeError: 'NoneType' object has no attribute 'split'
2021-12-10T05:12:15.1802046Z 
2021-12-10T05:12:15.1802453Z ----------------------------------------------------------------------
2021-12-10T05:12:15.1802747Z Ran 1 test in 0.001s
2021-12-10T05:12:15.1802852Z 
2021-12-10T05:12:15.1803033Z FAILED (errors=1)
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

The call to runRebootTestcase will automatically add prebootFiles as its default argument:

https://github.com/Azure/sonic-mgmt/blob/eff373d4b647f6b41e3cb591f232240db0945f75/tests/common/fixtures/advanced_reboot.py#L467

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
