### PR TITLE
Change router_mac for T2 profile in arp/conftest.py - PR to fix issue #4983

### DIFF
--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -139,10 +139,15 @@ def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
 
 
 @pytest.fixture(scope="module")
-def common_setup_teardown(duthosts, ptfhost, enum_rand_one_per_hwsku_frontend_hostname):
+def common_setup_teardown(duthosts, ptfhost, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, tbinfo):
     try:
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        router_mac = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
+        if tbinfo["topo"]["type"] == "t2":
+            config_facts = duthost.asic_instance(enum_frontend_asic_index).config_facts(host=duthost.hostname, source="running")['ansible_facts']
+            router_mac = config_facts['DEVICE_METADATA']['localhost']['mac'].lower()
+        else:
+            router_mac = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
+
         # Copy test files
         ptfhost.copy(src="ptftests", dest="/root")
         logging.info("router_mac {}".format(router_mac))

--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -142,11 +142,8 @@ def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
 def common_setup_teardown(duthosts, ptfhost, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, tbinfo):
     try:
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        if tbinfo["topo"]["type"] == "t2":
-            config_facts = duthost.asic_instance(enum_frontend_asic_index).config_facts(host=duthost.hostname, source="running")['ansible_facts']
-            router_mac = config_facts['DEVICE_METADATA']['localhost']['mac'].lower()
-        else:
-            router_mac = duthost.shell('sonic-cfggen -d -v \'DEVICE_METADATA.localhost.mac\'')["stdout_lines"][0].decode("utf-8")
+        config_facts = duthost.asic_instance(enum_frontend_asic_index).config_facts(host=duthost.hostname, source="running")['ansible_facts']
+        router_mac = config_facts['DEVICE_METADATA']['localhost']['mac'].lower()
 
         # Copy test files
         ptfhost.copy(src="ptftests", dest="/root")


### PR DESCRIPTION
### Description of PR
test_arp is failing for multi-asic chassis-packet system due to wrong router_mac. The test is picking the mac address of eth0 instead of picking the mac-address of the respective asic. This is a PR to fix #4983. @abdosi has context of the issue.

Summary:
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The test is picking the mac address of eth0 instead of picking the mac-address of the respective asic.

#### How did you do it?

#### How did you verify/test it?
Verified the fix on T2 profile.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
