### PR TITLE
egress Everflow tests: added a missing destination route for original flow

### DIFF
--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -91,8 +91,11 @@ class EverflowIPv4Tests(BaseEverflowTest):
         duthost.shell(duthost.get_vtysh_cmd_for_namespace("vtysh -c \"config\" -c \"router bgp\" -c \"address-family ipv4\" -c \"no redistribute static\"",setup_info[request.param]["namespace"]))
         time.sleep(15)
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def add_dest_routes(self, duthosts, rand_one_dut_hostname, setup_info, tbinfo, dest_port_type):
+        if self.acl_stage() != 'egress':
+            yield
+            return
         duthost = duthosts[rand_one_dut_hostname]
 
         default_traffic_port_type = "tor" if dest_port_type == "spine" else "spine"
@@ -109,7 +112,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         everflow_utils.remove_route(duthost, dst_mask, nexthop_ip, ns)
 
 
-    def test_everflow_basic_forwarding(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo, add_dest_routes):
+    def test_everflow_basic_forwarding(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
         """
         Verify basic forwarding scenarios for the Everflow feature.
 

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -91,8 +91,25 @@ class EverflowIPv4Tests(BaseEverflowTest):
         duthost.shell(duthost.get_vtysh_cmd_for_namespace("vtysh -c \"config\" -c \"router bgp\" -c \"address-family ipv4\" -c \"no redistribute static\"",setup_info[request.param]["namespace"]))
         time.sleep(15)
 
+    @pytest.fixture
+    def add_dest_routes(self, duthosts, rand_one_dut_hostname, setup_info, tbinfo, dest_port_type):
+        duthost = duthosts[rand_one_dut_hostname]
 
-    def test_everflow_basic_forwarding(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo):
+        default_traffic_port_type = "tor" if dest_port_type == "spine" else "spine"
+        rx_port = setup_info[default_traffic_port_type]["dest_port"][0]
+        nexthop_ip = everflow_utils.get_neighbor_info(duthost, rx_port, tbinfo)
+        
+        ns = setup_info[default_traffic_port_type]["namespace"]
+        dst_mask = "30.0.0.0/28"
+
+        everflow_utils.add_route(duthost, dst_mask, nexthop_ip, ns)
+
+        yield
+
+        everflow_utils.remove_route(duthost, dst_mask, nexthop_ip, ns)
+
+
+    def test_everflow_basic_forwarding(self, duthosts, rand_one_dut_hostname, setup_info, setup_mirror_session, dest_port_type, ptfadapter, tbinfo, add_dest_routes):
         """
         Verify basic forwarding scenarios for the Everflow feature.
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: egress Everflow tests - added a missing destination route for original flow
Fixes # (issue)
- added a missing destination route
Tests checking the Everflow feature on egress stage rely on a default static route to forward original flow packets but the route [was removed recently](https://github.com/Azure/sonic-buildimage/pull/9182) from SONiC causing packets drop. This prevents Everflow on egress to happen so tests fail expecting mirrored packets. The required route was setup to fix it
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix failing egress Everflow tests
#### How did you do it?
Setup the required route for original packet flow
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t1,any test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror -k test_everflow_basic_forwarding
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
