### PR TITLE
Fix sfp test failure in 202012

### DIFF
--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -78,7 +78,11 @@ def check_transceiver_details(dut, asic_index, interfaces, xcvr_skip_list):
     """
     asichost = dut.asic_instance(asic_index)
     logging.info("Check detailed transceiver information of each connected port")
-    expected_fields = ["type", "vendor_rev", "serial", "manufacturer", "model"]
+    if dut.sonic_release == "202012":
+        expected_fields = ["type", "hardware_rev", "serial", "manufacturer", "model"]
+    else:
+        expected_fields = ["type", "vendor_rev", "serial", "manufacturer", "model"]
+
     for intf in interfaces:
         if intf not in xcvr_skip_list[dut.hostname]:
             cmd = 'redis-cli -n 6 hgetall "TRANSCEIVER_INFO|%s"' % intf

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -245,6 +245,12 @@ class TestSfpApi(PlatformApiTestBase):
             if self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
                 if self.expect(isinstance(info_dict, dict), "Transceiver {} info appears incorrect".format(i)):
                     actual_keys = info_dict.keys()
+                    
+                    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+                    if duthost.sonic_release == "202012":
+                        EXPECTED_XCVR_INFO_KEYS = [key if key != 'vendor_rev' else 'hardware_rev' for key in
+                            self.EXPECTED_XCVR_INFO_KEYS]
+                        self.EXPECTED_XCVR_INFO_KEYS = EXPECTED_XCVR_INFO_KEYS
 
                     missing_keys = set(self.EXPECTED_XCVR_INFO_KEYS) - set(actual_keys)
                     for key in missing_keys:


### PR DESCRIPTION
Signed-off-by: Prince George <prgeor@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix sonic-mgt platform API test failures seen in 202012 related to SFP
[https://dev.azure.com/mssonic/12b9cbf4-b1d3-4768-8e49-669345c32e5d/_apis/build/builds/65630/logs/22](https://dev.azure.com/mssonic/12b9cbf4-b1d3-4768-8e49-669345c32e5d/_apis/build/builds/65630/logs/22)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
As part of SFP refactoring the 'hardware_rev' key was removed from transceiver info of QSFP+ and QSFP28 (as its not defined as per spec) . The sonic-mgmt test was modified to look for 'vendor_rev' instead of 'hardware_rev'. Since 202012 branch doesn't have sfp_refactor code, the tests are failing. 

#### How did you do it?
Only for 202012 look for 'hardware_rev' key in transceiver info.

#### How did you verify/test it?

Run 
1. platform_tests/test_xcvr_info_in_db.py
2. platform_tests/api/test_sfp.py

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
