### PR TITLE
[dhcp_relay] Interface binding test enhancement

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -224,8 +224,7 @@ def testing_config(request, duthosts, rand_one_dut_hostname, tbinfo):
             duthost.shell('redis-cli -n 4 HDEL "DEVICE_METADATA|localhost" "subtype"')
             restart_dhcp_service(duthost)
 
-def check_interface_status(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
+def check_interface_status(duthost):
     if ":67" in duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcrelay")["stdout"].encode("utf-8"):
         return True
     return False
@@ -235,7 +234,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data)
     skip_release(duthost, ["201811", "201911", "202106"])
     config_reload(duthost)
     wait_critical_processes(duthost)
-    wait_until(120, 5, 0, check_interface_status, duthosts, rand_one_dut_hostname)
+    pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
     output = duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcrelay")["stdout"].encode("utf-8")
     logger.info(output)
     for dhcp_relay in dut_dhcp_relay_data:

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -232,9 +232,10 @@ def check_interface_status(duthost):
 def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data):
     duthost = duthosts[rand_one_dut_hostname]
     skip_release(duthost, ["201811", "201911", "202106"])
-    config_reload(duthost)
-    wait_critical_processes(duthost)
-    pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
+    if not check_interface_status(duthost):
+        config_reload(duthost)
+        wait_critical_processes(duthost)
+        pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
     output = duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcrelay")["stdout"].encode("utf-8")
     logger.info(output)
     for dhcp_relay in dut_dhcp_relay_data:

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -12,6 +12,7 @@ from tests.ptf_runner import ptf_runner
 from tests.common import config_reload
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
     pytest.mark.topology('t0'),
@@ -111,9 +112,8 @@ def validate_dut_routes_exist(duthosts, rand_one_dut_hostname, dut_dhcp_relay_da
         assert len(rtInfo["nexthops"]) > 0, "Failed to find route to DHCP server '{0}'".format(dhcp_server)
 
 
-def check_interface_status(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    if ":547" in duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcrelay")["stdout"].encode("utf-8"):
+def check_interface_status(duthost):
+    if ":547" in duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcp6relay")["stdout"].encode("utf-8"):
         return True
     return False
 
@@ -122,7 +122,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data)
     skip_release(duthost, ["201811", "201911", "202106"])
     config_reload(duthost)
     wait_critical_processes(duthost)
-    wait_until(120, 5, 0, check_interface_status, duthosts, rand_one_dut_hostname)
+    pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
     output = duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcp6relay")["stdout"].encode("utf-8")
     logger.info(output)
     for dhcp_relay in dut_dhcp_relay_data:

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -120,9 +120,10 @@ def check_interface_status(duthost):
 def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data):
     duthost = duthosts[rand_one_dut_hostname]
     skip_release(duthost, ["201811", "201911", "202106"])
-    config_reload(duthost)
-    wait_critical_processes(duthost)
-    pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
+    if not check_interface_status(duthost):
+        config_reload(duthost)
+        wait_critical_processes(duthost)
+        pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
     output = duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcp6relay")["stdout"].encode("utf-8")
     logger.info(output)
     for dhcp_relay in dut_dhcp_relay_data:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Minimize minimum running time and fix typo
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Running config reload 4 times (dhcp_relay and dhcpv6_relay, for both 1vlan and 2vlans) takes up a lot of time. Reload config is unnecessary unless dhcrelay/dhcp6relay are not running.
Typo: dhcrelay should be dhcp6relay in dhcpv6_relay interface binding test. Wait_until was not asserted and it just timed out so it did not have affect the testing from passing.

#### How did you do it?
Check for port binding, only do config reload if port binding fails. Add pytest_assert to check after config reload.

#### How did you verify/test it?
Tested on kvm

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
