### PR TITLE
[advance-reboot] HOTFIX - remove unexpected argument from _parse_timestamp 

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -310,7 +310,7 @@ def verify_mac_jumping(test_name, timing_data):
         # and ends when SAI is instructed to enable MAC learning (warmboot recovery path)
         logging.info("Mac expiry for unexpected addresses started at {}".format(mac_expiry_start) +\
             " and FDB learning enabled at {}".format(fdb_aging_disable_end))
-        if _parse_timestamp(mac_expiry_start) > _parse_timestamp(fdb_aging_disable_start, FMT) and\
+        if _parse_timestamp(mac_expiry_start) > _parse_timestamp(fdb_aging_disable_start) and\
             _parse_timestamp(mac_expiry_start) < _parse_timestamp(fdb_aging_disable_end):
             pytest.fail("Mac expiry detected during the window when FDB ageing was disabled")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix the below error introduced by https://github.com/Azure/sonic-mgmt/pull/4883/files:

```
  File "/azp/agent/_work/18/s/tests/common/fixtures/advanced_reboot.py", line 464, in runRebootTest
    post_reboot_analysis(marker, reboot_oper=rebootOper)
  File "/azp/agent/_work/18/s/tests/platform_tests/conftest.py", line 418, in post_reboot_analysis
    verify_mac_jumping(test_name, analyze_result)
  File "/azp/agent/_work/18/s/tests/platform_tests/conftest.py", line 315, in verify_mac_jumping
    if _parse_timestamp(mac_expiry_start) > _parse_timestamp(fdb_aging_disable_start, FMT) and\
TypeError: _parse_timestamp() takes exactly 1 argument (2 given)
```
#### How did you do it?


#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
