### PR TITLE
Shutdown all eBGP neighbors when running SFP platform tests

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -190,7 +190,7 @@ def check_ebgp_routes(num_v4_routes, num_v6_routes, duthost):
     return rtn_val
 
 @pytest.fixture(scope="module")
-def shutdown_ebgp(duthosts, request):
+def shutdown_ebgp(duthosts):
     # To store the original number of eBGP v4 and v6 routes.
     v4ebgps = {}
     v6ebgps = {}

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -181,11 +181,12 @@ def check_orch_cpu_utilization(dut, orch_cpu_threshold):
 
 
 def check_ebgp_routes(num_v4_routes, num_v6_routes, duthost):
+    MAX_DIFF = 5
     sumv4, sumv6 = duthost.get_ip_route_summary()
     rtn_val = True
-    if 'ebgp' in sumv4 and 'routes' in sumv4['ebgp'] and sumv4['ebgp']['routes'] != num_v4_routes:
+    if 'ebgp' in sumv4 and 'routes' in sumv4['ebgp'] and abs(int(float(sumv4['ebgp']['routes'])) - int(float(num_v4_routes))) >= MAX_DIFF:
         rtn_val = False
-    if 'ebgp' in sumv6 and 'routes' in sumv6['ebgp'] and sumv6['ebgp']['routes'] != num_v6_routes:
+    if 'ebgp' in sumv6 and 'routes' in sumv6['ebgp'] and abs(int(float(sumv6['ebgp']['routes'])) - int(float(num_v6_routes))) >= MAX_DIFF:
         rtn_val = False
     return rtn_val
 

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -9,6 +9,7 @@ from tests.common.utilities import skip_release_for_platform
 from tests.common.platform.interface_utils import get_physical_port_indices
 from tests.common.utilities import wait_until
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts
+from tests.common.fixtures.duthost_utils import shutdown_ebgp
 
 from platform_api_test_base import PlatformApiTestBase
 
@@ -30,7 +31,7 @@ pytestmark = [
 ]
 
 @pytest.fixture(scope="class")
-def setup(request, duthosts, enum_rand_one_per_hwsku_hostname, xcvr_skip_list, conn_graph_facts):
+def setup(request, duthosts, enum_rand_one_per_hwsku_hostname, xcvr_skip_list, conn_graph_facts, shutdown_ebgp):
     sfp_setup = {}
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -28,7 +28,7 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
-def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list, shutdown_ebgp):
+def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):
     """
     @summary: Check SFP presence using 'sfputil show presence'
     """
@@ -46,7 +46,7 @@ def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostn
             assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
 @pytest.mark.parametrize("cmd_sfp_error_status", ["sudo sfputil show error-status", "sudo sfputil show error-status --fetch-from-hardware"])
-def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, cmd_sfp_error_status, xcvr_skip_list, shutdown_ebgp):
+def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, cmd_sfp_error_status, xcvr_skip_list):
     """
     @summary: Check SFP error status using 'sfputil show error-status' and 'sfputil show error-status --fetch-from-hardware'
               This feature is supported on 202106 and above
@@ -69,7 +69,7 @@ def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_h
             assert parsed_presence[intf] == "OK", "Interface error status is not 'OK'"
 
 
-def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list, shutdown_ebgp):
+def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):
     """
     @summary: Check SFP presence using 'sfputil show presence'
     """

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -15,6 +15,7 @@ from util import parse_eeprom
 from util import parse_output
 from util import get_dev_conn
 from tests.common.utilities import skip_release
+from tests.common.fixtures.duthost_utils import shutdown_ebgp
 
 cmd_sfp_presence = "sudo sfputil show presence"
 cmd_sfp_eeprom = "sudo sfputil show eeprom"
@@ -27,7 +28,7 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
-def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):
+def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list, shutdown_ebgp):
     """
     @summary: Check SFP presence using 'sfputil show presence'
     """
@@ -45,7 +46,7 @@ def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostn
             assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
 @pytest.mark.parametrize("cmd_sfp_error_status", ["sudo sfputil show error-status", "sudo sfputil show error-status --fetch-from-hardware"])
-def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, cmd_sfp_error_status, xcvr_skip_list):
+def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, cmd_sfp_error_status, xcvr_skip_list, shutdown_ebgp):
     """
     @summary: Check SFP error status using 'sfputil show error-status' and 'sfputil show error-status --fetch-from-hardware'
               This feature is supported on 202106 and above
@@ -68,7 +69,7 @@ def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_h
             assert parsed_presence[intf] == "OK", "Interface error status is not 'OK'"
 
 
-def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):
+def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list, shutdown_ebgp):
     """
     @summary: Check SFP presence using 'sfputil show presence'
     """
@@ -86,7 +87,7 @@ def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
             assert parsed_eeprom[intf] == "SFP EEPROM detected"
 
 
-def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo, xcvr_skip_list):
+def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo, xcvr_skip_list, shutdown_ebgp):
     """
     @summary: Check SFP presence using 'sfputil show presence'
     """
@@ -125,7 +126,7 @@ def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname
         "Some interfaces are down: {}".format(intf_facts["ansible_interface_link_down_ports"])
 
 
-def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo, xcvr_skip_list):
+def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts, tbinfo, xcvr_skip_list, shutdown_ebgp):
     """
     @summary: Check SFP low power mode
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The SFP tests sequentially do negative actions on all the SFPs on all the DUTs. The only check is that the command/API used worked - response is OK. Most of these tests will cause a quick link bounce (a few seconds)

In a scaled topology (like a T2 VOQ chassis) with 8K-12K routes per eBGP session, such quick link bounce of all the links within a span of a minute causes a lot of stress on the CPU of the DUTs. A top on one of the DUTs during the a test run on a linecard in a VoQ chassis shows that processes like 'zebra', 'bgpd', 'redis-server' 'orchargent' etc. are pegging at 50%-160% because of all the routes that have to be deleted and propogated to all the remote iBGP peers.

This causes the VoQ related tables to be in missing some info. Specifically, we see that some eBGP neighbors are missing in the 'ip neighbor table' as well as the ASIC_DB on the remote asics.

#### How did you do it?
To avoid this stress, we shutdown eBGP on all the neighbors on all the DUTs before running the SFP related tests. With eBGP disabled and thus all routes gone from eBGP, top shows that the processes are running at 2%-6% range as expected. This is similar to the approach taken in ARP and link flap tests.

To accomplish this added a module scope fixture 'shutdown_ebgp' in duthost_utils that would:
- In setup:
  - get the number of total eBGP routes - using 'show ip route summary'
  - shutdown all eBgp neighbors
  - verify that the eBGP routes are 0
  - verify that orchagent CPU utilization on all DUTs is less than 10% for 5 consecutive seconds
- In cleanup:
  - startup all eBGP neighbors
  - verify that the eBGP routes are the same what they were before we shutdown all eBGP neighbors
 - verify that orchagent CPU utilization on all DUTs is less than 10% for 5 consecutive seconds
 
We then call this fixure in the SFP tests as needed.

#### How did you verify/test it?
Ran the sfp related tests on a T2 VoQ chassis and validated that all neighbors are present in all asics (local and remote)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
