### PR TITLE
split kvmtest-t0 job into two parts for Azure.sonic-mgmt pipeline

### DIFF
--- a/.azure-pipelines/run-test-template.yml
+++ b/.azure-pipelines/run-test-template.yml
@@ -9,6 +9,8 @@ parameters:
   type: string
 - name: vmtype
   type: string
+- name: section
+  type: string
 
 steps:
 - script: |
@@ -53,7 +55,7 @@ steps:
 
     rm -rf $(Build.ArtifactStagingDirectory)/*
     parent_dir=$(basename $PWD)
-    docker exec sonic-mgmt-2 bash -c "/var/src/$parent_dir/tests/kvmtest.sh -en -T ${{ parameters.tbtype }} -d /var/src/$parent_dir ${{ parameters.tbname }} ${{ parameters.dut }}"
+    docker exec sonic-mgmt-2 bash -c "/var/src/$parent_dir/tests/kvmtest.sh -en -T ${{ parameters.tbtype }} -d /var/src/$parent_dir ${{ parameters.tbname }} ${{ parameters.dut }} ${{ parameters.section }}"
   displayName: "Run tests"
 
 - script: |

--- a/.azure-pipelines/run-test-template.yml
+++ b/.azure-pipelines/run-test-template.yml
@@ -11,6 +11,7 @@ parameters:
   type: string
 - name: section
   type: string
+  defaultValue: ''
 
 steps:
 - script: |

--- a/.azure-pipelines/run-test-template.yml
+++ b/.azure-pipelines/run-test-template.yml
@@ -11,7 +11,7 @@ parameters:
   type: string
 - name: section
   type: string
-  defaultValue: ''
+  default: ''
 
 steps:
 - script: |

--- a/.azure-pipelines/run-test-template.yml
+++ b/.azure-pipelines/run-test-template.yml
@@ -86,17 +86,17 @@ steps:
   condition: succeededOrFailed()
 
 - publish: $(Build.ArtifactStagingDirectory)/kvmdump
-  artifact: sonic-buildimage.kvmtest.${{ parameters.tbtype}}${{ parameters.section}}.memdump@$(System.JobAttempt)
+  artifact: sonic-buildimage.kvmtest.${{ parameters.tbtype}}${{ parameters.section }}.memdump@$(System.JobAttempt)
   displayName: "Archive sonic kvm memdump"
   condition: failed()
 
 - publish: $(Build.ArtifactStagingDirectory)/logs
-  artifact: sonic-buildimage.kvmtest.${{ parameters.tbtype }}${{ parameters.section}}.log@$(System.JobAttempt)
+  artifact: sonic-buildimage.kvmtest.${{ parameters.tbtype }}${{ parameters.section }}.log@$(System.JobAttempt)
   displayName: "Archive sonic kvm logs"
   condition: succeededOrFailed()
 
 - task: PublishTestResults@2
   inputs:
     testResultsFiles: '$(Build.ArtifactStagingDirectory)/logs/**/*.xml'
-    testRunTitle: kvmtest.${{ parameters.tbtype }}${{ parameters.section}}
+    testRunTitle: kvmtest.${{ parameters.tbtype }}${{ parameters.section }}
   condition: succeededOrFailed()

--- a/.azure-pipelines/run-test-template.yml
+++ b/.azure-pipelines/run-test-template.yml
@@ -86,17 +86,17 @@ steps:
   condition: succeededOrFailed()
 
 - publish: $(Build.ArtifactStagingDirectory)/kvmdump
-  artifact: sonic-buildimage.kvmtest.${{ parameters.tbtype}}.memdump@$(System.JobAttempt)
+  artifact: sonic-buildimage.kvmtest.${{ parameters.tbtype}}${{ parameters.section}}.memdump@$(System.JobAttempt)
   displayName: "Archive sonic kvm memdump"
   condition: failed()
 
 - publish: $(Build.ArtifactStagingDirectory)/logs
-  artifact: sonic-buildimage.kvmtest.${{ parameters.tbtype }}.log@$(System.JobAttempt)
+  artifact: sonic-buildimage.kvmtest.${{ parameters.tbtype }}${{ parameters.section}}.log@$(System.JobAttempt)
   displayName: "Archive sonic kvm logs"
   condition: succeededOrFailed()
 
 - task: PublishTestResults@2
   inputs:
     testResultsFiles: '$(Build.ArtifactStagingDirectory)/logs/**/*.xml'
-    testRunTitle: kvmtest.${{ parameters.tbtype }}
+    testRunTitle: kvmtest.${{ parameters.tbtype }}${{ parameters.section}}
   condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ stages:
   jobs:
   - job:
     pool: sonictest
-    displayName: "kvmtest-t0"
+    displayName: "kvmtest-t0-part1"
     timeoutInMinutes: 400
 
     steps:
@@ -31,6 +31,22 @@ stages:
         ptf_name: ptf_vms6-1
         tbtype: t0
         vmtype: ceos
+        section: part-1
+
+  - job:
+    pool: sonictest
+    displayName: "kvmtest-t0-part2"
+    timeoutInMinutes: 400
+
+    steps:
+    - template: .azure-pipelines/run-test-template.yml
+      parameters:
+        dut: vlab-01
+        tbname: vms-kvm-t0
+        ptf_name: ptf_vms6-1
+        tbtype: t0
+        vmtype: ceos
+        section: part-2
 
   - job:
     pool: sonictest-t1-lag

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,19 +18,6 @@ stages:
     value: vtestbed.csv
 
   jobs:
-  - job:
-    displayName: "kvmtest-t0"
-    timeoutInMinutes: 400
-    dependsOn:
-      - t0-part1
-      - t0-part2
-    condition: |
-      and
-      (
-        in(dependencies.t0-part1.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
-        in(dependencies.t0-part2.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
-      )
-
   - job: t0-part1
     pool: sonictest
     displayName: "kvmtest-t0-part1"
@@ -60,6 +47,19 @@ stages:
         tbtype: t0
         vmtype: ceos
         section: part-2
+
+  - job:
+    displayName: "kvmtest-t0"
+    timeoutInMinutes: 400
+    dependsOn:
+      - t0-part1
+      - t0-part2
+    condition: |
+      and
+      (
+        in(dependencies.t0-part1.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
+        in(dependencies.t0-part2.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+      )
 
   - job:
     pool: sonictest-t1-lag

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ stages:
     value: vtestbed.csv
 
   jobs:
-  - job: t0-part1
+  - job: part1
     pool: sonictest
     displayName: "kvmtest-t0-part1"
     timeoutInMinutes: 200
@@ -33,7 +33,7 @@ stages:
         vmtype: ceos
         section: part-1
 
-  - job: t0-part2
+  - job: part2
     pool: sonictest
     displayName: "kvmtest-t0-part2"
     timeoutInMinutes: 200
@@ -52,14 +52,28 @@ stages:
     displayName: "kvmtest-t0"
     timeoutInMinutes: 400
     dependsOn:
-      - t0-part1
-      - t0-part2
-    condition: |
-      and
-      (
-        in(dependencies.t0-part1.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
-        in(dependencies.t0-part2.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
-      )
+    - part1
+    - part2
+    variables:
+      resultOfPart1: $[ dependencies.part1.result ]
+      resultOfPart2: $[ dependencies.part2.result ]
+
+    steps:
+    - script: 'echo "Both job kvemtest-t0-part1 and kvemtest-t0-part2 are passed."'
+      condition: |
+        and
+        (
+          in(variables.resultOfPart1, 'Succeeded'),
+          in(variables.resultOfPart2, 'Succeeded')
+        )
+
+    - script: 'echo "Either job kvemtest-t0-part1 or job kvemtest-t0-part2 failed! Please check the detailed information." ; exit 1'
+      condition: |
+        or
+        (
+          notIn(variables.resultOfPart1, 'Succeeded'),
+          notIn(variables.resultOfPart2, 'Succeeded')
+        )
 
   - job:
     pool: sonictest-t1-lag

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,7 @@ stages:
     dependsOn:
     - t0_part1
     - t0_part2
+    condition: always()
     variables:
       resultOfPart1: $[ dependencies.t0_part1.result ]
       resultOfPart2: $[ dependencies.t0_part2.result ]
@@ -62,10 +63,10 @@ stages:
     steps:
     - script: |
         if [ $(resultOfPart1) == "Succeeded" ] && [ $(resultOfPart2) == "Succeeded" ]; then
-          echo "Both job kvemtest-t0-part1 and kvemtest-t0-part2 are passed."
+          echo "Both job kvmtest-t0-part1 and kvmtest-t0-part2 are passed."
           exit 0
         else
-          echo "Run kvmtest-t0 failed!Either job kvemtest-t0-part1 or job kvemtest-t0-part2 failed! Please check the detailed information."
+          echo "Either job kvmtest-t0-part1 or job kvmtest-t0-part2 failed! Please check the detailed information."
           exit 1
         fi
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,19 @@ stages:
 
   jobs:
   - job:
+    displayName: "kvmtest-t0"
+    timeoutInMinutes: 400
+    dependsOn:
+      - t0-part1
+      - t0-part2
+    condition: |
+      and
+      (
+        in(dependencies.t0-part1.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
+        in(dependencies.t0-part2.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+      )
+
+  - job: t0-part1
     pool: sonictest
     displayName: "kvmtest-t0-part1"
     timeoutInMinutes: 200
@@ -33,7 +46,7 @@ stages:
         vmtype: ceos
         section: part-1
 
-  - job:
+  - job: t0-part2
     pool: sonictest
     displayName: "kvmtest-t0-part2"
     timeoutInMinutes: 200

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ stages:
     value: vtestbed.csv
 
   jobs:
-  - job: part1
+  - job: t0_part1
     pool: sonictest
     displayName: "kvmtest-t0-part1"
     timeoutInMinutes: 200
@@ -33,7 +33,7 @@ stages:
         vmtype: ceos
         section: part-1
 
-  - job: part2
+  - job: t0_part2
     pool: sonictest
     displayName: "kvmtest-t0-part2"
     timeoutInMinutes: 200
@@ -49,31 +49,25 @@ stages:
         section: part-2
 
   - job:
+    pool: sonictest
     displayName: "kvmtest-t0"
     timeoutInMinutes: 400
     dependsOn:
-    - part1
-    - part2
+    - t0_part1
+    - t0_part2
     variables:
-      resultOfPart1: $[ dependencies.part1.result ]
-      resultOfPart2: $[ dependencies.part2.result ]
+      resultOfPart1: $[ dependencies.t0_part1.result ]
+      resultOfPart2: $[ dependencies.t0_part2.result ]
 
     steps:
-    - script: 'echo "Both job kvemtest-t0-part1 and kvemtest-t0-part2 are passed."'
-      condition: |
-        and
-        (
-          in(variables.resultOfPart1, 'Succeeded'),
-          in(variables.resultOfPart2, 'Succeeded')
-        )
-
-    - script: 'echo "Either job kvemtest-t0-part1 or job kvemtest-t0-part2 failed! Please check the detailed information." ; exit 1'
-      condition: |
-        or
-        (
-          notIn(variables.resultOfPart1, 'Succeeded'),
-          notIn(variables.resultOfPart2, 'Succeeded')
-        )
+    - script: |
+        if [ $(resultOfPart1) == "Succeeded" ] && [ $(resultOfPart2) == "Succeeded" ]; then
+          echo "Both job kvemtest-t0-part1 and kvemtest-t0-part2 are passed."
+          exit 0
+        else
+          echo "Run kvmtest-t0 failed!Either job kvemtest-t0-part1 or job kvemtest-t0-part2 failed! Please check the detailed information."
+          exit 1
+        fi
 
   - job:
     pool: sonictest-t1-lag

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ stages:
   - job:
     pool: sonictest
     displayName: "kvmtest-t0-part1"
-    timeoutInMinutes: 400
+    timeoutInMinutes: 200
 
     steps:
     - template: .azure-pipelines/run-test-template.yml
@@ -36,7 +36,7 @@ stages:
   - job:
     pool: sonictest
     displayName: "kvmtest-t0-part2"
-    timeoutInMinutes: 400
+    timeoutInMinutes: 200
 
     steps:
     - template: .azure-pipelines/run-test-template.yml

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -71,6 +71,7 @@ fi
 
 tbname=$1
 dut=$2
+section=$3
 
 RUNTEST_CLI_COMMON_OPTS="\
 -i $inventory \
@@ -93,71 +94,79 @@ test_t0() {
     # Run tests_1vlan on vlab-01 virtual switch
     # TODO: Use a marker to select these tests rather than providing a hard-coded list here.
     tgname=1vlan
-    tests="\
-    monit/test_monit_status.py \
-    platform_tests/test_advanced_reboot.py \
-    test_interfaces.py \
-    arp/test_arp_dualtor.py \
-    bgp/test_bgp_fact.py \
-    bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved \
-    bgp/test_bgp_speaker.py \
-    bgp/test_bgp_update_timer.py \
-    cacl/test_ebtables_application.py \
-    cacl/test_cacl_application.py \
-    cacl/test_cacl_function.py \
-    dhcp_relay/test_dhcp_relay.py \
-    dhcp_relay/test_dhcpv6_relay.py \
-    lldp/test_lldp.py \
-    ntp/test_ntp.py \
-    pc/test_po_cleanup.py \
-    pc/test_po_update.py \
-    route/test_default_route.py \
-    route/test_static_route.py \
-    arp/test_neighbor_mac.py \
-    arp/test_neighbor_mac_noptf.py \
-    snmp/test_snmp_cpu.py \
-    snmp/test_snmp_interfaces.py \
-    snmp/test_snmp_lldp.py \
-    snmp/test_snmp_pfc_counters.py \
-    snmp/test_snmp_queue.py \
-    snmp/test_snmp_loopback.py \
-    snmp/test_snmp_default_route.py \
-    ssh/test_ssh_stress.py \
-    ssh/test_ssh_ciphers.py \
-    syslog/test_syslog.py \
-    tacacs/test_rw_user.py \
-    tacacs/test_ro_user.py \
-    tacacs/test_ro_disk.py \
-    tacacs/test_jit_user.py \
-    telemetry/test_telemetry.py \
-    test_features.py \
-    test_procdockerstatsd.py \
-    iface_namingmode/test_iface_namingmode.py \
-    platform_tests/test_cpu_memory_usage.py \
-    bgp/test_bgpmon.py \
-    container_checker/test_container_checker.py \
-    process_monitoring/test_critical_process_monitoring.py \
-    system_health/test_system_status.py"
+    if [ x$section == x"part-1" ]; then
+      tests_1="\
+      monit/test_monit_status.py \
+      platform_tests/test_advanced_reboot.py \
+      test_interfaces.py \
+      arp/test_arp_dualtor.py \
+      bgp/test_bgp_fact.py \
+      bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved \
+      bgp/test_bgp_speaker.py \
+      bgp/test_bgp_update_timer.py \
+      cacl/test_ebtables_application.py \
+      cacl/test_cacl_application.py \
+      cacl/test_cacl_function.py \
+      dhcp_relay/test_dhcp_relay.py \
+      dhcp_relay/test_dhcpv6_relay.py \
+      lldp/test_lldp.py \
+      ntp/test_ntp.py \
+      pc/test_po_cleanup.py \
+      pc/test_po_update.py \
+      route/test_default_route.py \
+      route/test_static_route.py \
+      arp/test_neighbor_mac.py \
+      arp/test_neighbor_mac_noptf.py\
+      snmp/test_snmp_cpu.py \
+      snmp/test_snmp_interfaces.py \
+      snmp/test_snmp_lldp.py \
+      snmp/test_snmp_pfc_counters.py \
+      snmp/test_snmp_queue.py"
 
-    pushd $SONIC_MGMT_DIR/tests
-    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname
-    popd
+      pushd $SONIC_MGMT_DIR/tests
+      ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests_1" -p logs/$tgname
+      popd
+    else
+      tests_2="\
+      snmp/test_snmp_loopback.py \
+      snmp/test_snmp_default_route.py \
+      ssh/test_ssh_stress.py \
+      ssh/test_ssh_ciphers.py \
+      syslog/test_syslog.py\
+      tacacs/test_rw_user.py \
+      tacacs/test_ro_user.py \
+      tacacs/test_ro_disk.py \
+      tacacs/test_jit_user.py \
+      telemetry/test_telemetry.py \
+      test_features.py \
+      test_procdockerstatsd.py \
+      iface_namingmode/test_iface_namingmode.py \
+      platform_tests/test_cpu_memory_usage.py \
+      bgp/test_bgpmon.py \
+      container_checker/test_container_checker.py \
+      process_monitoring/test_critical_process_monitoring.py \
+      system_health/test_system_status.py"
 
-    # Create and deploy two vlan configuration (two_vlan_a) to the virtual switch
-    pushd $SONIC_MGMT_DIR/ansible
-    ./testbed-cli.sh -m $inventory -t $testbed_file deploy-mg $tbname lab password.txt -e vlan_config=two_vlan_a
-    popd
-    sleep 180
+      pushd $SONIC_MGMT_DIR/tests
+      ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests_2" -p logs/$tgname
+      popd
 
-    # Run tests_2vlans on vlab-01 virtual switch
-    tgname=2vlans
-    tests="\
-    dhcp_relay/test_dhcp_relay.py \
-    dhcp_relay/test_dhcpv6_relay.py"
+      # Create and deploy two vlan configuration (two_vlan_a) to the virtual switch
+      pushd $SONIC_MGMT_DIR/ansible
+      ./testbed-cli.sh -m $inventory -t $testbed_file deploy-mg $tbname lab password.txt -e vlan_config=two_vlan_a
+      popd
+      sleep 180
 
-    pushd $SONIC_MGMT_DIR/tests
-    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname
-    popd
+      # Run tests_2vlans on vlab-01 virtual switch
+      tgname=2vlans
+      tests="\
+      dhcp_relay/test_dhcp_relay.py \
+      dhcp_relay/test_dhcpv6_relay.py"
+
+      pushd $SONIC_MGMT_DIR/tests
+      ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname
+      popd
+    fi
 }
 
 test_t0_sonic() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Currently, Azure.sonic-mgmt pipeline is running for more than 4 hours, especially for kvmtest-t0 job. Split kvmtest-t0 job into two separated jobs, each job runs part of test cases for t0. Reduce the waiting time of PR merge.

#### How did you do it?
Split kvmtest-to job into kvmtest-t0-part1 and kvmtest-t0-part2, split t0 test cases into two jobs.

#### How did you verify/test it?
Submit PR will trigger the pipeline and check the whole running time of pipeline.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
