### PR TITLE
[Dynamic Buffer Calculation] Tolerance the scenario where the minigraph is empty

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -400,9 +400,13 @@ def check_pool_size(duthost, ingress_lossless_pool_oid, **kwargs):
         global PORTS_WITH_8LANES
         hostname = conn_graph_facts['device_conn'].keys()[0]
         ports_info = conn_graph_facts['device_conn'][hostname]
+        if not ports_info:
+            ports = [port.split('|')[1] for port in duthost.shell('redis-cli -n 4 keys "PORT|*"')['stdout'].split('\n')]
+        else:
+            ports = ports_info.keys()
         if PORTS_WITH_8LANES is None:
             PORTS_WITH_8LANES = []
-            for port in ports_info.keys():
+            for port in ports:
                 lanes = duthost.shell('redis-cli -n 4 hget "PORT|{}" lanes'.format(port))['stdout']
                 if len(lanes.split(',')) == 8:
                     PORTS_WITH_8LANES.append(port)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Tolerance the scenario whether the minigraph is empty

Signed-off-by: Stephen Sun <stephens@nvidia.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Dynamic buffer calculation test fetches information from the minigraph.
However, in some scenarios, the testbed is not configured via using the minigraph.
In that case, we will fetch the information from CONFIG_DB

#### How did you verify/test it?
Run the regression test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
