### PR TITLE
[dualtor] Fix dualtor downstream active testcases

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -733,6 +733,7 @@ def generate_hashed_packet_to_server(ptfadapter, duthost, hash_key, target_serve
             dl_vlan_enable=False,
             ipv6_src=src_ip,
             ipv6_dst=dst_ip,
+            ipv6_hlim=64,
             tcp_sport=sport,
             tcp_dport=dport
         )
@@ -741,7 +742,7 @@ def generate_hashed_packet_to_server(ptfadapter, duthost, hash_key, target_serve
         exp_pkt.set_do_not_care_scapy(scapyall.Ether, "src")
         exp_pkt.set_do_not_care_scapy(scapyall.IPv6, "hlim")
 
-        inner_packet = send_pkt[IPv6].copy()
+        inner_packet = send_pkt[IPv6]
         inner_packet[IPv6].hlim -= 1
         exp_tunnel_pkt = testutils.simple_ipv4ip_packet(
             eth_dst=dst_mac,
@@ -750,6 +751,8 @@ def generate_hashed_packet_to_server(ptfadapter, duthost, hash_key, target_serve
             ip_dst="10.1.0.33",
             inner_frame=inner_packet
         )
+        send_pkt.hlim = 64
+        exp_tunnel_pkt[TCP] = inner_packet[TCP]
         exp_tunnel_pkt = mask.Mask(exp_tunnel_pkt)
         exp_tunnel_pkt.set_do_not_care_scapy(scapyall.Ether, "dst")
         exp_tunnel_pkt.set_do_not_care_scapy(scapyall.Ether, "src")

--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -97,4 +97,4 @@ def run_arp_responder_ipv6(rand_selected_dut, ptfhost, tbinfo, apply_mock_dual_t
 
     yield
 
-    ptfhost.shell('supervisorctl restart arp_responder')
+    ptfhost.shell('supervisorctl stop arp_responder')

--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -45,7 +45,7 @@ def testbed_setup(ip_version, ptfhost, rand_selected_dut, rand_unselected_dut, t
         server_ip = testbed_params["target_server_ip"]
     elif ip_version == "ipv6":
         server_ip = testbed_params["target_server_ipv6"]
-        # setup arp_responder to answert ipv6 neighbor solicitation messages
+        # setup arp_responder to answer ipv6 neighbor solicitation messages
         request.getfixturevalue("run_arp_responder_ipv6")
     else:
         raise ValueError("Unknown IP version '%s'" % ip_version)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix `test_downstream_ecmp_nexthops`

#### How did you do it?
1. add fixture `mock_server_ipv6_mac_map` to mock the IPv6 neighbors for the mux servers.
2. ensure the expected tunnel packets have the same payload as the send packet as the send packet payload might be changed by the send method.
3. stop the `arp_responder` in the teardown of fixture `run_arp_responder_ipv6`

#### How did you verify/test it?
```
dualtor/test_orchagent_active_tor_downstream.py::test_active_tor_remove_neighbor_downstream_active[ipv4] PASSED                                                                                                                                                        [ 25%]
dualtor/test_orchagent_active_tor_downstream.py::test_active_tor_remove_neighbor_downstream_active[ipv6] PASSED                                                                                                                                                        [ 50%]
dualtor/test_orchagent_active_tor_downstream.py::test_downstream_ecmp_nexthops[ipv4] PASSED                                                                                                                                                                            [ 75%]
dualtor/test_orchagent_active_tor_downstream.py::test_downstream_ecmp_nexthops[ipv6] PASSED                                                                                                                                                                            [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
