### PR TITLE
[barefoot] Skip platform_tests/api/test_watchdog.py and qos/test_qos_sai.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -542,3 +542,15 @@ drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr:
     reason: "Cisco 8000 platform does not drop DIP loopback packets in 202012 version"
     conditions:
       - "asic_type=='cisco-8000' and release in ['202012']"
+
+platform_tests/api/test_watchdog.py:
+  skip:
+    reason: "Unsupported platform API"
+    conditions:
+      - "asic_type in ['barefoot'] and hwsku in ['newport', 'montara']"
+
+qos/test_qos_sai.py:
+  skip:
+    reason: "qos_sai tests not supported on t1 topo"
+    conditions:
+      - "asic_type in ['barefoot'] and topo_type in ['t1']"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip `platform_tests/api/test_watchdog.py` and `qos/test_qos_sai.py` for barefoot

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Skip `platform_tests/api/test_watchdog.py` for barefoot on newport and montara devices since this API is not supported.
Skip `qos/test_qos_sai.py` for barefoot on T1 topo.
#### How did you do it?
Added these tests to `conditional_mark` tests_mark_conditions.yaml
#### How did you verify/test it?
Run test_qos_sai.py and test_watchdog.py - all tests are skipped.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
