### PR TITLE
Skipping ipv6 testcase as Match 'IN_PORTS' is not supported for mirrorv6 ACL on Cisco platform

### DIFF
--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -31,10 +31,12 @@ def skip_if_not_supported(tbinfo, rand_selected_dut, ip_ver):
         pytest.skip("Skip running on dualtor testbed")
 
     asic_type = rand_selected_dut.facts["asic_type"]
-    unsupported_platforms = ["mellanox", "marvell", "barefoot"]
+    unsupported_platforms = ["mellanox", "marvell", "barefoot", "cisco-8000"]
     # Skip ipv6 test on Mellanox platform
     is_mellanox_ipv4 = asic_type == 'mellanox' and ip_ver == 'ipv4'
-    pytest_require(asic_type not in unsupported_platforms or is_mellanox_ipv4, "Match 'IN_PORTS' is not supported on {} platform".format(asic_type))
+    # Skip ipv6 test on cisco-8000 platform
+    is_cisco_ipv4 = asic_type == 'cisco-8000' and ip_ver == 'ipv4'	
+    pytest_require(asic_type not in unsupported_platforms or is_mellanox_ipv4 or is_cisco_ipv4, "Match 'IN_PORTS' is not supported on {} platform".format(asic_type))
 
 def build_candidate_ports(duthost, tbinfo):
     """


### PR DESCRIPTION
### Description of PR
Currently Cisco-8000 platform does not support Match 'IN_PORTS'  for mirrorv6 ACL, hence skipping ipv6 testcase.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Currently Cisco-8000 platform does not support Match 'IN_PORTS'  for mirrorv6 ACL, hence skipping ipv6 testcase.

#### How did you do it?

#### How did you verify/test it?
Verified that only ipv6 testcase skips for Cisco-8000 platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
