### PR TITLE
[k8s] skip tests if k8s inventory file not found

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -370,9 +370,12 @@ def k8smasters(ansible_adhoc, request):
     k8s_master_ansible_group = request.config.getoption("--kube_master")
     master_vms = {}
     inv_files = request.config.getoption("ansible_inventory")
+    k8s_inv_file = None
     for inv_file in inv_files:
         if "k8s" in inv_file:
             k8s_inv_file = inv_file
+    if not k8s_inv_file:
+        pytest.skip("k8s inventory not found, skipping tests")
     with open('../ansible/{}'.format(k8s_inv_file), 'r') as kinv:
         k8sinventory = yaml.safe_load(kinv)
         for hostname, attributes in k8sinventory[k8s_master_ansible_group]['hosts'].items():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skips k8s tests if inventory file was not found

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
k8s tests fail with the following error if inventory file is missing: 
```
        for inv_file in inv_files:
            if "k8s" in inv_file:
                k8s_inv_file = inv_file
>       with open('../ansible/{}'.format(k8s_inv_file), 'r') as kinv:
E       UnboundLocalError: local variable 'k8s_inv_file' referenced before assignment
```
#### How did you do it?
Added conditional skip if inventory file was not found - in this case tests will be marked as 'skipped':
`SKIPPED [3] /var/user/jenkins/sonic-mgmt/tests/conftest.py:374: k8s inventory file not found, skipping tests`
#### How did you verify/test it?
Run k8s/test_config_reload.py:
```
k8s/test_config_reload.py::test_config_reload_no_toggle SKIPPED          [ 33%]
k8s/test_config_reload.py::test_config_reload_toggle_join SKIPPED        [ 66%]
k8s/test_config_reload.py::test_config_reload_toggle_reset SKIPPED       [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
