### PR TITLE
[test_fdb] add missing import to new test

### DIFF
--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -11,6 +11,7 @@ import pprint
 import re
 import random
 
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # lgtm[py/unused-import]
 from tests.common.fixtures.duthost_utils import disable_fdb_aging


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix test issue. Added missing import for the test, which added in the commit #4813

```
        fdb_facts = rand_selected_dut.fdb_facts()['ansible_facts'] 
>       pytest_assert(self_mac not in fdb_facts, 
                        "Self-mac {} is not supposed to be learnt".format(self_mac)) 
E       NameError: global name 'pytest_assert' is not defined 
### Type of change

```
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Stabilize the test

#### How did you do it?
added import

#### How did you verify/test it?
Did run of the test

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
