### PR TITLE
[advance-reboot] Allow alt-password for reboot SAD-cases

### DIFF
--- a/ansible/roles/test/files/ptftests/sad_path.py
+++ b/ansible/roles/test/files/ptftests/sad_path.py
@@ -55,7 +55,10 @@ class SadPath(object):
         self.portchannel_ports = portchannel_ports
         self.vm_dut_map = vm_dut_map
         self.test_args = test_args
-        self.dut_connection = DeviceConnection(test_args['dut_hostname'], test_args['dut_username'], password=test_args['dut_password'])
+        self.dut_connection = DeviceConnection(test_args['dut_hostname'],
+            test_args['dut_username'],
+            password=test_args['dut_password'],
+            alt_password=test_args.get('alt_password'))
         self.vlan_ports = vlan_ports
         self.ports_per_vlan = ports_per_vlan
         self.vlan_if_port = self.test_args['vlan_if_port']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: In reboot/upgrades, the PTF's SSH key stored inside DUT gets deleted. Use a retry mechanism (alt_password) when default admin password does not work.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
In non-SAD cases, this is already covered. However for SAD cases, auth error is seen while testing public images.
Make change to SAD case similar to non-SAD here:
https://github.com/Azure/sonic-mgmt/blob/adef2e44d2663196350cdd1c0a586a7eecb60d50/ansible/roles/test/files/ptftests/advanced-reboot.py#L241

```
00:47:20.692  paramiko.transport: INFO    : Connected (version 2.0, client OpenSSH_7.9p1)
00:47:20.775  paramiko.transport: INFO    : Authentication (publickey) failed.
00:47:24.268  paramiko.transport: INFO    : Authentication (password) failed.
00:47:24.293  device_connection: ERROR   : SSH Command failed with message: Authentication failed.
00:47:25.917  dataplane : INFO    : Thread exit
```

#### How did you do it?

#### How did you verify/test it?
Tested on a KVM testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
