### PR TITLE
Ignore `No PG profile configured` error logs

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -17,3 +17,4 @@ r, ".* WARNING syncd#SDK:.* check_attribs_metadata: Not implemented attribute SA
 r, ".* WARNING syncd#SDK:.* check_attribs_metadata: Not implemented attribute SAI_SWITCH_ATTR_MAX_NUMBER_OF_TEMP_SENSORS.*"
 r, ".* WARNING syncd#SDK:.* check_attribs_metadata: Not supported attribute SAI_SWITCH_ATTR_AVAILABLE_IPMC_ENTRY.*"
 r, ".* WARNING syncd#SDK:.* sai_get_attributes: Failed attribs check.*"
+r, ".* ERR swss#buffermgrd:.* doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet(128|132|256|260).*"


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to ignore `No PG profile configured` error logs as the error logs are explainable.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to ignore `No PG profile configured` error logs.

#### How did you do it?
Add a new pattern into `loganalyzer_common_ignore.txt`.

#### How did you verify/test it?
Verified by running a python sample.
```
Python 2.7.13 (default, Nov 23 2017, 15:37:09) 
[GCC 6.3.0 20170406] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> r = re.compile(r".* ERR swss#buffermgrd:.* doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet(128|132|256|260).*")
>>> r.match("Jan 18 12:03:41.649042 str-7260cx3-acs-7 ERR swss#buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet128. No PG profile configured for speed 10000 and cable length 300m")
<_sre.SRE_Match object at 0x7f954da24648>
>>> r.match("Jan 18 12:03:41.649042 str-7260cx3-acs-7 ERR swss#buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet132. No PG profile configured for speed 10000 and cable length 300m")  
<_sre.SRE_Match object at 0x7f954da246c0>
>>> r.match("Jan 18 12:03:41.649042 str-7260cx3-acs-7 ERR swss#buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet256. No PG profile configured for speed 10000 and cable length 300m")   
<_sre.SRE_Match object at 0x7f954da24648>
>>> r.match("Jan 18 12:03:41.649042 str-7260cx3-acs-7 ERR swss#buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet260. No PG profile configured for speed 10000 and cable length 300m")  
<_sre.SRE_Match object at 0x7f954da246c0>
>>> r.match("Jan 18 12:03:41.649042 str-7260cx3-acs-7 ERR swss#buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet129. No PG profile configured for speed 10000 and cable length 300m")   
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
