### PR TITLE
[test_orchagent_slb] Filter tunnel packet explicitly with inner packet

### DIFF
--- a/tests/dualtor/test_orchagent_slb.py
+++ b/tests/dualtor/test_orchagent_slb.py
@@ -2,6 +2,7 @@ import ipaddress
 import pytest
 import random
 import time
+import scapy.all as scapyall
 
 from ptf import testutils
 
@@ -202,7 +203,10 @@ def test_orchagent_slb(
         ptf_t1_intf_index = int(ptf_t1_intf.strip("eth"))
         is_tunnel_traffic_existed = is_route_existed and not is_duthost_active
         is_server_traffic_existed = is_route_existed and is_duthost_active
-        tunnel_monitor = tunnel_traffic_monitor(duthost, existing=is_tunnel_traffic_existed)
+
+        tunnel_innner_pkt = pkt[scapyall.IP].copy()
+        tunnel_innner_pkt[scapyall.IP].ttl -= 1
+        tunnel_monitor = tunnel_traffic_monitor(duthost, existing=is_tunnel_traffic_existed, inner_packet=tunnel_innner_pkt)
         server_traffic_monitor = ServerTrafficMonitor(
             duthost, ptfhost, vmhost, tbinfo, connection["test_intf"],
             conn_graph_facts, exp_pkt, existing=is_server_traffic_existed


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
For tunnel traffic verification, the tunnel packet check might match the BGP keepalive message from the slb to the standby ToR. 
We should explicitly match the tunnel packet with the inner packet.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Let `tunnel_traffic_monitor` filters tunnel traffic with the inner packet signature.

#### How did you verify/test it?
```
dualtor/test_orchagent_slb.py::test_orchagent_slb PASSED                                                                                                                                                                                                               [100%]

========================================================================================================================= 1 passed in 330.92 seconds =========================================================================================================================
INFO:root:Can not get Allure report URL. Please check logs
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
