### PR TITLE
[test_techsupport]: Add show techsupport UTs to KVM test.

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -152,7 +152,7 @@ test_t0() {
       container_checker/test_container_checker.py \
       process_monitoring/test_critical_process_monitoring.py \
       system_health/test_system_status.py \
-      show_techsupport/test_techsupport.py"
+      show_techsupport/test_techsupport_no_secret.py"
 
       pushd $SONIC_MGMT_DIR/tests
       ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -151,7 +151,8 @@ test_t0() {
       bgp/test_bgpmon.py \
       container_checker/test_container_checker.py \
       process_monitoring/test_critical_process_monitoring.py \
-      system_health/test_system_status.py"
+      system_health/test_system_status.py \
+      show_techsupport/test_techsupport.py"
 
       pushd $SONIC_MGMT_DIR/tests
       ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -2,17 +2,14 @@ import os
 import pprint
 import pytest
 import time
-
 import logging
+import tech_support_cmds as cmds 
 
 from random import randint
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
-from tests.common.utilities import wait_until, skip_release
-
-from log_messages import *
-
-import tech_support_cmds as cmds 
+from tests.common.utilities import wait_until
+from log_messages import LOG_EXPECT_ACL_RULE_CREATE_RE, LOG_EXPECT_ACL_RULE_REMOVE_RE, LOG_EXCEPT_MIRROR_SESSION_REMOVE
 
 logger = logging.getLogger(__name__)
 
@@ -260,16 +257,6 @@ def config(request):
     e.g. : test_techsupport[acl]
     """
     return request.getfixturevalue(request.param)
-@pytest.fixture
-def setup_password(duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    # Setup TACACS/Radius password
-    duthost.shell("sudo config tacacs passkey %s" % creds_all_duts[duthost]['tacacs_passkey'])
-    duthost.shell("sudo config radius passkey %s" % creds_all_duts[duthost]['radius_passkey'])
-    yield
-    # Remove TACACS/Radius password
-    duthost.shell("sudo config tacacs default passkey")
-    duthost.shell("sudo config radius default passkey")
 
 def execute_command(duthost, since):
     """

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -260,17 +260,6 @@ def config(request):
     e.g. : test_techsupport[acl]
     """
     return request.getfixturevalue(request.param)
-
-@pytest.fixture
-def check_image_version(duthost):
-    """Skips this test if the SONiC image installed on DUT is older than 202112
-    Args:
-        duthost: Hostname of DUT.
-    Returns:
-        None.
-    """
-    skip_release(duthost, ["201811", "201911", "202012", "202106"])
-
 @pytest.fixture
 def setup_password(duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -445,14 +434,6 @@ def check_cmds(cmd_group_name, cmd_group_to_check, cmdlist):
 
     return cmd_not_found
 
-def check_no_result(duthost, command):
-    res = duthost.shell(command)
-    logger.info(command)
-    logger.info(res["stdout_lines"])
-    pytest_assert(res["rc"] == 0)
-    pytest_assert(len(res["stdout_lines"]) == 0)
-    pytest_assert(len(res["stderr_lines"]) == 0)
-
 def test_techsupport_commands(
     duthosts, enum_rand_one_per_hwsku_frontend_hostname, commands_to_check
 ):
@@ -487,62 +468,3 @@ def test_techsupport_commands(
         )
 
     pytest_assert(len(cmd_not_found) == 0, cmd_not_found)
-
-def test_secret_removed_from_show_techsupport(
-    duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_image_version, setup_password
-):
-    """
-    This test checks following secrets been removed from show techsupport result:
-        Tacacs key
-        Radius key
-        snmp community string
-        /etc/shadow, which includes the hash of local/domain users' password
-        Certificate files: *.cer *.crt *.pem *.key
-    """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-
-    tacacs_passkey = creds_all_duts[duthost]['tacacs_passkey']
-    radius_passkey = creds_all_duts[duthost]['radius_passkey']
-    snmp_rocommunity = creds_all_duts[duthost]['snmp_rocommunity']
-
-    # generate a new dump file. and find latest dump file with ls -t
-    duthost.shell('show techsupport')
-    dump_file_path = duthost.shell('ls -t /var/dump/sonic_dump_* | tail -1')['stdout']
-    dump_file_name = dump_file_path.replace("/var/dump/", "")
-
-    # extract for next step check
-    duthost.shell("tar -xf {0}".format(dump_file_path))
-    dump_extract_path="./{0}".format(dump_file_name.replace(".tar.gz", ""))
-    
-    # check Tacacs key
-    sed_command = "sed -nE '/secret={0}/P' {1}/etc/tacplus_nss.conf".format(tacacs_passkey, dump_extract_path)
-    check_no_result(duthost, sed_command)
-
-    sed_command = "sed -nE '/secret={0}/P' {1}/etc/pam.d/common-auth-sonic".format(radius_passkey, dump_extract_path)
-    check_no_result(duthost, sed_command)
-    
-    # check Radius key
-    sed_command = "sed -nE '/secret={0}/P' {1}/etc/radius_nss.conf".format(radius_passkey, dump_extract_path)
-    check_no_result(duthost, sed_command)
-
-    sed_command = "sed -nE '/{0}/P' {1}/etc/pam_radius_auth.conf".format(radius_passkey, dump_extract_path)
-    check_no_result(duthost, sed_command)
-    
-    # Check Radius passkey from per-server conf file /etc/pam_radius_auth.d/{ip}_{port}.conf
-    list_command = "ls {0}/etc/pam_radius_auth.d/*.conf || true".format(dump_extract_path)
-    config_file_list = duthost.shell(list_command)["stdout_lines"]
-    for config_file in config_file_list:
-        sed_command = "sed -nE '/{0}/P' {1}/etc/pam_radius_auth.d/{1}".format(radius_passkey, dump_extract_path, config_file)
-        check_no_result(duthost, sed_command)
-    
-    # check snmp community string not exist
-    sed_command = "sed -nE '/\s*snmp_rocommunity\s*:\s{0}/P' {1}/etc/sonic/snmp.yml".format(snmp_rocommunity, dump_extract_path)
-    check_no_result(duthost, sed_command)
-    
-    # check /etc/shadow not exist
-    test_command = "test -f {0}/etc/shadow && echo \"/etc/shadow exist\" || true".format(dump_extract_path)
-    check_no_result(duthost, test_command)
-    
-    # check *.cer *.crt *.pem *.key not exist in dump files
-    find_command = "find {0}/ -type f \( -iname \*.cer -o -iname \*.crt -o -iname \*.pem -o -iname \*.key \)".format(dump_extract_path)
-    check_no_result(duthost, find_command)

--- a/tests/show_techsupport/test_techsupport_no_secret.py
+++ b/tests/show_techsupport/test_techsupport_no_secret.py
@@ -1,0 +1,99 @@
+import os
+import pprint
+import pytest
+import time
+import logging
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import skip_release
+from log_messages import *
+import tech_support_cmds as cmds 
+
+logger = logging.getLogger(__name__)
+
+@pytest.fixture
+def check_image_version(duthost):
+    """Skips this test if the SONiC image installed on DUT is older than 202112
+    Args:
+        duthost: Hostname of DUT.
+    Returns:
+        None.
+    """
+    skip_release(duthost, ["201811", "201911", "202012", "202106"])
+
+@pytest.fixture
+def setup_password(duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    # Setup TACACS/Radius password
+    duthost.shell("sudo config tacacs passkey %s" % creds_all_duts[duthost]['tacacs_passkey'])
+    duthost.shell("sudo config radius passkey %s" % creds_all_duts[duthost]['radius_passkey'])
+    yield
+    # Remove TACACS/Radius password
+    duthost.shell("sudo config tacacs default passkey")
+    duthost.shell("sudo config radius default passkey")
+
+def check_no_result(duthost, command):
+    res = duthost.shell(command)
+    logger.info(command)
+    logger.info(res["stdout_lines"])
+    pytest_assert(res["rc"] == 0)
+    pytest_assert(len(res["stdout_lines"]) == 0)
+    pytest_assert(len(res["stderr_lines"]) == 0)
+
+def test_secret_removed_from_show_techsupport(
+    duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_image_version, setup_password
+):
+    """
+    This test checks following secrets been removed from show techsupport result:
+        Tacacs key
+        Radius key
+        snmp community string
+        /etc/shadow, which includes the hash of local/domain users' password
+        Certificate files: *.cer *.crt *.pem *.key
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    tacacs_passkey = creds_all_duts[duthost]['tacacs_passkey']
+    radius_passkey = creds_all_duts[duthost]['radius_passkey']
+    snmp_rocommunity = creds_all_duts[duthost]['snmp_rocommunity']
+
+    # generate a new dump file. and find latest dump file with ls -t
+    duthost.shell('show techsupport')
+    dump_file_path = duthost.shell('ls -t /var/dump/sonic_dump_* | tail -1')['stdout']
+    dump_file_name = dump_file_path.replace("/var/dump/", "")
+
+    # extract for next step check
+    duthost.shell("tar -xf {0}".format(dump_file_path))
+    dump_extract_path="./{0}".format(dump_file_name.replace(".tar.gz", ""))
+    
+    # check Tacacs key
+    sed_command = "sed -nE '/secret={0}/P' {1}/etc/tacplus_nss.conf".format(tacacs_passkey, dump_extract_path)
+    check_no_result(duthost, sed_command)
+
+    sed_command = "sed -nE '/secret={0}/P' {1}/etc/pam.d/common-auth-sonic".format(radius_passkey, dump_extract_path)
+    check_no_result(duthost, sed_command)
+    
+    # check Radius key
+    sed_command = "sed -nE '/secret={0}/P' {1}/etc/radius_nss.conf".format(radius_passkey, dump_extract_path)
+    check_no_result(duthost, sed_command)
+
+    sed_command = "sed -nE '/{0}/P' {1}/etc/pam_radius_auth.conf".format(radius_passkey, dump_extract_path)
+    check_no_result(duthost, sed_command)
+    
+    # Check Radius passkey from per-server conf file /etc/pam_radius_auth.d/{ip}_{port}.conf
+    list_command = "ls {0}/etc/pam_radius_auth.d/*.conf || true".format(dump_extract_path)
+    config_file_list = duthost.shell(list_command)["stdout_lines"]
+    for config_file in config_file_list:
+        sed_command = "sed -nE '/{0}/P' {1}/etc/pam_radius_auth.d/{1}".format(radius_passkey, dump_extract_path, config_file)
+        check_no_result(duthost, sed_command)
+    
+    # check snmp community string not exist
+    sed_command = "sed -nE '/\s*snmp_rocommunity\s*:\s{0}/P' {1}/etc/sonic/snmp.yml".format(snmp_rocommunity, dump_extract_path)
+    check_no_result(duthost, sed_command)
+    
+    # check /etc/shadow not exist
+    test_command = "test -f {0}/etc/shadow && echo \"/etc/shadow exist\" || true".format(dump_extract_path)
+    check_no_result(duthost, test_command)
+    
+    # check *.cer *.crt *.pem *.key not exist in dump files
+    find_command = "find {0}/ -type f \( -iname \*.cer -o -iname \*.crt -o -iname \*.pem -o -iname \*.key \)".format(dump_extract_path)
+    check_no_result(duthost, find_command)

--- a/tests/show_techsupport/test_techsupport_no_secret.py
+++ b/tests/show_techsupport/test_techsupport_no_secret.py
@@ -5,7 +5,6 @@ import time
 import logging
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release
-from log_messages import *
 import tech_support_cmds as cmds 
 
 logger = logging.getLogger(__name__)
@@ -57,6 +56,7 @@ def test_secret_removed_from_show_techsupport(
     snmp_rocommunity = creds_all_duts[duthost]['snmp_rocommunity']
 
     # generate a new dump file. and find latest dump file with ls -t
+    duthost.shell('rm -rf /var/dump/sonic_dump_*')
     duthost.shell('show techsupport')
     dump_file_path = duthost.shell('ls -t /var/dump/sonic_dump_* | tail -1')['stdout']
     dump_file_name = dump_file_path.replace("/var/dump/", "")


### PR DESCRIPTION
### Description of PR
    Add show techsupport UTs  to KVM test.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request

### Approach
#### What is the motivation for this PR?
    Make show techsupport UTs run with KVM test.

#### How did you do it?
   Add show_techsupport/test_techsupport.py to tests/kvmtest.sh.

#### How did you verify/test it?
   Make sure all current UT not break during merge validation.

#### Any platform specific information?
   N/A

#### Supported testbed topology if it's a new test case?

### Documentation 