### PR TITLE
[loganalyzer][logrotate]Check if logrotate is running before start logrotate in the test script.

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from .loganalyzer import LogAnalyzer
+from .loganalyzer import LogAnalyzer, DisableLogrotateCronContext
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
 
@@ -13,14 +13,15 @@ def pytest_addoption(parser):
 
 @reset_ansible_local_tmp
 def analyzer_logrotate(node=None, results=None):
-    logging.info("logrotate called on {}".format(node.hostname))
-    try:
-        node.shell("/usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1")
-    except RunAnsibleModuleFail as e:
-        logging.warning("logrotate is failed. Command returned:\n"
-                        "Stdout: {}\n"
-                        "Stderr: {}\n"
-                        "Return code: {}".format(e.results["stdout"], e.results["stderr"], e.results["rc"]))
+    with DisableLogrotateCronContext(node):
+        logging.info("logrotate called on {}".format(node.hostname))
+        try:
+            node.shell("/usr/sbin/logrotate -f /etc/logrotate.conf > /dev/null 2>&1")
+        except RunAnsibleModuleFail as e:
+            logging.warning("logrotate is failed. Command returned:\n"
+                            "Stdout: {}\n"
+                            "Stderr: {}\n"
+                            "Return code: {}".format(e.results["stdout"], e.results["stderr"], e.results["rc"]))
 
 
 @reset_ansible_local_tmp

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -18,6 +18,47 @@ COMMON_EXPECT = join(split(__file__)[0], "loganalyzer_common_expect.txt")
 SYSLOG_TMP_FOLDER = "/tmp/syslog"
 
 
+class DisableLogrotateCronContext:
+    """
+    Context class to help disable logrotate cron task and restore it automatically.
+    """
+
+    def __init__(self, ansible_host):
+        """
+        Constructor of DisableLogrotateCronContext.
+        :param ansible_host: DUT object representing a SONiC switch under test.
+        """
+        self.ansible_host = ansible_host
+
+    def __enter__(self):
+        """
+        Disable logrotate cron task and make sure the running logrotate is stopped.
+        """
+        # Disable logrotate cron task
+        self.ansible_host.command("sed -i 's/^/#/g' /etc/cron.d/logrotate")
+        logging.debug("Waiting for logrotate from previous cron task run to finish")
+        # Wait for logrotate from previous cron task run to finish
+        end = time.time() + 60
+        while time.time() < end:
+            # Verify for exception because self.ansible_host automatically handle command return codes and raise exception for none zero code
+            try:
+                self.ansible_host.command("pgrep -f logrotate")
+            except Exception:
+                break
+            else:
+                time.sleep(5)
+                continue
+        else:
+            logging.error("Logrotate from previous task was not finished during 60 seconds")
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Restore logrotate cron task.
+        """
+        # Enable logrotate cron task back
+        self.ansible_host.command("sed -i 's/^#//g' /etc/cron.d/logrotate")
+
+
 class LogAnalyzerError(Exception):
     """Raised when loganalyzer found matches during analysis phase."""
     def __repr__(self):
@@ -196,30 +237,13 @@ class LogAnalyzer:
         else:
             start_string = self.start_marker
 
-        try:
-            # Disable logrotate cron task
-            self.ansible_host.command("sed -i 's/^/#/g' /etc/cron.d/logrotate")
-
-            logging.debug("Waiting for logrotate from previous cron task run to finish")
-            # Wait for logrotate from previous cron task run to finish
-            end = time.time() + 60
-            while time.time() < end:
-                # Verify for exception because self.ansible_host automatically handle command return codes and raise exception for none zero code
-                try:
-                    self.ansible_host.command("pgrep -f logrotate")
-                except Exception:
-                    break
-                else:
-                    time.sleep(5)
-                    continue
-            else:
-                logging.error("Logrotate from previous task was not finished during 60 seconds")
-
+        with DisableLogrotateCronContext(self.ansible_host):
             # Add end marker into DUT syslog
             self._add_end_marker(marker)
 
             # On DUT extract syslog files from /var/log/ and create one file by location - /tmp/syslog
-            self.ansible_host.extract_log(directory='/var/log', file_prefix='syslog', start_string=start_string, target_filename=self.extracted_syslog)
+            self.ansible_host.extract_log(directory='/var/log', file_prefix='syslog', start_string=start_string,
+                                          target_filename=self.extracted_syslog)
             for idx, path in enumerate(self.additional_files):
                 file_dir, file_name = split(path)
                 extracted_file_name = os.path.join(self.dut_run_dir, file_name)
@@ -227,10 +251,8 @@ class LogAnalyzer:
                     start_str = self.additional_start_str[idx]
                 else:
                     start_str = start_string
-                self.ansible_host.extract_log(directory=file_dir, file_prefix=file_name, start_string=start_str, target_filename=extracted_file_name)
-        finally:
-            # Enable logrotate cron task back
-            self.ansible_host.command("sed -i 's/^#//g' /etc/cron.d/logrotate")
+                self.ansible_host.extract_log(directory=file_dir, file_prefix=file_name, start_string=start_str,
+                                              target_filename=extracted_file_name)
 
         # Download extracted logs from the DUT to the temporal folder defined in SYSLOG_TMP_FOLDER
         self.save_extracted_log(dest=tmp_folder)

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -6,6 +6,8 @@ from tests.common.fixtures.conn_graph_facts import fanout_graph_facts
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.pfc_storm import PFCStorm
 from .files.pfcwd_helper import start_wd_on_ports
+from tests.common.plugins.loganalyzer import DisableLogrotateCronContext
+
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -133,6 +135,7 @@ def set_storm_params(dut, fanout_info, fanout, peer_params):
     storm_handle.deploy_pfc_gen()
     return storm_handle
 
+
 @pytest.mark.usefixtures('pfcwd_timer_setup_restore')
 class TestPfcwdAllTimer(object):
     """ PFCwd timer test class """
@@ -140,8 +143,9 @@ class TestPfcwdAllTimer(object):
         """
         Test execution
         """
-        logger.info("Flush logs")
-        self.dut.shell("logrotate -f /etc/logrotate.conf")
+        with DisableLogrotateCronContext(self.ansible_host):
+            logger.info("Flush logs")
+            self.dut.shell("logrotate -f /etc/logrotate.conf")
         self.storm_handle.start_storm()
         logger.info("Wait for queue to recover from PFC storm")
         time.sleep(8)


### PR DESCRIPTION
If more than one logrotate is running, there will be some issue, such as some log info will be lost, refer to:. https://stackoverflow.com/questions/51852613/how-to-prevent-logrotate-from-producing-unwanted-backup-files

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Make sure there is no logrotate  is running before start a new logroate, and the logrotate cron task has been stopped.
Fixes # (issue) If more than one logrotate is running, there will be some issue, such as some log info will be lost

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Make sure there is no logrotate  is running before start a new logroate, and the logrotate cron task has been stopped.
#### How did you do it?
In loganalyzer or some test case, it will start the logrotate, before starting it, stop the cron task for logrotate, and check if there is logrotate is running, if it is running, wait for it to stop.
#### How did you verify/test it?
Run test case and make sure that the fix will not block existing test cases. And also create senario to make sure the logrotate is running in background when start the logrotate in the script to check the fix works fine.
#### Any platform specific information?
No
