### PR TITLE
Change router_mac for T2 profile in test_lldp script - PR to fix issue #4983

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -58,6 +58,8 @@ def test_lldp_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname, loca
     if tbinfo["topo"]["type"] != "t2":
         mgmt_alias = duthost.get_extended_minigraph_facts(tbinfo)["minigraph_mgmt_interface"]["alias"]
         switch_mac = duthost.get_dut_iface_mac(mgmt_alias)
+    elif tbinfo["topo"]["type"] == "t2":
+        switch_mac = config_facts['DEVICE_METADATA']['localhost']['mac'].lower()
     else:
         switch_mac = duthost.facts['router_mac']
 


### PR DESCRIPTION
### Description of PR
test_lldp is failing for multi-asic chassis-packet system due to wrong router_mac. The test is picking the mac address of eth0 instead of picking the mac-address of the respective asic. This is a PR to fix #4983. @abdosi has context of the issue.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The test is picking the mac address of eth0 instead of picking the mac-address of the respective asic. 

#### How did you do it?

#### How did you verify/test it?
Verified the fix on T2 profile.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
