### PR TITLE
[TestbedProcessing] Added syseeprom_info support for lab file in YAML format

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -615,6 +615,7 @@ def makeLabYAML(data, devices, testbed, outfile):
     fanoutDict = dict()
     ptfDict = dict()
     dutDict = dict()
+    serverDict = dict()
 
     if "sonic" in deviceGroup['lab']['children']:
         for group in deviceGroup['sonic']['children']:
@@ -634,21 +635,39 @@ def makeLabYAML(data, devices, testbed, outfile):
                         'ptf_host': devices[dut].get("ptf_host"),
                         'serial': devices[dut].get("serial"),
                         'os': devices[dut].get("os"),
-                        'model': devices[dut].get("model")
+                        'model': devices[dut].get("model"),
+                        'syseeprom_info': {"0x21": devices[dut].get("syseeprom_info").get("0x21"),
+                                           "0x22": devices[dut].get("syseeprom_info").get("0x22"),
+                                           "0x23": devices[dut].get("syseeprom_info").get("0x23"),
+                                           "0x24": devices[dut].get("syseeprom_info").get("0x24"),
+                                           "0x25": devices[dut].get("syseeprom_info").get("0x25"),
+                                           "0x26": devices[dut].get("syseeprom_info").get("0x26"),
+                                           "0x2A": devices[dut].get("syseeprom_info").get("0x2A"),
+                                           "0x2B": devices[dut].get("syseeprom_info").get("0x2B"),
+                                           "0xFE": devices[dut].get("syseeprom_info").get("0xFE")}
                         }
                     })
                     sonicDict[group]['hosts'].update(dutDict)
     if "fanout" in deviceGroup['lab']['children']:
-        for fanout in deviceGroup['fanout']['host']:
-            if fanout in devices:
-                fanoutDict.update({fanout:
-                    {'ansible_host': devices[fanout].get("ansible").get("ansible_host"),
-                    'ansible_ssh_user': devices[fanout].get("ansible").get("ansible_ssh_user"),
-                    'ansible_ssh_pass': devices[fanout].get("ansible").get("ansible_ssh_pass"),
-                    'os': devices[fanout].get("os"),
-                    'device_type': devices[fanout].get("device_type")
-                    }
-                })
+        for fanoutType in deviceGroup['fanout']['children']:
+            for fanout in deviceGroup[fanoutType]['host']:
+                if fanout in devices:
+                    fanoutDict.update({fanout:
+                        {'ansible_host': devices[fanout].get("ansible").get("ansible_host"),
+                        'ansible_ssh_user': devices[fanout].get("ansible").get("ansible_ssh_user"),
+                        'ansible_ssh_pass': devices[fanout].get("ansible").get("ansible_ssh_pass"),
+                        'os': devices[fanout].get("os"),
+                        'device_type': devices[fanout].get("device_type")
+                        }
+                    })
+    for server in deviceGroup['servers']['host']:
+        if server in devices:
+            serverDict.update({server:
+                        {'ansible_host': devices[server].get("ansible").get("ansible_host"),
+                        'ansible_ssh_user': devices[server].get("ansible").get("ansible_ssh_user"),
+                        'ansible_ssh_pass': devices[server].get("ansible").get("ansible_ssh_pass"),
+                        'device_type': devices[server].get("device_type")
+                        }})
     if 'ptf' in deviceGroup:
         for ptfhost in deviceGroup['ptf']['host']:
             if ptfhost in testbed:
@@ -667,7 +686,8 @@ def makeLabYAML(data, devices, testbed, outfile):
                                 'fanout': {'hosts': fanoutDict}
                                 }
                             },
-                        'ptf': {'hosts': ptfDict}
+                        'ptf': {'hosts': ptfDict},
+                        'server': serverDict
                         }
                     }
     })


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added parsing support of syseeprom_info from testbed file to lab file in YAML format.
Updated fanout parsing for different types of fanouts, and added server`s parsing.  

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
platform TC is failing due to missing syseeprom_info in inventory file when lab file created by TestbedProcessing.py in YAML format.
#### How did you do it?
Added parsing support of syseeprom_info to TestbedProcessing.py that allow to parse syseeprom_info from testbed file and create a lab file in YAML format.
#### How did you verify/test it?
Generate lab file and run tests
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
