### PR TITLE
 Check no routes from nexthop present in kernel after deleting lag ip and members

### DIFF
--- a/tests/pc/test_po_voq.py
+++ b/tests/pc/test_po_voq.py
@@ -1,8 +1,6 @@
 import pytest
 import tests.common.helpers.voq_lag as voq_lag
-#from tests.voq.voq_helpers import get_neighbor_info
 from tests.voq.voq_helpers import verify_no_routes_from_nexthop
-import time
 import logging
 logger = logging.getLogger(__name__)
 

--- a/tests/pc/test_po_voq.py
+++ b/tests/pc/test_po_voq.py
@@ -1,10 +1,14 @@
 import pytest
 import tests.common.helpers.voq_lag as voq_lag
+#from tests.voq.voq_helpers import get_neighbor_info
+from tests.voq.voq_helpers import verify_no_routes_from_nexthop
+import time
+import logging
+logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('t2')
 ]
-
 
 def get_asic_with_pc(duthost):
     """
@@ -48,6 +52,7 @@ def setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     asic = get_asic_with_pc(duthost)
     config_facts = duthost.config_facts(source='persistent',
                                         asic_index=asic.asic_index)['ansible_facts']
+
     portchannel = config_facts['PORTCHANNEL'].keys()[0]
     portchannel_members = config_facts['PORTCHANNEL'][portchannel].get('members')
 
@@ -58,10 +63,16 @@ def setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
             if '.' in ip:
                 portchannel_ip = ip
 
+    for addr in config_facts['BGP_NEIGHBOR']:
+        if portchannel_ip.split('/')[0] == config_facts['BGP_NEIGHBOR'][addr]['local_addr']:
+            nbr_addr = addr
+
+
     if len(portchannel_members) == 0:
         pytest.skip("Skip test due to there is no portchannel member exists in current topology.")
 
     voq_lag.delete_lag_members_ip(duthost, asic, portchannel_members, portchannel_ip, portchannel)
+    verify_no_routes_from_nexthop(duthosts, nbr_addr)
     voq_lag.add_lag(duthost, asic, portchannel_members, portchannel_ip)
 
     yield asic, portchannel_ip, portchannel_members
@@ -69,6 +80,7 @@ def setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     voq_lag.delete_lag_members_ip(duthost, asic, portchannel_members, portchannel_ip)
     # remove tmp portchannel
     voq_lag.delete_lag(duthost, asic)
+    verify_no_routes_from_nexthop(duthosts, nbr_addr)
     # add only lag members and ip since lag already exist
     voq_lag.add_lag(duthost, asic, portchannel_members, portchannel_ip, portchannel, add=False)
 

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -185,7 +185,7 @@ def check_no_routes_from_nexthop(asic, nexthop):
         ver = '-6'
     else:
         ver = '-4'
-    cmd = "ip {} route show | grep {} | wc ".format(ver, "\"" + nexthop + " \"")
+    cmd = "ip {} route show | grep -w {} | wc -l".format(ver, nexthop)
     if asic.namespace is not None:
         fullcmd = "sudo ip netns exec {} {}".format(asic.namespace, cmd)
         output = asic.sonichost.shell(fullcmd)

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -3,6 +3,7 @@ import logging
 import re
 import pytest
 
+from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.redis import AsicDbCli, AppDbCli, VoqDbCli
 
@@ -179,7 +180,30 @@ def check_bgp_kernel_route(host, asicnum, prefix, ipver, interface, present=True
         logger.info("Route %s is removed from remote neighbor: %s/%s", prefix, host.hostname, str(asicnum))
 
 
+def check_no_routes_from_nexthop(asic, nexthop):
+    if ':' in nexthop:
+        ver = '-6'
+    else:
+        ver = '-4'
+    cmd = "ip {} route show | grep {} | wc ".format(ver, "\"" + nexthop + " \"")
+    if asic.namespace is not None:
+        fullcmd = "sudo ip netns exec {} {}".format(asic.namespace, cmd)
+        output = asic.sonichost.shell(fullcmd)
+    else:
+        output = asic.sonichost.shell(cmd)
+    output = int(output['stdout'].split()[0])
+    return output == 0
+
+
+def verify_no_routes_from_nexthop(duthosts, nexthop):
+    for dut in duthosts.frontend_nodes:
+        for asic in dut.asics:
+            pytest_assert(wait_until(30, 2, 0, check_no_routes_from_nexthop, asic, nexthop),
+                          "Not all routes flushed from nexthop {} on asic {} on {}".format(nexthop, asic.asic_index, dut.hostname))
+
+
 def check_host_kernel_route(host, asicnum, ipaddr, ipver, interface, present=True):
+
     """
     Checks the kernel route on the host OS.
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
In the setup_teardown fixture of test_po_voq, we prepare dut by deleting members and ip of an existing port channel, and add a new portchannel and assign the same members and ip to the new portchannel.

However, sometimes this removal and addition was causing orchanent on a remote ASIC to exit when run against T2 topology, where we have 12K routes pointing to the portchannel being deleted.  The reason for this is:
- orchagent on the remote asic receives the SWSS record for the neighbor delete of the portchannel.
- It then tries to delete the IP address of the PortChannel.
   - This is not successful right away as there are lots of routes pointing to it.
   - orchagent then postpones the deletion of the IP address.
- orchagent on the remote asic receives the SWSS record for the same ip for the new PortChannel.
   - There was no validation that the previous lag/ip has been removed on the remote asics.
- Since the IP is still having routes (from previous portchannel), it causes a neighbor reference count mismatch and orchagent exits.

#### How did you do it?
To fix this issue, have added verification that after deletion of the LAG and and IP, all routes pointing to the ebgp nbr to that IP
are deleted in the kernel of all the remote asics.

#### How did you verify/test it?
Ran the suite multiple times against a T2 topology with 12K routes

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
