### PR TITLE
Enhance test_reporting to support uploading expected test runs data

### DIFF
--- a/test_reporting/kusto/setup.kql
+++ b/test_reporting/kusto/setup.kql
@@ -87,6 +87,17 @@
                                                                                   {"column":"TestbedName","Properties":{"path":"$.testbed"}},
                                                                                   {"column":"UploadTimestamp","Properties":{"path":"$.upload_time"}}]'
 
+###############################################################################
+# EXPECTED TEST RUNS TABLE SETUP                                              #
+# 1. Create a ExpectedTestRuns table to store expected test runs data         #
+# 2. Add a JSON mapping for the table                                         #
+###############################################################################
+
+.create table ExpectedTestRuns (Timestamp: datetime,
+                                TestbedName: string)
+
+.create table ExpectedTestRuns ingestion json mapping 'ExpectedTestRunsV1' '[{"column":"Timestamp","Properties":{"path":"$.timestamp"}},
+                                                                             {"column":"TestbedName","Properties":{"path":"$.testbed"}}]'
 
 ###############################################################################
 # RAW REBOOT REPORT TABLE SETUP                                               #

--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -62,6 +62,13 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
                 pdu_data.extend(json.load(f))
 
         kusto_db.upload_pdu_status_data(pdu_data)
+    elif args.category == 'expected_runs':
+        expected_runs = []
+        for path_name in args.path_list:
+            with open(path_name) as f:
+                expected_runs.extend(json.load(f))
+        kusto_db.upload_expected_runs(expected_runs)
+
     else:
         print('Unknown category "{}"'.format(args.category))
         sys.exit(1)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
For nightly tests scheduled by Azure Pipelines, we want to have a clear picture
of when a testbed is expected to trigger a round of testing and upload test
results. Then based on the expected runs data and actual test results uploaded
by testbeds, we can have a metric of percentage of testbeds reliably uploaded
test results.

#### How did you do it?
This change enhanced the test reporting tool to support ingesting expected
test runs data to Kusto.

Code for gathering expected runs data will be in other internal PRs.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
