### PR TITLE
[VLAN] Fixed FDB population for untagged ports

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -1,4 +1,3 @@
-
 import pytest
 import ptf.packet as scapy
 import ptf.testutils as testutils
@@ -175,7 +174,7 @@ def setup_vlan(duthosts, rand_one_dut_hostname, ptfadapter, tbinfo, work_vlan_po
             res = duthost.command('show int portchannel')
             logger.info('"show int portchannel" output on DUT:\n{}'.format(pprint.pformat(res['stdout_lines'])))
 
-            populate_fdb_for_tagged_ports(ptfadapter, work_vlan_ports_list, vlan_intfs_dict)
+            populate_fdb(ptfadapter, work_vlan_ports_list, vlan_intfs_dict)
     # --------------------- Testing -----------------------
         yield
     # --------------------- Teardown -----------------------
@@ -284,15 +283,18 @@ def verify_unicast_packets(ptfadapter, send_pkt, exp_pkt, src_port, dst_ports):
             logger.error("Expected packet was not received")
         raise
 
-def populate_fdb_for_tagged_ports(ptfadapter, work_vlan_ports_list, vlan_intfs_dict):
-    # send icmp packet from each tagged port in each test vlan to populate fdb
+
+def populate_fdb(ptfadapter, work_vlan_ports_list, vlan_intfs_dict):
+    # send icmp packet from each tagged and untagged port in each test vlan to populate fdb
     for vlan in vlan_intfs_dict:
         for vlan_port in work_vlan_ports_list:
-            if vlan_port['pvid'] != vlan and vlan in vlan_port['permit_vlanid']:
+            if vlan in vlan_port['permit_vlanid']:
+                vlan_id = 0 if vlan == vlan_port['pvid'] else vlan  # vlan_id: 0 - untagged, vlan = tagged
                 port_id = vlan_port['port_index'][0]
                 src_mac = ptfadapter.dataplane.get_mac(0, port_id)
-                pkt = build_icmp_packet(vlan_id=vlan, src_mac=src_mac)
+                pkt = build_icmp_packet(vlan_id=vlan_id, src_mac=src_mac)
                 testutils.send(ptfadapter, port_id, pkt)
+
 
 @pytest.mark.bsl
 def test_vlan_tc1_send_untagged(ptfadapter, work_vlan_ports_list, toggle_all_simulator_ports_to_rand_selected_tor_m):
@@ -425,7 +427,7 @@ def test_vlan_tc5_untagged_unicast(ptfadapter, work_vlan_ports_list, vlan_intfs_
         if len(ports_for_test) < 2:
             continue
 
-        #take two tagged ports for test
+        #take two untagged ports for test
         src_port = ports_for_test[0]
         dst_port = ports_for_test[-1]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_vlan_tc5_untagged_unicast has been failing due to missing FDB entries. Unicast packets have been flooded due to the destination MAC address hasn't been learned for untagged ports.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The issue is similar to [[vlan] Populate fdb for tagged ports on DUT #4809](https://github.com/Azure/sonic-mgmt/pull/4809) but it hasn't fixed test_vlan_tc5_untagged_unicast. So, sometimes unicast packets have been flooded and received on other ports: 
>  Received packet that we expected not to receive on device 0, port 2.

#### How did you do it?
Adjusted function for populating FDB table to work also for **untagged** ports. The function **populate_fdb** works once in the setup_vlan fixture and sends ICMP packets from PTF to DUT for each tagged and untagged port in each VLAN in order to have FDB entries for further testing.

#### How did you verify/test it?
Executed vlan/test_vlan.py -> all test cases have been passed
Executed 5 times in a loop vlan/test_vlan.py  -> all test cases have been passed

