### PR TITLE
Improve infrastructure to support over 100 VMs per server

### DIFF
--- a/ansible/library/testbed_vm_info.py
+++ b/ansible/library/testbed_vm_info.py
@@ -2,13 +2,8 @@
 
 import re
 import yaml
-import os
 import traceback
-import subprocess
 import ipaddr as ipaddress
-from operator import itemgetter
-from itertools import groupby
-from collections import defaultdict
 import re
 
 from ansible.parsing.dataloader import DataLoader
@@ -17,13 +12,13 @@ from ansible.inventory.manager import InventoryManager
 DOCUMENTATION = '''
 module: testbed_vm_info.py
 Ansible_version_added:  2.0.0.2
-short_description:   Gather all related VMs info
+short_description: Gather all related VMs info
 Description:
        When deploy testbed topology with VM connected to SONiC, gather neighbor VMs info for generating SONiC minigraph file
  options:
     base_vm:  base vm name defined in testbed.csv for the deployed topology; required: True
     topo:     topology name defined in testbed.csv for the deployed topology; required: True
-    vm_file:  the virtual machine file path ; default: 'veos'
+    vm_file:  the virtual machine file path; default: 'veos'
 
 Ansible_facts:
     'neighbor_eosvm_mgmt':  all VM hosts management IPs
@@ -36,7 +31,7 @@ EXAMPLES = '''
       testbed_vm_info: base_vm='VM0100' topo='t1' vm_file='veos'
 '''
 
-### Here are the assumption/expectation of files to gather VM informations, if the file location or name changes, please modify it here
+### Here are the assumption/expectation of files to gather VM information, if the file location or name changes, please modify it here
 TOPO_PATH = 'vars/'
 VM_INV_FILE = 'veos'
 TGEN_MGMT_NETWORK = '10.65.32.0/24'
@@ -48,28 +43,38 @@ class TestbedVMFacts():
 
     """
 
-    def __init__(self, toponame, vmbase, vmfile):
+    def __init__(self, toponame, base_vm, vm_file):
         CLET_SUFFIX = "-clet"
         toponame = re.sub(CLET_SUFFIX + "$", "", toponame)
         self.topofile = TOPO_PATH+'topo_'+toponame +'.yml'
-        if vmbase != '':
-            self.start_index = int(re.findall('VM(\d+)', vmbase)[0])
-        else:
-            self.start_index = 0
-        self.vmhosts = {}
-        self.vmfile = vmfile
-        self.inv_mgr = InventoryManager(loader=DataLoader(), sources=self.vmfile)
-        return
-
+        self.base_vm = base_vm
+        self.vm_file = vm_file
+        self.inv_mgr = InventoryManager(loader=DataLoader(), sources=self.vm_file)
 
     def get_neighbor_eos(self):
         eos = {}
         with open(self.topofile) as f:
             vm_topology = yaml.safe_load(f)
         self.topoall = vm_topology
-        for  vm in vm_topology['topology']['VMs']:
-            vm_index = int(vm_topology['topology']['VMs'][vm]['vm_offset'])+self.start_index
-            eos[vm] = vm_index
+
+        vm_names = [vm_name for vm_name in self.inv_mgr.hosts if vm_name.startswith('VM')]
+        vm_names.sort()
+        vm_names_count = len(vm_names)
+
+        if self.base_vm != '':
+            start_index = vm_names.index(self.base_vm)
+        else:
+            start_index = 0
+
+        for vm in vm_topology['topology']['VMs']:
+            if start_index < 0:  # Unable to find base_vm in inventory file
+                eos[vm] = ''
+            else:
+                vm_index = int(vm_topology['topology']['VMs'][vm]['vm_offset']) + start_index
+                if vm_index < vm_names_count:
+                    eos[vm] = vm_names[vm_index]
+                else:
+                    eos[vm] = ''
         return eos
 
 
@@ -86,26 +91,30 @@ def main():
     topo_type = m_args['topo']
     if 'ptf' in topo_type:
         module.exit_json(ansible_facts={'neighbor_eosvm_mgmt': {}})
+
+    vm_mgmt_ip = {}
     try:
-        vmsall = TestbedVMFacts(m_args['topo'], m_args['base_vm'], m_args['vm_file'])
-        neighbor_eos = vmsall.get_neighbor_eos()
+        vm_facts = TestbedVMFacts(m_args['topo'], m_args['base_vm'], m_args['vm_file'])
+        neighbor_eos = vm_facts.get_neighbor_eos()
+
         tgen_mgmt_ips = list(ipaddress.IPNetwork(unicode(TGEN_MGMT_NETWORK)))
         for index, eos in enumerate(neighbor_eos):
-            vmname = 'VM'+format(neighbor_eos[eos], '04d')
+            vm_name = neighbor_eos[eos]
             if 'tgen' in topo_type:
-                vmsall.vmhosts[eos] = str(tgen_mgmt_ips[index])
-            elif vmname in vmsall.inv_mgr.hosts:
-                vmsall.vmhosts[eos] = vmsall.inv_mgr.get_host(vmname).get_vars()['ansible_host']
+                vm_mgmt_ip[eos] = str(tgen_mgmt_ips[index])
+            elif vm_name != '':
+                vm_mgmt_ip[eos] = vm_facts.inv_mgr.get_host(vm_name).get_vars()['ansible_host']
             else:
-                err_msg = "cannot find the vm " + vmname + " in VM inventory file, please make sure you have enough VMs for the topology you are using"
+                err_msg = "Cannot find the vm {} in VM inventory file {}, please make sure you have enough VMs" \
+                          "for the topology you are using."
+                err_msg.format(vm_name, vm_facts.vm_file)
                 module.fail_json(msg=err_msg)
-        module.exit_json(ansible_facts={'neighbor_eosvm_mgmt':vmsall.vmhosts, 'topoall': vmsall.topoall})
+        module.exit_json(ansible_facts={'neighbor_eosvm_mgmt':vm_mgmt_ip, 'topoall': vm_facts.topoall})
     except (IOError, OSError):
-        module.fail_json(msg="Can not find file "+vmsall.topofile+" or "+m_args['vm_file']+" or "+VM_INV_FILE)
+        module.fail_json(msg='Can not find VM file {} or {}'.format(m_args['vm_file'], VM_INV_FILE))
     except Exception as e:
         module.fail_json(msg=traceback.format_exc())
 
 from ansible.module_utils.basic import *
 if __name__ == "__main__":
     main()
-

--- a/ansible/linkstate/scripts/ptf_proxy.py
+++ b/ansible/linkstate/scripts/ptf_proxy.py
@@ -123,9 +123,10 @@ def parse_veos(vms):
 
 def generate_vm_mappings(vms, base_vm, dut_ports, vm_2_ip):
     base_vm_id = int(base_vm[2:])
+    vm_name_fmt = 'VM%0{}d'.format(len(base_vm) - 2)
     required_ports = {}
     for vm_offset, ports in vms.items():
-        vm = 'VM%04d' % (base_vm_id + vm_offset)
+        vm = vm_name_fmt % (base_vm_id + vm_offset)
         vm_ip = vm_2_ip[vm]
         p = {dut_ports[port]: (vm_ip, 'Ethernet%d' % (offset + 1)) for offset, port in enumerate(ports)}
         required_ports.update(p)
@@ -137,9 +138,10 @@ def generate_vm_port_mapping(vm_base):
         data = yaml.load(fp)
 
     base = int(vm_base.replace("VM", ""))
+    vm_name_fmt = 'VM%0{}d'.format(len(vm_base) - 2)
 
     vm_ports = {v['vm_offset']:v['vlans'] for v in data['topology']['VMs'].values()}
-    vm_list  = ["VM%04d" % (base + p) for p in sorted(vm_ports.keys())]
+    vm_list  = [vm_name_fmt % (base + p) for p in sorted(vm_ports.keys())]
 
     return vm_ports, vm_list
 

--- a/ansible/linkstate/testbed_inv.py
+++ b/ansible/linkstate/testbed_inv.py
@@ -37,7 +37,8 @@ def parse_testbed_configuration(filename, target):
 def parse_topology(topology_name, vm_start):
     with open("vars/topo_%s.yml" % topology_name) as fp:
         topo = yaml.load(fp)
-    vms = ["%s%04d" % (vm_start[0:2], int(vm_start[2:]) + v["vm_offset"]) for v in topo['topology']['VMs'].values()]
+    vm_name_fmt = vm_start[0:2] + "%0{}d".format(len(vm_start) - 2)
+    vms = [vm_name_fmt % (int(vm_start[2:]) + v["vm_offset"]) for v in topo['topology']['VMs'].values()]
     ports = list(itertools.chain(*(val['vlans'] for val in topo['topology']['VMs'].values())))
     return vms, ports
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -403,6 +403,7 @@ def nbrhosts(ansible_adhoc, tbinfo, creds, request):
         return devices
 
     vm_base = int(tbinfo['vm_base'][2:])
+    vm_name_fmt = 'VM%0{}d'.format(len(tbinfo['vm_base']) - 2)
     neighbor_type = request.config.getoption("--neighbor_type")
 
     if not 'VMs' in tbinfo['topo']['properties']['topology']:
@@ -410,9 +411,10 @@ def nbrhosts(ansible_adhoc, tbinfo, creds, request):
         return devices
 
     for k, v in tbinfo['topo']['properties']['topology']['VMs'].items():
+        vm_name = vm_name_fmt % (vm_base + v['vm_offset'])
         if neighbor_type == "eos":
             devices[k] = {'host': EosHost(ansible_adhoc,
-                                        "VM%04d" % (vm_base + v['vm_offset']),
+                                        vm_name,
                                         creds['eos_login'],
                                         creds['eos_password'],
                                         shell_user=creds['eos_root_user'] if 'eos_root_user' in creds else None,
@@ -420,7 +422,7 @@ def nbrhosts(ansible_adhoc, tbinfo, creds, request):
                         'conf': tbinfo['topo']['properties']['configuration'][k]}
         elif neighbor_type == "sonic":
             devices[k] = {'host': SonicHost(ansible_adhoc,
-                                        "VM%04d" % (vm_base + v['vm_offset']),
+                                        vm_name,
                                         ssh_user=creds['sonic_login'] if 'sonic_login' in creds else None,
                                         ssh_passwd=creds['sonic_password'] if 'sonic_password' in creds else None),
                         'conf': tbinfo['topo']['properties']['configuration'][k]}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Currently name of VMs running in test server follows the pattern of "VMXXXX". Each "X" is a decimal digit. The first
two digits usually are for server. The last 2 digits are for VMs. Because of this limitation, at most 100 VMs can
be defined for a test server. After the T2 topology is introduced, a single testbed may need more than 100 VMs as
neighbors. We need to get rid of this limitation to support over 100 VMs on single test server.

#### How did you do it?
This change updated the infrastructure to get rid of this limitation. Now the VM name can have 4 digits or more.

#### How did you verify/test it?
Run below tasks for both VMs with 4 digits and 5 digits.
  * Test run add-topo, remove-topo, deploy-mg
  * Test run scripts test_bgp_facts.py, test_nbr_health.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
