### PR TITLE
Auto collect DB dump when test failed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1288,7 +1288,7 @@ def duts_minigraph_facts(duthosts, tbinfo):
     """
     return duthosts.get_extended_minigraph_facts(tbinfo)
 
-def collect_db_dump_on_duts(request, duthosts, duthost):
+def collect_db_dump_on_duts(request, duthosts):
     '''
         When test failed, teardown of this fixture will dump all the DB and collect to the test servers
     '''
@@ -1299,7 +1299,7 @@ def collect_db_dump_on_duts(request, duthosts, duthost):
 
         # Collect DB config
         dbs = {}
-        result = duthost.shell("cat /var/run/redis/sonic-db/database_config.json")
+        result = duthosts[0].shell("cat /var/run/redis/sonic-db/database_config.json")
         logger.debug("db_config: {}".format(result['stdout']))
         db_config = json.loads(result['stdout'])
         for db in db_config['DATABASES']:
@@ -1319,4 +1319,4 @@ def collect_db_dump(request, duthosts):
         When test failed, teardown of this fixture will dump all the DB and collect to the test servers
     '''
     yield
-    collect_db_dump_on_duts(request, duthosts, duthosts[0])
+    collect_db_dump_on_duts(request, duthosts)


### PR DESCRIPTION
Signed-off-by: Yuxuan Ye <yuxuanye@microsoft.com>

### Description of PR

Collect DB dump when test failed

Summary:
Fixes #(issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

Collect DB dump when test failed

#### How did you do it?

Add a common fixture `collect_db_dump` set as autouse. When test failed, all of the DBs will be dumped, collected and sent to the test server

#### How did you verify/test it?

Failed a test and check the collection

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 