### PR TITLE
[dualtor] Add ipv6 support for downstream standby testcases

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -629,7 +629,7 @@ def mux_cable_server_ip(dut):
     return json.loads(mux_cable_config)
 
 
-def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip, standby_tor_ip, selected_port, target_server_ip, target_server_ipv6, target_server_port, ptf_portchannel_indices):
+def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip, standby_tor_ip, selected_port, target_server_ip, target_server_ipv6, target_server_port, ptf_portchannel_indices, check_ipv6=False):
     """
     Function for testing traffic distribution among all avtive T1.
     A test script will be running on ptf to generate traffic to standby interface, and the traffic will be forwarded to
@@ -643,6 +643,7 @@ def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip, stan
         target_server_ip: The IP address of server for testing. The mux cable connected to this server must be standby
         target_server_port: PTF port indice on which server is connected
         ptf_portchannel_indices: A dict, the mapping from portchannel to ptf port indices
+        check_ipv6: if True, check ipv6 traffic, if False, check ipv4 traffic
     Returns:
         None.
     """
@@ -657,6 +658,9 @@ def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip, stan
         "ptf_portchannel_indices": ptf_portchannel_indices,
         "hash_key_list": HASH_KEYS
     }
+    if check_ipv6:
+        params["server_ip"] = target_server_ipv6
+
     logging.info("run ptf test for verifying IPinIP tunnel balance")
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
     log_file = "/tmp/ip_in_ip_tunnel_test.{}.log".format(timestamp)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Add ipv6 support for the downstream standby testcases.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
1. parameterize the testcases with `ip_version`(either `ipv4` or `ipv6`)
2. add ipv6 support for `check_tunnel_balance`
3. run `arp_responder` for ipv6 testcases to populate the neighbor table for servers' ipv6 addresses

#### How did you verify/test it?
```
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream[ipv4] PASSED [  8%]
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream[ipv6] PASSED [ 16%]
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_t1_link_recovered[ipv4]
PASSED [ 25%]
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_t1_link_recovered[ipv6] PASSED [ 33%]
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_bgp_recovered[ipv4] SKIPPED [ 41%]
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_bgp_recovered[ipv6] SKIPPED [ 50%]
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_loopback_route_readded[ipv4] SKIPPED [ 58%]
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_loopback_route_readded[ipv6] SKIPPED [ 66%]
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_remove_neighbor_downstream_standby[ipv4] PASSED [ 75%]
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_remove_neighbor_downstream_standby[ipv6] PASSED [ 83%]
dualtor/test_orchagent_standby_tor_downstream.py::test_downstream_standby_mux_toggle_active[ipv4] XFAIL [ 91%]
dualtor/test_orchagent_standby_tor_downstream.py::test_downstream_standby_mux_toggle_active[ipv6] XPASS [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
