### PR TITLE
[test_link_flap] Shutdown all bgp sessions before start the link flap test

### DIFF
--- a/tests/platform_tests/link_flap/conftest.py
+++ b/tests/platform_tests/link_flap/conftest.py
@@ -4,6 +4,12 @@ Pytest configuration used by the link flap tests.
 Teardowns used by the link flap tests.
 """
 import pytest
+import logging
+from tests.common.utilities import wait_until
+
+logger = logging.getLogger()
+
+
 def pytest_addoption(parser):
     """
     Adds options to pytest that are used by the Link flap tests.
@@ -17,7 +23,24 @@ def pytest_addoption(parser):
         help="Orchagent CPU threshold",
     )
 
+
 @pytest.fixture(scope='module')
 def get_loop_times(pytestconfig):
     return pytestconfig.getoption("--loop_times")
 
+
+@pytest.fixture()
+def bgp_sessions_config(duthost):
+    logger.info("Stop all bgp sessions")
+    duthost.command('sudo config bgp shutdown all')
+    logger.info("Wait all bgp sessions are down")
+    wait_until(60, 10, 0, check_bgp_is_shutdown, duthost)
+    yield
+    logger.info("Start all bgp sessions")
+    duthost.command('sudo config bgp startup all')
+
+
+def check_bgp_is_shutdown(duthost):
+    logger.info("checking bgp status")
+    return not duthost.command("show ip route bgp")["stdout_lines"] and \
+           not duthost.command("show ipv6 route bgp")["stdout_lines"]

--- a/tests/platform_tests/link_flap/test_link_flap.py
+++ b/tests/platform_tests/link_flap/test_link_flap.py
@@ -22,6 +22,8 @@ def get_port_list(duthost, tbinfo):
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     return mg_facts["minigraph_ports"].keys()
 
+
+@pytest.mark.usefixtures("bgp_sessions_config")
 @pytest.mark.platform('physical')
 def test_link_flap(request, duthosts, rand_one_dut_hostname, tbinfo, fanouthosts, get_loop_times):
     """


### PR DESCRIPTION
The link flap test failed due to the oper_state of the interface will be change to UP after 30s.
This happens due to 3 facts: orchagent beeing single threaded, SPC1 has weaker CPU and SDK time to configure routes.
The port comes up in ~10 sec actually if you look at dmesg. But, when you shutdown the port orchagent starts to updated 6k ipv4 and 6k ipv6 routes with new ECMP wihtout the neighbor behind the port that is shutdown - this takes a while, now we startup the port, frr starts sending updates to orchagent and now we are adding back the neighbor (6k ipv4 and 6k ipv6 routes), this takes a while and only then the orchagent queue is free to process a notification that the port is up.

So shutdown the bgp sessions before this test to stablize the test

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  Shutdown all bgp sessions before start the link flap test
Fixes # (issue) make the test case much more stable

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
make the test_link_flap test case much more stable, the fix for https://github.com/Azure/sonic-mgmt/issues/4873

#### How did you do it?
Shutdown all bgp sessions before start the link flap test
#### How did you verify/test it?
run the test_link_flap, it can pass on the testbed which got failure.
#### Any platform specific information?
No

