### PR TITLE
[is_ipv4_address] Convert ip_address to unicode

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -431,6 +431,7 @@ def get_test_server_visible_vars(inv_files, server):
 
 def is_ipv4_address(ip_address):
     """Check if ip address is ipv4."""
+    ip_address = unicode(ip_address)
     try:
         ipaddress.IPv4Address(ip_address)
         return True


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
For recent `test_mac_move` failures:
```
gaierror: [Errno -9] Address family for hostname not supported
```
This is because if we pass ipv4 address of string type to `is_ipv4_address`, it will return `False`.

#### How did you do it?
Convert the input to unicode before the check

#### How did you verify/test it?
Run `test_mac_move`
```
dualtor/test_orchagent_mac_move.py::test_mac_move
PASSED                                                                                                                                                                                                               [100%]

========================================================================================================================= 1 passed in 543.13 seconds =========================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
