### PR TITLE
Changes to add is_speed_controllable check for fans and run the chassis_fans tests with thermalctld process stopped.

### DIFF
--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -10,7 +10,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import chassis, fan
 
 from platform_api_test_base import PlatformApiTestBase
-from tests.platform_tests.thermal_control_test_helper import *
+from tests.platform_tests.thermal_control_test_helper import start_thermal_control_daemon, stop_thermal_control_daemon
 
 ###################################################
 # TODO: Remove this after we transition to Python 3

--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -10,6 +10,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import chassis, fan
 
 from platform_api_test_base import PlatformApiTestBase
+from tests.platform_tests.thermal_control_test_helper import *
 
 ###################################################
 # TODO: Remove this after we transition to Python 3
@@ -48,12 +49,15 @@ class TestChassisFans(PlatformApiTestBase):
     # level, so we must do the same here to prevent a scope mismatch.
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, platform_api_conn):
+    def setup(self, platform_api_conn, duthost):
         if self.num_fans is None:
             try:
                 self.num_fans = int(chassis.get_num_fans(platform_api_conn))
             except:
                 pytest.fail("num_fans is not an integer")
+        stop_thermal_control_daemon(duthost)
+        yield
+        start_thermal_control_daemon(duthost) 
 
     #
     # Helper functions

--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -10,7 +10,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import chassis, fan
 
 from platform_api_test_base import PlatformApiTestBase
-from tests.platform_tests.thermal_control_test_helper import start_thermal_control_daemon, stop_thermal_control_daemon
+from tests.platform_tests.thermal_control_test_helper import *
 
 ###################################################
 # TODO: Remove this after we transition to Python 3

--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -55,9 +55,6 @@ class TestChassisFans(PlatformApiTestBase):
                 self.num_fans = int(chassis.get_num_fans(platform_api_conn))
             except:
                 pytest.fail("num_fans is not an integer")
-            else:
-                if self.num_fans == 0:
-                    pytest.skip("No fans found on device")
         stop_thermal_control_daemon(duthost)
         yield
         start_thermal_control_daemon(duthost) 

--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -55,6 +55,9 @@ class TestChassisFans(PlatformApiTestBase):
                 self.num_fans = int(chassis.get_num_fans(platform_api_conn))
             except:
                 pytest.fail("num_fans is not an integer")
+            else:
+                if self.num_fans == 0:
+                    pytest.skip("No fans found on device")
         stop_thermal_control_daemon(duthost)
         yield
         start_thermal_control_daemon(duthost) 

--- a/tests/platform_tests/api/test_psu_fans.py
+++ b/tests/platform_tests/api/test_psu_fans.py
@@ -190,14 +190,12 @@ class TestPsuFans(PlatformApiTestBase):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
-            fans_skipped = 0
 
             for i in range(num_fans):
             # Ensure the fan speed is sane
                 speed_controllable = self.get_fan_facts(duthost, j, i, True, "speed", "controllable")
                 if not speed_controllable:
                     logger.info("test_get_speed: Skipping PSU {} fan {} (speed not controllable)".format(j, i))
-                    fans_skipped += 1
                     continue
                 speed = psu_fan.get_speed(platform_api_conn, j, i)
                 if self.expect(speed is not None, "Unable to retrieve psu {} fan {} speed".format(j, i)):
@@ -266,13 +264,11 @@ class TestPsuFans(PlatformApiTestBase):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
-            fans_skipped = 0
             
             for i in range(num_fans):
                 speed_controllable = self.get_fan_facts(duthost, j, i, True, "speed", "controllable")
                 if not speed_controllable:
                     logger.info("test_get_fans_speed_tolerance: Skipping PSU {} fan {} (speed not controllable)".format(j, i))
-                    fans_skipped += 1
                     continue
                 speed_tolerance = psu_fan.get_speed_tolerance(platform_api_conn, j, i)
                 if self.expect(speed_tolerance is not None, "Unable to retrieve psu {} fan {} speed tolerance".format(j, i)):

--- a/tests/platform_tests/api/test_psu_fans.py
+++ b/tests/platform_tests/api/test_psu_fans.py
@@ -187,12 +187,18 @@ class TestPsuFans(PlatformApiTestBase):
     #
 
     def test_get_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
+            fans_skipped = 0
 
             for i in range(num_fans):
             # Ensure the fan speed is sane
+                speed_controllable = self.get_fan_facts(duthost, j, i, True, "speed", "controllable")
+                if not speed_controllable:
+                    logger.info("test_get_speed: Skipping PSU {} fan {} (speed not controllable)".format(j, i))
+                    fans_skipped += 1
+                    continue
                 speed = psu_fan.get_speed(platform_api_conn, j, i)
                 if self.expect(speed is not None, "Unable to retrieve psu {} fan {} speed".format(j, i)):
                     if self.expect(isinstance(speed, int), "psu {} fan {} speed appears incorrect".format(j, i)):
@@ -257,11 +263,17 @@ class TestPsuFans(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_fans_speed_tolerance(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
-
+            fans_skipped = 0
+            
             for i in range(num_fans):
+                speed_controllable = self.get_fan_facts(duthost, j, i, True, "speed", "controllable")
+                if not speed_controllable:
+                    logger.info("test_get_fans_speed_tolerance: Skipping PSU {} fan {} (speed not controllable)".format(j, i))
+                    fans_skipped += 1
+                    continue
                 speed_tolerance = psu_fan.get_speed_tolerance(platform_api_conn, j, i)
                 if self.expect(speed_tolerance is not None, "Unable to retrieve psu {} fan {} speed tolerance".format(j, i)):
                     if self.expect(isinstance(speed_tolerance, int), "psu {} fan {} speed tolerance appears incorrect".format(j, i)):

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -296,8 +296,6 @@ def stop_thermal_control_daemon(dut):
         assert len(output["stdout_lines"]) >= 1, "There should be at least 1 thermalctld process"
         logging.info("thermalctld processes stopped successfully on {}".format(dut.hostname))
         return
-    # try restore by config reload...
-    config_reload(dut)
     assert 0, 'Wait thermal control daemon stop failed'
 
 def start_thermal_control_daemon(dut):

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -8,7 +8,6 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.config_reload import config_reload
 from tests.common.reboot import reboot
-from tests.common.platform.daemon_utils import check_pmon_daemon_enable_status
 
 DUT_THERMAL_POLICY_FILE = '/usr/share/sonic/device/{}/thermal_policy.json'
 DUT_THERMAL_POLICY_BACKUP_FILE = '/usr/share/sonic/device/{}/thermal_policy.json.bak'

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -8,7 +8,6 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.config_reload import config_reload
 from tests.common.reboot import reboot
-from tests.common.utilities import wait_until
 
 DUT_THERMAL_POLICY_FILE = '/usr/share/sonic/device/{}/thermal_policy.json'
 DUT_THERMAL_POLICY_BACKUP_FILE = '/usr/share/sonic/device/{}/thermal_policy.json.bak'

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -8,6 +8,7 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.config_reload import config_reload
 from tests.common.reboot import reboot
+from tests.common.utilities import wait_until
 
 DUT_THERMAL_POLICY_FILE = '/usr/share/sonic/device/{}/thermal_policy.json'
 DUT_THERMAL_POLICY_BACKUP_FILE = '/usr/share/sonic/device/{}/thermal_policy.json.bak'
@@ -15,6 +16,9 @@ BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 FILES_DIR = os.path.join(BASE_DIR, 'files')
 
 daemon_name = "thermalctld"
+
+expected_running_status = "RUNNING"
+expected_stopped_status = "STOPPED"
 
 class BaseMocker:
     """
@@ -251,6 +255,9 @@ def check_thermal_algorithm_status(dut, mocker_factory, expected_status):
         return thermal_mocker.check_thermal_algorithm_status(expected_status)
     return True  # if vendor doesn't provide a thermal mocker, ignore this check by return True.
 
+def check_expected_daemon_status(duthost, expected_daemon_status):
+    daemon_status, _ = duthost.get_pmon_daemon_status(daemon_name)
+    return daemon_status == expected_daemon_status
 
 def restart_thermal_control_daemon(dut):
     """
@@ -286,7 +293,7 @@ def start_thermal_control_daemon(dut):
     daemon_status, daemon_pid = dut.get_pmon_daemon_status(daemon_name)
     if daemon_status != "RUNNING":
         dut.start_pmon_daemon(daemon_name)
-        time.sleep(10)
+        wait_until(10, 2, 0, check_expected_daemon_status, dut, expected_running_status)
     running_daemon_status, daemon_pid = dut.get_pmon_daemon_status(daemon_name)
     assert running_daemon_status == "RUNNING", "Run command '{}' failed after starting of thermalctld on {}".format(start_pmon_daemon, dut.hostname)
     logging.info("thermalctld processes started successfully on {}".format(dut.hostname))
@@ -295,7 +302,7 @@ def stop_thermal_control_daemon(dut):
     daemon_status, daemon_pid = dut.get_pmon_daemon_status(daemon_name)
     if daemon_status == "RUNNING":
         dut.stop_pmon_daemon(daemon_name)
-        time.sleep(10)
+        wait_until(10, 2, 0, check_expected_daemon_status, dut, expected_stopped_status)
     stopped_daemon_status, daemon_pid = dut.get_pmon_daemon_status(daemon_name)
     assert stopped_daemon_status == "STOPPED", "Run command '{}' failed after stopping of thermalctld on {}".format(stop_pmon_daemon, dut.hostname)
     logging.info("thermalctld processes stopped successfully on {}".format(dut.hostname))

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -14,6 +14,8 @@ DUT_THERMAL_POLICY_BACKUP_FILE = '/usr/share/sonic/device/{}/thermal_policy.json
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 FILES_DIR = os.path.join(BASE_DIR, 'files')
 
+daemon_name = "thermalctld"
+
 class BaseMocker:
     """
     @summary: Base class for thermal control data mocker

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -289,21 +289,21 @@ def restart_thermal_control_daemon(dut):
     assert 0, 'Wait thermal control daemon restart failed'
 
 def start_thermal_control_daemon(dut):
-    daemon_status, daemon_pid = dut.get_pmon_daemon_status(daemon_name)
-    if daemon_status != "RUNNING":
+    daemon_status, _ = dut.get_pmon_daemon_status(daemon_name)
+    if daemon_status != expected_running_status:
         dut.start_pmon_daemon(daemon_name)
         wait_until(10, 2, 0, check_expected_daemon_status, dut, expected_running_status)
-    running_daemon_status, daemon_pid = dut.get_pmon_daemon_status(daemon_name)
-    assert running_daemon_status == "RUNNING", "Run command '{}' failed after starting of thermalctld on {}".format(start_pmon_daemon, dut.hostname)
+    running_daemon_status, _ = dut.get_pmon_daemon_status(daemon_name)
+    assert running_daemon_status == expected_running_status, "Run command '{}' failed after starting of thermalctld on {}".format(start_pmon_daemon, dut.hostname)
     logging.info("thermalctld processes started successfully on {}".format(dut.hostname))
 
 def stop_thermal_control_daemon(dut):
-    daemon_status, daemon_pid = dut.get_pmon_daemon_status(daemon_name)
-    if daemon_status == "RUNNING":
+    daemon_status, _ = dut.get_pmon_daemon_status(daemon_name)
+    if daemon_status == expected_running_status:
         dut.stop_pmon_daemon(daemon_name)
         wait_until(10, 2, 0, check_expected_daemon_status, dut, expected_stopped_status)
-    stopped_daemon_status, daemon_pid = dut.get_pmon_daemon_status(daemon_name)
-    assert stopped_daemon_status == "STOPPED", "Run command '{}' failed after stopping of thermalctld on {}".format(stop_pmon_daemon, dut.hostname)
+    stopped_daemon_status, _ = dut.get_pmon_daemon_status(daemon_name)
+    assert stopped_daemon_status == expected_stopped_status, "Run command '{}' failed after stopping of thermalctld on {}".format(stop_pmon_daemon, dut.hostname)
     logging.info("thermalctld processes stopped successfully on {}".format(dut.hostname))
                                                                 
 class ThermalPolicyFileContext:


### PR DESCRIPTION
1. Add controllable flag to deterministicly skip some tests base on platform.json
2.  make test_chassis_fans tests run with thermalctld OFF

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
