### PR TITLE
Fixes to make VoQ tests more stable and work with latest sonic-buildimage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1151,6 +1151,9 @@ def pytest_generate_tests(metafunc):
     elif "enum_rand_one_asic_index" in metafunc.fixturenames:
         asic_fixture_name = "enum_rand_one_asic_index"
         asics_selected = generate_param_asic_index(metafunc, duts_selected, ASIC_PARAM_TYPE_ALL, random_asic=True)
+    elif "enum_rand_one_frontend_asic_index" in metafunc.fixturenames:
+        asic_fixture_name = "enum_rand_one_frontend_asic_index"
+        asics_selected = generate_param_asic_index(metafunc, duts_selected, ASIC_PARAM_TYPE_FRONTEND, random_asic=True)
 
     # Create parameterization tuple of dut_fixture_name, asic_fixture_name and feature to parameterize
     if dut_fixture_name and asic_fixture_name and ("enum_dut_feature" in metafunc.fixturenames):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1247,6 +1247,10 @@ def enum_dut_feature(request):
     return request.param
 
 @pytest.fixture(scope="module")
+def enum_rand_one_frontend_asic_index(request):
+    return request.param
+
+@pytest.fixture(scope="module")
 def duthost_console(duthosts, rand_one_dut_hostname, localhost, conn_graph_facts, creds):
     duthost = duthosts[rand_one_dut_hostname]
     dut_hostname = duthost.hostname

--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -27,7 +27,7 @@ from voq_helpers import asic_cmd
 from voq_helpers import get_port_by_ip
 from voq_helpers import get_sonic_mac
 from voq_helpers import get_ptf_port
-
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -563,7 +563,7 @@ class TestTableValidation(object):
                 routes = ipv4_routes
 
             for route in routes:
-                if route.startswith("{} via {} dev {} proto bgp".format(str(lbip.ip), str(neigh_ip), local_port)):
+                if re.match("{}.*via {} dev {} proto bgp".format(str(lbip.ip), str(neigh_ip), local_port), route):
                     logger.info("Matched route for %s", str(lbip.ip))
                     break
             else:

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -21,7 +21,7 @@ from voq_helpers import check_all_neighbors_present, check_one_neighbor_present
 from voq_helpers import asic_cmd, sonic_ping
 from voq_helpers import check_neighbors_are_gone
 from voq_helpers import dump_and_verify_neighbors_on_asic
-from voq_helpers import check_host_arp_table_deleted
+from voq_helpers import poll_neighbor_table_delete
 from voq_helpers import get_inband_info
 from voq_helpers import get_ptf_port
 from voq_helpers import get_vm_with_ip
@@ -176,19 +176,7 @@ def setup(duthosts, nbrhosts, all_cfg_facts):
             logger.error('Missing kwarg "node" or "results"')
             return
 
-        node_results = []
-        for asic in node.asics:
-            asic_cfg_facts = cfg_facts[node.hostname][asic.asic_index]['ansible_facts']
-
-            if 'BGP_NEIGHBOR' not in asic_cfg_facts:
-                continue
-
-            for neighbor in asic_cfg_facts['BGP_NEIGHBOR']:
-                logger.info(
-                    "Shut down neighbor: {} on host {} asic {}".format(neighbor, node.hostname, asic.asic_index))
-
-                node_results.append(node.command("sudo config bgp shutdown neighbor {}".format(neighbor)))
-
+        node_results = node.command("sudo config bgp shutdown all")
         results[node.hostname] = node_results
 
     parallel_run(disable_dut_bgp_neighs, [all_cfg_facts], {}, duthosts.frontend_nodes, timeout=120)
@@ -230,7 +218,7 @@ def setup(duthosts, nbrhosts, all_cfg_facts):
 
         results[node['host'].hostname] = node_results
 
-    parallel_run(disable_nbr_bgp_neighs, [], {}, nbrhosts.values(), timeout=120)
+    parallel_run(disable_nbr_bgp_neighs, [], {}, nbrhosts.values(), timeout=240)
 
     logger.info("Poll for routes to be gone.")
     endtime = time.time() + 120
@@ -280,28 +268,7 @@ def teardown(duthosts, nbrhosts, all_cfg_facts):
             logger.error('Missing kwarg "node" or "results"')
             return
 
-        node_results = []
-        for asic in node.asics:
-            asic_cfg_facts = cfg_facts[node.hostname][asic.asic_index]['ansible_facts']
-            if 'BGP_NEIGHBOR' not in asic_cfg_facts:
-                continue
-            logger.info('enable neighbors {} on dut host {}'.format(asic_cfg_facts['BGP_NEIGHBOR'], node.hostname))
-            asnum = asic_cfg_facts['DEVICE_METADATA']['localhost']['bgp_asn']
-
-            for neighbor in asic_cfg_facts['BGP_NEIGHBOR']:
-                logger.info(
-                    "Startup neighbor: {} on host {} asic {}".format(neighbor, node.hostname, asic.asic_index))
-
-                node_results.append(node.command("sudo config bgp startup neighbor {}".format(neighbor)))
-                if node.is_multi_asic:
-                    node_results.append(node.command(
-                        "docker exec bgp{} vtysh -c \"config t\" -c \"router bgp {}\" -c \"no neighbor {} shutdown\"".format(
-                            asic.asic_index, asnum, neighbor)))
-                else:
-                    node_results.append(node.command(
-                        "docker exec bgp vtysh -c \"config t\" -c \"router bgp {}\" -c \"no neighbor {} shutdown\"".format(
-                            asnum, neighbor)))
-
+        node_results = node.command("sudo config bgp startup all")
         results[node.hostname] = node_results
 
     # restore neighbors on vms
@@ -360,7 +327,7 @@ def teardown(duthosts, nbrhosts, all_cfg_facts):
     try:
         parallel_run(enable_dut_bgp_neighs, [all_cfg_facts], {}, duthosts.frontend_nodes, timeout=300)
     finally:
-        parallel_run(enable_nbr_bgp_neighs, [], {}, nbrhosts.values(), timeout=120)
+        parallel_run(enable_nbr_bgp_neighs, [], {}, nbrhosts.values(), timeout=300)
 
 
 def ping_all_dut_local_nbrs(duthosts):
@@ -429,45 +396,7 @@ def established_arp(duthosts):
     logger.info("Ping all local neighbors to establish ARP")
     ping_all_dut_local_nbrs(duthosts)
 
-
-def poll_neighbor_table_delete(duthosts, neighs, delay=1, poll_time=180):
-    """
-    Poller for clear tests to determine when to proceed with test after issuing
-    clear commands.
-
-    Args:
-        duthosts: The duthosts fixture.
-        neighs: List of neighbor IPs which should be cleared.
-        delay: How long to delay between checks.
-        poll_time: How long to poll for.
-
-    """
-
-    t0 = time.time()
-    endtime = t0 + poll_time
-
-    for node in duthosts.frontend_nodes:
-        for asic in node.asics:
-            logger.info("Poll for ARP clear on host: %s/%s", node.hostname, asic.asic_index)
-            node_cleared = False
-            while time.time() < endtime and node_cleared is False:
-                if node.is_multi_asic:
-                    arptable = node.switch_arptable(namespace=asic.namespace)['ansible_facts']
-                else:
-                    arptable = node.switch_arptable()['ansible_facts']
-                for nbr in neighs:
-                    try:
-                        check_host_arp_table_deleted(node, asic, nbr, arptable)
-                    except AssertionError:
-                        time.sleep(delay)
-                        break
-                    else:
-                        node_cleared = True
-
-    logger.info("Neighbor poll ends after %s seconds", str(time.time() - t0))
-
-
-def test_neighbor_clear_all(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
+def test_neighbor_clear_all(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index,
                             setup, teardown, nbrhosts, all_cfg_facts, nbr_macs, established_arp):
     """
     Verify tables, databases, and kernel routes are correctly deleted when the entire neighbor table is cleared.
@@ -496,7 +425,7 @@ def test_neighbor_clear_all(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     """
 
     per_host = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+    asic = per_host.asics[enum_rand_one_frontend_asic_index if enum_rand_one_frontend_asic_index is not None else 0]
     cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
     if 'BGP_NEIGHBOR' in cfg_facts:
         neighs = cfg_facts['BGP_NEIGHBOR']
@@ -516,7 +445,11 @@ def test_neighbor_clear_all(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     # relearn and check
     logger.info("Relearn neighbors on all nodes")
     ping_all_dut_local_nbrs(duthosts)
-    check_all_neighbors_present(duthosts, nbrhosts, all_cfg_facts, nbr_macs)
+    for neighbor in neighs:
+        pytest_assert(wait_until(60, 2, 0, check_arptable_state, per_host, asic, neighbor, "REACHABLE"),
+                      "STATE for neighbor {} did not change to reachable".format(neighbor))
+    logger.info("Checking mac {} on all the duts".format(nbr_macs))
+    check_all_neighbors_present(duthosts, nbrhosts, all_cfg_facts, nbr_macs, check_nbr_state=False)
 
 
 def select_neighbors(port_cfg, cfg_facts):
@@ -547,7 +480,7 @@ def select_neighbors(port_cfg, cfg_facts):
     return nbr_to_test
 
 
-def test_neighbor_clear_one(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
+def test_neighbor_clear_one(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index,
                             setup, teardown, nbrhosts, all_cfg_facts, nbr_macs, established_arp):
     """
     Verify tables, databases, and kernel routes are correctly deleted when a single neighbor adjacency is cleared.
@@ -573,7 +506,7 @@ def test_neighbor_clear_one(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
 
     """
     per_host = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+    asic = per_host.asics[enum_rand_one_frontend_asic_index if enum_rand_one_frontend_asic_index is not None else 0]
     cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
     if 'BGP_NEIGHBOR' in cfg_facts:
         neighs = cfg_facts['BGP_NEIGHBOR']
@@ -611,8 +544,11 @@ def test_neighbor_clear_one(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     # relearn and check
     logger.info("Relearn neighbors on all nodes")
     ping_all_dut_local_nbrs(duthosts)
+    for neighbor in nbr_to_test:
+        pytest_assert(wait_until(60, 2, 0, check_arptable_state, per_host, asic, neighbor, "REACHABLE"),
+                      "STATE for neighbor {} did not change to reachable".format(neighbor))
     logger.info("Check neighbor relearn on all nodes.")
-    check_all_neighbors_present(duthosts, nbrhosts, all_cfg_facts, nbr_macs)
+    check_all_neighbors_present(duthosts, nbrhosts, all_cfg_facts, nbr_macs, check_nbr_state=False)
 
 
 def change_mac(nbr, intf, mac):
@@ -666,6 +602,8 @@ def check_arptable_mac(host, asic, neighbor, mac, checkstate=True):
 
 
 def check_arptable_state(host, asic, neighbor, state):
+    logger.info("Checking arp table state {} of nbr {} on {}".format(state, neighbor, asic))
+    sonic_ping(asic, neighbor, verbose=True)
     arptable = asic.switch_arptable()['ansible_facts']
 
     if ':' in neighbor:
@@ -679,7 +617,7 @@ def check_arptable_state(host, asic, neighbor, state):
     return table[neighbor]['state'] == state
 
 
-def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
+def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index,
                                 setup, teardown, nbrhosts, all_cfg_facts, nbr_macs, established_arp):
     """
     Verify tables, databases, and kernel routes are correctly updated when the MAC address of a neighbor changes
@@ -704,7 +642,7 @@ def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostn
     Args:
         duthosts: duthosts fixture.
         enum_rand_one_per_hwsku_frontend_hostname: frontend iteration fixture.
-        enum_asic_index: asic iteration fixture.
+        enum_rand_one_frontend_asic_index: asic iteration fixture.
         setup: setup fixture for this module.
         nbrhosts: nbrhosts fixture.
         established_arp: Fixture to establish arp on all nodes
@@ -712,7 +650,7 @@ def test_neighbor_hw_mac_change(duthosts, enum_rand_one_per_hwsku_frontend_hostn
     """
 
     per_host = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+    asic = per_host.asics[enum_rand_one_frontend_asic_index if enum_rand_one_frontend_asic_index is not None else 0]
     cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
 
     if 'BGP_NEIGHBOR' in cfg_facts:
@@ -918,7 +856,7 @@ def pick_ports(cfg_facts):
 
 class TestNeighborLinkFlap(LinkFlap):
 
-    def test_front_panel_admindown_port(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
+    def test_front_panel_admindown_port(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index,
                                         all_cfg_facts, setup, teardown, nbrhosts, nbr_macs, established_arp):
         """
         Verify tables, databases, and kernel routes are correctly deleted when the DUT port is admin down/up.
@@ -940,7 +878,7 @@ class TestNeighborLinkFlap(LinkFlap):
         Args:
             duthosts: duthosts fixture.
             enum_rand_one_per_hwsku_frontend_hostname: frontend iteration fixture.
-            enum_asic_index: asic iteration fixture.
+            enum_rand_one_frontend_asic_index: asic iteration fixture.
             all_cfg_facts: all_cfg_facts fixture from voq/conftest.py
             setup: setup fixture for this module.
             nbrhosts: nbrhosts fixture.
@@ -949,7 +887,7 @@ class TestNeighborLinkFlap(LinkFlap):
         """
 
         per_host = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+        asic = per_host.asics[enum_rand_one_frontend_asic_index if enum_rand_one_frontend_asic_index is not None else 0]
         cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
 
         if 'BGP_NEIGHBOR' in cfg_facts:
@@ -983,7 +921,7 @@ class TestNeighborLinkFlap(LinkFlap):
 
             dump_and_verify_neighbors_on_asic(duthosts, per_host, asic, neighbors, nbrhosts, all_cfg_facts, nbr_macs)
 
-    def test_front_panel_linkflap_port(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
+    def test_front_panel_linkflap_port(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index,
                                        all_cfg_facts,
                                        fanouthosts, setup, teardown, nbrhosts, established_arp):
         """
@@ -1005,7 +943,7 @@ class TestNeighborLinkFlap(LinkFlap):
         Args:
             duthosts: duthosts fixture.
             enum_rand_one_per_hwsku_frontend_hostname: frontend iteration fixture.
-            enum_asic_index: asic iteration fixture.
+            enum_rand_one_frontend_asic_index: asic iteration fixture.
             all_cfg_facts: all_cfg_facts fixture from voq/conftest.py
             fanouthosts: fanouthosts fixture.
             setup: setup fixture for this module.
@@ -1017,7 +955,7 @@ class TestNeighborLinkFlap(LinkFlap):
             pytest.skip("Fanouthosts fixture did not return anything, this test case can not run.")
 
         per_host = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        asic = per_host.asics[enum_asic_index if enum_asic_index is not None else 0]
+        asic = per_host.asics[enum_rand_one_frontend_asic_index if enum_rand_one_frontend_asic_index is not None else 0]
         cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
 
         if 'BGP_NEIGHBOR' in cfg_facts:
@@ -1034,7 +972,6 @@ class TestNeighborLinkFlap(LinkFlap):
             local_ips = [i.split("/")[0] for i in intfs[intf].keys()]  # [u'2064:100::2/64', u'100.0.0.2/24']
             neighbors = [n for n in neighs if neighs[n]['local_addr'] in local_ips]
             logger.info("Testing neighbors: %s on intf: %s", neighbors, intf)
-
             if "portchannel" in intf.lower():
                 pc_cfg = cfg_facts['PORTCHANNEL_MEMBER']
                 pc_members = pc_cfg[intf]
@@ -1049,8 +986,7 @@ class TestNeighborLinkFlap(LinkFlap):
                     logger.info("fanout port: %s %s, host: %s", fanout, fanport, fanout.host)
                     self.linkflap_down(fanout, fanport, per_host, lport)
 
-                for neighbor in neighbors:
-                    check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all_cfg_facts)
+                check_neighbors_are_gone(duthosts, all_cfg_facts, per_host, asic, neighbors)
 
             finally:
                 for lport in portbounce_list:
@@ -1058,6 +994,7 @@ class TestNeighborLinkFlap(LinkFlap):
                     self.linkflap_up(fanout, fanport, per_host, lport)
 
             for neighbor in neighbors:
+                sonic_ping(asic, neighbor)
                 check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all_cfg_facts)
 
 
@@ -1089,7 +1026,7 @@ class TestGratArp(object):
                    log_file=log_file, timeout=3)
         logger.info("Grat packet sent.")
 
-    def test_gratarp_macchange(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index,
+    def test_gratarp_macchange(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index,
                                ptfhost, tbinfo, nbrhosts, setup, teardown, all_cfg_facts, established_arp):
         """
         Verify tables, databases, and kernel routes are correctly updated when a unsolicited ARP packet changes
@@ -1113,7 +1050,7 @@ class TestGratArp(object):
         Args:
             duthosts: The duthosts fixture
             enum_rand_one_per_hwsku_frontend_hostname: frontend enumeration fixture
-            enum_asic_index: asic enumeration fixture
+            enum_rand_one_frontend_asic_index: asic enumeration fixture
             ptfhost: The ptfhost fixure.
             tbinfo: The tbinfo fixture
             nbrhosts: The nbrhosts fixture.
@@ -1127,7 +1064,7 @@ class TestGratArp(object):
 
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-        asic = duthost.asics[enum_asic_index if enum_asic_index is not None else 0]
+        asic = duthost.asics[enum_rand_one_frontend_asic_index if enum_rand_one_frontend_asic_index is not None else 0]
         cfg_facts = all_cfg_facts[duthost.hostname][asic.asic_index]['ansible_facts']
 
         if 'BGP_NEIGHBOR' in cfg_facts:

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -9,6 +9,51 @@ from tests.common.helpers.sonic_db import AsicDbCli, AppDbCli, VoqDbCli
 
 logger = logging.getLogger(__name__)
 
+def check_host_arp_table_deleted(host, asic, neighs):
+    """
+    Verifies the ARP entry is deleted.
+
+    Args:
+        host: instance of SonicHost to run the arp show.
+        neighbor_ip: IP address of the neighbor to verify.
+        arptable: Optional arptable output, if not provided it will be fetched from host.
+
+    """
+    if host.is_multi_asic:
+        arptable = host.switch_arptable(namespace=asic.namespace)['ansible_facts']
+    else:
+        arptable = host.switch_arptable()['ansible_facts']
+
+    neighs_present = []
+    for neighbor_ip in neighs:
+        if ':' in neighbor_ip:
+            table = arptable['arptable']['v6']
+        else:
+            table = arptable['arptable']['v4']
+        if neighbor_ip in table:
+            neighs_present.append(neighbor_ip)
+    logger.debug("On host {} asic {}, found neighbors {} that were supposed to be deleted".format(host, asic.asic_index, neighs_present))
+    return len(neighs_present) == 0
+
+
+def poll_neighbor_table_delete(duthosts, neighs, delay=2, poll_time=180):
+    """
+    Poller for clear tests to determine when to proceed with test after issuing
+    clear commands.
+
+    Args:
+        duthosts: The duthosts fixture.
+        neighs: List of neighbor IPs which should be cleared.
+        delay: How long to delay between checks.
+        poll_time: How long to poll for.
+
+    """
+    for node in duthosts.frontend_nodes:
+        for asic in node.asics:
+            logger.info("Poll for ARP clear of %s on host: %s/%s", neighs, node.hostname, asic.asic_index)
+            pytest_assert(wait_until(poll_time, delay, 0, check_host_arp_table_deleted, node, asic, neighs),
+                          "Not all neighbors {} deleted on host {}/{}".format(neighs, node.hostname, asic.asic_index))
+
 
 def check_host_arp_table(host, asic, neighbor_ip, neighbor_mac, interface, state, arptable=None):
     """
@@ -39,33 +84,9 @@ def check_host_arp_table(host, asic, neighbor_ip, neighbor_mac, interface, state
                   "table MAC %s does not match neighbor mac: %s" % (table[neighbor_ip]['macaddress'], neighbor_mac))
     pytest_assert(table[neighbor_ip]['interface'] == interface,
                   "table interface %s does not match interface: %s" % (table[neighbor_ip]['interface'], interface))
-    pytest_assert(table[neighbor_ip]['state'].lower() == state.lower(),
-                  "table state %s is not %s" % (table[neighbor_ip]['state'].lower(), state.lower()))
-
-
-def check_host_arp_table_deleted(host, asic, neighbor_ip, arptable=None):
-    """
-    Verifies the ARP entry is deleted.
-
-    Args:
-        host: instance of SonicHost to run the arp show.
-        neighbor_ip: IP address of the neighbor to verify.
-        arptable: Optional arptable output, if not provided it will be fetched from host.
-
-    """
-    if arptable is None:
-        if host.is_multi_asic:
-            arptable = host.switch_arptable(namespace=asic.namespace)['ansible_facts']
-        else:
-            arptable = host.switch_arptable()['ansible_facts']
-
-    logger.debug("ARP: %s", arptable)
-    if ':' in neighbor_ip:
-        table = arptable['arptable']['v6']
-    else:
-        table = arptable['arptable']['v4']
-    if neighbor_ip in table:
-        raise AssertionError("ip %s is still in table: %s" % (neighbor_ip, table[neighbor_ip]))
+    if state:
+        pytest_assert(table[neighbor_ip]['state'].lower() == state.lower(),
+                      "table state %s is not %s" % (table[neighbor_ip]['state'].lower(), state.lower()))
 
 
 def check_local_neighbor_asicdb(asic, neighbor_ip, neighbor_mac):
@@ -290,9 +311,6 @@ def check_voq_remote_neighbor(host, asic, neighbor_ip, neighbor_mac, interface, 
     pytest_assert(asicdb.get_neighbor_value(neighbor_key,
                                             'SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX') == encap_idx,
                   "Encap index does not match in asicDB")
-    pytest_assert(asicdb.get_neighbor_value(neighbor_key,
-                                            'SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX') == "true",
-                  "Encap impose is not true in asicDB")
     pytest_assert(asicdb.get_neighbor_value(neighbor_key,
                                             'SAI_NEIGHBOR_ENTRY_ATTR_IS_LOCAL') == "false",
                   "is local is not false in asicDB")
@@ -629,7 +647,7 @@ def check_one_neighbor_present(duthosts, per_host, asic, neighbor, nbrhosts, all
                                       local_dict['encap_index'], remote_inband_mac)
 
 
-def check_all_neighbors_present(duthosts, nbrhosts, all_cfg_facts, nbr_macs):
+def check_all_neighbors_present(duthosts, nbrhosts, all_cfg_facts, nbr_macs, check_nbr_state=True):
     """
     Verifies all neighbors for all sonic hosts in a voq system.
 
@@ -641,11 +659,9 @@ def check_all_neighbors_present(duthosts, nbrhosts, all_cfg_facts, nbr_macs):
 
     """
     for per_host in duthosts.frontend_nodes:
-
         for asic in per_host.asics:
             logger.info("Checking local neighbors on host: %s, asic: %s", per_host.hostname, asic.asic_index)
             cfg_facts = all_cfg_facts[per_host.hostname][asic.asic_index]['ansible_facts']
-            logger.info("Checking local neighbors on host: %s, asic: %s", per_host.hostname, asic.asic_index)
             if 'BGP_NEIGHBOR' in cfg_facts:
                 neighs = cfg_facts['BGP_NEIGHBOR']
             else:
@@ -653,10 +669,10 @@ def check_all_neighbors_present(duthosts, nbrhosts, all_cfg_facts, nbr_macs):
                 continue
 
             dump_and_verify_neighbors_on_asic(duthosts, per_host, asic, neighs.keys(),
-                                              nbrhosts, all_cfg_facts, nbr_macs)
+                                              nbrhosts, all_cfg_facts, nbr_macs, check_nbr_state=check_nbr_state)
 
 
-def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_cfg_facts, nbrhosts, nbr_macs):
+def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_cfg_facts, nbrhosts, nbr_macs, check_nbr_state=True):
     """
     Dumps out data from redis and CLI and validates all local neighbors at once.
 
@@ -685,6 +701,7 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
     app_dump = appdb.dump_neighbor_table()
 
     encaps = {}
+
     if per_host.is_multi_asic:
         arptable = per_host.switch_arptable(namespace=asic.namespace)['ansible_facts']
     else:
@@ -746,7 +763,10 @@ def check_all_neighbors_present_local(duthosts, per_host, asic, neighbors, all_c
             fail_cnt += 1
 
         # Validate the arp table entries
-        check_host_arp_table(per_host, asic, neighbor, neigh_mac, local_port, 'REACHABLE', arptable=arptable)
+        if check_nbr_state:
+            check_host_arp_table(per_host, asic, neighbor, neigh_mac, local_port, 'REACHABLE', arptable=arptable)
+        else:
+            check_host_arp_table(per_host, asic, neighbor, neigh_mac, local_port, None, arptable=arptable)
 
         # supervisor checks
         for entry in voq_dump:
@@ -878,8 +898,6 @@ def check_all_neighbors_present_remote(local_host, rem_host, rem_asic, neighs, e
                     logger.debug("Asic neighbor encap for %s match: %s == %s", neighbor, encap_id,
                                  asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX'])
 
-                pytest_assert(asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX'] == "true",
-                              "Encap impose is not true in asicDB")
                 pytest_assert(asic_dump[entry]['value']['SAI_NEIGHBOR_ENTRY_ATTR_IS_LOCAL'] == "false",
                               "is local is not false in asicDB")
 
@@ -942,7 +960,7 @@ def check_all_neighbors_present_remote(local_host, rem_host, rem_asic, neighs, e
     return {'fail_cnt': fail_cnt}
 
 
-def dump_and_verify_neighbors_on_asic(duthosts, per_host, asic, neighs, nbrhosts, all_cfg_facts, nbr_macs):
+def dump_and_verify_neighbors_on_asic(duthosts, per_host, asic, neighs, nbrhosts, all_cfg_facts, nbr_macs, check_nbr_state=True):
     """
     Verifies all neighbors for all sonic hosts in a voq system.
 
@@ -958,7 +976,7 @@ def dump_and_verify_neighbors_on_asic(duthosts, per_host, asic, neighs, nbrhosts
     """
 
     logger.info("Checking local neighbors on host: %s, asic: %s", per_host.hostname, asic.asic_index)
-    ret = check_all_neighbors_present_local(duthosts, per_host, asic, neighs, all_cfg_facts, nbrhosts, nbr_macs)
+    ret = check_all_neighbors_present_local(duthosts, per_host, asic, neighs, all_cfg_facts, nbrhosts, nbr_macs, check_nbr_state=check_nbr_state)
     encaps = ret['encaps']
     fail_cnt = ret['fail_cnt']
 
@@ -971,6 +989,7 @@ def dump_and_verify_neighbors_on_asic(duthosts, per_host, asic, neighs, nbrhosts
                 continue
             ret = check_all_neighbors_present_remote(per_host, rem_host, rem_asic, neighs, encaps,
                                                      all_cfg_facts, nbrhosts, nbr_macs)
+
             fail_cnt += ret['fail_cnt']
 
     if fail_cnt > 1:
@@ -1052,25 +1071,18 @@ def check_neighbors_are_gone(duthosts, all_cfg_facts, per_host, asic, neighbors)
     """
     asicdb = AsicDbCli(asic)
     appdb = AppDbCli(asic)
+
+    # Check that the arp entry is deleted for all the neighbors on all the asics.
+    poll_neighbor_table_delete(duthosts, neighbors, poll_time=30)
+
     asicdb_neigh_table = asicdb.dump_neighbor_table()
     app_neigh_table = appdb.dump_neighbor_table()
-
-    if per_host.is_multi_asic:
-        arptable = per_host.switch_arptable(namespace=asic.namespace)['ansible_facts']
-    else:
-        arptable = per_host.switch_arptable()['ansible_facts']
-
-    if len(duthosts.supervisor_nodes) == 1:
-        voqdb = VoqDbCli(duthosts.supervisor_nodes[0])
-        voq_dump = voqdb.dump_neighbor_table()
-    else:
-        voq_dump = {}
+    voqdb = VoqDbCli(duthosts.supervisor_nodes[0])
+    voq_dump = voqdb.dump_neighbor_table()
 
     for neighbor in neighbors:
-        logger.info("Checking ARP/NDP for %s is deleted from host: %s, asic: %s", neighbor, per_host.hostname,
+        logger.info("Checking neighbor entry for %s is deleted from host: %s, asic: %s", neighbor, per_host.hostname,
                     asic.asic_index)
-        # check local host
-        check_host_arp_table_deleted(per_host, asic, neighbor, arptable)
 
         for entry in asicdb_neigh_table.keys():
             search = '"ip":"%s"' % neighbor
@@ -1107,12 +1119,6 @@ def check_neighbors_are_gone(duthosts, all_cfg_facts, per_host, asic, neighbors)
                 appdb = AppDbCli(rem_asic)
                 asicdb_neigh_table = asicdb.dump_neighbor_table()
                 app_neigh_table = appdb.dump_neighbor_table()
-                if per_host.is_multi_asic:
-                    arptable = rem_host.switch_arptable(namespace=rem_asic.namespace)['ansible_facts']
-                else:
-                    arptable = rem_host.switch_arptable()['ansible_facts']
-
-                check_host_arp_table_deleted(rem_host, rem_asic, neighbor, arptable)
 
                 for entry in asicdb_neigh_table.keys():
                     search = '"ip":"%s"' % neighbor


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
When running the VoQ tests with the latest sonic-buildimage (with  latest VoQ PR's merged and updated kernel), some tests needed to be adjusted. Also, the tests in voq_nbr.py were intermittently failing in a VoQ chassis where all front-panel ports are connected to eBGP peers.

This PR addresses these issues to have the VoQ tests pass consistently.

#### How did you do it?
The following changes were made:
- conftest.py:
   - Adding enum_rand_one_frontend_asic_index to select one of the frontend asics. 
        - Some tests (like tests in voq/test_voq_nbr) were being repeating for all the asics in a multi-asic linecard. However, test coverage is the same on all the asics. So, need capability to run the test only on a randomly selected asic from all the frontend asics. There was already enum_rand_one_asic_index, but that would include both frontend and backend asics

- test_voq_ipfwd.py:
   - With the latest (version: 5.10.0-8-2-amd64 - bullseye) the ip route command has added 'nhid' field. Example:
      ```
      10.0.0.10/31 nhid 47 via 3.3.3.2 dev Ethernet-IB0 proto bgp src 10.1.0.1 metric 20 onlink
      ```
       So, when trying to match the route, instead of using 'startsWith', use a regular expression to be backward compatible.

- test_voq_nbr.py:
   - Use 'sudo config bgp shutdown/startup all' to disable all eBGP nbrs instead of figuring out eBGP neighbors from config and disabling each individually.
   - Increase the timeout when disabling eBGP on the eos dockers from 120 to 240.
       - With fully loaded line cards, doing the above on all dockers sometimes takes more that 120 seconds.
   - Use enum_rand_one_frontend_asic_index parameter in the voq_nbr tests that were being repeated on all asics.
   - test_front_panel_linkflap_ports:
       - With the latest kernel (version: 5.10.0-8-2-amd64 - bullseye), when a link goes down, the arp entries learnt on that link are immediately removed, and thus also removed from the local asic and app db. This was not the case with linux kernel version 4.19. Thus, in test_front_panel_linkflap_ports, we need to now
            - check that the neighbor entries are gone from local and remote asics when the link on the fanout is brought down. Up
            - Upon recovery, need to ping the local neighbor to allow for the arp and entries to re-added.

   - test_neighbor_clear_one, test_neighbor_clear_all:
       - In the voq_nbr tests, we disable all eBGP peers on the DUT and the eos peers to avoid any traffic. The test does a ping of all the eBGP peers, but in a T2 topology that could take 90+ seconds and then checks if the neighbor entries are installed in all asic. With no other traffic, some neighbors might not always be in 'REACHABLE' state. So, ignoring the state and just checking that the neighbor entry exists

- voq_helpers.py:
  - Removal of ENCAP_IMPOSE_INDEX
       - With latest github code, the 'SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX' is removed from 'SAI_OBJECT_TYPE_NEIGHBOR_ENTRY' in the asic_db.
      - Remove validation based on this field from voq_helpers.py
   - Poll for arp entries deleted on all asics when neighbor goes down and use wait_until utility
   - Support for check_nbr_state in check_host_arp_table

#### How did you verify/test it?
Ran the VoQ Tests against T2 chassis with all front panel ports connected multiple times and validated consistent results.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
