### PR TITLE
[fix] use env_proxy on downloading

### DIFF
--- a/ansible/group_vars/all/env.yml
+++ b/ansible/group_vars/all/env.yml
@@ -3,3 +3,4 @@
 #proxy_env:
 #  http_proxy: http://10.252.0.99:3128
 #  https_proxy: http://10.252.0.99:3128
+#  no_proxy: 127.0.0.1,localhost

--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -27,6 +27,7 @@
     url: "{{ vm_images_url }}/{{ ceos_image_filename }}?{{ ceosimage_saskey }}"
     dest: "{{ root_path }}/images/{{ ceos_image_filename }}"
     timeout: 1800
+  environment: "{{ proxy_env | default({}) }}"
   when: (ceos_stat.images | length == 0) and not skip_ceos_image_downloading
 
 - name: Import cEOS image

--- a/ansible/roles/vm_set/tasks/start.yml
+++ b/ansible/roles/vm_set/tasks/start.yml
@@ -29,6 +29,7 @@
 
     - name: Download hdd image
       get_url: url="{{ vm_images_url }}/{{ hdd_image_filename }}?{{ vmimage_saskey }}" dest="{{ root_path }}/images/{{ hdd_image_filename }}"
+      environment: "{{ proxy_env | default({}) }}"
       when: not hdd_stat.stat.exists and not skip_image_downloading
 
     - name: Check cd image
@@ -41,6 +42,7 @@
 
     - name: Download cd image
       get_url: url="{{ vm_images_url }}/{{ cd_image_filename }}?{{ cdimage_saskey }}" dest="{{ root_path }}/images/{{ cd_image_filename }}"
+      environment: "{{ proxy_env | default({}) }}"
       when: not cd_stat.stat.exists and not skip_image_downloading
 
     - set_fact:

--- a/ansible/roles/vm_set/tasks/start_k8s.yml
+++ b/ansible/roles/vm_set/tasks/start_k8s.yml
@@ -26,6 +26,7 @@
 
 - name: Download Ubuntu 18.04 hdd image
   get_url: url="{{ k8s_vm_images_url }}/{{ k8s_hdd_image_filename }}?{{ k8s_vmimage_saskey }}" dest="{{ k8s_root_path }}/images/{{ k8s_hdd_image_filename }}"
+  environment: "{{ proxy_env | default({}) }}"
   when: not cloudimg_local_stat.stat.exists
   become: yes
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
After the network env is changed, some downloading tasks have to run with proxy_env.
#### How did you do it?
Add necessary proxy_env
#### How did you verify/test it?
Run add_topo on a physical machine and it works well.
