### PR TITLE
Fix KeyError in Everflow test

### DIFF
--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -98,7 +98,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             return
         duthost = duthosts[rand_one_dut_hostname]
 
-        default_traffic_port_type = "tor" if dest_port_type == "spine" else "spine"
+        default_traffic_port_type = DOWN_STREAM if dest_port_type == UP_STREAM else UP_STREAM
         rx_port = setup_info[default_traffic_port_type]["dest_port"][0]
         nexthop_ip = everflow_utils.get_neighbor_info(duthost, rx_port, tbinfo)
         


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

This PR is to fix `KeyError` found in fixture `add_dest_routes`. 
```
default_traffic_port_type = "tor" if dest_port_type == "spine" else "spine"
>       rx_port = setup_info[default_traffic_port_type]["dest_port"][0]
E       KeyError: 'spine'
```
The error is intrduced by recent PR [#4760](https://github.com/Azure/sonic-mgmt/pull/4760), which changed the `key` name of `setup_info`.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix `KeyError` found in fixture `add_dest_routes`. 

#### How did you do it?
Correct the hardcoded key name.

#### How did you verify/test it?
Verified by running `TestEverflowV4EgressAclEgressMirror`. All passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
