### PR TITLE
[inner hahsing] extension of PBH tests

### DIFF
--- a/ansible/roles/test/files/ptftests/inner_hash_test.py
+++ b/ansible/roles/test/files/ptftests/inner_hash_test.py
@@ -79,6 +79,7 @@ class InnerHashTest(BaseTest):
         self.vxlan_port = self.test_params['vxlan_port']
         self.outer_encap_formats = self.test_params['outer_encap_formats']
         self.symmetric_hashing = self.test_params.get('symmetric_hashing', False)
+        self.gre_key = self.test_params.get('gre_key', '')
         self.outer_dst_ip = self.outer_dst_ip_interval.get_first_ip()
 
         self.next_hop = self.fib[self.outer_dst_ip]
@@ -226,6 +227,7 @@ class InnerHashTest(BaseTest):
 
         outer_ip_src = self.outer_src_ip_interval.get_random_ip() if hash_key == 'outer-tuples' else self.outer_src_ip_interval.get_first_ip()
         outer_ip_dst = self.outer_dst_ip_interval.get_random_ip() if hash_key == 'outer-tuples' else self.outer_dst_ip_interval.get_first_ip()
+        nvgre_tni = 0x25 if self.gre_key else random.randint(1, 254) + 20000
 
         pkt = self.generate_inner_pkt(sport, dport, ip_src, ip_dst, ip_proto)
         nvgre_pkt = simple_nvgre_packet(
@@ -235,8 +237,9 @@ class InnerHashTest(BaseTest):
                     ip_src=outer_ip_src,
                     ip_dst=outer_ip_dst,
                     ip_ttl=64,
-                    nvgre_tni=random.randint(1, 254)+20000,
-                    inner_frame=pkt)
+                    inner_frame=pkt,
+                    nvgre_tni=nvgre_tni,
+                    nvgre_flowid=0)
 
         logging.info("Sending packet from port {} outer_ip_src {} outer_ip_dst {} inner_src_ip {} inner_dst_ip {} inner_sport {} inner_dport {} inner_ipproto {}"\
                 .format(src_port, outer_ip_src, outer_ip_dst, ip_src, ip_dst, sport, dport, ip_proto))
@@ -316,6 +319,7 @@ class InnerHashTest(BaseTest):
 
         outer_ip_src = self.outer_src_ip_interval.get_random_ip() if hash_key == 'outer-tuples' else self.outer_src_ip_interval.get_first_ip()
         outer_ip_dst = self.outer_dst_ip_interval.get_random_ip() if hash_key == 'outer-tuples' else self.outer_dst_ip_interval.get_first_ip()
+        nvgre_tni = 0x25 if self.gre_key else random.randint(1, 254) + 20000
 
         pkt = self.generate_inner_pkt(sport, dport, ip_src, ip_dst, ip_proto)
         nvgre_pkt = self.simple_nvgrev6_packet(
@@ -323,8 +327,9 @@ class InnerHashTest(BaseTest):
                     eth_src=src_mac,
                     ipv6_src=outer_ip_src,
                     ipv6_dst=outer_ip_dst,
-                    nvgre_tni=random.randint(1, 254)+20000,
-                    inner_frame=pkt)
+                    inner_frame=pkt,
+                    nvgre_tni=nvgre_tni,
+                    nvgre_flowid=0)
 
         logging.info("Sending packet from port {} outer_ip_src {} outer_ip_dst {} inner_src_ip {} inner_dst_ip {} inner_sport {} inner_dport {} inner_ipproto {}"\
                 .format(src_port, outer_ip_src, outer_ip_dst, ip_src, ip_dst, sport, dport, ip_proto))

--- a/ansible/roles/test/files/ptftests/inner_hash_test.py
+++ b/ansible/roles/test/files/ptftests/inner_hash_test.py
@@ -79,7 +79,7 @@ class InnerHashTest(BaseTest):
         self.vxlan_port = self.test_params['vxlan_port']
         self.outer_encap_formats = self.test_params['outer_encap_formats']
         self.symmetric_hashing = self.test_params.get('symmetric_hashing', False)
-        self.gre_key = self.test_params.get('gre_key', '')
+        self.nvgre_tni = self.test_params.get('nvgre_tni', '')
         self.outer_dst_ip = self.outer_dst_ip_interval.get_first_ip()
 
         self.next_hop = self.fib[self.outer_dst_ip]
@@ -227,7 +227,7 @@ class InnerHashTest(BaseTest):
 
         outer_ip_src = self.outer_src_ip_interval.get_random_ip() if hash_key == 'outer-tuples' else self.outer_src_ip_interval.get_first_ip()
         outer_ip_dst = self.outer_dst_ip_interval.get_random_ip() if hash_key == 'outer-tuples' else self.outer_dst_ip_interval.get_first_ip()
-        nvgre_tni = 0x25 if self.gre_key else random.randint(1, 254) + 20000
+        nvgre_tni = self.nvgre_tni if self.nvgre_tni else random.randint(1, 254) + 20000
 
         pkt = self.generate_inner_pkt(sport, dport, ip_src, ip_dst, ip_proto)
         nvgre_pkt = simple_nvgre_packet(
@@ -319,7 +319,7 @@ class InnerHashTest(BaseTest):
 
         outer_ip_src = self.outer_src_ip_interval.get_random_ip() if hash_key == 'outer-tuples' else self.outer_src_ip_interval.get_first_ip()
         outer_ip_dst = self.outer_dst_ip_interval.get_random_ip() if hash_key == 'outer-tuples' else self.outer_dst_ip_interval.get_first_ip()
-        nvgre_tni = 0x25 if self.gre_key else random.randint(1, 254) + 20000
+        nvgre_tni = self.nvgre_tni if self.nvgre_tni else random.randint(1, 254) + 20000
 
         pkt = self.generate_inner_pkt(sport, dport, ip_src, ip_dst, ip_proto)
         nvgre_pkt = self.simple_nvgrev6_packet(

--- a/tests/ecmp/inner_hashing/conftest.py
+++ b/tests/ecmp/inner_hashing/conftest.py
@@ -3,6 +3,7 @@ import json
 import logging
 import tempfile
 import re
+import allure
 
 from datetime import datetime
 
@@ -28,6 +29,7 @@ FIB_INFO_FILE_DST = '/root/fib_info.txt'
 VXLAN_PORT = 13330
 DUT_VXLAN_PORT_JSON_FILE = '/tmp/vxlan.switch.json'
 
+T0_VLAN = "1000"
 IP_VERSIONS_LIST = ["ipv4", "ipv6"]
 OUTER_ENCAP_FORMATS = ["vxlan", "nvgre"]
 TABLE_NAME = "pbh_table"
@@ -42,10 +44,15 @@ V4_ETHER_TYPE = "0x0800"
 V6_ETHER_TYPE = "0x86dd"
 VXLAN_IP_PROTOCOL = "0x11"
 NVGRE_IP_PROTOCOL = "0x2f"
+GRE_KEY = "0x2500"
+GRE_MASK = "0xffffff00"
 VXLAN_L4_DST_PORT = "0x3412"
 VXLAN_L4_DST_PORT_OPTION = " --l4-dst-port {}".format(VXLAN_L4_DST_PORT)
+NVGRE_GRE_KEY_OPTION = " --gre-key {}/{}".format(GRE_KEY, GRE_MASK)
 ADD_PBH_TABLE_CMD = "sudo config pbh table add '{}' --interface-list '{}' --description '{}'"
 DEL_PBH_TABLE_CMD = "sudo config pbh table delete '{}'"
+ADD_PBH_RULE_BASE_CMD = "sudo config pbh rule add '{}' '{}' --priority '{}' --ether-type {}" \
+                        " --inner-ether-type '{}' --hash '{}' --packet-action '{}' --flow-counter 'ENABLED'"
 ADD_PBH_RULE_BASE_CMD = "sudo config pbh rule add '{}' '{}' --priority '{}' --ether-type {}" \
                         " --inner-ether-type '{}' --hash '{}' --packet-action '{}' --flow-counter 'ENABLED'"
 DEL_PBH_RULE_CMD = "sudo config pbh rule delete '{}' '{}'"
@@ -182,6 +189,56 @@ def vlan_ptf_ports(config_facts, tbinfo, duthost):
 
 
 @pytest.fixture(scope='module')
+def lag_port_map(duthost, config_facts, vlan_ptf_ports, tbinfo):
+    portchannels = config_facts.get('PORTCHANNEL', {}).keys()
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    port_list_idx = 0
+    lag_port_map = {}
+    port_key_list = list(mg_facts['minigraph_ptf_indices'].keys())
+    port_val_list = list(mg_facts['minigraph_ptf_indices'].values())
+
+    for portchannel_idx in range(1, 10000):  # Max len of PortChannel index can be '9999'
+        lag_port = 'PortChannel{}'.format(portchannel_idx)
+
+        if lag_port not in portchannels:
+            port_idx_value = vlan_ptf_ports[port_list_idx]
+            position = port_val_list.index(port_idx_value)
+            port_name = port_key_list[position]
+            lag_port_map[lag_port] = port_name
+            port_list_idx += 1
+
+        if len(lag_port_map) == len(vlan_ptf_ports):
+            break
+
+    return lag_port_map
+
+
+@pytest.fixture(scope='module')
+def lag_ip_map(lag_port_map):
+    index = 1
+    base_ipv4_addr = '100.0.{}.1/31'
+    base_ipv6_addr = 'fc00:{}::1/126'
+    lag_ip_map = {}
+
+    for lag_port, _ in lag_port_map.items():
+        ipv4_addr = base_ipv4_addr.format(index)
+        ipv6_addr = base_ipv6_addr.format(index)
+        lag_ip_map[lag_port] = {'ipv4': ipv4_addr, 'ipv6': ipv6_addr}
+        index += 1
+
+    return lag_ip_map
+
+
+@pytest.fixture(scope='module')
+def config_lag_ports(duthost, lag_port_map, lag_ip_map):
+    add_lag_config(duthost, lag_port_map, lag_ip_map)
+
+    yield
+
+    remove_lag_config(duthost, lag_port_map, lag_ip_map)
+
+
+@pytest.fixture(scope='module')
 def router_mac(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     return duthost.facts['router_mac']
@@ -215,7 +272,22 @@ def inner_ipver(request):
 
 
 @pytest.fixture(scope="module")
+def config_pbh_table_lag(duthost, lag_port_map):
+    logging.info("Create PBH table: {}".format(TABLE_NAME))
+    test_intfs_str = ",".join(lag_port_map.keys())
+
+    duthost.command(ADD_PBH_TABLE_CMD.format(TABLE_NAME,
+                                             test_intfs_str,
+                                             TABLE_DESCRIPTION))
+
+    yield
+
+    duthost.command(DEL_PBH_TABLE_CMD.format(TABLE_NAME))
+
+
+@pytest.fixture(scope="module")
 def config_pbh_table(duthost, vlan_ptf_ports, tbinfo):
+    logging.info("Create PBH table: {}".format(TABLE_NAME))
     test_intfs_str = get_dut_test_intfs_str(duthost, vlan_ptf_ports, tbinfo)
 
     duthost.command(ADD_PBH_TABLE_CMD.format(TABLE_NAME,
@@ -239,6 +311,7 @@ def get_dut_test_intfs_str(duthost, vlan_ptf_ports, tbinfo):
 
 @pytest.fixture(scope="module")
 def config_hash_fields(duthost):
+    logging.info("Create PBH hash-fields")
     for hash_field, hash_field_params_dict in HASH_FIELD_CONFIG.items():
         cmd = get_hash_field_add_cmd(hash_field, hash_field_params_dict)
         duthost.command(cmd)
@@ -260,6 +333,7 @@ def get_hash_field_add_cmd(hash_field_name, hash_field_params_dict):
 
 @pytest.fixture(scope="module")
 def config_hash(duthost):
+    logging.info("Create PBH hash: {}".format(HASH_NAME))
     duthost.command(ADD_PBH_HASH_CMD.format(HASH_NAME, PBH_HASH_FIELD_LIST))
 
     yield
@@ -291,6 +365,7 @@ def config_ipv6_rules(duthost, inner_ipver):
 
 
 def config_vxlan_rule(duthost, ip_ver_option, ether_type, outer_ipver, inner_ipver):
+    logging.info("Create PBH rule: {}".format(VXLAN_RULE_NAME.format(outer_ipver, inner_ipver)))
     inner_ether_type = V4_ETHER_TYPE if inner_ipver == "ipv4" else V6_ETHER_TYPE
     duthost.command((ADD_PBH_RULE_BASE_CMD + ip_ver_option + VXLAN_L4_DST_PORT_OPTION)
                     .format(TABLE_NAME,
@@ -305,8 +380,9 @@ def config_vxlan_rule(duthost, ip_ver_option, ether_type, outer_ipver, inner_ipv
 
 
 def config_nvgre_rule(duthost, ip_ver_option, ether_type, outer_ipver, inner_ipver):
+    logging.info("Create PBH rule: {}".format(NVGRE_RULE_NAME.format(outer_ipver, inner_ipver)))
     inner_ether_type = V4_ETHER_TYPE if inner_ipver == "ipv4" else V6_ETHER_TYPE
-    duthost.command((ADD_PBH_RULE_BASE_CMD + ip_ver_option)
+    duthost.command((ADD_PBH_RULE_BASE_CMD + ip_ver_option + NVGRE_GRE_KEY_OPTION)
                     .format(TABLE_NAME,
                             NVGRE_RULE_NAME.format(outer_ipver, inner_ipver),
                             NVGRE_RULE_PRIO,
@@ -341,16 +417,40 @@ def get_src_dst_ip_range(ipver):
 
 
 def check_pbh_counters(duthost, outer_ipver, inner_ipver, balancing_test_times, symmetric_hashing, hash_keys):
-    symmetric_multiplier = 2 if symmetric_hashing else 1
-    exp_port_multiplier = 4  # num of POs in t0 topology
-    hash_keys_multiplier = len(hash_keys)
-    # for hash key "ip-proto", the traffic sends always in one way
-    exp_count = str((balancing_test_times * symmetric_multiplier * exp_port_multiplier * (hash_keys_multiplier-1))
-                    + (balancing_test_times * exp_port_multiplier))
-    pbh_statistic_output = duthost.shell("show pbh statistic")['stdout']
-    for outer_encap_format in OUTER_ENCAP_FORMATS:
-        regex = r'{}\s+{}_{}_{}\s+(\d+)\s+\d+'.format(TABLE_NAME, outer_encap_format, outer_ipver, inner_ipver)
-        current_count = re.search(regex, pbh_statistic_output).group(1)
-        assert current_count == exp_count,\
-            "PBH counters are different from expected for {}, outer ipver {}, inner ipver {}. Expected: {}, " \
-            "Current: {}".format(outer_encap_format, outer_ipver, inner_ipver, exp_count, current_count)
+    logging.info('Verify PBH counters')
+    with allure.step('Verify PBH counters'):
+        symmetric_multiplier = 2 if symmetric_hashing else 1
+        exp_port_multiplier = 4  # num of POs in t0 topology
+        hash_keys_multiplier = len(hash_keys)
+        # for hash key "ip-proto", the traffic sends always in one way
+        exp_count = str((balancing_test_times * symmetric_multiplier * exp_port_multiplier * (hash_keys_multiplier-1))
+                        + (balancing_test_times * exp_port_multiplier))
+        pbh_statistic_output = duthost.shell("show pbh statistic")['stdout']
+        for outer_encap_format in OUTER_ENCAP_FORMATS:
+            regex = r'{}\s+{}_{}_{}\s+(\d+)\s+\d+'.format(TABLE_NAME, outer_encap_format, outer_ipver, inner_ipver)
+            current_count = re.search(regex, pbh_statistic_output).group(1)
+            assert current_count == exp_count,\
+                "PBH counters are different from expected for {}, outer ipver {}, inner ipver {}. Expected: {}, " \
+                "Current: {}".format(outer_encap_format, outer_ipver, inner_ipver, exp_count, current_count)
+
+
+def add_lag_config(duthost, lag_port_map, lag_ip_map):
+    logging.info('Add LAG configuration')
+    with allure.step('Add LAG configuration'):
+        for lag_port, port_name in lag_port_map.items():
+            duthost.shell('sudo config vlan member del {} {}'.format(T0_VLAN, port_name))
+            duthost.shell('sudo config portchannel add {} --fallback enable'.format(lag_port))
+            duthost.shell('sudo config portchannel member add {} {}'.format(lag_port, port_name))
+            duthost.shell('config interface ip add {} {}'.format(lag_port, lag_ip_map[lag_port]['ipv4']))
+            duthost.shell('config interface ip add {} {}'.format(lag_port, lag_ip_map[lag_port]['ipv6']))
+
+
+def remove_lag_config(duthost, lag_port_map, lag_ip_map):
+    logging.info('Remove LAG configuration')
+    with allure.step('Remove LAG configuration'):
+        for lag_port, port_name in lag_port_map.items():
+            duthost.shell('config interface ip remove {} {}'.format(lag_port, lag_ip_map[lag_port]['ipv4']))
+            duthost.shell('config interface ip remove {} {}'.format(lag_port, lag_ip_map[lag_port]['ipv6']))
+            duthost.shell('sudo config portchannel member del {} {}'.format(lag_port, port_name))
+            duthost.shell('sudo config portchannel del {}'.format(lag_port))
+            duthost.shell('sudo config vlan member add {} {} --untagged'.format(T0_VLAN, port_name))

--- a/tests/ecmp/inner_hashing/conftest.py
+++ b/tests/ecmp/inner_hashing/conftest.py
@@ -278,37 +278,6 @@ def inner_ipver(request):
 
 
 @pytest.fixture(scope="module")
-def save_config_teardown(duthost):
-
-    yield
-
-    duthost.command('sudo config save -y')
-
-
-@pytest.fixture(scope="module")
-def setup_acl_config(duthost):
-    """
-    Setup/teardown fixture for acl config
-    """
-    config_tmpfile = "/etc/sonic/config_db.json.orig"
-    logger.info("config_tmpfile {} Backing up config_db.json".format(config_tmpfile))
-    duthost.command("sudo cp /etc/sonic/config_db.json {}".format(config_tmpfile))
-
-    # Cleanup acl config
-    duthost.command('sudo config acl remove table EVERFLOW')
-    duthost.command('sudo config acl remove table EVERFLOWV6')
-
-    yield
-
-    logger.info("Restoring config_db.json")
-    duthost.command("sudo cp {} /etc/sonic/config_db.json".format(config_tmpfile))
-    delete_tmpfile(duthost, config_tmpfile)
-
-     # Restore acl config
-    config_reload(duthost)
-
-
-@pytest.fixture(scope="module")
 def config_pbh_table_lag(duthost, lag_port_map):
     logging.info("Create PBH table: {}".format(TABLE_NAME))
     test_intfs_str = ",".join(lag_port_map.keys())

--- a/tests/ecmp/inner_hashing/conftest.py
+++ b/tests/ecmp/inner_hashing/conftest.py
@@ -10,8 +10,6 @@ from datetime import datetime
 import pytest
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory, change_mac_addresses   # lgtm[py/unused-import]
-from tests.common.config_reload import config_reload
-from tests.generic_config_updater.gu_utils import delete_tmpfile
 
 logger = logging.getLogger(__name__)
 

--- a/tests/ecmp/inner_hashing/test_inner_hashing.py
+++ b/tests/ecmp/inner_hashing/test_inner_hashing.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from retry.api import retry_call
 from tests.ptf_runner import ptf_runner
 from tests.ecmp.inner_hashing.conftest import get_src_dst_ip_range, FIB_INFO_FILE_DST,\
-    VXLAN_PORT, PTF_QLEN, check_pbh_counters, OUTER_ENCAP_FORMATS, GRE_KEY
+    VXLAN_PORT, PTF_QLEN, check_pbh_counters, OUTER_ENCAP_FORMATS, NVGRE_TNI
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ class TestDynamicInnerHashing():
                                "balancing_test_times": balancing_test_times,
                                "balancing_range": balancing_range,
                                "outer_encap_formats": OUTER_ENCAP_FORMATS,
-                               "gre_key": GRE_KEY,
+                               "nvgre_tni": NVGRE_TNI,
                                "symmetric_hashing": symmetric_hashing},
                        log_file=log_file,
                        qlen=PTF_QLEN,

--- a/tests/ecmp/inner_hashing/test_inner_hashing_lag.py
+++ b/tests/ecmp/inner_hashing/test_inner_hashing_lag.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from retry.api import retry_call
 from tests.ptf_runner import ptf_runner
 from tests.ecmp.inner_hashing.conftest import get_src_dst_ip_range, FIB_INFO_FILE_DST,\
-    VXLAN_PORT, PTF_QLEN, check_pbh_counters, OUTER_ENCAP_FORMATS, GRE_KEY
+    VXLAN_PORT, PTF_QLEN, check_pbh_counters, OUTER_ENCAP_FORMATS, NVGRE_TNI
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +25,8 @@ class TestDynamicInnerHashingLag():
 
     @pytest.fixture(scope="class", autouse=True)
     def setup_dynamic_pbh(self, request):
+        with allure.step('Setup ACL config'):
+            request.getfixturevalue("setup_acl_config")
         with allure.step('Add required LAG config'):
             request.getfixturevalue("config_lag_ports")
         with allure.step('Config Dynamic PBH'):
@@ -63,7 +65,7 @@ class TestDynamicInnerHashingLag():
                                "balancing_test_times": balancing_test_times,
                                "balancing_range": balancing_range,
                                "outer_encap_formats": OUTER_ENCAP_FORMATS,
-                               "gre_key" : GRE_KEY,
+                               "nvgre_tni": NVGRE_TNI,
                                "symmetric_hashing": symmetric_hashing},
                        log_file=log_file,
                        qlen=PTF_QLEN,

--- a/tests/ecmp/inner_hashing/test_inner_hashing_lag.py
+++ b/tests/ecmp/inner_hashing/test_inner_hashing_lag.py
@@ -21,12 +21,14 @@ pytestmark = [
 
 
 @pytest.mark.dynamic_config
-class TestDynamicInnerHashing():
+class TestDynamicInnerHashingLag():
 
     @pytest.fixture(scope="class", autouse=True)
     def setup_dynamic_pbh(self, request):
+        with allure.step('Add required LAG config'):
+            request.getfixturevalue("config_lag_ports")
         with allure.step('Config Dynamic PBH'):
-            request.getfixturevalue("config_pbh_table")
+            request.getfixturevalue("config_pbh_table_lag")
             request.getfixturevalue("config_hash_fields")
             request.getfixturevalue("config_hash")
             request.getfixturevalue("config_rules")
@@ -61,7 +63,7 @@ class TestDynamicInnerHashing():
                                "balancing_test_times": balancing_test_times,
                                "balancing_range": balancing_range,
                                "outer_encap_formats": OUTER_ENCAP_FORMATS,
-                               "gre_key": GRE_KEY,
+                               "gre_key" : GRE_KEY,
                                "symmetric_hashing": symmetric_hashing},
                        log_file=log_file,
                        qlen=PTF_QLEN,
@@ -71,36 +73,3 @@ class TestDynamicInnerHashing():
                    fargs=[duthost, outer_ipver, inner_ipver, balancing_test_times, symmetric_hashing, hash_keys],
                    tries=5,
                    delay=5)
-
-
-@pytest.mark.static_config
-class TestStaticInnerHashing():
-
-    def test_inner_hashing(self, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac, vlan_ptf_ports, symmetric_hashing):
-        logging.info("Executing static inner hash test for outer {} and inner {} with symmetric_hashing set to {}"
-                     .format(outer_ipver, inner_ipver, str(symmetric_hashing)))
-        timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
-        log_file = "/tmp/inner_hash_test.StaticInnerHashTest.{}.{}.{}.log".format(outer_ipver, inner_ipver, timestamp)
-        logging.info("PTF log file: %s" % log_file)
-
-        outer_src_ip_range, outer_dst_ip_range = get_src_dst_ip_range(outer_ipver)
-        inner_src_ip_range, inner_dst_ip_range = get_src_dst_ip_range(inner_ipver)
-
-        ptf_runner(ptfhost,
-                   "ptftests",
-                   "inner_hash_test.InnerHashTest",
-                   platform_dir="ptftests",
-                   params={"fib_info": FIB_INFO_FILE_DST,
-                           "router_mac": router_mac,
-                           "src_ports": vlan_ptf_ports,
-                           "hash_keys": hash_keys,
-                           "vxlan_port": VXLAN_PORT,
-                           "inner_src_ip_range": ",".join(inner_src_ip_range),
-                           "inner_dst_ip_range": ",".join(inner_dst_ip_range),
-                           "outer_src_ip_range": ",".join(outer_src_ip_range),
-                           "outer_dst_ip_range": ",".join(outer_dst_ip_range),
-                           "outer_encap_formats": OUTER_ENCAP_FORMATS,
-                           "symmetric_hashing": symmetric_hashing},
-                   log_file=log_file,
-                   qlen=PTF_QLEN,
-                   socket_recv_size=16384)

--- a/tests/ecmp/inner_hashing/test_inner_hashing_lag.py
+++ b/tests/ecmp/inner_hashing/test_inner_hashing_lag.py
@@ -25,8 +25,6 @@ class TestDynamicInnerHashingLag():
 
     @pytest.fixture(scope="class", autouse=True)
     def setup_dynamic_pbh(self, request):
-        with allure.step('Setup ACL config'):
-            request.getfixturevalue("setup_acl_config")
         with allure.step('Add required LAG config'):
             request.getfixturevalue("config_lag_ports")
         with allure.step('Config Dynamic PBH'):

--- a/tests/ecmp/inner_hashing/test_wr_inner_hashing.py
+++ b/tests/ecmp/inner_hashing/test_wr_inner_hashing.py
@@ -7,7 +7,7 @@ import allure
 from datetime import datetime
 from tests.common import reboot
 from tests.ecmp.inner_hashing.conftest import get_src_dst_ip_range, FIB_INFO_FILE_DST, VXLAN_PORT,\
-    PTF_QLEN, OUTER_ENCAP_FORMATS, GRE_KEY
+    PTF_QLEN, OUTER_ENCAP_FORMATS, NVGRE_TNI
 from tests.ptf_runner import ptf_runner
 
 logger = logging.getLogger(__name__)
@@ -22,6 +22,7 @@ class TestWRDynamicInnerHashing():
 
     @pytest.fixture(scope="class", autouse=True)
     def setup_dynamic_pbh(self, request):
+        request.getfixturevalue("save_config_teardown")
         with allure.step('Config Dynamic PBH'):
             request.getfixturevalue("config_pbh_table")
             request.getfixturevalue("config_hash_fields")
@@ -67,7 +68,7 @@ class TestWRDynamicInnerHashing():
                                "balancing_test_times": balancing_test_times,
                                "balancing_range": balancing_range,
                                "outer_encap_formats": outer_encap_format,
-                               "gre_key": GRE_KEY,
+                               "nvgre_tni": NVGRE_TNI,
                                "symmetric_hashing": symmetric_hashing},
                        log_file=log_file,
                        qlen=PTF_QLEN,

--- a/tests/ecmp/inner_hashing/test_wr_inner_hashing.py
+++ b/tests/ecmp/inner_hashing/test_wr_inner_hashing.py
@@ -2,11 +2,12 @@ import logging
 import threading
 import pytest
 import random
+import allure
 
 from datetime import datetime
 from tests.common import reboot
 from tests.ecmp.inner_hashing.conftest import get_src_dst_ip_range, FIB_INFO_FILE_DST, VXLAN_PORT,\
-    PTF_QLEN, OUTER_ENCAP_FORMATS
+    PTF_QLEN, OUTER_ENCAP_FORMATS, GRE_KEY
 from tests.ptf_runner import ptf_runner
 
 logger = logging.getLogger(__name__)
@@ -17,62 +18,65 @@ pytestmark = [
 ]
 
 @pytest.mark.dynamic_config
-class TestDynamicInnerHashing():
+class TestWRDynamicInnerHashing():
 
     @pytest.fixture(scope="class", autouse=True)
     def setup_dynamic_pbh(self, request):
-        request.getfixturevalue("config_pbh_table")
-        request.getfixturevalue("config_hash_fields")
-        request.getfixturevalue("config_hash")
-        request.getfixturevalue("config_rules")
+        with allure.step('Config Dynamic PBH'):
+            request.getfixturevalue("config_pbh_table")
+            request.getfixturevalue("config_hash_fields")
+            request.getfixturevalue("config_hash")
+            request.getfixturevalue("config_rules")
 
     def test_inner_hashing(self, duthost, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
                            vlan_ptf_ports, symmetric_hashing, localhost):
         logging.info("Executing warm boot dynamic inner hash test for outer {} and inner {} with symmetric_hashing"
                      " set to {}".format(outer_ipver, inner_ipver, str(symmetric_hashing)))
-        timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
-        log_file = "/tmp/wr_inner_hash_test.DynamicInnerHashTest.{}.{}.{}.log".format(outer_ipver, inner_ipver, timestamp)
-        logging.info("PTF log file: %s" % log_file)
+        with allure.step('Run ptf test InnerHashTest and warm-reboot in parallel'):
+            timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+            log_file = "/tmp/wr_inner_hash_test.DynamicInnerHashTest.{}.{}.{}.log".format(outer_ipver, inner_ipver, timestamp)
+            logging.info("PTF log file: %s" % log_file)
 
-        # to reduce test run time, check one of encapsulation formats
-        outer_encap_format = random.choice(OUTER_ENCAP_FORMATS).split()
-        logging.info("Tested encapsulation format: {}".format(outer_encap_format[0]))
+            # to reduce test run time, check one of encapsulation formats
+            outer_encap_format = random.choice(OUTER_ENCAP_FORMATS).split()
+            logging.info("Tested encapsulation format: {}".format(outer_encap_format[0]))
 
-        outer_src_ip_range, outer_dst_ip_range = get_src_dst_ip_range(outer_ipver)
-        inner_src_ip_range, inner_dst_ip_range = get_src_dst_ip_range(inner_ipver)
+            outer_src_ip_range, outer_dst_ip_range = get_src_dst_ip_range(outer_ipver)
+            inner_src_ip_range, inner_dst_ip_range = get_src_dst_ip_range(inner_ipver)
 
-        balancing_test_times = 200
-        balancing_range = 0.3
+            balancing_test_times = 200
+            balancing_range = 0.3
 
-        duthost.command('sudo config save -y')
-        reboot_thr = threading.Thread(target=reboot, args=(duthost, localhost, 'warm',))
-        reboot_thr.start()
+            duthost.command('sudo config save -y')
+            reboot_thr = threading.Thread(target=reboot, args=(duthost, localhost, 'warm',))
+            reboot_thr.start()
 
-        ptf_runner(ptfhost,
-                   "ptftests",
-                   "inner_hash_test.InnerHashTest",
-                   platform_dir="ptftests",
-                   params={"fib_info": FIB_INFO_FILE_DST,
-                           "router_mac": router_mac,
-                           "src_ports": vlan_ptf_ports,
-                           "hash_keys": hash_keys,
-                           "vxlan_port": VXLAN_PORT,
-                           "inner_src_ip_range": ",".join(inner_src_ip_range),
-                           "inner_dst_ip_range": ",".join(inner_dst_ip_range),
-                           "outer_src_ip_range": ",".join(outer_src_ip_range),
-                           "outer_dst_ip_range": ",".join(outer_dst_ip_range),
-                           "balancing_test_times": balancing_test_times,
-                           "balancing_range": balancing_range,
-                           "outer_encap_formats": outer_encap_format,
-                           "symmetric_hashing": symmetric_hashing},
-                   log_file=log_file,
-                   qlen=PTF_QLEN,
-                   socket_recv_size=16384)
-        reboot_thr.join()
+            ptf_runner(ptfhost,
+                       "ptftests",
+                       "inner_hash_test.InnerHashTest",
+                       platform_dir="ptftests",
+                       params={"fib_info": FIB_INFO_FILE_DST,
+                               "router_mac": router_mac,
+                               "src_ports": vlan_ptf_ports,
+                               "hash_keys": hash_keys,
+                               "vxlan_port": VXLAN_PORT,
+                               "inner_src_ip_range": ",".join(inner_src_ip_range),
+                               "inner_dst_ip_range": ",".join(inner_dst_ip_range),
+                               "outer_src_ip_range": ",".join(outer_src_ip_range),
+                               "outer_dst_ip_range": ",".join(outer_dst_ip_range),
+                               "balancing_test_times": balancing_test_times,
+                               "balancing_range": balancing_range,
+                               "outer_encap_formats": outer_encap_format,
+                               "gre_key": GRE_KEY,
+                               "symmetric_hashing": symmetric_hashing},
+                       log_file=log_file,
+                       qlen=PTF_QLEN,
+                       socket_recv_size=16384)
+            reboot_thr.join()
 
 
 @pytest.mark.static_config
-class TestStaticInnerHashing():
+class TestWRStaticInnerHashing():
 
     def test_inner_hashing(self, duthost, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
                            vlan_ptf_ports, symmetric_hashing, localhost):

--- a/tests/ecmp/inner_hashing/test_wr_inner_hashing.py
+++ b/tests/ecmp/inner_hashing/test_wr_inner_hashing.py
@@ -22,7 +22,6 @@ class TestWRDynamicInnerHashing():
 
     @pytest.fixture(scope="class", autouse=True)
     def setup_dynamic_pbh(self, request):
-        request.getfixturevalue("save_config_teardown")
         with allure.step('Config Dynamic PBH'):
             request.getfixturevalue("config_pbh_table")
             request.getfixturevalue("config_hash_fields")
@@ -48,7 +47,6 @@ class TestWRDynamicInnerHashing():
             balancing_test_times = 200
             balancing_range = 0.3
 
-            duthost.command('sudo config save -y')
             reboot_thr = threading.Thread(target=reboot, args=(duthost, localhost, 'warm',))
             reboot_thr.start()
 
@@ -90,7 +88,6 @@ class TestWRStaticInnerHashing():
         outer_src_ip_range, outer_dst_ip_range = get_src_dst_ip_range(outer_ipver)
         inner_src_ip_range, inner_dst_ip_range = get_src_dst_ip_range(inner_ipver)
 
-        duthost.command('sudo config save -y')
         reboot_thr = threading.Thread(target=reboot, args=(duthost, localhost, 'warm',))
         reboot_thr.start()
 

--- a/tests/ecmp/inner_hashing/test_wr_inner_hashing_lag.py
+++ b/tests/ecmp/inner_hashing/test_wr_inner_hashing_lag.py
@@ -7,7 +7,7 @@ import allure
 from datetime import datetime
 from tests.common import reboot
 from tests.ecmp.inner_hashing.conftest import get_src_dst_ip_range, FIB_INFO_FILE_DST, VXLAN_PORT,\
-    PTF_QLEN, OUTER_ENCAP_FORMATS, GRE_KEY
+    PTF_QLEN, OUTER_ENCAP_FORMATS, NVGRE_TNI
 from tests.ptf_runner import ptf_runner
 
 logger = logging.getLogger(__name__)
@@ -22,6 +22,8 @@ class TestWRDynamicInnerHashingLag():
 
     @pytest.fixture(scope="class", autouse=True)
     def setup_dynamic_pbh(self, request):
+        with allure.step('Setup ACL config'):
+            request.getfixturevalue("setup_acl_config")
         with allure.step('Add required LAG config'):
             request.getfixturevalue("config_lag_ports")
         with allure.step('Config Dynamic PBH'):
@@ -68,7 +70,7 @@ class TestWRDynamicInnerHashingLag():
                            "balancing_test_times": balancing_test_times,
                            "balancing_range": balancing_range,
                            "outer_encap_formats": outer_encap_format,
-                           "gre_key": GRE_KEY,
+                           "nvgre_tni": NVGRE_TNI,
                            "symmetric_hashing": symmetric_hashing},
                    log_file=log_file,
                    qlen=PTF_QLEN,

--- a/tests/ecmp/inner_hashing/test_wr_inner_hashing_lag.py
+++ b/tests/ecmp/inner_hashing/test_wr_inner_hashing_lag.py
@@ -22,8 +22,6 @@ class TestWRDynamicInnerHashingLag():
 
     @pytest.fixture(scope="class", autouse=True)
     def setup_dynamic_pbh(self, request):
-        with allure.step('Setup ACL config'):
-            request.getfixturevalue("setup_acl_config")
         with allure.step('Add required LAG config'):
             request.getfixturevalue("config_lag_ports")
         with allure.step('Config Dynamic PBH'):
@@ -50,7 +48,6 @@ class TestWRDynamicInnerHashingLag():
         balancing_test_times = 200
         balancing_range = 0.3
 
-        duthost.command('sudo config save -y')
         reboot_thr = threading.Thread(target=reboot, args=(duthost, localhost, 'warm',))
         reboot_thr.start()
 

--- a/tests/ecmp/inner_hashing/test_wr_inner_hashing_lag.py
+++ b/tests/ecmp/inner_hashing/test_wr_inner_hashing_lag.py
@@ -1,0 +1,76 @@
+import logging
+import threading
+import pytest
+import random
+import allure
+
+from datetime import datetime
+from tests.common import reboot
+from tests.ecmp.inner_hashing.conftest import get_src_dst_ip_range, FIB_INFO_FILE_DST, VXLAN_PORT,\
+    PTF_QLEN, OUTER_ENCAP_FORMATS, GRE_KEY
+from tests.ptf_runner import ptf_runner
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('t0'),
+    pytest.mark.asic('mellanox')
+]
+
+@pytest.mark.dynamic_config
+class TestWRDynamicInnerHashingLag():
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_dynamic_pbh(self, request):
+        with allure.step('Add required LAG config'):
+            request.getfixturevalue("config_lag_ports")
+        with allure.step('Config Dynamic PBH'):
+            request.getfixturevalue("config_pbh_table_lag")
+            request.getfixturevalue("config_hash_fields")
+            request.getfixturevalue("config_hash")
+            request.getfixturevalue("config_rules")
+
+    def test_inner_hashing(self, duthost, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
+                           vlan_ptf_ports, symmetric_hashing, localhost):
+        logging.info("Executing warm boot dynamic inner hash test for outer {} and inner {} with symmetric_hashing"
+                     " set to {}".format(outer_ipver, inner_ipver, str(symmetric_hashing)))
+        timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+        log_file = "/tmp/wr_inner_hash_test.DynamicInnerHashTest.{}.{}.{}.log".format(outer_ipver, inner_ipver, timestamp)
+        logging.info("PTF log file: %s" % log_file)
+
+        # to reduce test run time, check one of encapsulation formats
+        outer_encap_format = random.choice(OUTER_ENCAP_FORMATS).split()
+        logging.info("Tested encapsulation format: {}".format(outer_encap_format[0]))
+
+        outer_src_ip_range, outer_dst_ip_range = get_src_dst_ip_range(outer_ipver)
+        inner_src_ip_range, inner_dst_ip_range = get_src_dst_ip_range(inner_ipver)
+
+        balancing_test_times = 200
+        balancing_range = 0.3
+
+        duthost.command('sudo config save -y')
+        reboot_thr = threading.Thread(target=reboot, args=(duthost, localhost, 'warm',))
+        reboot_thr.start()
+
+        ptf_runner(ptfhost,
+                   "ptftests",
+                   "inner_hash_test.InnerHashTest",
+                   platform_dir="ptftests",
+                   params={"fib_info": FIB_INFO_FILE_DST,
+                           "router_mac": router_mac,
+                           "src_ports": vlan_ptf_ports,
+                           "hash_keys": hash_keys,
+                           "vxlan_port": VXLAN_PORT,
+                           "inner_src_ip_range": ",".join(inner_src_ip_range),
+                           "inner_dst_ip_range": ",".join(inner_dst_ip_range),
+                           "outer_src_ip_range": ",".join(outer_src_ip_range),
+                           "outer_dst_ip_range": ",".join(outer_dst_ip_range),
+                           "balancing_test_times": balancing_test_times,
+                           "balancing_range": balancing_range,
+                           "outer_encap_formats": outer_encap_format,
+                           "gre_key": GRE_KEY,
+                           "symmetric_hashing": symmetric_hashing},
+                   log_file=log_file,
+                   qlen=PTF_QLEN,
+                   socket_recv_size=16384)
+        reboot_thr.join()


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
Extension of PBH tests.
Added coverage of multiple interface types(LAG) and all possible match fields in pbh_rule.

added 2 new tests: test_inner_hashing_lag.py, test_wr_inner_hashing_lag.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Full coverage of the feature

#### How did you do it?

#### How did you verify/test it?
All tests executed on a testbed with t0 topo


#### Supported testbed topology if it's a new test case?
t0

