### PR TITLE
Upgrade path with SAD cases and code refactor

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -559,7 +559,7 @@ class AdvancedReboot:
         self.__updateAndRestartArpResponder(rebootOper)
 
 
-        logger.info('Run advanced-reboot ReloadTest on the PTF host')
+        logger.info('Run advanced-reboot ReloadTest on the PTF host. Case: {}'.format(str(rebootOper)))
         result = ptf_runner(
             self.ptfhost,
             "ptftests",

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -40,7 +40,7 @@ class AdvancedReboot:
         @param tbinfo: fixture provides information about testbed
         @param kwargs: extra parameters including reboot type
         '''
-        assert 'rebootType' in kwargs and kwargs['rebootType'] in ['fast-reboot', 'warm-reboot'], (
+        assert 'rebootType' in kwargs and kwargs['rebootType'] in ['fast-reboot', 'warm-reboot', 'warm-reboot -f'], (
             "Please set rebootType var."
         )
 
@@ -538,7 +538,8 @@ class AdvancedReboot:
             "bgp_v4_v6_time_diff": self.bgpV4V6TimeDiff,
             "asic_type": self.duthost.facts["asic_type"],
             "allow_mac_jumping": self.allowMacJump,
-            "preboot_files" : self.prebootFiles
+            "preboot_files" : self.prebootFiles,
+            "alt_password": self.duthost.host.options['variable_manager']._hostvars[self.duthost.hostname].get("ansible_altpassword")
         }
 
         if not isinstance(rebootOper, SadOperation):
@@ -556,6 +557,7 @@ class AdvancedReboot:
             params.update({'logfile_suffix': str(rebootOper)})
 
         self.__updateAndRestartArpResponder(rebootOper)
+
 
         logger.info('Run advanced-reboot ReloadTest on the PTF host')
         result = ptf_runner(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,8 @@ from tests.common.cache import FactsCache
 from tests.common.connections.console_host import ConsoleHost
 from tests.common.utilities import str2bool
 from tests.platform_tests.args.advanced_reboot_args import add_advanced_reboot_args
+from tests.platform_tests.args.cont_warm_reboot_args import add_cont_warm_reboot_args
+from tests.platform_tests.args.normal_reboot_args import add_normal_reboot_args
 
 
 logger = logging.getLogger(__name__)
@@ -130,10 +132,12 @@ def pytest_addoption(parser):
     ############################
     parser.addoption("--testnum", action="store", default=None, type=str)
 
-    ############################
-    # upgrade_path options     #
-    ############################
+    ##################################
+    # advance-reboot,upgrade options #
+    ##################################
     add_advanced_reboot_args(parser)
+    add_cont_warm_reboot_args(parser)
+    add_normal_reboot_args(parser)
 
     ############################
     #   loop_times options     #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ from tests.common.cache import FactsCache
 
 from tests.common.connections.console_host import ConsoleHost
 from tests.common.utilities import str2bool
+from tests.platform_tests.args.advanced_reboot_args import add_advanced_reboot_args
 
 
 logger = logging.getLogger(__name__)
@@ -132,21 +133,8 @@ def pytest_addoption(parser):
     ############################
     # upgrade_path options     #
     ############################
-    parser.addoption("--upgrade_type", default="warm",
-        help="Specify the type (warm/fast/cold/soft) of upgrade that is needed from source to target image",
-    )
+    add_advanced_reboot_args(parser)
 
-    parser.addoption("--base_image_list", default="",
-        help="Specify the base image(s) for upgrade (comma seperated list is allowed)",
-    )
-
-    parser.addoption("--target_image_list", default="",
-        help="Specify the target image(s) for upgrade (comma seperated list is allowed)",
-    )
-
-    parser.addoption("--restore_to_image", default="",
-        help="Specify the target image to restore to, or stay in target image if empty",
-    )
     ############################
     #   loop_times options     #
     ############################

--- a/tests/platform_tests/args/advanced_reboot_args.py
+++ b/tests/platform_tests/args/advanced_reboot_args.py
@@ -100,3 +100,23 @@ def add_advanced_reboot_args(parser):
         default=40,
         help="Time difference (in sec) between BGP V4 and V6 establishment time"
     )
+
+    parser.addoption("--upgrade_type",
+        default="warm",
+        help="Specify the type (warm/fast/cold/soft) of upgrade that is needed from source to target image",
+    )
+
+    parser.addoption("--base_image_list",
+        default="",
+        help="Specify the base image(s) for upgrade (comma seperated list is allowed)",
+    )
+
+    parser.addoption("--target_image_list",
+        default="",
+        help="Specify the target image(s) for upgrade (comma seperated list is allowed)",
+    )
+
+    parser.addoption("--restore_to_image",
+        default="",
+        help="Specify the target image to restore to, or stay in target image if empty",
+    )

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -13,9 +13,7 @@ from tests.common.mellanox_data import is_mellanox_device
 from tests.common.broadcom_data import is_broadcom_device
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.plugins.sanity_check.recover import neighbor_vm_restore
-from .args.advanced_reboot_args import add_advanced_reboot_args
-from .args.cont_warm_reboot_args import add_cont_warm_reboot_args
-from .args.normal_reboot_args import add_normal_reboot_args
+
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
 FMT = "%b %d %H:%M:%S.%f"
@@ -474,12 +472,6 @@ def capture_interface_counters(duthosts, rand_one_dut_hostname):
         res.pop('stderr')
         outputs.append(res)
     logging.info("Counters after reboot test: dut={}, cmd_outputs={}".format(duthost.hostname,json.dumps(outputs, indent=4)))
-
-
-def pytest_addoption(parser):
-    add_advanced_reboot_args(parser)
-    add_cont_warm_reboot_args(parser)
-    add_normal_reboot_args(parser)
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/upgrade_path/conftest.py
+++ b/tests/upgrade_path/conftest.py
@@ -2,12 +2,6 @@ import pytest
 from tests.platform_tests.args.advanced_reboot_args import add_advanced_reboot_args
 
 
-# upgrade_path pytest arguments
-def pytest_addoption(parser):
-    options_group = parser.getgroup("Upgrade_path test suite options")
-    add_advanced_reboot_args(parser)
-
-
 def pytest_runtest_setup(item):
     from_list = item.config.getoption('base_image_list')
     to_list = item.config.getoption('target_image_list')

--- a/tests/upgrade_path/conftest.py
+++ b/tests/upgrade_path/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-from tests.platform_tests.args.advanced_reboot_args import add_advanced_reboot_args
 
 
 def pytest_runtest_setup(item):

--- a/tests/upgrade_path/conftest.py
+++ b/tests/upgrade_path/conftest.py
@@ -1,4 +1,11 @@
 import pytest
+from tests.platform_tests.args.advanced_reboot_args import add_advanced_reboot_args
+
+
+# upgrade_path pytest arguments
+def pytest_addoption(parser):
+    options_group = parser.getgroup("Upgrade_path test suite options")
+    add_advanced_reboot_args(parser)
 
 
 def pytest_runtest_setup(item):

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -16,7 +16,7 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses      # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # lgtm[py/unused-import]
 
-from tests.platform_tests.warmboot_sad_cases import get_sad_case_list
+from tests.platform_tests.warmboot_sad_cases import get_sad_case_list, SAD_CASE_LIST
 
 
 pytestmark = [
@@ -27,6 +27,11 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
+
+def pytest_generate_tests(metafunc):
+    if "sad_case_type" in metafunc.fixturenames:
+        sad_cases = SAD_CASE_LIST
+        metafunc.parametrize("sad_case_type", sad_cases, scope="module")
 
 @pytest.fixture(scope="module")
 def upgrade_path_lists(request):

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -65,7 +65,7 @@ def test_upgrade_path(localhost, duthosts, ptfhost, rand_one_dut_hostname, nbrho
             # Install target image
             logger.info("Upgrading to {}".format(to_image))
             install_sonic(duthost, to_image, tbinfo)
-            if upgrade_type == REBOOT_TYPE_COLD: #reboot_ctrl_dict.get(REBOOT_TYPE_COLD).get("command"):
+            if upgrade_type == REBOOT_TYPE_COLD:
                 # advance-reboot test (on ptf) does not support cold reboot yet
                 reboot(duthost, localhost)
             else:

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -84,7 +84,7 @@ def test_warm_upgrade_sad_path(localhost, duthosts, ptfhost, rand_one_dut_hostna
                         upgrade_path_lists, backup_and_restore_config_db, advanceboot_neighbor_restore,
                         sad_case_type):
     duthost = duthosts[rand_one_dut_hostname]
-    _, from_list_images, to_list_images, _ = upgrade_path_lists
+    upgrade_type, from_list_images, to_list_images, _ = upgrade_path_lists
     from_list = from_list_images.split(',')
     to_list = to_list_images.split(',')
     assert (from_list and to_list)

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -8,11 +8,19 @@ from tests.common import reboot
 from tests.common.reboot import get_reboot_cause, reboot_ctrl_dict
 from tests.common.reboot import REBOOT_TYPE_COLD
 from tests.upgrade_path.upgrade_helpers import check_services, install_sonic, check_sonic_version, get_reboot_command
-from tests.upgrade_path.upgrade_helpers import ptf_params, setup  # lgtm[py/unused-import]
+from tests.upgrade_path.upgrade_helpers import restore_image
+from tests.common.fixtures.advanced_reboot import get_advanced_reboot
+from tests.platform_tests.verify_dut_health import verify_dut_health
+from tests.common.fixtures.duthost_utils import backup_and_restore_config_db
+
+from tests.platform_tests.conftest import advanceboot_loganalyzer, advanceboot_neighbor_restore  # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses      # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # lgtm[py/unused-import]
+
+from tests.platform_tests.warmboot_sad_cases import get_sad_case_list, SAD_CASE_LIST
+
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -22,34 +30,6 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
-
-# upgrade_path pytest arguments
-def pytest_addoption(parser):
-    options_group = parser.getgroup("Upgrade_path test suite options")
-
-    options_group.addoption(
-        "--upgrade_type",
-        default="warm",
-        help="Specify the type (warm/fast/cold) of upgrade that is needed from source to target image",
-    )
-
-    options_group.addoption(
-        "--base_image_list",
-        default="",
-        help="Specify the base image(s) for upgrade (comma seperated list is allowed)",
-    )
-
-    options_group.addoption(
-        "--target_image_list",
-        default="",
-        help="Specify the target image(s) for upgrade (comma seperated list is allowed)",
-    )
-
-    options_group.addoption(
-        "--restore_to_image",
-        default="",
-        help="Specify the target image to restore to, or stay in target image if empty",
-    )
 
 @pytest.fixture(scope="module")
 def upgrade_path_lists(request):
@@ -61,7 +41,9 @@ def upgrade_path_lists(request):
 
 
 @pytest.mark.device_type('vs')
-def test_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, upgrade_path_lists, ptf_params, setup, tbinfo):
+def test_upgrade_path(localhost, duthosts, ptfhost, rand_one_dut_hostname, nbrhosts, fanouthosts, tbinfo,
+                        restore_image, get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,
+                        upgrade_path_lists):
     duthost = duthosts[rand_one_dut_hostname]
     upgrade_type, from_list_images, to_list_images, _ = upgrade_path_lists
     from_list = from_list_images.split(',')
@@ -81,23 +63,50 @@ def test_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, upgra
             # Install target image
             logger.info("Upgrading to {}".format(to_image))
             target_version = install_sonic(duthost, to_image, tbinfo)
-            test_params = ptf_params
-            test_params['target_version'] = target_version
-            test_params['reboot_type'] = get_reboot_command(duthost, upgrade_type)
-            prepare_testbed_ssh_keys(duthost, ptfhost, test_params['dut_username'])
-            log_file = "/tmp/advanced-reboot.ReloadTest.{}.log".format(datetime.now().strftime('%Y-%m-%d-%H:%M:%S'))
-            if test_params['reboot_type'] == reboot_ctrl_dict.get(REBOOT_TYPE_COLD).get("command"):
+            if upgrade_type == REBOOT_TYPE_COLD: #reboot_ctrl_dict.get(REBOOT_TYPE_COLD).get("command"):
                 # advance-reboot test (on ptf) does not support cold reboot yet
                 reboot(duthost, localhost)
             else:
-                ptf_runner(ptfhost,
-                        "ptftests",
-                        "advanced-reboot.ReloadTest",
-                        platform_dir="ptftests",
-                        params=test_params,
-                        platform="remote",
-                        qlen=10000,
-                        log_file=log_file)
+                advancedReboot = get_advanced_reboot(rebootType=get_reboot_command(duthost, upgrade_type),\
+                    advanceboot_loganalyzer=advanceboot_loganalyzer)
+                advancedReboot.runRebootTestcase()
+            reboot_cause = get_reboot_cause(duthost)
+            logger.info("Check reboot cause. Expected cause {}".format(upgrade_type))
+            pytest_assert(reboot_cause == upgrade_type, "Reboot cause {} did not match the trigger - {}".format(reboot_cause, upgrade_type))
+            check_services(duthost)
+
+
+@pytest.mark.device_type('vs')
+def test_warm_upgrade_sad_path(localhost, duthosts, ptfhost, rand_one_dut_hostname, nbrhosts, fanouthosts, tbinfo,
+                        restore_image, get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,
+                        upgrade_path_lists, backup_and_restore_config_db, advanceboot_neighbor_restore,
+                        sad_case_type):
+    duthost = duthosts[rand_one_dut_hostname]
+    _, from_list_images, to_list_images, _ = upgrade_path_lists
+    from_list = from_list_images.split(',')
+    to_list = to_list_images.split(',')
+    assert (from_list and to_list)
+    for from_image in from_list:
+        for to_image in to_list:
+            logger.info("Test upgrade path from {} to {}".format(from_image, to_image))
+            # Install base image
+            logger.info("Installing {}".format(from_image))
+            target_version = install_sonic(duthost, from_image, tbinfo)
+            # Perform a cold reboot
+            logger.info("Cold reboot the DUT to make the base image as current")
+            reboot(duthost, localhost)
+            check_sonic_version(duthost, target_version)
+
+            # Install target image
+            logger.info("Upgrading to {}".format(to_image))
+            target_version = install_sonic(duthost, to_image, tbinfo)
+            advancedReboot = get_advanced_reboot(rebootType=get_reboot_command(duthost, "warm"),\
+                advanceboot_loganalyzer=advanceboot_loganalyzer)
+            sad_preboot_list, sad_inboot_list = get_sad_case_list(duthost, nbrhosts, fanouthosts, tbinfo, sad_case_type)
+            advancedReboot.runRebootTestcase(
+                prebootList=sad_preboot_list,
+                inbootList=sad_inboot_list
+            )
             reboot_cause = get_reboot_cause(duthost)
             logger.info("Check reboot cause. Expected cause {}".format(upgrade_type))
             pytest_assert(reboot_cause == upgrade_type, "Reboot cause {} did not match the trigger - {}".format(reboot_cause, upgrade_type))

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -1,11 +1,8 @@
 import pytest
 import logging
-from datetime import datetime
-from tests.ptf_runner import ptf_runner
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.platform.ssh_utils import prepare_testbed_ssh_keys
 from tests.common import reboot
-from tests.common.reboot import get_reboot_cause, reboot_ctrl_dict
+from tests.common.reboot import get_reboot_cause
 from tests.common.reboot import REBOOT_TYPE_COLD
 from tests.upgrade_path.upgrade_helpers import check_services, install_sonic, check_sonic_version, get_reboot_command
 from tests.upgrade_path.upgrade_helpers import restore_image
@@ -19,7 +16,7 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses      # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # lgtm[py/unused-import]
 
-from tests.platform_tests.warmboot_sad_cases import get_sad_case_list, SAD_CASE_LIST
+from tests.platform_tests.warmboot_sad_cases import get_sad_case_list
 
 
 pytestmark = [
@@ -62,7 +59,7 @@ def test_upgrade_path(localhost, duthosts, ptfhost, rand_one_dut_hostname, nbrho
 
             # Install target image
             logger.info("Upgrading to {}".format(to_image))
-            target_version = install_sonic(duthost, to_image, tbinfo)
+            install_sonic(duthost, to_image, tbinfo)
             if upgrade_type == REBOOT_TYPE_COLD: #reboot_ctrl_dict.get(REBOOT_TYPE_COLD).get("command"):
                 # advance-reboot test (on ptf) does not support cold reboot yet
                 reboot(duthost, localhost)
@@ -99,7 +96,7 @@ def test_warm_upgrade_sad_path(localhost, duthosts, ptfhost, rand_one_dut_hostna
 
             # Install target image
             logger.info("Upgrading to {}".format(to_image))
-            target_version = install_sonic(duthost, to_image, tbinfo)
+            install_sonic(duthost, to_image, tbinfo)
             advancedReboot = get_advanced_reboot(rebootType=get_reboot_command(duthost, "warm"),\
                 advanceboot_loganalyzer=advanceboot_loganalyzer)
             sad_preboot_list, sad_inboot_list = get_sad_case_list(duthost, nbrhosts, fanouthosts, tbinfo, sad_case_type)

--- a/tests/upgrade_path/upgrade_helpers.py
+++ b/tests/upgrade_path/upgrade_helpers.py
@@ -1,11 +1,7 @@
 import pytest
 import logging
-import json
-import os
 import time
 from urlparse import urlparse
-from jinja2 import Template
-import ipaddr
 import ipaddress
 from tests.common.helpers.assertions import pytest_assert
 from tests.common import reboot

--- a/tests/upgrade_path/upgrade_helpers.py
+++ b/tests/upgrade_path/upgrade_helpers.py
@@ -28,60 +28,17 @@ def pytest_runtest_setup(item):
         pytest.skip("base_image_list or target_image_list is empty")
 
 
-def cleanup(localhost, ptfhost, duthost, upgrade_path_lists, tbinfo):
+@pytest.fixture(scope="module")
+def restore_image(localhost, duthosts, rand_one_dut_hostname, upgrade_path_lists, tbinfo):
     _, _, _, restore_to_image = upgrade_path_lists
+    yield
+    duthost = duthosts[rand_one_dut_hostname]
     if restore_to_image:
         logger.info("Preparing to cleanup and restore to {}".format(restore_to_image))
         # restore orignial image
         install_sonic(duthost, restore_to_image, tbinfo)
         # Perform a cold reboot
         reboot(duthost, localhost)
-    # cleanup
-    ptfhost.shell("rm -f {} {} {}".format(TMP_VLAN_FILE, TMP_VLAN_PORTCHANNEL_FILE, TMP_PORTS_FILE),
-                  module_ignore_errors=True)
-    os.remove(TMP_VLAN_FILE)
-    os.remove(TMP_VLAN_PORTCHANNEL_FILE)
-    os.remove(TMP_PORTS_FILE)
-
-
-def prepare_ptf(ptfhost, duthost, tbinfo):
-    logger.info("Preparing ptfhost")
-
-    # Prapare vlan conf file
-    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-
-    with open(TMP_VLAN_PORTCHANNEL_FILE, "w") as file:
-        file.write(json.dumps(mg_facts['minigraph_portchannels']))
-    ptfhost.copy(src=TMP_VLAN_PORTCHANNEL_FILE,
-                 dest=TMP_VLAN_PORTCHANNEL_FILE)
-
-    with open(TMP_VLAN_FILE, "w") as file:
-        file.write(json.dumps(mg_facts['minigraph_vlans']))
-    ptfhost.copy(src=TMP_VLAN_FILE,
-                 dest=TMP_VLAN_FILE)
-
-    with open(TMP_PORTS_FILE, "w") as file:
-        file.write(json.dumps(mg_facts['minigraph_ptf_indices']))
-    ptfhost.copy(src=TMP_PORTS_FILE,
-                 dest=TMP_PORTS_FILE)
-
-    with open(TMP_PEER_INFO_FILE, "w") as file:
-        file.write(json.dumps(mg_facts['minigraph_devices']))
-    ptfhost.copy(src=TMP_PEER_INFO_FILE,
-                 dest=TMP_PEER_INFO_FILE)
-
-    with open(TMP_PEER_PORT_INFO_FILE, "w") as file:
-        file.write(json.dumps(mg_facts['minigraph_neighbors']))
-    ptfhost.copy(src=TMP_PEER_PORT_INFO_FILE,
-                 dest=TMP_PEER_PORT_INFO_FILE)
-
-    arp_responder_conf = Template(open("../ansible/roles/test/templates/arp_responder.conf.j2").read())
-    ptfhost.copy(content=arp_responder_conf.render(arp_responder_args="-e"),
-                 dest="/etc/supervisor/conf.d/arp_responder.conf")
-    ptfhost.copy(src='scripts/dual_tor_sniffer.py', dest="/root/ptftests/advanced_reboot_sniffer.py")
-
-    ptfhost.shell("supervisorctl reread")
-    ptfhost.shell("supervisorctl update")
 
 
 def get_reboot_command(duthost, upgrade_type):
@@ -163,63 +120,3 @@ def check_reboot_cause(duthost, expected_cause):
     reboot_cause = get_reboot_cause(duthost)
     logging.info("Checking cause from dut {} to expected {}".format(reboot_cause, expected_cause))
     return reboot_cause == expected_cause
-
-
-@pytest.fixture(scope="module")
-def setup(localhost, ptfhost, duthosts, rand_one_dut_hostname, upgrade_path_lists, tbinfo):
-    duthost = duthosts[rand_one_dut_hostname]
-    prepare_ptf(ptfhost, duthost, tbinfo)
-    yield
-    cleanup(localhost, ptfhost, duthost, upgrade_path_lists, tbinfo)
-
-
-@pytest.fixture(scope="module")
-def ptf_params(duthosts, rand_one_dut_hostname, creds, tbinfo):
-    duthost = duthosts[rand_one_dut_hostname]
-
-    if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
-        reboot_limit_in_seconds = 150
-    else:
-        reboot_limit_in_seconds = 30
-
-    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    lo_v6_prefix = ""
-    for intf in mg_facts["minigraph_lo_interfaces"]:
-        ipn = ipaddr.IPNetwork(intf['addr'])
-        if ipn.version == 6:
-            lo_v6_prefix = str(ipaddr.IPNetwork(intf['addr'] + '/64').network) + '/64'
-            break
-
-    mgFacts = duthost.get_extended_minigraph_facts(tbinfo)
-    vm_hosts = [
-            attr['mgmt_addr'] for dev, attr in mgFacts['minigraph_devices'].items() if attr['hwsku'] == 'Arista-VM'
-        ]
-
-    vlan_ip_range = dict()
-    for vlan in mgFacts['minigraph_vlan_interfaces']:
-        if type(ipaddress.ip_network(vlan['subnet'])) is ipaddress.IPv4Network:
-            vlan_ip_range[vlan['attachto']] = vlan['subnet']
-
-    sonicadmin_alt_password = duthost.host.options['variable_manager']._hostvars[duthost.hostname].get("ansible_altpassword")
-    ptf_params = {
-        "verbose": False,
-        "dut_username": creds.get('sonicadmin_user'),
-        "dut_password": creds.get('sonicadmin_password'),
-        "alt_password": sonicadmin_alt_password,
-        "dut_hostname": duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host'],
-        "reboot_limit_in_seconds": reboot_limit_in_seconds,
-        "reboot_type": "warm-reboot",
-        "portchannel_ports_file": TMP_VLAN_PORTCHANNEL_FILE,
-        "vlan_ports_file": TMP_VLAN_FILE,
-        "ports_file": TMP_PORTS_FILE,
-        "dut_mac": duthost.facts["router_mac"],
-        "dut_vlan_ip": "192.168.0.1",
-        "default_ip_range": "192.168.100.0/18",
-        "vlan_ip_range": json.dumps(vlan_ip_range),
-        "lo_v6_prefix": lo_v6_prefix,
-        "arista_vms": vm_hosts,
-        "setup_fdb_before_test": True,
-        "target_version": "Unknown",
-        "preboot_files" : "peer_dev_info,neigh_port_info"
-    }
-    return ptf_params


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

WAIT FOR MERGE of https://github.com/Azure/sonic-mgmt/pull/4876/files first

Summary: New SAD case upgrade path scenario and code reuse between upgrade and reboot path cases.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
For better coverage of upgrade path scenario.

Changes added here:
1. New testcases - test_warm_upgrade_sad_path - supported for both Physical and KVM platform.
2. Enable log_analyzer for upgrade path scenario.
3.  Refactor upgrade path code and resuse the code from advanced_reboot.py - this reuse of code allows singular changes (not needed twice), and less code to maintain.

#### How did you do it?
Add SAD case for upgrade path using changes done in PR #4876.
Add log_analyzer fixture.
Remvoed duplicated code between upgrade_helpers and advanced_reboot.py

#### How did you verify/test it?
Tested on KVM platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
