### PR TITLE
[mvrf][ntp] Add timeout and specify user id for ntpd -gq

### DIFF
--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -202,7 +202,8 @@ class TestServices():
         # Check if ntp was not in sync with ntp server before enabling mvrf, if yes then setup ntp server on ptf
         if check_ntp_sync:
             setup_ntp(ptfhost, duthost, ntp_servers)
-        force_ntp = "ntpd -gq"
+        ntp_uid = ":".join(duthost.command("getent passwd ntp")['stdout'].split(':')[2:4])
+        force_ntp = "timeout 20 ntpd -gq -u {}".format(ntp_uid)
         duthost.service(name="ntp", state="stopped")
         logger.info("Ntp restart in mgmt vrf")
         execute_dut_command(duthost, force_ntp)

--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -111,7 +111,8 @@ def test_ntp(duthosts, rand_one_dut_hostname, setup_ntp):
     duthost = duthosts[rand_one_dut_hostname]
 
     duthost.service(name='ntp', state='stopped')
-    duthost.command("ntpd -gq")
+    ntp_uid = ":".join(duthost.command("getent passwd ntp")['stdout'].split(':')[2:4])
+    duthost.command("timeout 20 ntpd -gq -u {}".format(ntp_uid))
     duthost.service(name='ntp', state='restarted')
     pytest_assert(wait_until(720, 10, 0, check_ntp_status, duthost),
                   "NTP not in sync")


### PR DESCRIPTION
Summary:

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
1. It has possibility that the test hang when perform the `ntpd -gq` operation
if the remote ntpd server is not started, therefore, add the timeout 20 sec
to avoid test case hang in this case

2. The ntpd may generate the `/var/lib/ntp/driftfile` automatically, the properly
user would be ntp, therefore, addd to specify the ntp's user id to avoid the file
be generated as root owns file

#### How did you do it?

#### How did you verify/test it?
1. Disable the remote ntpd server and make sure the test case is not hang 
2. Run these test case and use the `watch -n 0.5 ps aux` to monitor the user of ntpd process

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 

