### PR TITLE
[advanced-reboot] Fix KVM sad case error when fanout doesn't exist

### DIFF
--- a/tests/common/helpers/sad_path.py
+++ b/tests/common/helpers/sad_path.py
@@ -139,7 +139,8 @@ class NeighVlanMemberDown(VlanMemberDown):
 
         for port in self.ports:
             fanout, fanport = fanout_switch_port_lookup(self.fanouthosts, self.duthost.hostname, port)
-            fanout.shutdown(fanport)
+            if fanout and fanport:
+                fanout.shutdown(fanport)
 
     def verify(self):
         facts = self.duthost.show_interface(command="status", interfaces=self.ports)
@@ -149,7 +150,8 @@ class NeighVlanMemberDown(VlanMemberDown):
     def revert(self):
         for port in self.ports:
             fanout, fanport = fanout_switch_port_lookup(self.fanouthosts, self.duthost.hostname, port)
-            fanout.no_shutdown(fanport)
+            if fanout and fanport:
+                fanout.no_shutdown(fanport)
 
     def __str__(self):
         return "neigh_vlan_member_down:{}".format(len(self.ports))
@@ -270,10 +272,11 @@ class NeighLagMemberDown(LagMemberDown):
                 nbrhost.shutdown(nbrport)
 
             fanout, fanport = fanout_switch_port_lookup(self.fanouthosts, self.duthost.hostname, port)
-            if bring_up:
-                fanout.no_shutdown(fanport)
-            else:
-                fanout.shutdown(fanport)
+            if fanout and fanport:
+                if bring_up:
+                    fanout.no_shutdown(fanport)
+                else:
+                    fanout.shutdown(fanport)
 
 
     def __str__(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix advanced-reboot SAD case scenario when error is hit while shutting down and no-shutdown fanout ports.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
While testing advance-reboot SAD cases on KVM switch, below error was hit in some cases. The reason is that for virtual testbed, fanout does not exist, and invoking APIs on fanout will error out:

```
DutLagMemberDown(duthost, nbrhosts, DatetimeSelector(1), PhyPropsPortSelector(duthost, 1)),
	  File "/var/src/sonic-mgmt/tests/common/helpers/sad_path.py", line 260, in revert
		self._change_ports_state(bring_up=True)
	  File "/var/src/sonic-mgmt/tests/common/helpers/sad_path.py", line 274, in _change_ports_state
		fanout.no_shutdown(fanport)
	AttributeError: 'NoneType' object has no attribute 'no_shutdown'
```

#### How did you do it?
Check if fanout and fanport are not None.

#### How did you verify/test it?
Tested on KVM platform and the issue was not seen.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
