### PR TITLE
[Bugfix] Fix extra overhead in dynamic buffer calculation test

### DIFF
--- a/tests/qos/files/dynamic_buffer_param.json
+++ b/tests/qos/files/dynamic_buffer_param.json
@@ -26,7 +26,7 @@
 	    }
 	},
 	"extra_overhead": {
-	    "400000": "95232",
+	    "8": "95232",
 	    "default": "58368"
 	},
 	"shared-headroom-pool": {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix extra overhead in dynamic buffer calculation test

Signed-off-by: Stephen Sun <stephens@nvidia.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix extra overhead in dynamic buffer calculation test

#### How did you do it?
It should be indexed by the number of lanes instead of the speed.

#### How did you verify/test it?
Run regression test

#### Any platform specific information?
Affecting Mellanox platforms only

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
