### PR TITLE
[python3 migration] Added Python3 support for new test cases

### DIFF
--- a/ansible/library/lldp_facts.py
+++ b/ansible/library/lldp_facts.py
@@ -235,9 +235,9 @@ def main():
             try:
                 if_name = inverse_if_table[str(current_oid.split(".")[-2])]
             except Exception as e:
-                print json.dumps({
+                print(json.dumps({
                     "unbound_interface_index": str(current_oid.split(".")[-2])
-                })
+                }))
                 module.fail_json(msg="unboundinterface in inverse if table")
 
             if v.lldp_rem_sys_name in current_oid:
@@ -258,7 +258,7 @@ def main():
 
     lldp_data = dict()
 
-    for intf in lldp_rem_sys.viewkeys():
+    for intf in lldp_rem_sys.keys():
         lldp_data[intf] = {'neighbor_sys_name': lldp_rem_sys[intf],
                                 'neighbor_port_desc': lldp_rem_port_desc[intf],
                                 'neighbor_port_id': lldp_rem_port_id[intf],

--- a/ansible/library/lldp_facts.py
+++ b/ansible/library/lldp_facts.py
@@ -258,7 +258,7 @@ def main():
 
     lldp_data = dict()
 
-    for intf in lldp_rem_sys.keys():
+    for intf in lldp_rem_sys:
         lldp_data[intf] = {'neighbor_sys_name': lldp_rem_sys[intf],
                                 'neighbor_port_desc': lldp_rem_port_desc[intf],
                                 'neighbor_port_id': lldp_rem_port_id[intf],

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -537,7 +537,7 @@ class MultiAsicSonicHost(object):
         ))
 
         vty_cmd_args = "-c \"configure terminal\" -c \"{} ip route {} {}\"".format(
-            op, ipaddress.ip_interface(unicode(ip + "/24")).network, nexthop
+            op, ipaddress.ip_interface(ip + "/24".encode().decode()).network, nexthop
         )
 
         if namespace != DEFAULT_NAMESPACE:

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1075,10 +1075,10 @@ default nhid 224 proto bgp src fc00:1::32 metric 20 pref medium
 
             m = re.match(".+\s+via\s+(\S+)\s+.*dev\s+(\S+)\s+.*src\s+(\S+)\s+", rt[0])
             if m:
-                nexthop_ip = ipaddress.ip_address(unicode(m.group(1)))
+                nexthop_ip = ipaddress.ip_address(m.group(1).encode().decode("utf-8"))
                 gw_if = m.group(2)
                 rtinfo['nexthops'].append((nexthop_ip, gw_if))
-                rtinfo['set_src'] = ipaddress.ip_address(unicode(m.group(3)))
+                rtinfo['set_src'] = ipaddress.ip_address(m.group(3).encode().decode("utf-8"))
         else:
             raise ValueError("Wrong type of dstip")
 

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1075,10 +1075,10 @@ default nhid 224 proto bgp src fc00:1::32 metric 20 pref medium
 
             m = re.match(".+\s+via\s+(\S+)\s+.*dev\s+(\S+)\s+.*src\s+(\S+)\s+", rt[0])
             if m:
-                nexthop_ip = ipaddress.ip_address(m.group(1).encode().decode("utf-8"))
+                nexthop_ip = ipaddress.ip_address(m.group(1))
                 gw_if = m.group(2)
                 rtinfo['nexthops'].append((nexthop_ip, gw_if))
-                rtinfo['set_src'] = ipaddress.ip_address(m.group(3).encode().decode("utf-8"))
+                rtinfo['set_src'] = ipaddress.ip_address(m.group(3))
         else:
             raise ValueError("Wrong type of dstip")
 

--- a/tests/common/errors.py
+++ b/tests/common/errors.py
@@ -26,8 +26,7 @@ class RunAnsibleModuleFail(AnsibleError):
         self.results = results
 
     def _to_string(self):
-        return unicode(u"{}, Ansible Results =>\n{}".format(self.message, dump_ansible_results(self.results)))\
-            .encode('ascii', 'backslashreplace')
+        return "{}, Ansible Results =>\n{}".format(self.message, dump_ansible_results(self.results)).encode().decode("utf-8")
 
     def __str__(self):
         return self._to_string()

--- a/tests/common/fixtures/fib_utils.py
+++ b/tests/common/fixtures/fib_utils.py
@@ -75,7 +75,7 @@ def get_t2_fib_info(duthosts, duts_cfg_facts, duts_mg_facts):
 
                     oports = []
                     for idx, ifname in enumerate(ifnames):
-                        if po.has_key(ifname):
+                        if ifname in po:
                             # ignore the prefix, if the prefix nexthop is not a frontend port
                             if 'members' in po[ifname]:
                                 if 'role' in ports[po[ifname]['members'][0]] and ports[po[ifname]['members'][0]]['role'] == 'Int':
@@ -85,7 +85,7 @@ def get_t2_fib_info(duthosts, duts_cfg_facts, duts_mg_facts):
                                     oports.append([str(mg_facts['minigraph_ptf_indices'][x]) for x in po[ifname]['members']])
                                     skip = False
                         else:
-                            if ports.has_key(ifname):
+                            if ifname in ports:
                                 if 'role' in ports[ifname] and ports[ifname]['role'] == 'Int':
                                     if len(oports) == 0:
                                         skip = True
@@ -182,7 +182,7 @@ def get_fib_info(duthost, dut_cfg_facts, duts_mg_facts):
 
                 oports = []
                 for ifname in ifnames:
-                    if po.has_key(ifname):
+                    if ifname in po:
                         # ignore the prefix, if the prefix nexthop is not a frontend port
                         if 'members' in po[ifname]:
                             if 'role' in ports[po[ifname]['members'][0]] and ports[po[ifname]['members'][0]]['role'] == 'Int':
@@ -190,9 +190,9 @@ def get_fib_info(duthost, dut_cfg_facts, duts_mg_facts):
                             else:
                                 oports.append([str(duts_mg_facts['minigraph_ptf_indices'][x]) for x in po[ifname]['members']])
                     else:
-                        if sub_interfaces.has_key(ifname):
+                        if ifname in sub_interfaces:
                             oports.append([str(duts_mg_facts['minigraph_ptf_indices'][ifname.split('.')[0]])])
-                        elif ports.has_key(ifname):
+                        elif ifname in ports:
                             if 'role' in ports[ifname] and ports[ifname]['role'] == 'Int':
                                 skip = True
                             else:
@@ -227,13 +227,13 @@ def gen_fib_info_file(ptfhost, fib_info, filename):
     """
     tmp_fib_info = tempfile.NamedTemporaryFile()
     for prefix, oports in fib_info.items():
-        tmp_fib_info.write(prefix)
+        tmp_fib_info.write(prefix.encode())
         if oports:
             for op in oports:
-                tmp_fib_info.write(' [{}]'.format(' '.join(op)))
+                tmp_fib_info.write(' [{}]'.format(' '.join(op)).encode())
         else:
-            tmp_fib_info.write(' []')
-        tmp_fib_info.write('\n')
+            tmp_fib_info.write(' []'.encode())
+        tmp_fib_info.write('\n'.encode())
     tmp_fib_info.flush()
     ptfhost.copy(src=tmp_fib_info.name, dest=filename)
 
@@ -326,4 +326,4 @@ def single_fib_for_duts(tbinfo):
     if tbinfo['topo']['type'] == "t2":
         return True
     return False
- 
+

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -182,7 +182,7 @@ def ptf_portmap_file(duthosts, rand_one_dut_hostname, ptfhost):
         file.write("# ptf host interface @ switch front port name\n")
         file.writelines(
             map(
-                    lambda (index, port): "{0}@{1}\n".format(index, port),
+                    lambda index, port: "{0}@{1}\n".format(index, port),
                     enumerate(portList)
                 )
             )
@@ -195,7 +195,7 @@ def ptf_portmap_file(duthosts, rand_one_dut_hostname, ptfhost):
 @pytest.fixture(scope="module", autouse=True)
 def run_icmp_responder(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     """Run icmp_responder.py over ptfhost."""
-    # No vlan is avaliable on non-t0 testbed, so skip this fixture 
+    # No vlan is available on non-t0 testbed, so skip this fixture
     if 't0' not in tbinfo['topo']['type']:
         logger.info("Not running on a T0 testbed, not starting ICMP responder")
         yield
@@ -314,7 +314,7 @@ def ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url):
             }
         else:
             # PTF port is mapped to single DUT
-            target_dut_index = int(dut_intf_map.keys()[0])
+            target_dut_index = int(list(dut_intf_map.keys())[0])
             ports_map[ptf_port] = {
                 'target_dut': target_dut_index,
                 'target_mac': router_macs[target_dut_index]

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -168,7 +168,7 @@ def find_longest_matches(nodeid, conditions):
     max_length = -1
     for condition in conditions:
         # condition is a dict which has only one item, so we use condition.keys()[0] to get its key.
-        if nodeid.startswith(condition.keys()[0]):
+        if nodeid.startswith(list(condition.keys())[0]):
             length = len(condition)
             if length > max_length:
                 max_length = length
@@ -312,7 +312,7 @@ def pytest_collection_modifyitems(session, config, items):
 
             for match in longest_matches:
                 # match is a dict which has only one item, so we use match.values()[0] to get its value.
-                for mark_name, mark_details in match.values()[0].items():
+                for mark_name, mark_details in list(match.values())[0].items():
 
                     add_mark = False
                     mark_conditions = mark_details.get('conditions', None)

--- a/tests/common/plugins/log_section_start/__init__.py
+++ b/tests/common/plugins/log_section_start/__init__.py
@@ -105,8 +105,8 @@ def _pytest_import_callback(module):
             func = None
             if len(args) == 1 and callable(args[0]) and not kargs:
                 func = args[0]
-            elif len(kargs) == 1 and callable(kargs.values()[0]) and not args:
-                func = kargs.values()[0]
+            elif len(kargs) == 1 and callable(list(kargs.values())[0]) and not args:
+                func = list(kargs.values())[0]
             if func is not None:
                 args = ()
                 kargs = {}

--- a/tests/common/plugins/ptfadapter/ptfadapter.py
+++ b/tests/common/plugins/ptfadapter/ptfadapter.py
@@ -114,11 +114,11 @@ class PtfTestAdapter(BaseTest):
         """ Close dataplane socket and kill data plane thread """
         if self.connected:
             self.dataplane.kill()
-            
+
             for injector in DataPlanePortNN.packet_injecters.values():
                 injector.socket.close()
             DataPlanePortNN.packet_injecters.clear()
-        
+
         self.connected = False
 
     def reinit(self, ptf_config=None):
@@ -182,7 +182,7 @@ class PtfTestAdapter(BaseTest):
             if len_new >= len_old:
                 return self.payload_pattern[:len_old]
             else:
-                factor = len_old/len_new + 1
+                factor = int(len_old/len_new) + 1
                 new_payload = self.payload_pattern * factor
                 return new_payload[:len_old]
         else:

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -4,7 +4,7 @@ import re
 import logging
 from multiprocessing.pool import ThreadPool, TimeoutError
 from collections import deque
-from utilities import wait_until
+from .utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -187,18 +187,18 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
         raise Exception('DUT {} did not startup'.format(hostname))
 
     logger.info('ssh has started up on {}'.format(hostname))
-    
+
     logger.info('waiting for switch {} to initialize'.format(hostname))
 
     time.sleep(wait)
-    
+
     # Wait warmboot-finalizer service
     if reboot_type == REBOOT_TYPE_WARM and wait_warmboot_finalizer:
         logger.info('waiting for warmboot-finalizer service to finish on {}'.format(hostname))
         ret = wait_until(warmboot_finalizer_timeout, 5, 0, check_warmboot_finalizer_inactive, duthost)
         if not ret:
             raise Exception('warmboot-finalizer service timeout on DUT {}'.format(hostname))
-    
+
     DUT_ACTIVE.set()
     logger.info('{} reboot finished on {}'.format(reboot_type, hostname))
     pool.terminate()

--- a/tests/dhcp_relay/test_dhcp_pkt_fwd.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_fwd.py
@@ -66,6 +66,30 @@ class DhcpPktFwdBase:
 
         return lags, peerIp
 
+    def __updateRoute(self, duthost, ip, peerIp, op=""):
+        """
+        Update route to add/remove for a given IP <ip> towards BGP peer
+
+         Args:
+            duthost(Ansible Fixture): instance of SonicHost class of DUT
+            ip(str): IP to add/remove route for
+            peerIp(str): BGP peer IP
+            op(str): operation add/remove to be performed, default add
+
+        Returns:
+            None
+        """
+        logger.info("{0} route to '{1}' via '{2}'".format(
+            "Deleting" if "no" == op else "Adding",
+            ip,
+            peerIp
+        ))
+        duthost.shell("vtysh -c \"configure terminal\" -c \"{} ip route {} {}\"".format(
+            op,
+            ipaddress.ip_interface((ip + "/24").encode().decode("utf-8")).network,
+            peerIp
+        ))
+
     @pytest.fixture(scope="class")
     def dutPorts(self, duthosts, rand_one_dut_hostname, tbinfo):
         """

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -156,7 +156,7 @@ def check_routes_to_dhcp_server(duthost, dut_dhcp_relay_data):
                 logger.info("Found route to DHCP server via default GW(MGMT interface)")
                 return False
     return True
-        
+
 
 @pytest.fixture(scope="module")
 def validate_dut_routes_exist(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data):
@@ -233,7 +233,7 @@ def testing_config(request, duthosts, rand_one_dut_hostname, tbinfo):
             restart_dhcp_service(duthost)
 
 def check_interface_status(duthost):
-    if ":67" in duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcrelay", module_ignore_errors=True)["stdout"].encode("utf-8"):
+    if ":67" in duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcrelay", module_ignore_errors=True)["stdout"]:
         return True
 
     return False
@@ -245,7 +245,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data)
         config_reload(duthost)
         wait_critical_processes(duthost)
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
-    output = duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcrelay", module_ignore_errors=True)["stdout"].encode("utf-8")
+    output = duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcrelay", module_ignore_errors=True)["stdout"]
     logger.info(output)
     for dhcp_relay in dut_dhcp_relay_data:
         assert "{}:67".format(dhcp_relay['downlink_vlan_iface']['name']) in output, "{} is not found in {}".format("{}:67".format(dhcp_relay['downlink_vlan_iface']['name']), output)
@@ -312,7 +312,7 @@ def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_r
         # Bring all uplink interfaces back up
         for iface in dhcp_relay['uplink_interfaces']:
             duthost.shell('ifconfig {} up'.format(iface))
-            
+
         # Wait until uplinks are up and routes are recovered
         pytest_assert(wait_until(50, 5, 0, check_routes_to_dhcp_server, duthost, dut_dhcp_relay_data),
                       "Not all DHCP servers are routed")

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -112,7 +112,7 @@ def validate_dut_routes_exist(duthosts, rand_one_dut_hostname, dut_dhcp_relay_da
         assert len(rtInfo["nexthops"]) > 0, "Failed to find route to DHCP server '{0}'".format(dhcp_server)
 
 def check_interface_status(duthost):
-    if ":547" in duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcp6relay")["stdout"].encode("utf-8"):
+    if ":547" in duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcp6relay")["stdout"]:
         return True
     return False
 
@@ -123,7 +123,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data)
         config_reload(duthost)
         wait_critical_processes(duthost)
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
-    output = duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcp6relay")["stdout"].encode("utf-8")
+    output = duthost.shell("docker exec -it dhcp_relay ss -nlp | grep dhcp6relay")["stdout"]
     logger.info(output)
     for dhcp_relay in dut_dhcp_relay_data:
         assert "*:{}".format(dhcp_relay['downlink_vlan_iface']['name']) in output, "{} is not found in {}".format("*:{}".format(dhcp_relay['downlink_vlan_iface']['name']), output)
@@ -140,7 +140,7 @@ def test_dhcpv6_relay_counter(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp
         for message in messages:
             cmd = 'sonic-db-cli STATE_DB hmset "DHCPv6_COUNTER_TABLE|{}" {} 0'.format(dhcp_relay['downlink_vlan_iface']['name'], message)
             duthost.shell(cmd)
-        
+
         # Send the DHCP relay traffic on the PTF host
         ptf_runner(ptfhost,
                    "ptftests",
@@ -156,7 +156,7 @@ def test_dhcpv6_relay_counter(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp
                            "relay_link_local": str(dhcp_relay['uplink_interface_link_local']),
                            "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr'])},
                    log_file="/tmp/dhcpv6_relay_test.DHCPCounterTest.log")
-        
+
         for message in messages:
             get_message = 'sonic-db-cli STATE_DB hget "DHCPv6_COUNTER_TABLE|{}" {}'.format(dhcp_relay['downlink_vlan_iface']['name'], message)
             message_count = duthost.shell(get_message)['stdout']

--- a/tests/vxlan/vnet_utils.py
+++ b/tests/vxlan/vnet_utils.py
@@ -4,8 +4,8 @@ import logging
 from jinja2 import Template
 from os import path
 from time import sleep
-from vnet_constants import *
-from vnet_constants import VXLAN_PORT, VXLAN_MAC
+from .vnet_constants import *
+from .vnet_constants import VXLAN_PORT, VXLAN_MAC
 from tests.common.helpers.assertions import pytest_assert
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
#### This PR includes necessary changes from [#9277](https://github.com/Azure/sonic-buildimage/pull/9277) for the setup of the Python3  virtual environment in the sonic-mgmt docker container.
Summary:
- Added Python3 support for lldp test case.
- Added Python3 support for dhcp_relay test case.
- Added Python3 support for decap test case.
- Added Python3 support for fib test case.
- Added Python3 support for bgp_bounce test case.
### How to use Python3 environment for running test cases?
1. Connect to the sonic-mgmt container
```
$ docker exec -ti sonic-mgmt bash
```
2. Activate the virtual environment
```
$ source /var/user/env-python3/bin/activate
```
3. Deploy t0/t1 topology
4. Run test case
```
py.test --testbed=testbed-t0 --inventory=../ansible/lab --testbed_file=../ansible/testbed.csv --host-pattern=testbed-t0 -- module-path=../ansible/library lldp
```
```
py.test --testbed=testbed-t0 --inventory=../ansible/lab --testbed_file=../ansible/testbed.csv --host-pattern=testbed-t0 -- module-path=../ansible/library dhcp_relay
```
```
py.test --testbed=testbed-t0 --inventory=../ansible/lab --testbed_file=../ansible/testbed.csv --host-pattern=testbed-t0 -- module-path=../ansible/library decap
```
```
py.test --testbed=testbed-t0 --inventory=../ansible/lab --testbed_file=../ansible/testbed.csv --host-pattern=testbed-t0 -- module-path=../ansible/library fib
```
```
py.test --testbed=testbed-t0 --inventory=../ansible/lab --testbed_file=../ansible/testbed.csv --host-pattern=testbed-t0 -- module-path=../ansible/library bgp/test_bgp_bounce.py
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Migration of sonic-mgmt codebase from Python 2 to Python 3
#### How did you do it?
Updated codebase of sonic-mgmt for supporting Python3
#### How did you verify/test it?
Run test cases. Tests passed.
#### Any platform specific information?
SONiC Software Version: SONiC.master.60600-dirty-20211221.191419
Distribution: Debian 11.2
Kernel: 5.10.0-8-2-amd64
Build commit: 67e40b553
Build date: Tue Dec 21 19:22:34 UTC 2021
ASIC: barefoot
#### Supported testbed topology if it's a new test case?
t0, t1
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
