### PR TITLE
Change router_mac for T2 profile in test_interface script - PR to fix issue #4983

### DIFF
--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -37,11 +37,8 @@ def test_interfaces(duthosts, enum_frontend_dut_hostname, tbinfo, enum_asic_inde
     verify_ip_address(host_facts, mg_facts['minigraph_lo_interfaces'])
 
     topo = tbinfo["topo"]["name"]
-    if tbinfo["topo"]["type"] == "t2":
-        config_facts = duthost.asic_instance(enum_asic_index).config_facts(host=duthost.hostname, source="running")['ansible_facts']
-        router_mac = config_facts['DEVICE_METADATA']['localhost']['mac'].lower()
-    else:
-        router_mac = duthost.facts['router_mac']
+    config_facts = duthost.asic_instance(enum_asic_index).config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    router_mac = config_facts['DEVICE_METADATA']['localhost']['mac'].lower()
 
     verify_mac_address(host_facts, mg_facts['minigraph_portchannel_interfaces'], router_mac)
     if "dualtor" not in topo:

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -37,7 +37,12 @@ def test_interfaces(duthosts, enum_frontend_dut_hostname, tbinfo, enum_asic_inde
     verify_ip_address(host_facts, mg_facts['minigraph_lo_interfaces'])
 
     topo = tbinfo["topo"]["name"]
-    router_mac = duthost.facts['router_mac']
+    if tbinfo["topo"]["type"] == "t2":
+        config_facts = duthost.asic_instance(enum_asic_index).config_facts(host=duthost.hostname, source="running")['ansible_facts']
+        router_mac = config_facts['DEVICE_METADATA']['localhost']['mac'].lower()
+    else:
+        router_mac = duthost.facts['router_mac']
+
     verify_mac_address(host_facts, mg_facts['minigraph_portchannel_interfaces'], router_mac)
     if "dualtor" not in topo:
         verify_mac_address(host_facts, mg_facts['minigraph_vlan_interfaces'], router_mac)


### PR DESCRIPTION
### Description of PR
test_interfaces is failing for multi-asic chassis-packet system due to wrong router_mac. The test is picking the mac address of eth0 instead of picking the mac-address of the respective asic. This is a PR to fix #4983. @abdosi has context of the issue.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The test is picking the mac address of eth0 instead of picking the mac-address of the respective asic.

#### How did you do it?

#### How did you verify/test it?
Verified the fix on T2 profile.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
