### PR TITLE
[iface_namingmode]: Fix regex in show interfaces counters test case

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -256,7 +256,7 @@ class TestShowInterfaces():
         as per the configured naming mode
         """
         dutHostGuest, mode, ifmode = setup_config_mode
-        regex_int = re.compile(r'(\S+)(\w)(\d+)')
+        regex_int = re.compile(r'(\S+)(\d+)')
         interfaces = list()
 
         show_intf_counter = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show interfaces counter'.format(ifmode))
@@ -265,7 +265,7 @@ class TestShowInterfaces():
         for line in show_intf_counter['stdout_lines']:
             line = line.strip()
             if regex_int.match(line):
-                interfaces.append(regex_int.match(line).group(1))
+                interfaces.append(regex_int.match(line).group(0))
 
         assert(len(interfaces) > 0)
 

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -256,7 +256,7 @@ class TestShowInterfaces():
         as per the configured naming mode
         """
         dutHostGuest, mode, ifmode = setup_config_mode
-        regex_int = re.compile(r'(\S+)\s+(\w)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\d+)\s+(\d+)\s+(\d+)')
+        regex_int = re.compile(r'(\S+)(\w)(\d+)')
         interfaces = list()
 
         show_intf_counter = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show interfaces counter'.format(ifmode))
@@ -266,6 +266,8 @@ class TestShowInterfaces():
             line = line.strip()
             if regex_int.match(line):
                 interfaces.append(regex_int.match(line).group(1))
+
+        assert(len(interfaces) > 0)
 
         for item in interfaces:
             if mode == 'alias':


### PR DESCRIPTION
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
show interfaces counters was not testing the output lines correctly as the regex match was not matching any
of the output lines. Ideally the regex should match with all output lines except the header lines. 

#### How did you do it?
This fix is to fix the regex expression so that the interfaces list is generated correctly.
Also add an additional assert to ensure interfaces list is generated.
The regex expression will match a string of the format: (Any non-space character followed by any numbers) and this should match all Interface names in default or alias mode.

#### How did you verify/test it?
Run this test on KVM testbed with T0 topology.
pytest --testbed=vms-kvm-t0 --inventory=veos_vtb --testbed_file=vtestbed.csv --host-pattern=vlab-01 --module-path=../ansible/library "iface_namingmode/test_iface_namingmode.py" --show-capture=no --disable_loganalyzer --skip_sanity -v
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================ test session starts =============================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.17', 'Platform': 'Linux-5.4.0-1063-azure-x86_64-with-Ubuntu-18.04-bionic', 'Packages': {'py': '1.10.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.9.1', u'ansible': u'2.2.2', u'xdist': u'1.28.0', u'html': u'1.22.1', u'forked': u'1.3.0', u'metadata': u'1.11.0'}}
ansible: 2.8.12
rootdir: /data/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, html-1.22.1, repeat-0.9.1, xdist-1.28.0, ansible-2.2.2
collecting ... ['conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut', 'inv_name', 'auto_recover', 'comment']
Finished testbed info generating.
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 60 items                                                                                                                                                           

iface_namingmode/test_iface_namingmode.py::TestShowLLDP::test_show_lldp_table[alias-vlab-01] PASSED                                                                    [  1%]
iface_namingmode/test_iface_namingmode.py::TestShowLLDP::test_show_lldp_neighbor[alias-vlab-01] PASSED                                                                 [  3%]
iface_namingmode/test_iface_namingmode.py::TestShowInterfaces::test_show_interfaces_counter[alias-vlab-01] PASSED                                                      [  5%]
iface_namingmode/test_iface_namingmode.py::TestShowInterfaces::test_show_interfaces_description[alias-vlab-01] PASSED                                                  [  6%]
iface_namingmode/test_iface_namingmode.py::TestShowInterfaces::test_show_interfaces_status[alias-vlab-01] PASSED                                                       [  8%]
iface_namingmode/test_iface_namingmode.py::TestShowInterfaces::test_show_interfaces_portchannel[alias-vlab-01] PASSED                                                  [ 10%]
iface_namingmode/test_iface_namingmode.py::test_show_pfc_counters[alias-vlab-01] PASSED                                                                                [ 11%]
iface_namingmode/test_iface_namingmode.py::TestShowPriorityGroup::test_show_priority_group_persistent_watermark_headroom[alias-vlab-01] PASSED                         [ 13%]
iface_namingmode/test_iface_namingmode.py::TestShowPriorityGroup::test_show_priority_group_persistent_watermark_shared[alias-vlab-01] PASSED                           [ 15%]
iface_namingmode/test_iface_namingmode.py::TestShowPriorityGroup::test_show_priority_group_watermark_headroom[alias-vlab-01] PASSED                                    [ 16%]
iface_namingmode/test_iface_namingmode.py::TestShowPriorityGroup::test_show_priority_group_watermark_shared[alias-vlab-01] PASSED                                      [ 18%]
iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_counters[alias-vlab-01] PASSED                                                               [ 20%]
iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_counters_interface[alias-vlab-01] PASSED                                                     [ 21%]
iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_persistent_watermark_multicast[alias-vlab-01] PASSED                                         [ 23%]
iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_persistent_watermark_unicast[alias-vlab-01] PASSED                                           [ 25%]
iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_watermark_multicast[alias-vlab-01] PASSED                                                    [ 26%]
iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_watermark_unicast[alias-vlab-01] PASSED                                                      [ 28%]
iface_namingmode/test_iface_namingmode.py::TestShowVlan::test_show_vlan_brief[alias-vlab-01] PASSED                                                                    [ 30%]
iface_namingmode/test_iface_namingmode.py::TestShowVlan::test_show_vlan_config[alias-vlab-01] PASSED                                                                   [ 31%]
iface_namingmode/test_iface_namingmode.py::TestConfigInterface::test_config_interface_ip[alias-vlab-01] SKIPPED                                                        [ 33%]
iface_namingmode/test_iface_namingmode.py::TestConfigInterface::test_config_interface_state[alias-vlab-01] SKIPPED                                                     [ 35%]
iface_namingmode/test_iface_namingmode.py::TestConfigInterface::test_config_interface_speed[alias-vlab-01] SKIPPED                                                     [ 36%]
iface_namingmode/test_iface_namingmode.py::test_show_acl_table[alias-vlab-01] SKIPPED                                                                                  [ 38%]
iface_namingmode/test_iface_namingmode.py::test_show_interfaces_neighbor_expected[alias-vlab-01] SKIPPED                                                               [ 40%]
iface_namingmode/test_iface_namingmode.py::TestNeighbors::test_show_arp[alias-vlab-01] SKIPPED                                                                         [ 41%]
iface_namingmode/test_iface_namingmode.py::TestNeighbors::test_show_ndp[alias-vlab-01] SKIPPED                                                                         [ 43%]
iface_namingmode/test_iface_namingmode.py::TestShowIP::test_show_ip_interface[alias-vlab-01] SKIPPED                                                                   [ 45%]
iface_namingmode/test_iface_namingmode.py::TestShowIP::test_show_ipv6_interface[alias-vlab-01] SKIPPED                                                                 [ 46%]
iface_namingmode/test_iface_namingmode.py::TestShowIP::test_show_ip_route_v4[alias-vlab-01] SKIPPED                                                                    [ 48%]
iface_namingmode/test_iface_namingmode.py::TestShowIP::test_show_ip_route_v6[alias-vlab-01] SKIPPED                                                                    [ 50%]
iface_namingmode/test_iface_namingmode.py::TestShowLLDP::test_show_lldp_table[default-vlab-01] PASSED                                                                  [ 51%]
iface_namingmode/test_iface_namingmode.py::TestShowLLDP::test_show_lldp_neighbor[default-vlab-01] PASSED                                                               [ 53%]
iface_namingmode/test_iface_namingmode.py::TestShowInterfaces::test_show_interfaces_counter[default-vlab-01] PASSED                                                    [ 55%]
iface_namingmode/test_iface_namingmode.py::TestShowInterfaces::test_show_interfaces_description[default-vlab-01] PASSED                                                [ 56%]
iface_namingmode/test_iface_namingmode.py::TestShowInterfaces::test_show_interfaces_status[default-vlab-01] PASSED                                                     [ 58%]
iface_namingmode/test_iface_namingmode.py::TestShowInterfaces::test_show_interfaces_portchannel[default-vlab-01] PASSED                                                [ 60%]
iface_namingmode/test_iface_namingmode.py::test_show_pfc_counters[default-vlab-01] PASSED                                                                              [ 61%]
iface_namingmode/test_iface_namingmode.py::TestShowPriorityGroup::test_show_priority_group_persistent_watermark_headroom[default-vlab-01] PASSED                       [ 63%]
iface_namingmode/test_iface_namingmode.py::TestShowPriorityGroup::test_show_priority_group_persistent_watermark_shared[default-vlab-01] PASSED                         [ 65%]
iface_namingmode/test_iface_namingmode.py::TestShowPriorityGroup::test_show_priority_group_watermark_headroom[default-vlab-01] PASSED                                  [ 66%]
iface_namingmode/test_iface_namingmode.py::TestShowPriorityGroup::test_show_priority_group_watermark_shared[default-vlab-01] PASSED                                    [ 68%]
iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_counters[default-vlab-01] PASSED                                                             [ 70%]
iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_counters_interface[default-vlab-01] PASSED                                                   [ 71%]
iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_persistent_watermark_multicast[default-vlab-01] PASSED                                       [ 73%]
iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_persistent_watermark_unicast[default-vlab-01] PASSED                                         [ 75%]
iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_watermark_multicast[default-vlab-01] PASSED                                                  [ 76%]
iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_watermark_unicast[default-vlab-01] PASSED                                                    [ 78%]
iface_namingmode/test_iface_namingmode.py::TestShowVlan::test_show_vlan_brief[default-vlab-01] PASSED                                                                  [ 80%]
iface_namingmode/test_iface_namingmode.py::TestShowVlan::test_show_vlan_config[default-vlab-01] PASSED                                                                 [ 81%]
iface_namingmode/test_iface_namingmode.py::TestConfigInterface::test_config_interface_ip[default-vlab-01] SKIPPED                                                      [ 83%]
iface_namingmode/test_iface_namingmode.py::TestConfigInterface::test_config_interface_state[default-vlab-01] SKIPPED                                                   [ 85%]
iface_namingmode/test_iface_namingmode.py::TestConfigInterface::test_config_interface_speed[default-vlab-01] SKIPPED                                                   [ 86%]
iface_namingmode/test_iface_namingmode.py::test_show_acl_table[default-vlab-01] SKIPPED                                                                                [ 88%]
iface_namingmode/test_iface_namingmode.py::test_show_interfaces_neighbor_expected[default-vlab-01] SKIPPED                                                             [ 90%]
iface_namingmode/test_iface_namingmode.py::TestNeighbors::test_show_arp[default-vlab-01] SKIPPED                                                                       [ 91%]
iface_namingmode/test_iface_namingmode.py::TestNeighbors::test_show_ndp[default-vlab-01] SKIPPED                                                                       [ 93%]
iface_namingmode/test_iface_namingmode.py::TestShowIP::test_show_ip_interface[default-vlab-01] SKIPPED                                                                 [ 95%]
iface_namingmode/test_iface_namingmode.py::TestShowIP::test_show_ipv6_interface[default-vlab-01] SKIPPED                                                               [ 96%]
iface_namingmode/test_iface_namingmode.py::TestShowIP::test_show_ip_route_v4[default-vlab-01] SKIPPED                                                                  [ 98%]
iface_namingmode/test_iface_namingmode.py::TestShowIP::test_show_ip_route_v6[default-vlab-01] SKIPPED                                                                  [100%]

============================================================================== warnings summary ==============================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================================ 38 passed, 22 skipped, 1 warnings in 200.39 seconds =============================================================
sumeenak@a63ad7d92012:/data/sonic-mgmt/tests$ 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
