### PR TITLE
[test_fgnhg] add module ignore error to ptfhost command

### DIFF
--- a/tests/ecmp/test_fgnhg.py
+++ b/tests/ecmp/test_fgnhg.py
@@ -133,7 +133,7 @@ def setup_neighbors(duthost, ptfhost, ip_to_port):
 def setup_arpresponder(ptfhost, ip_to_port):
     logger.info("Copy arp_responder to ptfhost")
     # Stop existing arp responder if running
-    ptfhost.command('supervisorctl stop arp_responder')
+    ptfhost.command('supervisorctl stop arp_responder', module_ignore_errors=True)
 
     d = defaultdict(list)
 


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added module ignore error to ptfhost command, while stopping the arp_responder.
When it's first run of the test on testbed, the command "supervisorctl stop arp_responder" can fail as the arp_responder still unknown process.

Example of failure:
```
E                   "module_args": {
E                       "_raw_params": "supervisorctl stop arp_responder", 
E                       "_uses_shell": false, 
E                       "argv": null, 
E                       "chdir": null, 
E                       "creates": null, 
E                       "executable": null, 
E                       "removes": null, 
E                       "stdin": null, 
E                       "stdin_add_newline": true, 
E                       "strip_empty_ends": true, 
E                       "warn": true
E                   }
E               }, 
E               "msg": "non-zero return code", 
E               "rc": 1, 
E               "start": "2021-12-28 15:57:38.740765", 
E               "stderr": "", 
E               "stderr_lines": [], 
E               "stdout": "arp_responder: ERROR (no such process)", 
E               "stdout_lines": [
E                   "arp_responder: ERROR (no such process)"
E               ]
E           }
```



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix the test

#### How did you do it?
Added module ignore to cmd

#### How did you verify/test it?
Executed on testbed

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
