### PR TITLE
[tacacs] remove the testing accounts in teardown

### DIFF
--- a/tests/tacacs/conftest.py
+++ b/tests/tacacs/conftest.py
@@ -10,7 +10,7 @@ def check_tacacs(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_
 
     yield
 
-    cleanup_tacacs(ptfhost, duthost, tacacs_server_ip)
+    cleanup_tacacs(ptfhost, creds_all_duts, duthost, tacacs_server_ip)
 
 
 @pytest.fixture(scope="module")
@@ -25,4 +25,4 @@ def check_tacacs_v6(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_a
 
     yield
 
-    cleanup_tacacs(ptfhost, duthost, tacacs_server_ip)
+    cleanup_tacacs(ptfhost, creds_all_duts, duthost, tacacs_server_ip)

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -64,7 +64,7 @@ def setup_tacacs_server(ptfhost, creds_all_duts, duthost):
     check_all_services_status(ptfhost)
 
 
-def cleanup_tacacs(ptfhost, duthost, tacacs_server_ip):
+def cleanup_tacacs(ptfhost, creds_all_duts, duthost, tacacs_server_ip):
     # stop tacacs server
     ptfhost.service(name="tacacs_plus", state="stopped")
     check_all_services_status(ptfhost)
@@ -74,3 +74,6 @@ def cleanup_tacacs(ptfhost, duthost, tacacs_server_ip):
     duthost.shell("sudo config tacacs default passkey")
     duthost.shell("sudo config aaa authentication login default")
     duthost.shell("sudo config aaa authentication failthrough default")
+    duthost.user(name=creds_all_duts[duthost]['tacacs_ro_user'], state='absent', remove='yes', force='yes', module_ignore_errors=True)
+    duthost.user(name=creds_all_duts[duthost]['tacacs_rw_user'], state='absent', remove='yes', force='yes', module_ignore_errors=True)
+    duthost.user(name=creds_all_duts[duthost]['tacacs_jit_user'], state='absent', remove='yes', force='yes', module_ignore_errors=True)


### PR DESCRIPTION
### Description of PR
The original implementation miss to remove the testing accounts -
`test_rwuser` and `test_rouser` and `test_jituser` after testing. Add to remove them in
the teardown

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The accounts were still left in the DUT

#### How did you do it?

#### How did you verify/test it?
Verify account and the home directory be removed after testing

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
