### PR TITLE
[dualtor/data_plane_utils]: Delaying disruptive action while traffic is established.

### DIFF
--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -1,5 +1,6 @@
 import pytest
 import json
+import time
 from tests.common.dualtor.dual_tor_io import DualTorIO
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import InterruptableThread
@@ -150,6 +151,7 @@ def run_test(duthosts, activehost, ptfhost, ptfadapter, action,
         # IO threads (sender and sniffer) are ready
         logger.info("Sender and sniffer threads started, ready to execute the "\
             "callback action")
+        time.sleep(15)
         action()
     # do not time-wait the test, if early stop is not requested (when stop_after=None)
     if stop_after is not None:


### PR DESCRIPTION
### Description of PR
Adding sleep to delay disruptive action so that the traffic has more time to be established. Discussed this change with @theasianpianist and verified that it fixes the issue on our testbeds.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The sleep is put to address the timing issues that we noticed while running Dualtor tests.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
