### PR TITLE
For Ubuntu 18.04, install j2cli 0.3.10 instead of 0.3.12b0

### DIFF
--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -21,8 +21,8 @@ First, we need to prepare the host where we will be configuring the virtual test
    2. Option : If your host is **Ubuntu 18.04**
         ```
         sudo apt install python python-pip
-        # v0.3.12b Jinja2 is required, lower version may cause uncompatible issue
-        sudo pip install j2cli==0.3.12b0
+        # v0.3.10 Jinja2 is required, lower version may cause uncompatible issue
+        sudo pip install j2cli==0.3.10
         ```
 
 3. Run the host setup script to install required packages and initialize the management bridge network

--- a/setup-container.sh
+++ b/setup-container.sh
@@ -365,7 +365,7 @@ if docker ps -a --format "{{.Names}}" | grep -q "^${CONTAINER_NAME}$"; then
     fi
 fi
 
-if ! j2 -v &> /dev/null; then
+if ! which j2 &> /dev/null; then
     exit_failure "missing Jinja2 templates support: make sure j2cli package is installed"
 fi
 


### PR DESCRIPTION
Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Change the VS testbed instructions so that on Ubuntu 18.04, j2cli 0.3.10 is installed instead of 0.3.12b0.

Also change the j2cli check in `setup-container.sh` so that it uses `which` instead of getting the version, so that the exit code will always be 0 if it exists (even if the user has 0.3.12b0 installed).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

Version 0.3.12b0 is considered a pre-release version on pip, and at any rate, version 0.3.10 would be installed by default (and is probably the version that gets installed on new Ubuntu 20.04 systems).

More importantly, on 0.3.12b0, the exit code of `j2cli -v` and `j2cli -h` is 1 instead of 0. This breaks the `setup-container.sh` script which expects an exit code of 0 for `j2cli -v`.

#### How did you do it?

#### How did you verify/test it?

Verfied by installing 0.3.12b0 and checking the Dockerfile that was generated to see if it was valid.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
