### PR TITLE
change mgmt IP of vlab-02 to avoid the duplication with ptf-01

### DIFF
--- a/ansible/lab
+++ b/ansible/lab
@@ -103,7 +103,7 @@ sonic_s6100:
     lab-s6100-01:
       ansible_host: 10.251.0.190
     vlab-02:
-      ansible_host: 10.250.0.102
+      ansible_host: 10.250.0.114
 
 sonic_a7260:
   vars:

--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -76,7 +76,7 @@ all:
           ansible_password: password
           ansible_user: admin
         vlab-02:
-          ansible_host: 10.250.0.102
+          ansible_host: 10.250.0.114
           ansible_hostv6: fec0::ffff:afa:2
           type: kvm
           hwsku: Force10-S6100


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The mgmt IP of vlab-02 is duplicated with mgmt IP of ptf-01 in veos_vtb inventory file for topo t0-64. Both of them are 10.250.0.102

#### How did you do it?
Choose the mgmt IP of vlab-02 to “10.250.0.114” which is not used by any host/server.
Update the mgmt IP of vlab-02 in ansible/lab as well.

#### How did you verify/test it?
Deploy vms-kvm-t0-64 in kvm testbed and run test cases.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
