### PR TITLE
[TestbedProcessing] add asic_type to makeLab and makeLabYAML

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -584,6 +584,13 @@ def makeLab(data, devices, testbed, outfile):
                         except AttributeError:
                             print("\t\t" + host + " serial not found")
 
+                        try: #get asic_type
+                            asic_type=dev.get("asic_type")
+                            if asic_type is not None:
+                                entry += "\tasic_type=" + str( asic_type )
+                        except AttributeError:
+                            print("\t\t" + host + " asic_type not found")
+
                     toWrite.write(entry + "\n")
                 toWrite.write("\n")
 
@@ -636,6 +643,7 @@ def makeLabYAML(data, devices, testbed, outfile):
                         'serial': devices[dut].get("serial"),
                         'os': devices[dut].get("os"),
                         'model': devices[dut].get("model"),
+                        'asic_type': devices[dut].get("asic_type"),
                         'syseeprom_info': {"0x21": devices[dut].get("syseeprom_info").get("0x21"),
                                            "0x22": devices[dut].get("syseeprom_info").get("0x22"),
                                            "0x23": devices[dut].get("syseeprom_info").get("0x23"),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adds support for 'asic_type' to TestbedProcessing

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
[Conditional_mark plugin](https://github.com/Azure/sonic-mgmt/tree/master/tests/common/plugins/conditional_mark) is used to skip tests based on asic_type, hwsku etc. This plugin parses lab file to check if skip condition matches current configuration.
TestbedProcessing.py does not add 'asic_type' to generated lab files, causing `conditional_mark` plugin not to handle conditions based on 'asic_type'
#### How did you do it?
Added 'asic_type' to makeLab and makeLabYAML
#### How did you verify/test it?
Applied changes from [4990](https://github.com/Azure/sonic-mgmt/pull/4990) and ran qos/test_qos_sai.py - test was skipped as expected.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
