### PR TITLE
[vxlan] Enhance VxLAN test for dynamic VxLAN src port range feature

### DIFF
--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -56,17 +56,15 @@ def pytest_addoption(parser):
     )
 
     vxlan_group.addoption(
-        "--lower_bound_udp_port",
+        "--udp_src_port",
         action="store",
-        default=0,
         type=int,
-        help="Lowest expected src port for VXLAN UPD packet"
+        help="Expected base VXLAN UDP src port"
     )
 
     vxlan_group.addoption(
-        "--upper_bound_udp_port",
+        "--udp_src_port_mask",
         action="store",
-        default=65535,
         type=int,
-        help="Highest expected src port for VXLAN UPD packet"
+        help="Expected base VXLAN UDP src port mask"
     )

--- a/tests/vxlan/test_vnet_vxlan.py
+++ b/tests/vxlan/test_vnet_vxlan.py
@@ -4,13 +4,13 @@ import pytest
 
 from datetime import datetime
 from tests.ptf_runner import ptf_runner
-from vnet_constants import CLEANUP_KEY, LOWER_BOUND_UDP_PORT_KEY, UPPER_BOUND_UDP_PORT_KEY
+from vnet_constants import CLEANUP_KEY, VXLAN_UDP_SPORT_KEY, VXLAN_UDP_SPORT_MASK_KEY, VXLAN_RANGE_ENABLE_KEY
+
 from vnet_utils import generate_dut_config_files, safe_open_template, \
                        apply_dut_config_files, cleanup_dut_vnets, cleanup_vxlan_tunnels, cleanup_vnet_routes
 
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses, change_mac_addresses, \
                                                 copy_arp_responder_py, copy_ptftests_directory
-from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
 
 logger = logging.getLogger(__name__)
 
@@ -22,16 +22,6 @@ pytestmark = [
 
 vlan_tagging_mode = ""
 
-def get_vxlan_srcport_range_enabled(duthost):
-    if not isMellanoxDevice(duthost):
-	return False
-    dut_platform = duthost.facts["platform"]
-    dut_hwsku = duthost.facts["hwsku"]
-    sai_profile = "/usr/share/sonic/device/%s/%s/sai.profile" % (dut_platform, dut_hwsku)
-    cmd = "grep SAI_VXLAN_SRCPORT_RANGE_ENABLE {} | cut -d'=' -f2".format(sai_profile)
-    vxlan_srcport_range_enabled = duthost.shell(cmd)["stdout"].strip() == "1"
-
-    return vxlan_srcport_range_enabled
 
 def prepare_ptf(ptfhost, mg_facts, dut_facts, vnet_config):
     """
@@ -150,11 +140,10 @@ def test_vnet_vxlan(setup, vxlan_status, duthosts, rand_one_dut_hostname, ptfhos
         vnet_test_params: Dictionary containing vnet test parameters
     """
     duthost = duthosts[rand_one_dut_hostname]
-    vxlan_srcport_range_enabled =  get_vxlan_srcport_range_enabled(duthost)
 
     vxlan_enabled, scenario = vxlan_status
 
-    logger.info("vxlan_enabled={}, scenario={}, vxlan_srcport_range_enabled={}".format(vxlan_enabled, scenario, vxlan_srcport_range_enabled))
+    logger.info("vxlan_enabled={}, scenario={}".format(vxlan_enabled, scenario))
 
     log_file = "/tmp/vnet-vxlan.Vxlan.{}.{}.log".format(scenario, datetime.now().strftime('%Y-%m-%d-%H:%M:%S'))
     ptf_params = {"vxlan_enabled": vxlan_enabled,
@@ -162,10 +151,11 @@ def test_vnet_vxlan(setup, vxlan_status, duthosts, rand_one_dut_hostname, ptfhos
                   "sonic_admin_user": creds.get('sonicadmin_user'),
                   "sonic_admin_password": creds.get('sonicadmin_password'),
                   "dut_host": duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host'],
-                  "vxlan_srcport_range_enabled": vxlan_srcport_range_enabled,
-                  "lower_bound_port" : vnet_test_params[LOWER_BOUND_UDP_PORT_KEY],
-                  "upper_bound_port" : vnet_test_params[UPPER_BOUND_UDP_PORT_KEY]
+                  "vxlan_udp_sport" : vnet_test_params[VXLAN_UDP_SPORT_KEY],
+                  "vxlan_udp_sport_mask" : vnet_test_params[VXLAN_UDP_SPORT_MASK_KEY],
+                  "vxlan_range_enable" : vnet_test_params[VXLAN_RANGE_ENABLE_KEY]
                   }
+
     if scenario == "Cleanup":
         ptf_params["routes_removed"] = True
 

--- a/tests/vxlan/vnet_constants.py
+++ b/tests/vxlan/vnet_constants.py
@@ -1,10 +1,11 @@
 __all__ = ["CLEANUP_KEY", "IPV6_VXLAN_TEST_KEY", "APPLY_NEW_CONFIG_KEY", "NUM_VNET_KEY", "NUM_ROUTES_KEY", "NUM_ENDPOINTS_KEY", "NUM_INTF_PER_VNET_KEY",
-            "DUT_VNET_SWITCH_JSON", "DUT_VNET_CONF_JSON", "DUT_VNET_ROUTE_JSON", "DUT_VNET_INTF_JSON", "DUT_VNET_NBR_JSON",
-            "TEMPLATE_DIR", "LOWER_BOUND_UDP_PORT_KEY", "UPPER_BOUND_UDP_PORT_KEY"]
+            "DUT_VNET_SWITCH_JSON", "DUT_VNET_CONF_JSON", "DUT_VNET_ROUTE_JSON", "DUT_VNET_INTF_JSON", "DUT_VNET_NBR_JSON", "DUT_VXLAN_RANGE_JSON",
+            "TEMPLATE_DIR", "VXLAN_UDP_SPORT_KEY", "VXLAN_UDP_SPORT_MASK_KEY", "VXLAN_RANGE_ENABLE_KEY"]
 
 VXLAN_PORT = "13330"
 VXLAN_MAC = "00:aa:bb:cc:78:9a"
 DUT_VNET_SWITCH_JSON = "/tmp/vnet.switch.json"
+DUT_VXLAN_RANGE_JSON = "/tmp/vxlan_range.json"
 DUT_VNET_CONF_JSON = "/tmp/vnet.conf.json"
 DUT_VNET_ROUTE_JSON = "/tmp/vnet.route.json"
 DUT_VNET_INTF_JSON = "/tmp/vnet.intf.json"
@@ -19,5 +20,6 @@ NUM_VNET_KEY = "num_vnet"
 NUM_ROUTES_KEY = "num_routes"
 NUM_ENDPOINTS_KEY = "num_endpoints"
 NUM_INTF_PER_VNET_KEY = "num_intf_per_vnet"
-LOWER_BOUND_UDP_PORT_KEY = "lower_bound_udp_port"
-UPPER_BOUND_UDP_PORT_KEY = "upper_bound_udp_port"
+VXLAN_UDP_SPORT_KEY = "vxlan_udp_sport"
+VXLAN_UDP_SPORT_MASK_KEY = "vxlan_udp_sport_mask"
+VXLAN_RANGE_ENABLE_KEY = "vxlan_range_enable"


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Update existing test to add possibility dynamically configure VXLAN UDP src port range

#### How did you do it?
Add additional parameters in json files that applied while setting up VXLAN tunnel

#### How did you verify/test it?
py.test vxlan/test_vnet_vxlan.py --inventory "../ansible/inventory, ../ansible/veos" --host-pattern DUT --module-path ../ansible/library/ --testbed DUT-t0 --testbed_file ../ansible/testbed.csv --allow_recover --assert plain --log-cli-level info --show-capture=no --disable_loganalyzer -ra --showlocals --skip_sanity --udp_src_port 65280 --udp_src_port_mask 8

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
