### PR TITLE
Fix testbed_vm_info for "tgen" topologies

### DIFF
--- a/ansible/library/testbed_vm_info.py
+++ b/ansible/library/testbed_vm_info.py
@@ -39,14 +39,14 @@ TGEN_MGMT_NETWORK = '10.65.32.0/24'
 
 class TestbedVMFacts():
     """
-    Retrieve testbed VMs management information that for a specified toplogy defined in testbed.csv
+    Retrieve testbed VMs management information that for a specified toplogy defined in testbed.yaml
 
     """
 
     def __init__(self, toponame, base_vm, vm_file):
         CLET_SUFFIX = "-clet"
-        toponame = re.sub(CLET_SUFFIX + "$", "", toponame)
-        self.topofile = TOPO_PATH+'topo_'+toponame +'.yml'
+        self.toponame = re.sub(CLET_SUFFIX + "$", "", toponame)
+        self.topofile = TOPO_PATH + 'topo_' + self.toponame + '.yml'
         self.base_vm = base_vm
         self.vm_file = vm_file
         self.inv_mgr = InventoryManager(loader=DataLoader(), sources=self.vm_file)
@@ -57,10 +57,18 @@ class TestbedVMFacts():
             vm_topology = yaml.safe_load(f)
         self.topoall = vm_topology
 
-        vm_base = int(self.base_vm[2:])
-        vm_name_fmt = 'VM%0{}d'.format(len(self.base_vm) - 2)
+        if len(self.base_vm) > 2:
+            vm_start_index = int(self.base_vm[2:])
+            vm_name_fmt = 'VM%0{}d'.format(len(self.base_vm) - 2)
+        else:
+            if 'tgen' in self.toponame:
+                vm_start_index = 0
+                vm_name_fmt = 'VM%05d'
+            else:
+                return eos
+
         for eos_name, eos_value in vm_topology['topology']['VMs'].items():
-            vm_name = vm_name_fmt % (vm_base + eos_value['vm_offset'])
+            vm_name = vm_name_fmt % (vm_start_index + eos_value['vm_offset'])
             eos[eos_name] = vm_name
         return eos
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
PR https://github.com/Azure/sonic-mgmt/pull/4862 introduced a bug in the testbed_vm_info module.
This caused `testbed-cli.sh deploy-mg` failed for "tgen*" topologies:

```
fatal: [dut-1 -> localhost]: FAILED! => {"changed": false, "msg": "Traceback (most recent call last):\n
    File \"/tmp/ansible_testbed_vm_info_payload_mccbiM/__main__.py\", line 85, in main\n
    neighbor_eos = vm_facts.get_neighbor_eos()\n
    File \"/tmp/ansible_testbed_vm_info_payload_mccbiM/__main__.py\", line 60, in get_neighbor_eos\n
    vm_base = int(self.base_vm[2:])\n
    ValueError: invalid literal for int() with base 10: ''\n"}
```

#### How did you do it?
The reason is that "tgen*" topologies have VM in topology file. For testbeds using "tgen*" topology,
their "vm_base" in testbed.yaml file is empty. Some special handlings are required for testbeds using
"tgen*" topologies. Another fix is to add check for length of "vm_base". Only try to parse start VM
index from "vm_base" only when its length is greater than 2.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
