### PR TITLE
Recover bgpd in neighbors parallelly in sanity check. 

### DIFF
--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -101,7 +101,7 @@ def recover(dut, localhost, fanouthosts, check_results, recover_method):
         __recover_with_command(dut, method['cmd'], wait_time)
 
 @reset_ansible_local_tmp
-def neighbor_vm_restart_bgpd(node=None):
+def neighbor_vm_recover_bgpd(node=None):
     nbr_host = node['host']
     intf_list = node['conf']['interfaces'].keys()
     # restore interfaces and portchannels
@@ -118,4 +118,4 @@ def neighbor_vm_restore(duthost, nbrhosts, tbinfo):
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     vm_neighbors = mg_facts['minigraph_neighbors']
     if vm_neighbors:
-        parallel_run(neighbor_vm_restart_bgpd, (), {}, nbrhosts.values(), timeout=600)
+        parallel_run(neighbor_vm_recover_bgpd, (), {}, nbrhosts.values(), timeout=300)

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -101,7 +101,7 @@ def recover(dut, localhost, fanouthosts, check_results, recover_method):
         __recover_with_command(dut, method['cmd'], wait_time)
 
 @reset_ansible_local_tmp
-def neighbor_vm_restart_bgpd(node=None, results=None):
+def neighbor_vm_restart_bgpd(node=None):
     nbr_host = node['host']
     intf_list = node['conf']['interfaces'].keys()
     # restore interfaces and portchannels

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -8,6 +8,7 @@ from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.config_reload import config_force_option_supported
 from tests.common.reboot import reboot
 from tests.common.reboot import REBOOT_TYPE_WARM, REBOOT_TYPE_FAST, REBOOT_TYPE_COLD
+from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
 
 logger = logging.getLogger(__name__)
 
@@ -99,23 +100,22 @@ def recover(dut, localhost, fanouthosts, check_results, recover_method):
     else:
         __recover_with_command(dut, method['cmd'], wait_time)
 
+@reset_ansible_local_tmp
+def neighbor_vm_restart_bgpd(node=None, results=None):
+    nbr_host = node['host']
+    intf_list = node['conf']['interfaces'].keys()
+    # restore interfaces and portchannels
+    for intf in intf_list:
+        nbr_host.no_shutdown(intf)
+    asn = node['conf']['bgp']['asn']
+    # start BGPd
+    nbr_host.start_bgpd()
+    # restore BGP session
+    nbr_host.no_shutdown_bgp(asn)
 
 def neighbor_vm_restore(duthost, nbrhosts, tbinfo):
     logger.info("Restoring neighbor VMs for {}".format(duthost))
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     vm_neighbors = mg_facts['minigraph_neighbors']
     if vm_neighbors:
-        lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
-        for lag_name in lag_facts['names']:
-            nbr_intf = lag_facts['lags'][lag_name]['po_config']['ports'].keys()[0]
-            peer_device   = vm_neighbors[nbr_intf]['name']
-            nbr_host = nbrhosts[peer_device]['host']
-            intf_list = nbrhosts[peer_device]['conf']['interfaces'].keys()
-            # restore interfaces and portchannels
-            for intf in intf_list:
-                nbr_host.no_shutdown(intf)
-            asn = nbrhosts[peer_device]['conf']['bgp']['asn']
-            # start BGPd
-            nbr_host.start_bgpd()
-            # restore BGP session
-            nbr_host.no_shutdown_bgp(asn)
+        parallel_run(neighbor_vm_restart_bgpd, (), {}, nbrhosts.values(), timeout=600)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

In sanity check, if the bgp state between dut and neighbors is not `Establish`, it will recover the state to `Establish`. Before, we recover the state one by one. Now, we recover the state parallelly to save time. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

In sanity check, if the bgp state between dut and neighbors is not "Establish", it will recover the state to "Establish". Before, we recover the state one by one. Now, we recover the state parallelly to save time. 

#### How did you do it?

I change `for...in...` to `parallel_run` to recover the state parallelly.

#### How did you verify/test it?

I shutdown the bgp neighbor on dut, and then run sanity check to recover it. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
