### PR TITLE
[conditional_mark] Add parser option to specify inventory file

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -38,6 +38,13 @@ def pytest_addoption(parser):
         default=False,
         help="Ignore the conditional mark plugin. No conditional mark will be added.")
 
+    parser.addoption(
+        '--customize_inventory_file',
+        action='store',
+        dest='customize_inventory_file',
+        default=False,
+        help="Location of your custom inventory file. If it is not specified, and inv_name not in testbed.csv, 'lab' will be used")
+
 def load_conditions(session):
     """Load the content from mark conditions file
 
@@ -103,7 +110,13 @@ def load_dut_basic_facts(session):
         results['topo_name'] = tbinfo['topo']['name']
 
         dut_name = tbinfo['duts'][0]
-        inv_name = tbinfo['inv_name']
+        if session.config.option.customize_inventory_file:
+            inv_name = session.config.option.customize_inventory_file
+        elif 'inv_name' in tbinfo.keys():
+            inv_name = tbinfo['inv_name']
+        else:
+            inv_name = 'lab'
+
         ansible_cmd = 'ansible -m dut_basic_facts -i ../ansible/{} {} -o'.format(inv_name, dut_name)
 
         raw_output = subprocess.check_output(ansible_cmd.split()).decode('utf-8')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adds support for `conditional_mark` plugin to work with deprecated format of testbed.csv

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Conditional_mark plugin uses testbed.csv to get location of inventory file, which is later used for gathering information about device hwsku, model etc. 
Deprecated format of testbed.csv does not include 'inv_name' field, which makes plugin unable to locate and parse lab file.
#### How did you do it?
Added parser option to specify inventory file, or use 'lab' as default value if no value was passed and 'inv_name' not in testbed.csv
#### How did you verify/test it?
Applied changes from [4990](https://github.com/Azure/sonic-mgmt/pull/4990) and ran qos/test_qos_sai.py - test was skipped, as expected.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
