### PR TITLE
Add the show ip/ipv6 bgp test ro user commands

### DIFF
--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -41,7 +41,7 @@ def ssh_remote_allow_run(localhost, remote_ip, username, password, cmd):
     res = ssh_remote_run(localhost, remote_ip, username, password, cmd)
     # Verify that the command is allowed
     logger.info("check command \"{}\" rc={}".format(cmd, res['rc']))
-    expected = res['rc'] == 0 or (res['rc'] != 0 and "Make sure your account has RW permission to current device" not in res['stderr'])
+    expected = "Make sure your account has RW permission to current device" not in res['stderr']
     if not expected:
         logger.error("error output=\"{}\"".format(res["stderr"]))
     return expected

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -121,8 +121,12 @@ def test_ro_user_allowed_command(localhost, duthosts, enum_rand_one_per_hwsku_ho
             "show interface status",
             "show interface portchannel",
             "show ip bgp summary",
+            "show ip bgp neighbors",
+            "show ip bgp network",
             "show ip interface",
             "show ipv6 interface",
+            "show ipv6 bgp neighbors",
+            "show ipv6 bgp network",
             "show lldp table",
         ],
     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add UTs to cover the 'show ip bgp' ro commands.
Fix some of the commands that prompt rw required message, but not detected issue.
Add stricter testing checks, for any ro/rw commands, if any error log which contains the "RW permission" required message, the UT will be failed.
The checks will be succeeded after the PR https://github.com/Azure/sonic-utilities/pull/2011 merged.
```
show ip bgp neighbors 

Make sure your account has RW permission to current device.
Otherwise sudo requests will be rejected.
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Add test cases for PR https://github.com/Azure/sonic-utilities/pull/2011

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
