### PR TITLE
Add host server to forced_mgmt_routes for VS setup

### DIFF
--- a/ansible/group_vars/lab/lab.yml
+++ b/ansible/group_vars/lab/lab.yml
@@ -12,7 +12,7 @@ syslog_servers: ['10.0.0.5', '10.0.0.6']
 dns_servers: ['10.0.0.5', '10.0.0.6']
 
 # forced_mgmt_routes
-forced_mgmt_routes: []
+forced_mgmt_routes: ['172.17.0.1']
 
 # ErspanDestinationIpv4
 erspan_dest: ['10.0.0.7']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
For some scenarios, the SONiC DUT may need to access the host server.
For example, for dualtor VS setup, the simulated ycable driver running
in SONiC needs to access mux simulator server running in host server.
Accessing host server from SONiC DUT should go through the management
interface instead of the dataplane default route. Otherwise there is
accessibility issue.

#### How did you do it?
This change added host server IP address 172.17.0.1 to the forced_mgmt_routes
list for VS setup. After minigraph is redeployed to SONiC DUT, then accessing
this IP will go through management interface.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
