### PR TITLE
[FIX] fix the issue of docker image pull, add proxy for docker service

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -346,6 +346,32 @@
         cert_subject: "{{ subject_t }}"
     when: deploy is defined and deploy|bool == true
 
+  - name: Set docker proxy
+    block:
+      - name: Ensures /etc/systemd/system/docker.service.d dir exists
+        file:
+          path: /etc/systemd/system/docker.service.d
+          state: directory
+          recurse: yes
+
+      - name: Render docker proxy config
+        template:
+          src: 'templates/docker_http_proxy.j2'
+          dest: '/etc/systemd/system/docker.service.d/http-proxy.conf'
+          force: yes
+
+      - name: restart docker service, let docker proxy takes effect
+        systemd:
+          state: restarted
+          daemon_reload: yes
+          name: docker
+
+      - name: Wait 10s for docker containers to restart
+        pause:
+          seconds: 10
+    become: true
+    when: proxy_env['https_proxy'] is defined
+
   - block:
       - name: saved original minigraph file in SONiC DUT(ignore errors when file does not exist)
         shell: mv /etc/sonic/minigraph.xml /etc/sonic/minigraph.xml.orig

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -370,7 +370,7 @@
         pause:
           seconds: 10
     become: true
-    when: proxy_env['https_proxy'] is defined
+    when: proxy_env is defined
 
   - block:
       - name: saved original minigraph file in SONiC DUT(ignore errors when file does not exist)

--- a/ansible/templates/docker_http_proxy.j2
+++ b/ansible/templates/docker_http_proxy.j2
@@ -1,0 +1,4 @@
+[Service]
+Environment="HTTP_PROXY={{ proxy_env['http_proxy'] | default({}) }}"
+Environment="HTTPS_PROXY={{ proxy_env['https_proxy'] | default({}) }}"
+Environment="NO_PROXY={{ proxy_env['no_proxy'] | default({}) }}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes the host unreachable issue of docker pull.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fixes the host unreachable issue of docker pull.

#### How did you do it?
Add docker proxy configuration in DUT during deploy-mg

#### How did you verify/test it?
Deploy-mg on physical testbeds and docker pull works as expected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
