### PR TITLE
[pfcwd_timer_accuracy] fix test issue - object has no attribute

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -143,7 +143,7 @@ class TestPfcwdAllTimer(object):
         """
         Test execution
         """
-        with DisableLogrotateCronContext(self.ansible_host):
+        with DisableLogrotateCronContext(self.dut):
             logger.info("Flush logs")
             self.dut.shell("logrotate -f /etc/logrotate.conf")
         self.storm_handle.start_storm()


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: In the change #4872 was added usage of the wrong variable.
The fix for error in test test_pfcwd_timer_accuracy:
Failed: 'TestPfcwdAllTimer' object has no attribute 'ansible_host' 


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix failed test

#### How did you do it?
executed updated test 

#### How did you verify/test it?
test passed 

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
