### PR TITLE
Fix a compatibility issue after azure.kusto.ingest was upgraded

### DIFF
--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -12,7 +12,12 @@ except ImportError:
     from azure.kusto.ingest import QueuedIngestClient as KustoIngestClient
 
 from azure.kusto.ingest import IngestionProperties
-from azure.kusto.ingest import DataFormat
+
+# Resolve azure.kusto.ingest compatibility issue
+try:
+    from azure.kusto.ingest import DataFormat
+except ImportError:
+    from azure.kusto.data.data_format import DataFormat
 
 from utilities import validate_json_file
 from datetime import datetime


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Package azure.kusto.ingest was upgraded from 2.3.2 to 3.0.0 on Jan 16th. Definitino of
DataFormat in azure.kusto.ingest was removed. Need to import DataFormat from
azure.kusto.data.data_format now.

#### How did you do it?
This added code to try importing DataFormat from azure.kusto.ingest firstly. If importing
failed, then tries to import DataFormat from azure.kusto.data.data_format.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
