### PR TITLE
[test_system_health] add dockers check after critical processes restart

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -10,6 +10,7 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_require
 from tests.platform_tests.thermal_control_test_helper import disable_thermal_policy
 from device_mocker import device_mocker_factory
+from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -384,3 +385,6 @@ class ProcessExitContext:
     def __exit__(self, exc_type, exc_val, exc_tb):
         logging.info('Starting {}:{}'.format(self.container_name, self.process_name))
         self.dut.command('docker exec -it {} bash -c "supervisorctl start {}"'.format(self.container_name, self.process_name))
+        # check with delay in which the dockers can be restarted
+        pytest_assert(wait_until(300, 20, 8, self.dut.critical_services_fully_started),
+                      "Not all critical services are fully started")


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixed test issue in which the dockers can be restarted.
If restart some critical processes, as coppmgrd in swss, all the dockers can be restarted. The restart starts after "start" of the process.
To avoid failure of next tests, added a check of critical processes at the end of the "problematic" test. 


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Add test stability

#### How did you do it?
added checker "critical_services_fully_started" in a teardown of the test.

#### How did you verify/test it?
Executed with known "problematic" process and not random, as it's in the test.

#### Any platform specific information?
N/A



### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
