### PR TITLE
fixed port autoneg advertised speed setup for EOS

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -253,9 +253,10 @@ class EosHost(AnsibleHostBase):
             # so this branch left nop intentionally
             return True
             
+        speed_mode = 'auto' if self.get_auto_negotiation_mode(interface_name) else 'forced'
         speed = speed[:-3] + 'gfull'
         out = self.host.eos_config(
-                lines=['speed forced {}'.format(speed)],
+                lines=['speed {} {}'.format(speed_mode, speed)],
                 parents='interface %s' % interface_name)[self.hostname]
         logger.debug('Set force speed for port {} : {}'.format(interface_name, out))
         return not self._has_cli_cmd_failed(out)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fixed port autoneg advertised speed setup for EOS
Fixes # (issue)

EosHost includes API to EOS fanout for port autoneg management. There is a set_speed method which tests call to set interface speed for an interface based on autoneg feature state:

- when autoneg is off the method is expected to set forced speed
- when autoneg is on the method is expected to set a given speed as advertised speed
Current impl fails the 2nd rule and always set forced speed whatever autoneg state is. The PR fixes it
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix port autoneg tests running with EOS fanout
#### How did you do it?
Fixed method for setting advertised port speed
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
