### PR TITLE
Add a test to check if pfcwd gets started after load_minigraph

### DIFF
--- a/tests/pfcwd/test_pfc_config.py
+++ b/tests/pfcwd/test_pfc_config.py
@@ -2,6 +2,8 @@ import json
 import os
 import pytest
 import logging
+import re
+import time
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
@@ -112,6 +114,65 @@ def cfg_setup(setup_pfc_test, duthosts, rand_one_dut_hostname):
     logger.info("--- Clean up config dir from DUT ---")
     cfg_teardown(duthost)
 
+def update_init_cfg_file(duthost, default_pfcwd_value):
+    """
+    Set default_pfcwd_status in /etc/sonic/init_cfg.json with parameter default_pfcwd_value
+
+    Args:
+        duthost (AnsibleHost): instance
+        default_pfcwd_value: value of default_pfcwd_status, enable or disable
+
+    Returns:
+        original value of default_pfcwd_status
+    """
+    output = duthost.shell("cat /etc/sonic/init_cfg.json | grep default_pfcwd_status")['stdout']
+    matched = re.search('"default_pfcwd_status": "(.*)"', output)
+    if matched:
+        original_value = matched.group(1)
+    else:
+        pytest.failed("There is no default_pfcwd_status in /etc/sonic/init_cfg.json.")
+
+    sed_command = "sed -i \'s/\"default_pfcwd_status\": \"{}\"/\"default_pfcwd_status\": \"{}\"/g\' /etc/sonic/init_cfg.json".format(original_value, default_pfcwd_value)
+    duthost.shell(sed_command)
+
+    return original_value
+
+def mg_cfg_teardown(duthost, default_pfcwd_value):
+    """
+    Reset default_pfcwd_status to its orignial value after the case run
+
+    Args:
+        duthost (AnsibleHost): instance
+        default_pfcwd_value: value of default_pfcwd_status, enable or disable
+
+    Returns:
+        None
+    """
+    update_init_cfg_file(duthost, default_pfcwd_value)
+
+@pytest.fixture(scope='class', autouse=True)
+def mg_cfg_setup(duthosts, rand_one_dut_hostname):
+    """
+    Class level automatic fixture. Prior to the test run, enable default pfcwd configuration
+    before load_minigraph.
+    After the test case is done, recover the configuration
+
+    Args:
+        duthost: instance of AnsibleHost class
+        rand_one_dut_hostname(string) : randomly pick a dut in multi DUT setup
+    Returns:
+        None
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    logger.info("Enable pfcwd in configuration file")
+    original_pfcwd_value = update_init_cfg_file(duthost, "enable")
+
+    yield
+    logger.info("--- Start running default pfcwd config test---")
+
+    logger.info("--- Recover configuration ---")
+    mg_cfg_teardown(duthost, original_pfcwd_value)
 
 @pytest.fixture(scope='function', autouse=True)
 def stop_pfcwd(duthosts, rand_one_dut_hostname):
@@ -268,3 +329,27 @@ class TestPfcConfig(object):
         """
         duthost = duthosts[rand_one_dut_hostname]
         self.execute_test(duthost, "pfc_wd_high_restore_time", None, [CONFIG_TEST_EXPECT_INVALID_RESTORE_TIME_RE], True)
+
+@pytest.mark.usefixtures('mg_cfg_setup')
+class TestDefaultPfcConfig(object):
+    def test_default_cfg_after_load_mg(self, duthosts, rand_one_dut_hostname):
+        """
+        Tests for checking if pfcwd gets started after load_minigraph
+
+        Args:
+            duthost(AnsibleHost): instance
+
+        Returns:
+            None
+        """
+        duthost = duthosts[rand_one_dut_hostname]
+
+        duthost.shell('config load_minigraph -y &>/dev/null', executable="/bin/bash")
+        # sleep 20 seconds to make sure configuration is loaded
+        time.sleep(20)
+        res = duthost.command('pfcwd show config')
+        for l in res['stdout_lines']:
+            if "ethernet" in l.lower():
+                return
+        # If no ethernet port existing in stdout, failed this case.
+        pytest.fail("Failed to start pfcwd after load_minigraph")

--- a/tests/pfcwd/test_pfc_config.py
+++ b/tests/pfcwd/test_pfc_config.py
@@ -7,6 +7,7 @@ import time
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
+from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +131,7 @@ def update_init_cfg_file(duthost, default_pfcwd_value):
     if matched:
         original_value = matched.group(1)
     else:
-        pytest.failed("There is no default_pfcwd_status in /etc/sonic/init_cfg.json.")
+        pytest.fail("There is no default_pfcwd_status in /etc/sonic/init_cfg.json.")
 
     sed_command = "sed -i \'s/\"default_pfcwd_status\": \"{}\"/\"default_pfcwd_status\": \"{}\"/g\' /etc/sonic/init_cfg.json".format(original_value, default_pfcwd_value)
     duthost.shell(sed_command)
@@ -343,8 +344,7 @@ class TestDefaultPfcConfig(object):
             None
         """
         duthost = duthosts[rand_one_dut_hostname]
-
-        duthost.shell('config load_minigraph -y &>/dev/null', executable="/bin/bash")
+        config_reload(duthost, config_source='minigraph')
         # sleep 20 seconds to make sure configuration is loaded
         time.sleep(20)
         res = duthost.command('pfcwd show config')


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To fix #4740.
Add a test to check if pfcwd gets started after load_minigraph.

#### How did you do it?
Add a new test case test_default_cfg_after_load_mg, steps are:
1. Add a fixture to enable pfcwd configuration in init_cfg.json file.
2. run shell command: config load_minigraph -y
3. Check if pfcwd gets started with command: pfcwd show config

#### How did you verify/test it?
Run test case test_default_cfg_after_load_mg in tests/pfcwd/test_pfc_config.py.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
