### PR TITLE
Fix image download issues found in upgrade path case for public images

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -80,14 +80,14 @@ def reduce_installed_sonic_images(module):
 def download_new_sonic_image(module, new_image_url, save_as):
     global results
 
-    # Clean-up previous downloads first
-    exec_command(module,
-                 cmd="rm -f {}".format(save_as),
-                 msg="clean up previously downloaded image",
-                 ignore_error=True)
     if new_image_url:
+        # Before downloading new image, clean-up previous downloads first
         exec_command(module,
-                    cmd="curl -o {} {}".format(save_as, new_image_url),
+                    cmd="rm -f {}".format(save_as),
+                    msg="clean up previously downloaded image",
+                    ignore_error=True)
+        exec_command(module,
+                    cmd="curl -Lo {} {}".format(save_as, new_image_url),
                     msg="downloading new image")
 
     if path.exists(save_as):

--- a/tests/upgrade_path/upgrade_helpers.py
+++ b/tests/upgrade_path/upgrade_helpers.py
@@ -114,7 +114,7 @@ def install_sonic(duthost, image_url, tbinfo):
             # Temporarily change the default route to mgmt-gateway address. This is done so that
             # DUT can download an image from a remote host over the mgmt network.
             logger.info("Add default mgmt-gateway-route to the device via {}".format(mg_gwaddr))
-            duthost.shell("ip route add default via {} metric 1".format(mg_gwaddr), module_ignore_errors=True)
+            duthost.shell("ip route replace default via {}".format(mg_gwaddr), module_ignore_errors=True)
             new_route_added = True
         res = duthost.reduce_and_add_sonic_images(new_image_url=image_url)
     else:

--- a/tests/upgrade_path/upgrade_helpers.py
+++ b/tests/upgrade_path/upgrade_helpers.py
@@ -114,7 +114,7 @@ def install_sonic(duthost, image_url, tbinfo):
             # Temporarily change the default route to mgmt-gateway address. This is done so that
             # DUT can download an image from a remote host over the mgmt network.
             logger.info("Add default mgmt-gateway-route to the device via {}".format(mg_gwaddr))
-            duthost.shell("ip route add default via {}".format(mg_gwaddr), module_ignore_errors=True)
+            duthost.shell("ip route add default via {} metric 1".format(mg_gwaddr), module_ignore_errors=True)
             new_route_added = True
         res = duthost.reduce_and_add_sonic_images(new_image_url=image_url)
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix image download issues found by upgrade path tests
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Three changes included in this PR

1. Allow CURL to download from URL redirects. While testing upgrade path with public images, it is found that the latest image URL redirects to artifacts from the latest build. Without `-L` option in CURL, the redirected URL is rejected. With `-L` option, CURL now redirects and downloads the publicly available latest image.
https://stackoverflow.com/questions/20440706/download-file-with-url-redirection

2. If images are available locally, do not delete them. In present code, it is assumed that `reduce_installed_sonic_images` will always get a URL to download the image. However, in upgrade path tests, the image to be used can be stored locally too and SCP'd to the device. In this case deleting the SCP'd image would result in no image at all as there will be no download initiated.

3. In upgrade path case, to allow image download, the DUT should be able to reach public network. For this purpose, a default IP route via eth0 port is added (and removed after image is downloaded). However, in the present code, this new default route is added when there already exists. So use `ip route replace` to forcefully add the new route.
`Before adding new route:`
```
admin@vlab-01:~$ show ip route | more
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, P - PIM, A - Babel,
       > - selected route, * - FIB route

B>* 0.0.0.0/0 [20/0] via 10.0.0.57, PortChannel101, src 10.1.0.32, 00:00:19
  *                  via 10.0.0.59, PortChannel102, src 10.1.0.32, 00:00:19
  *                  via 10.0.0.61, PortChannel103, src 10.1.0.32, 00:00:19
  *                  via 10.0.0.63, PortChannel104, src 10.1.0.32, 00:00:19
S   0.0.0.0/0 [200/0] via 10.250.0.1, eth0
```
`After adding new route:`
```
admin@vlab-01:~$ show ip route 0.0.0.0
Routing entry for 0.0.0.0/0
  Known via "bgp", distance 20, metric 0, best
  Last update 00:18:18 ago
  * 10.0.0.57, via PortChannel101, weight 1
  * 10.0.0.59, via PortChannel102, weight 1
  * 10.0.0.61, via PortChannel103, weight 1
  * 10.0.0.63, via PortChannel104, weight 1
admin@vlab-01:~$
admin@vlab-01:~$ sudo ip route replace default via 10.250.0.1 
admin@vlab-01:~$ 
admin@vlab-01:~$ show ip route 0.0.0.0
Routing entry for 0.0.0.0/0
  Known via "kernel", distance 0, metric 0, best
  Last update 00:00:02 ago
  * 10.250.0.1, via eth0
Routing entry for 0.0.0.0/0
  Known via "bgp", distance 20, metric 0
  Last update 00:18:24 ago
    10.0.0.57, via PortChannel101, weight 1
    10.0.0.59, via PortChannel102, weight 1
    10.0.0.61, via PortChannel103, weight 1
    10.0.0.63, via PortChannel104, weight 1
admin@vlab-01:~$ 
```


#### How did you do it?
Added `-L` option to CURL cmd.
Added a new default route with metric 1 so that it is preferred route.
Moved the logic to remove old images only when the new image exists and is going to be downloaded.

#### How did you verify/test it?
Tested on KVM.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
