### PR TITLE
Improve tacacs creds definition

### DIFF
--- a/ansible/group_vars/lab/lab.yml
+++ b/ansible/group_vars/lab/lab.yml
@@ -24,17 +24,6 @@ radius_passkey: testing123
 tacacs_servers: ['10.0.0.9', '10.0.0.8']
 
 tacacs_passkey: testing123
-tacacs_rw_user: test_rwuser
-tacacs_rw_user_passwd: '123456'
-tacacs_ro_user: test_rouser
-tacacs_ro_user_passwd: '123456'
-tacacs_jit_user: test_jituser
-tacacs_jit_user_passwd: '123456'
-tacacs_jit_user_membership: netuser
-tacacs_authorization_user: test_auuser
-tacacs_authorization_user_passwd: '123456'
-local_user: test_louser
-local_user_passwd: '123456'
 
 # tacacs grous
 tacacs_group: 'testlab'

--- a/tests/common/helpers/snmp_helpers.py
+++ b/tests/common/helpers/snmp_helpers.py
@@ -1,3 +1,5 @@
+import logging
+
 from tests.common.utilities import wait_until
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.assertions import pytest_assert
@@ -38,4 +40,3 @@ def get_snmp_facts(localhost, host, version, community, is_dell=False, module_ig
     pytest_assert(wait_until(timeout, interval, 0, _update_snmp_facts, localhost, host, version,
                              community, is_dell), "Timeout waiting for SNMP facts")
     return global_snmp_facts
-

--- a/tests/snmp/test_snmp_cpu.py
+++ b/tests/snmp/test_snmp_cpu.py
@@ -36,7 +36,7 @@ def test_snmp_cpu(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_a
     logger.info("found {} cpu on the dut".format(host_vcpus))
 
     # Gather facts with SNMP version 2
-    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"], is_dell=True, wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], is_dell=True, wait=True)['ansible_facts']
 
     assert int(snmp_facts['ansible_ChStackUnitCpuUtil5sec'])
 
@@ -48,7 +48,7 @@ def test_snmp_cpu(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_a
         time.sleep(20)
 
         # Gather facts with SNMP version 2
-        snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"], is_dell=True, wait=True)['ansible_facts']
+        snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], is_dell=True, wait=True)['ansible_facts']
 
         # Pull CPU utilization via shell
         # Explanation: Run top command with 2 iterations, 5sec delay.
@@ -57,8 +57,8 @@ def test_snmp_cpu(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_a
 
         output = duthost.shell("top -bn2 -d5 | awk '/^top -/ { p=!p } { if (!p) print }' | awk '/Cpu/ { cpu = 100 - $8 };END   { print cpu }' | awk '{printf \"%.0f\",$1}'")
 
-        print int(snmp_facts['ansible_ChStackUnitCpuUtil5sec'])
-        print int(output['stdout'])
+        logger.info(str(snmp_facts['ansible_ChStackUnitCpuUtil5sec']))
+        logger.info(str(output['stdout']))
 
         cpu_diff = abs(int(snmp_facts['ansible_ChStackUnitCpuUtil5sec']) - int(output['stdout']))
 

--- a/tests/snmp/test_snmp_default_route.py
+++ b/tests/snmp/test_snmp_default_route.py
@@ -17,7 +17,7 @@ def test_snmp_default_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     pytest_require('backend' not in tbinfo['topo']['name'], "Skip this testcase since this topology {} has no default routes".format(tbinfo['topo']['name']))
 
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
     dut_result = duthost.shell('show ip route 0.0.0.0/0 | grep "\*"')
 
     dut_result_nexthops = []

--- a/tests/snmp/test_snmp_fdb.py
+++ b/tests/snmp/test_snmp_fdb.py
@@ -84,7 +84,7 @@ def test_snmp_fdb_send_tagged(ptfadapter, utils_vlan_ports_list, toggle_all_simu
     ptfadapter.dataplane.flush()
 
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
     assert 'snmp_fdb' in snmp_facts
     assert 'snmp_interfaces' in snmp_facts
     dummy_mac_cnt = 0

--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.snmp_helpers import get_snmp_facts
@@ -7,6 +8,7 @@ pytestmark = [
     pytest.mark.device_type('vs')
 ]
 
+logger = logging.getLogger(__name__)
 
 def collect_all_facts(duthost, ports_list, namespace=None):
     """
@@ -143,10 +145,10 @@ def test_snmp_interfaces(localhost, creds_all_duts, duthosts, enum_rand_one_per_
 
     namespace = duthost.get_namespace_from_asic_id(enum_asic_index)
     config_facts  = duthost.config_facts(host=duthost.hostname, source="persistent", namespace=namespace)['ansible_facts']
-    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
 
-    snmp_ifnames = [ v['name'] for k, v in snmp_facts['snmp_interfaces'].items() ]
-    print snmp_ifnames
+    snmp_ifnames = [v['name'] for k, v in snmp_facts['snmp_interfaces'].items()]
+    logger.info('snmp_ifnames: {}'.format(snmp_ifnames))
 
     # Verify all physical ports in snmp interface list
     for _, alias in config_facts['port_name_to_alias_map'].items():
@@ -163,11 +165,11 @@ def test_snmp_mgmt_interface(localhost, creds_all_duts, duthosts, enum_rand_one_
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
-    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
     config_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
 
     snmp_ifnames = [ v['name'] for k, v in snmp_facts['snmp_interfaces'].items() ]
-    print snmp_ifnames
+    logger.info('snmp_ifnames: {}'.format(snmp_ifnames))
 
     # Verify management port in snmp interface list
     for name in config_facts.get('MGMT_INTERFACE', {}):
@@ -190,7 +192,7 @@ def test_snmp_interfaces_mibs(duthosts, enum_rand_one_per_hwsku_hostname, localh
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     namespace = duthost.get_namespace_from_asic_id(enum_asic_index)
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
     config_facts = duthost.config_facts(host=duthost.hostname, source="persistent", namespace=namespace)['ansible_facts']
 
     ports_list = []

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -1,11 +1,14 @@
-import pytest
+import logging
 import re
+import pytest
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 
 pytestmark = [
     pytest.mark.topology('any'),
     pytest.mark.device_type('vs')
 ]
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module", autouse="True")
@@ -38,14 +41,14 @@ def test_snmp_lldp(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_
         pytest.skip("LLDP not supported on supervisor node")
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
-    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
     mg_facts = {}
     for asic_id in duthost.get_asic_ids():
         mg_facts_ns   = duthost.asic_instance(asic_id).get_extended_minigraph_facts(tbinfo)['minigraph_neighbors']
         if mg_facts_ns is not None:
             mg_facts.update(mg_facts_ns)
 
-    print snmp_facts['snmp_lldp']
+    logger.info('snmp_lldp: {}'.format(snmp_facts['snmp_lldp']))
     for k in ['lldpLocChassisIdSubtype', 'lldpLocChassisId', 'lldpLocSysName', 'lldpLocSysDesc']:
         assert snmp_facts['snmp_lldp'][k]
         assert "No Such Object currently exists" not in snmp_facts['snmp_lldp'][k]
@@ -69,7 +72,7 @@ def test_snmp_lldp(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_
     for k, v in mg_facts.items():
         if "server" not in v['name'].lower():
             minigraph_lldp_nei.append(k)
-    print minigraph_lldp_nei
+    logger.info('minigraph_lldp_nei: {}'.format(minigraph_lldp_nei))
 
     # Check if lldpRemTable is present
     active_intf = []
@@ -84,19 +87,20 @@ def test_snmp_lldp(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_
            v.has_key("lldpRemSysCapSupported") and \
            v.has_key("lldpRemSysCapEnabled"):
             active_intf.append(k)
-    print "lldpRemTable: ", active_intf
+    logger.info('lldpRemTable: {}'.format(active_intf))
 
     assert len(active_intf) >= len(minigraph_lldp_nei) * 0.8
 
     # skip neighbors that do not send chassis information via lldp
     lldp_facts= {}
-    for asic_id in duthost.get_asic_ids(): 
+    for asic_id in duthost.get_asic_ids():
        lldp_facts_ns = duthost.lldpctl_facts(asic_instance_id=asic_id)['ansible_facts']['lldpctl']
        if lldp_facts_ns is not None:
            lldp_facts.update(lldp_facts_ns)
     pattern = re.compile(r'^eth0|^Ethernet-IB')
     nei = [k for k, v in lldp_facts.items() if not re.match(pattern, k) and v['chassis'].has_key('mgmt-ip') ]
-    print "neighbors {} send chassis management IP information".format(nei)
+    logger.info("neighbors {} send chassis management IP information".format(nei))
+
 
     # Check if lldpRemManAddrTable is present
     active_intf = []
@@ -106,6 +110,6 @@ def test_snmp_lldp(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_
            v.has_key("lldpRemManAddrOID") and \
            v['name'] != 'eth0' and 'Etherent-IB' not in v['name']:
             active_intf.append(k)
-    print "lldpRemManAddrTable: ", active_intf
+    logger.info('lldpRemManAddrTable: {}'.format(active_intf))
 
     assert len(active_intf) == len(nei)

--- a/tests/snmp/test_snmp_loopback.py
+++ b/tests/snmp/test_snmp_loopback.py
@@ -24,7 +24,7 @@ def get_snmp_output(ip, duthost, nbr, creds_all_duts):
     ip_tbl_rule_add = "sudo {} -I INPUT 1 -p udp --dport 161 -d {} -j ACCEPT".format(iptables_cmd, ip)
     duthost.shell(ip_tbl_rule_add)
 
-    eos_snmpget = "bash snmpget -v2c -c {} {} 1.3.6.1.2.1.1.1.0".format(quote(creds_all_duts[duthost]['snmp_rocommunity']), ip)
+    eos_snmpget = "bash snmpget -v2c -c {} {} 1.3.6.1.2.1.1.1.0".format(quote(creds_all_duts[duthost.hostname]['snmp_rocommunity']), ip)
     out = nbr['host'].eos_command(commands=[eos_snmpget])
 
     ip_tbl_rule_del = "sudo {} -D INPUT -p udp --dport 161 -d {} -j ACCEPT".format(iptables_cmd, ip)
@@ -43,7 +43,7 @@ def test_snmp_loopback(duthosts, enum_rand_one_per_hwsku_frontend_hostname, nbrh
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
     config_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
     # Get first neighbor VM information
     nbr = nbrhosts[list(nbrhosts.keys())[0]]

--- a/tests/snmp/test_snmp_memory.py
+++ b/tests/snmp/test_snmp_memory.py
@@ -62,7 +62,7 @@ def test_snmp_memory(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
     # Allow the test to retry a few times before claiming failure.
     for _ in range(3):
         snmp_facts = get_snmp_facts(localhost, host=host_ip, version="v2c",
-                                    community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+                                    community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
         facts = collect_memory(duthost)
         # Verify correct behaviour of sysTotalMemery
         pytest_assert(not abs(snmp_facts['ansible_sysTotalMemery'] - int(facts['MemTotal'])),
@@ -93,7 +93,7 @@ def test_snmp_memory_load(duthosts, enum_rand_one_per_hwsku_hostname, localhost,
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     host_ip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
     snmp_facts = get_snmp_facts(localhost, host=host_ip, version="v2c",
-                                community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+                                community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
     mem_free = duthost.shell("grep MemFree /proc/meminfo | awk '{print $2}'")['stdout']
     pytest_assert(CALC_DIFF(snmp_facts['ansible_sysTotalFreeMemery'], mem_free) < percent,
                   "sysTotalFreeMemery differs by more than {}".format(percent))

--- a/tests/snmp/test_snmp_pfc_counters.py
+++ b/tests/snmp/test_snmp_pfc_counters.py
@@ -11,7 +11,7 @@ def test_snmp_pfc_counters(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
 
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
-    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
 
     # Check PFC counters
     # Ignore management ports, assuming the names starting with 'eth', eg. eth0

--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -170,7 +170,7 @@ def is_sensor_test_supported(duthost):
     The new sensor test is not supported in 201811, 201911 and 202012
     The assumption is that image under test always has a correct version.
     If image version doesn't including above "version keyword", it will be considered
-    as a newer version which support the new sensor test. 
+    as a newer version which support the new sensor test.
     """
     if "201811" in duthost.os_version or "201911" in duthost.os_version or "202012" in duthost.os_version:
         logging.info("Image doesn't support new sensor test, image version {}, test will be skipped".format(duthost.os_version))
@@ -203,7 +203,7 @@ def get_entity_and_sensor_mib(duthost, localhost, creds_all_duts):
     """
     mib_info = {}
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
     entity_mib = {}
     sensor_mib = {}
     for oid, info in snmp_facts['snmp_physical_entities'].items():
@@ -472,7 +472,7 @@ def test_thermal_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physical_
         assert thermal_snmp_fact['entPhysMfgName'] == ''
         assert thermal_snmp_fact['entPhysModelName'] == ''
         assert thermal_snmp_fact['entPhysIsFRU'] == NOT_REPLACEABLE
-        
+
         # snmp_entity_sensor_info is only supported in image newer than 202012
         if is_sensor_test_supported(duthost):
             thermal_sensor_snmp_fact = snmp_entity_sensor_info[expect_oid]

--- a/tests/snmp/test_snmp_psu.py
+++ b/tests/snmp/test_snmp_psu.py
@@ -16,7 +16,7 @@ def test_snmp_numpsu(duthosts, enum_supervisor_dut_hostname, localhost, creds_al
 
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
-    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
     res = duthost.shell("psuutil numpsus")
     assert int(res[u'rc']) == 0, "Failed to get number of PSUs"
 
@@ -28,7 +28,7 @@ def test_snmp_numpsu(duthosts, enum_supervisor_dut_hostname, localhost, creds_al
 def test_snmp_psu_status(duthosts, enum_supervisor_dut_hostname, localhost, creds_all_duts):
     duthost = duthosts[enum_supervisor_dut_hostname]
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
 
     psus_on = 0
     msg = "Unexpected operstatus results {} != {} for PSU {}"

--- a/tests/snmp/test_snmp_queue.py
+++ b/tests/snmp/test_snmp_queue.py
@@ -12,7 +12,7 @@ def test_snmp_queues(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
         pytest.skip("interfaces not present on supervisor node")
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
-    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
 
     for k, v in snmp_facts['snmp_interfaces'].items():
         if "Ethernet" in v['description']:

--- a/tests/snmp/test_snmp_v2mib.py
+++ b/tests/snmp/test_snmp_v2mib.py
@@ -18,7 +18,7 @@ def test_snmp_v2mib(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     host_ip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
     snmp_facts = get_snmp_facts(localhost, host=host_ip, version="v2c",
-                                community=creds_all_duts[duthost]["snmp_rocommunity"], wait=True)['ansible_facts']
+                                community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
     dut_facts = duthost.setup()['ansible_facts']
     debian_ver = duthost.shell('cat /etc/debian_version')['stdout']
     cmd = 'docker exec snmp grep "sysContact" /etc/snmp/snmpd.conf'

--- a/tests/tacacs/conftest.py
+++ b/tests/tacacs/conftest.py
@@ -1,28 +1,44 @@
+import os
+import logging
+import yaml
 import pytest
 from .utils import setup_tacacs_client, setup_tacacs_server, cleanup_tacacs
 
+logger = logging.getLogger(__name__)
+TACACS_CREDS_FILE='tacacs_creds.yaml'
+
+
 @pytest.fixture(scope="module")
-def check_tacacs(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts):
+def tacacs_creds(creds_all_duts):
+    creds_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), TACACS_CREDS_FILE)
+    hardcoded_creds = yaml.safe_load(open(creds_file_path).read())
+    creds_all_duts.update(hardcoded_creds)
+    return creds_all_duts
+
+
+@pytest.fixture(scope="module")
+def check_tacacs(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds):
+    logger.info('tacacs_creds: {}'.format(str(tacacs_creds)))
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    tacacs_server_ip = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
-    setup_tacacs_client(duthost, creds_all_duts, tacacs_server_ip)
-    setup_tacacs_server(ptfhost, creds_all_duts, duthost)
+    tacacs_server_ip = ptfhost.mgmt_ip
+    setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip)
+    setup_tacacs_server(ptfhost, tacacs_creds, duthost)
 
     yield
 
-    cleanup_tacacs(ptfhost, creds_all_duts, duthost, tacacs_server_ip)
+    cleanup_tacacs(ptfhost, tacacs_creds, duthost)
 
 
 @pytest.fixture(scope="module")
-def check_tacacs_v6(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts):
+def check_tacacs_v6(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     ptfhost_vars = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars
     if 'ansible_hostv6' not in ptfhost_vars:
         pytest.skip("Skip IPv6 test. ptf ansible_hostv6 not configured.")
     tacacs_server_ip = ptfhost_vars['ansible_hostv6']
-    setup_tacacs_client(duthost, creds_all_duts, tacacs_server_ip)
-    setup_tacacs_server(ptfhost, creds_all_duts, duthost)
+    setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip)
+    setup_tacacs_server(ptfhost, tacacs_creds, duthost)
 
     yield
 
-    cleanup_tacacs(ptfhost, creds_all_duts, duthost, tacacs_server_ip)
+    cleanup_tacacs(ptfhost, tacacs_creds, duthost)

--- a/tests/tacacs/tacacs_creds.yaml
+++ b/tests/tacacs/tacacs_creds.yaml
@@ -1,0 +1,12 @@
+---
+tacacs_rw_user: test_rwuser
+tacacs_rw_user_passwd: '123456'
+tacacs_ro_user: test_rouser
+tacacs_ro_user_passwd: '123456'
+tacacs_jit_user: test_jituser
+tacacs_jit_user_passwd: '123456'
+tacacs_jit_user_membership: netuser
+tacacs_authorization_user: test_auuser
+tacacs_authorization_user_passwd: '123456'
+local_user: test_louser
+local_user_passwd: '123456'

--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -1,5 +1,5 @@
-import crypt
-import paramiko
+import logging
+
 import pytest
 
 from .test_authorization import ssh_connect_remote, ssh_run_command, per_command_check_skip_versions, remove_all_tacacs_server
@@ -27,8 +27,8 @@ def cleanup_tacacs_log(ptfhost, rw_user_client):
 
     ssh_run_command(rw_user_client, 'sudo truncate -s 0 /var/log/syslog')
 
-def check_tacacs_server_log_exist(ptfhost, duthost, creds_all_duts, command):
-    username = creds_all_duts[duthost]['tacacs_rw_user']
+def check_tacacs_server_log_exist(ptfhost, tacacs_creds, command):
+    username = tacacs_creds['tacacs_rw_user']
     """
         Find logs run by tacacs_rw_user from tac_plus.acct:
             Find logs match following format: "tacacs_rw_user ... cmd=command"
@@ -40,8 +40,8 @@ def check_tacacs_server_log_exist(ptfhost, duthost, creds_all_duts, command):
     logger.info(res["stdout_lines"])
     pytest_assert(len(res["stdout_lines"]) > 0)
 
-def check_tacacs_server_no_other_user_log(ptfhost, duthost, creds_all_duts):
-    username = creds_all_duts[duthost]['tacacs_rw_user']
+def check_tacacs_server_no_other_user_log(ptfhost, tacacs_creds):
+    username = tacacs_creds['tacacs_rw_user']
     """
         Find logs not run by tacacs_rw_user from tac_plus.acct:
             Remove all tacacs_rw_user's log with /D command.
@@ -53,8 +53,8 @@ def check_tacacs_server_no_other_user_log(ptfhost, duthost, creds_all_duts):
     logger.info(res["stdout_lines"])
     pytest_assert(len(res["stdout_lines"]) == 0)
 
-def check_local_log_exist(rw_user_client, duthost, creds_all_duts, command):
-    username = creds_all_duts[duthost]['tacacs_rw_user']
+def check_local_log_exist(rw_user_client, tacacs_creds, command):
+    username = tacacs_creds['tacacs_rw_user']
     """
         Find logs run by tacacs_rw_user from syslog:
             Find logs match following format: "INFO audisp-tacplus: Accounting: user: tacacs_rw_user,.*, command: .*command,"
@@ -67,12 +67,12 @@ def check_local_log_exist(rw_user_client, duthost, creds_all_duts, command):
     logger.info(stdout)
     pytest_assert(len(stdout) > 0)
 
-def check_local_no_other_user_log(rw_user_client, duthost, creds_all_duts):
-    username = creds_all_duts[duthost]['tacacs_rw_user']
+def check_local_no_other_user_log(rw_user_client, tacacs_creds):
+    username = tacacs_creds['tacacs_rw_user']
     """
         Find logs not run by tacacs_rw_user from syslog:
             Remove all tacacs_rw_user's log with /D command, which will match following format: "INFO audisp-tacplus: Accounting: user: tacacs_rw_user"
-            Find all other user's log, which will match following format: "INFO audisp-tacplus: Accounting: user:" 
+            Find all other user's log, which will match following format: "INFO audisp-tacplus: Accounting: user:"
             Print matched logs with /P command, which are not run by tacacs_rw_user.
     """
     sed_command = "sudo sed -nE '/INFO audisp-tacplus: Accounting: user: {0},/D;/INFO audisp-tacplus: Accounting: user:/P' /var/log/syslog".format(username)
@@ -83,11 +83,11 @@ def check_local_no_other_user_log(rw_user_client, duthost, creds_all_duts):
     pytest_assert(len(stdout) == 0)
 
 @pytest.fixture
-def rw_user_client(duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts):
+def rw_user_client(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    ssh_client = ssh_connect_remote(dutip, creds_all_duts[duthost]['tacacs_rw_user'],
-                         creds_all_duts[duthost]['tacacs_rw_user_passwd'])
+    dutip = duthost.mgmt_ip
+    ssh_client = ssh_connect_remote(dutip, tacacs_creds['tacacs_rw_user'],
+                         tacacs_creds['tacacs_rw_user_passwd'])
     yield ssh_client
     ssh_client.close()
 
@@ -101,7 +101,7 @@ def check_image_version(duthost):
     """
     skip_release(duthost, per_command_check_skip_versions)
 
-def test_accounting_tacacs_only(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs, rw_user_client):
+def test_accounting_tacacs_only(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs, rw_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     duthost.shell("sudo config aaa accounting tacacs+")
     cleanup_tacacs_log(ptfhost, rw_user_client)
@@ -109,12 +109,12 @@ def test_accounting_tacacs_only(localhost, ptfhost, duthosts, enum_rand_one_per_
     ssh_run_command(rw_user_client, "grep")
 
     # Verify TACACS+ server side have user command record.
-    check_tacacs_server_log_exist(ptfhost, duthost, creds_all_duts, "grep")
+    check_tacacs_server_log_exist(ptfhost, tacacs_creds, "grep")
     # Verify TACACS+ server side not have any command record which not run by user.
-    check_tacacs_server_no_other_user_log(ptfhost, duthost, creds_all_duts)
+    check_tacacs_server_no_other_user_log(ptfhost, tacacs_creds)
 
 
-def test_accounting_tacacs_only_all_tacacs_server_down(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs, rw_user_client):
+def test_accounting_tacacs_only_all_tacacs_server_down(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs, rw_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     duthost.shell("sudo config aaa accounting tacacs+")
     cleanup_tacacs_log(ptfhost, rw_user_client)
@@ -126,15 +126,15 @@ def test_accounting_tacacs_only_all_tacacs_server_down(localhost, ptfhost, dutho
     ssh_run_command(rw_user_client, "grep")
 
     # Verify TACACS+ server side have user command record.
-    check_tacacs_server_log_exist(ptfhost, duthost, creds_all_duts, "grep")
+    check_tacacs_server_log_exist(ptfhost, tacacs_creds, "grep")
     # Verify TACACS+ server side not have any command record which not run by user.
-    check_tacacs_server_no_other_user_log(ptfhost, duthost, creds_all_duts)
+    check_tacacs_server_no_other_user_log(ptfhost, tacacs_creds)
 
     cleanup_tacacs_log(ptfhost, rw_user_client)
 
     # Shutdown tacacs server
     stop_tacacs_server(ptfhost)
-    
+
     """
         then all server not accessible, and run some command
         Verify local user still can run command without any issue.
@@ -144,15 +144,14 @@ def test_accounting_tacacs_only_all_tacacs_server_down(localhost, ptfhost, dutho
     #  Cleanup UT.
     start_tacacs_server(ptfhost)
 
-def test_accounting_tacacs_only_some_tacacs_server_down(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs, rw_user_client):
+def test_accounting_tacacs_only_some_tacacs_server_down(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs, rw_user_client):
     """
         Setup multiple tacacs server for this UT.
         Tacacs server 127.0.0.1 not accessible.
     """
     invalid_tacacs_server_ip = "127.0.0.1"
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    tacacs_server_ip = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
-    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    tacacs_server_ip = ptfhost.mgmt_ip
     duthost.shell("sudo config tacacs timeout 1")
     remove_all_tacacs_server(duthost)
     duthost.shell("sudo config tacacs add %s" % invalid_tacacs_server_ip)
@@ -164,14 +163,14 @@ def test_accounting_tacacs_only_some_tacacs_server_down(localhost, ptfhost, duth
     ssh_run_command(rw_user_client, "grep")
 
     # Verify TACACS+ server side have user command record.
-    check_tacacs_server_log_exist(ptfhost, duthost, creds_all_duts, "grep")
+    check_tacacs_server_log_exist(ptfhost, tacacs_creds, "grep")
     # Verify TACACS+ server side not have any command record which not run by user.
-    check_tacacs_server_no_other_user_log(ptfhost, duthost, creds_all_duts)
+    check_tacacs_server_no_other_user_log(ptfhost, tacacs_creds)
 
     # Cleanup
     duthost.shell("sudo config tacacs delete %s" % invalid_tacacs_server_ip)
 
-def test_accounting_local_only(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs, rw_user_client):
+def test_accounting_local_only(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs, rw_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     duthost.shell("sudo config aaa accounting local")
     cleanup_tacacs_log(ptfhost, rw_user_client)
@@ -179,11 +178,11 @@ def test_accounting_local_only(localhost, ptfhost, duthosts, enum_rand_one_per_h
     ssh_run_command(rw_user_client, "grep")
 
     # Verify syslog have user command record.
-    check_local_log_exist(rw_user_client, duthost, creds_all_duts, "grep")
+    check_local_log_exist(rw_user_client, tacacs_creds, "grep")
     # Verify syslog not have any command record which not run by user.
-    check_local_no_other_user_log(rw_user_client, duthost, creds_all_duts)
+    check_local_no_other_user_log(rw_user_client, tacacs_creds)
 
-def test_accounting_tacacs_and_local(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs, rw_user_client):
+def test_accounting_tacacs_and_local(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs, rw_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     duthost.shell('sudo config aaa accounting "tacacs+ local"')
     cleanup_tacacs_log(ptfhost, rw_user_client)
@@ -191,20 +190,20 @@ def test_accounting_tacacs_and_local(localhost, ptfhost, duthosts, enum_rand_one
     ssh_run_command(rw_user_client, "grep")
 
     # Verify TACACS+ server and syslog have user command record.
-    check_tacacs_server_log_exist(ptfhost, duthost, creds_all_duts, "grep")
-    check_local_log_exist(rw_user_client, duthost, creds_all_duts, "grep")
+    check_tacacs_server_log_exist(ptfhost, tacacs_creds, "grep")
+    check_local_log_exist(rw_user_client, tacacs_creds, "grep")
     # Verify TACACS+ server and syslog not have any command record which not run by user.
-    check_tacacs_server_no_other_user_log(ptfhost, duthost, creds_all_duts)
-    check_local_no_other_user_log(rw_user_client, duthost, creds_all_duts)
+    check_tacacs_server_no_other_user_log(ptfhost, tacacs_creds)
+    check_local_no_other_user_log(rw_user_client, tacacs_creds)
 
-def test_accounting_tacacs_and_local_all_tacacs_server_down(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs, rw_user_client):
+def test_accounting_tacacs_and_local_all_tacacs_server_down(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs, rw_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     duthost.shell('sudo config aaa accounting "tacacs+ local"')
     cleanup_tacacs_log(ptfhost, rw_user_client)
 
     # Shutdown tacacs server
     stop_tacacs_server(ptfhost)
-    
+
     """
         After all server not accessible, run some command
         Verify local user still can run command without any issue.
@@ -212,9 +211,9 @@ def test_accounting_tacacs_and_local_all_tacacs_server_down(localhost, ptfhost, 
     ssh_run_command(rw_user_client, "grep")
 
     # Verify syslog have user command record.
-    check_local_log_exist(rw_user_client, duthost, creds_all_duts, "grep")
+    check_local_log_exist(rw_user_client, tacacs_creds, "grep")
     # Verify syslog not have any command record which not run by user.
-    check_local_no_other_user_log(rw_user_client, duthost, creds_all_duts)
+    check_local_no_other_user_log(rw_user_client, tacacs_creds)
 
     #  Cleanup UT.
     start_tacacs_server(ptfhost)

--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -36,7 +36,7 @@ def check_tacacs_server_log_exist(ptfhost, tacacs_creds, command):
     """
     sed_command = "sed -nE '/	{0}	.*	cmd=.*{1}/P' /var/log/tac_plus.acct".format(username, command)
     res = ptfhost.command(sed_command)
-    logger.info(sed_command)
+    logger.info(sed_command)  # lgtm [py/clear-text-logging-sensitive-data]
     logger.info(res["stdout_lines"])
     pytest_assert(len(res["stdout_lines"]) > 0)
 
@@ -49,7 +49,7 @@ def check_tacacs_server_no_other_user_log(ptfhost, tacacs_creds):
     """
     sed_command = "sed -nE '/	{0}	/D;/.*/P' /var/log/tac_plus.acct".format(username)
     res = ptfhost.command(sed_command)
-    logger.info(sed_command)
+    logger.info(sed_command)  # lgtm [py/clear-text-logging-sensitive-data]
     logger.info(res["stdout_lines"])
     pytest_assert(len(res["stdout_lines"]) == 0)
 
@@ -63,7 +63,7 @@ def check_local_log_exist(rw_user_client, tacacs_creds, command):
     sed_command = "sudo sed -nE '/INFO audisp-tacplus: Accounting: user: {0},.*, command: .*{1},/P' /var/log/syslog".format(username, command)
     exit_code, stdout, stderr = ssh_run_command(rw_user_client, sed_command)
     pytest_assert(exit_code == 0)
-    logger.info(sed_command)
+    logger.info(sed_command)  # lgtm [py/clear-text-logging-sensitive-data]
     logger.info(stdout)
     pytest_assert(len(stdout) > 0)
 
@@ -78,7 +78,7 @@ def check_local_no_other_user_log(rw_user_client, tacacs_creds):
     sed_command = "sudo sed -nE '/INFO audisp-tacplus: Accounting: user: {0},/D;/INFO audisp-tacplus: Accounting: user:/P' /var/log/syslog".format(username)
     exit_code, stdout, stderr = ssh_run_command(rw_user_client, sed_command)
     pytest_assert(exit_code == 0)
-    logger.info(sed_command)
+    logger.info(sed_command)  # lgtm [py/clear-text-logging-sensitive-data]
     logger.info(stdout)
     pytest_assert(len(stdout) == 0)
 

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -1,8 +1,7 @@
-import crypt
+import logging
 import paramiko
 import pytest
 
-from .test_ro_user import ssh_remote_run
 from .utils import stop_tacacs_server, start_tacacs_server, per_command_check_skip_versions, remove_all_tacacs_server
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release
@@ -26,10 +25,10 @@ def ssh_connect_remote(remote_ip, remote_username, remote_password):
 def check_ssh_connect_remote_failed(remote_ip, remote_username, remote_password):
     login_failed = False
     try:
-        ssh_client_local = ssh_connect_remote(remote_ip, remote_username, remote_password)
+        ssh_connect_remote(remote_ip, remote_username, remote_password)
     except paramiko.ssh_exception.AuthenticationException as e:
         login_failed = True
-    
+
     pytest_assert(login_failed == True)
 
 def ssh_run_command(ssh_client, command):
@@ -48,16 +47,14 @@ def check_ssh_output(res, exp_val):
     pytest_assert(content_exist)
 
 @pytest.fixture
-def remote_user_client(duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts):
+def remote_user_client(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    with ssh_connect_remote(dutip, creds_all_duts[duthost]['tacacs_authorization_user'], creds_all_duts[duthost]['tacacs_authorization_user_passwd']) as ssh_client:
+    dutip = duthost.mgmt_ip
+    with ssh_connect_remote(dutip, tacacs_creds['tacacs_authorization_user'], tacacs_creds['tacacs_authorization_user_passwd']) as ssh_client:
         yield ssh_client
 
 @pytest.fixture
-def local_user_client(duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+def local_user_client():
     with paramiko.SSHClient() as ssh_client:
         ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         yield ssh_client
@@ -72,7 +69,7 @@ def check_image_version(duthost):
     """
     skip_release(duthost, per_command_check_skip_versions)
 
-def test_authorization_tacacs_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs, remote_user_client):
+def check_authorization_tacacs_only(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs, remote_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     duthost.shell("sudo config aaa authorization tacacs+")
 
@@ -98,19 +95,23 @@ def test_authorization_tacacs_only(localhost, duthosts, enum_rand_one_per_hwsku_
     check_ssh_output(stdout, '/usr/bin/cat authorize failed by TACACS+ with given arguments, not executing')
 
     # Verify Local user can't login.
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    check_ssh_connect_remote_failed(dutip, creds_all_duts[duthost]['local_user'],
-                             creds_all_duts[duthost]['local_user_passwd'])
+    dutip = duthost.mgmt_ip
+    check_ssh_connect_remote_failed(dutip, tacacs_creds['local_user'],
+                             tacacs_creds['local_user_passwd'])
 
-def test_authorization_tacacs_only_some_server_down(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts,ptfhost, check_tacacs, remote_user_client):
+
+def test_authorization_tacacs_only(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs, remote_user_client):
+    check_authorization_tacacs_only(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs, remote_user_client)
+
+
+def test_authorization_tacacs_only_some_server_down(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, ptfhost, check_tacacs, remote_user_client):
     """
         Setup multiple tacacs server for this UT.
         Tacacs server 127.0.0.1 not accessible.
     """
     invalid_tacacs_server_ip = "127.0.0.1"
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    tacacs_server_ip = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
-    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    tacacs_server_ip = ptfhost.mgmt_ip
     duthost.shell("sudo config tacacs timeout 1")
 
     # cleanup all tacacs server, if UT break, tacacs server may still left in dut and will break next UT.
@@ -118,7 +119,7 @@ def test_authorization_tacacs_only_some_server_down(localhost, duthosts, enum_ra
 
     duthost.shell("sudo config tacacs add %s" % invalid_tacacs_server_ip)
     duthost.shell("sudo config tacacs add %s" % tacacs_server_ip)
-    
+
     """
         Verify TACACS+ user run command in server side whitelist:
             If command have local permission, user can run command.
@@ -126,12 +127,12 @@ def test_authorization_tacacs_only_some_server_down(localhost, duthosts, enum_ra
         Verify TACACS+ user can't run command not in server side whitelist.
         Verify Local user can't login.
     """
-    test_authorization_tacacs_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs, remote_user_client)
+    check_authorization_tacacs_only(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs, remote_user_client)
 
     # Cleanup
     duthost.shell("sudo config tacacs delete %s" % invalid_tacacs_server_ip)
 
-def test_authorization_tacacs_only_then_server_down_after_login(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts,ptfhost, check_tacacs, remote_user_client):
+def test_authorization_tacacs_only_then_server_down_after_login(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, ptfhost, check_tacacs, remote_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     duthost.shell("sudo config aaa authorization tacacs+")
 
@@ -151,7 +152,7 @@ def test_authorization_tacacs_only_then_server_down_after_login(localhost, dutho
     #  Cleanup UT.
     start_tacacs_server(ptfhost)
 
-def test_authorization_tacacs_and_local(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts,ptfhost, check_tacacs, remote_user_client):
+def test_authorization_tacacs_and_local(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs, remote_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     duthost.shell("sudo config aaa authorization \"tacacs+ local\"")
 
@@ -177,23 +178,23 @@ def test_authorization_tacacs_and_local(localhost, duthosts, enum_rand_one_per_h
     check_ssh_output(stdout, 'root:x:0:0:root:/root:/bin/bash')
 
     # Verify Local user can't login.
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    check_ssh_connect_remote_failed(dutip, creds_all_duts[duthost]['local_user'],
-                             creds_all_duts[duthost]['local_user_passwd'])
+    dutip = duthost.mgmt_ip
+    check_ssh_connect_remote_failed(dutip, tacacs_creds['local_user'],
+                             tacacs_creds['local_user_passwd'])
 
 
-def test_authorization_tacacs_and_local_then_server_down_after_login(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts,ptfhost, check_tacacs, remote_user_client, local_user_client):
+def test_authorization_tacacs_and_local_then_server_down_after_login(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, ptfhost, check_tacacs, remote_user_client, local_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     duthost.shell("sudo config aaa authorization \"tacacs+ local\"")
 
     # Shutdown tacacs server
     stop_tacacs_server(ptfhost)
-    
+
     # Verify TACACS+ user can run command not in server side whitelist but have permission in local.
     exit_code, stdout, stderr = ssh_run_command(remote_user_client, "cat /etc/passwd")
     pytest_assert(exit_code == 0)
     check_ssh_output(stdout, 'root:x:0:0:root:/root:/bin/bash')
-    
+
     # Verify TACACS+ user can't run command in server side whitelist also not have permission in local.
     exit_code, stdout, stderr = ssh_run_command(remote_user_client, "config tacacs")
     pytest_assert(exit_code == 1)
@@ -201,9 +202,9 @@ def test_authorization_tacacs_and_local_then_server_down_after_login(localhost, 
     check_ssh_output(stderr, 'Root privileges are required for this operation')
 
     # Verify Local user can login when tacacs closed, and run command with local permission.
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    local_user_client.connect(dutip, username=creds_all_duts[duthost]['local_user'],
-                                        password=creds_all_duts[duthost]['local_user_passwd'],
+    dutip = duthost.mgmt_ip
+    local_user_client.connect(dutip, username=tacacs_creds['local_user'],
+                                        password=tacacs_creds['local_user_passwd'],
                                         allow_agent=False, look_for_keys=False, auth_timeout=TIMEOUT_LIMIT)
 
     exit_code, stdout, stderr = ssh_run_command(local_user_client, "show aaa")
@@ -212,14 +213,14 @@ def test_authorization_tacacs_and_local_then_server_down_after_login(localhost, 
 
     # Start tacacs server
     start_tacacs_server(ptfhost)
-    
+
     # Verify after Local user login, then server becomes accessible, Local user still can run command with local permission.
     exit_code, stdout, stderr = ssh_run_command(local_user_client, "show aaa")
     pytest_assert(exit_code == 0)
     check_ssh_output(stdout, 'AAA authentication')
 
 
-def test_authorization_local(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts,ptfhost, check_tacacs, remote_user_client, local_user_client):
+def test_authorization_local(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, ptfhost, check_tacacs, remote_user_client, local_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     duthost.shell("sudo config aaa authorization local")
 
@@ -246,20 +247,20 @@ def test_authorization_local(localhost, duthosts, enum_rand_one_per_hwsku_hostna
         TACACS server down:
             Verify Local user can login, and run command with local permission.
     """
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    local_user_client.connect(dutip, username=creds_all_duts[duthost]['local_user'],
-                                        password=creds_all_duts[duthost]['local_user_passwd'],
+    dutip = duthost.mgmt_ip
+    local_user_client.connect(dutip, username=tacacs_creds['local_user'],
+                                        password=tacacs_creds['local_user_passwd'],
                                         allow_agent=False, look_for_keys=False, auth_timeout=TIMEOUT_LIMIT)
 
     exit_code, stdout, stderr = ssh_run_command(local_user_client, "show aaa")
     pytest_assert(exit_code == 0)
     check_ssh_output(stdout, 'AAA authentication')
-    
+
     # Cleanup
     start_tacacs_server(ptfhost)
 
 
-def test_bypass_authorization(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts,ptfhost, check_tacacs, remote_user_client):
+def test_bypass_authorization(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs, remote_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     duthost.shell("sudo config aaa authorization tacacs+")
 
@@ -300,17 +301,17 @@ def test_bypass_authorization(localhost, duthosts, enum_rand_one_per_hwsku_hostn
     exit_code, stdout, stderr = ssh_run_command(remote_user_client, "\\sh")
     pytest_assert(exit_code == 1)
     check_ssh_output(stdout, 'authorize failed by TACACS+ with given arguments, not executing')
-    
+
     exit_code, stdout, stderr = ssh_run_command(remote_user_client, '"sh"')
     pytest_assert(exit_code == 1)
     check_ssh_output(stdout, 'authorize failed by TACACS+ with given arguments, not executing')
-    
+
     exit_code, stdout, stderr = ssh_run_command(remote_user_client, "echo $(sh -c ls)")
     # echo command will run success and return 0, but sh command will be blocked.
     pytest_assert(exit_code == 0)
     check_ssh_output(stdout, 'authorize failed by TACACS+ with given arguments, not executing')
 
-def test_backward_compatibility_disable_authorization(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts,ptfhost, check_tacacs, remote_user_client, local_user_client):
+def test_backward_compatibility_disable_authorization(duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, ptfhost, check_tacacs, remote_user_client, local_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     duthost.shell("sudo config aaa authorization local")
 
@@ -323,14 +324,14 @@ def test_backward_compatibility_disable_authorization(localhost, duthosts, enum_
     stop_tacacs_server(ptfhost)
 
     # Verify domain account can't login to device successfully.
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    check_ssh_connect_remote_failed(dutip, creds_all_duts[duthost]['tacacs_authorization_user'],
-                         creds_all_duts[duthost]['tacacs_authorization_user_passwd'])
+    dutip = duthost.mgmt_ip
+    check_ssh_connect_remote_failed(dutip, tacacs_creds['tacacs_authorization_user'],
+                         tacacs_creds['tacacs_authorization_user_passwd'])
 
     # Verify local admin account can run command if have permission in local.
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    local_user_client.connect(dutip, username=creds_all_duts[duthost]['local_user'],
-                                        password=creds_all_duts[duthost]['local_user_passwd'],
+    dutip = duthost.mgmt_ip
+    local_user_client.connect(dutip, username=tacacs_creds['local_user'],
+                                        password=tacacs_creds['local_user_passwd'],
                                         allow_agent=False, look_for_keys=False, auth_timeout=TIMEOUT_LIMIT)
 
     exit_code, stdout, stderr = ssh_run_command(local_user_client, "show aaa")

--- a/tests/tacacs/test_jit_user.py
+++ b/tests/tacacs/test_jit_user.py
@@ -1,5 +1,5 @@
+import logging
 import pytest
-from tests.common.helpers.assertions import pytest_assert
 from .test_ro_user import ssh_remote_run
 from .utils import check_output, setup_tacacs_server
 
@@ -11,29 +11,29 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
-def test_jit_user(localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs):
+def test_jit_user(localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
     """check jit user. netuser -> netadmin -> netuser"""
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+    dutip = duthost.mgmt_ip
 
-    res = ssh_remote_run(localhost, dutip, creds_all_duts[duthost]['tacacs_jit_user'], creds_all_duts[duthost]['tacacs_jit_user_passwd'], 'cat /etc/passwd')
-    
+    res = ssh_remote_run(localhost, dutip, tacacs_creds['tacacs_jit_user'], tacacs_creds['tacacs_jit_user_passwd'], 'cat /etc/passwd')
+
     check_output(res, 'test', 'remote_user')
 
     # change jit user to netadmin
-    creds_all_duts[duthost]['tacacs_jit_user_membership'] = 'netadmin'
-    setup_tacacs_server(ptfhost, creds_all_duts, duthost)
+    tacacs_creds['tacacs_jit_user_membership'] = 'netadmin'
+    setup_tacacs_server(ptfhost, tacacs_creds, duthost)
 
-    res = ssh_remote_run(localhost, dutip, creds_all_duts[duthost]['tacacs_jit_user'],
-                         creds_all_duts[duthost]['tacacs_jit_user_passwd'], 'cat /etc/passwd')
+    res = ssh_remote_run(localhost, dutip, tacacs_creds['tacacs_jit_user'],
+                         tacacs_creds['tacacs_jit_user_passwd'], 'cat /etc/passwd')
 
     check_output(res, 'testadmin', 'remote_user_su')
 
     # change jit user back to netuser
-    creds_all_duts[duthost]['tacacs_jit_user_membership'] = 'netuser'
-    setup_tacacs_server(ptfhost, creds_all_duts, duthost)
+    tacacs_creds['tacacs_jit_user_membership'] = 'netuser'
+    setup_tacacs_server(ptfhost, tacacs_creds, duthost)
 
-    res = ssh_remote_run(localhost, dutip, creds_all_duts[duthost]['tacacs_jit_user'],
-                         creds_all_duts[duthost]['tacacs_jit_user_passwd'], 'cat /etc/passwd')
+    res = ssh_remote_run(localhost, dutip, tacacs_creds['tacacs_jit_user'],
+                         tacacs_creds['tacacs_jit_user_passwd'], 'cat /etc/passwd')
     check_output(res, 'test', 'remote_user')

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -1,9 +1,7 @@
 import pytest
-import crypt
-import json
 import logging
-from pkg_resources import parse_version
 
+from tests.common.devices.base import RunAnsibleModuleFail
 from tests.common.utilities import wait_until
 from tests.common.utilities import skip_release
 from tests.common.utilities import wait
@@ -49,7 +47,7 @@ def do_reboot(duthost, localhost, dutip, rw_user, rw_pass):
     wait_time = 120
     retries = 3
     for i in range(retries):
-        # Regular reboot command would not work, as it would try to 
+        # Regular reboot command would not work, as it would try to
         # collect show tech, which will fail in RO state.
         #
         chk_ssh_remote_run(localhost, dutip, rw_user, rw_pass, "sudo /sbin/reboot")
@@ -64,19 +62,19 @@ def do_reboot(duthost, localhost, dutip, rw_user, rw_pass):
     wait(wait_time, msg="Wait {} seconds for system to be stable.".format(wait_time))
 
 
-def test_ro_disk(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs):
+def test_ro_disk(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
     """test tacacs rw user
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     skip_release(duthost, ["201911", "201811"])
 
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+    dutip = duthost.mgmt_ip
 
-    ro_user = creds_all_duts[duthost]['tacacs_ro_user']
-    ro_pass = creds_all_duts[duthost]['tacacs_ro_user_passwd']
+    ro_user = tacacs_creds['tacacs_ro_user']
+    ro_pass = tacacs_creds['tacacs_ro_user_passwd']
 
-    rw_user = creds_all_duts[duthost]['tacacs_rw_user']
-    rw_pass = creds_all_duts[duthost]['tacacs_rw_user_passwd']
+    rw_user = tacacs_creds['tacacs_rw_user']
+    rw_pass = tacacs_creds['tacacs_rw_user_passwd']
 
     res = duthost.shell("ls -l /home/{}".format(ro_user), module_ignore_errors=True)
     if  res["rc"] == 0:
@@ -91,7 +89,7 @@ def test_ro_disk(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_al
     try:
         # Ensure rw user can get in, as we need this to be able to reboot
         ret = chk_ssh_remote_run(localhost, dutip, rw_user, rw_pass, "ls")
-        
+
         assert ret, "Failed to ssh as rw user"
 
         # Set disk in RO state
@@ -109,5 +107,3 @@ def test_ro_disk(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_al
         assert wait_until(600, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
         logger.debug("  END: reboot {} to restore disk RW state".
                 format(enum_rand_one_per_hwsku_hostname))
-
-       

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -72,25 +72,25 @@ def wait_for_tacacs(localhost, remote_ip, username, password):
             else:
                 current_attempt += 1
 
-def test_ro_user(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs):
+def test_ro_user(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    res = ssh_remote_run(localhost, dutip, creds_all_duts[duthost]['tacacs_ro_user'],
-                         creds_all_duts[duthost]['tacacs_ro_user_passwd'], 'cat /etc/passwd')
+    dutip = duthost.mgmt_ip
+    res = ssh_remote_run(localhost, dutip, tacacs_creds['tacacs_ro_user'],
+                         tacacs_creds['tacacs_ro_user_passwd'], 'cat /etc/passwd')
 
     check_output(res, 'test', 'remote_user')
 
-def test_ro_user_ipv6(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs_v6):
+def test_ro_user_ipv6(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs_v6):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    res = ssh_remote_run(localhost, dutip, creds_all_duts[duthost]['tacacs_ro_user'],
-                         creds_all_duts[duthost]['tacacs_ro_user_passwd'], 'cat /etc/passwd')
+    dutip = duthost.mgmt_ip
+    res = ssh_remote_run(localhost, dutip, tacacs_creds['tacacs_ro_user'],
+                         tacacs_creds['tacacs_ro_user_passwd'], 'cat /etc/passwd')
 
     check_output(res, 'test', 'remote_user')
 
-def test_ro_user_allowed_command(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs):
+def test_ro_user_allowed_command(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dutip = duthost.host.options["inventory_manager"].get_host(duthost.hostname).vars["ansible_host"]
+    dutip = duthost.mgmt_ip
 
     # Run as RO and use the commands allowed by the sudoers file
     commands = {
@@ -139,31 +139,31 @@ def test_ro_user_allowed_command(localhost, duthosts, enum_rand_one_per_hwsku_ho
     # sudo sfputil show
 
     for command in commands:
-        if does_command_exist(localhost, dutip, creds_all_duts[duthost]['tacacs_ro_user'],
-                              creds_all_duts[duthost]['tacacs_ro_user_passwd'], command):
+        if does_command_exist(localhost, dutip, tacacs_creds['tacacs_ro_user'],
+                              tacacs_creds['tacacs_ro_user_passwd'], command):
             for subcommand in commands[command]:
-                allowed = ssh_remote_allow_run(localhost, dutip, creds_all_duts[duthost]['tacacs_ro_user'],
-                                               creds_all_duts[duthost]['tacacs_ro_user_passwd'], subcommand)
+                allowed = ssh_remote_allow_run(localhost, dutip, tacacs_creds['tacacs_ro_user'],
+                                               tacacs_creds['tacacs_ro_user_passwd'], subcommand)
                 pytest_assert(allowed, "command '{}' not authorized".format(subcommand))
         else:
             logger.info('"{}" not found on DUT, skipping...'.format(command))
 
-    dash_allowed = ssh_remote_allow_run(localhost, dutip, creds_all_duts[duthost]['tacacs_ro_user'],
-                                        creds_all_duts[duthost]['tacacs_ro_user_passwd'], 'sudo sonic-installer list')
+    dash_allowed = ssh_remote_allow_run(localhost, dutip, tacacs_creds['tacacs_ro_user'],
+                                        tacacs_creds['tacacs_ro_user_passwd'], 'sudo sonic-installer list')
     if not dash_allowed:
-        dash_banned = ssh_remote_ban_run(localhost, dutip, creds_all_duts[duthost]['tacacs_ro_user'],
-                                         creds_all_duts[duthost]['tacacs_ro_user_passwd'], 'sudo sonic-installer list')
+        dash_banned = ssh_remote_ban_run(localhost, dutip, tacacs_creds['tacacs_ro_user'],
+                                         tacacs_creds['tacacs_ro_user_passwd'], 'sudo sonic-installer list')
         pytest_assert(dash_banned, "command 'sudo sonic-installer list' should be either allowed or banned")
-        underscore_allowed = ssh_remote_allow_run(localhost, dutip, creds_all_duts[duthost]['tacacs_ro_user'],
-                                                  creds_all_duts[duthost]['tacacs_ro_user_passwd'],
+        underscore_allowed = ssh_remote_allow_run(localhost, dutip, tacacs_creds['tacacs_ro_user'],
+                                                  tacacs_creds['tacacs_ro_user_passwd'],
                                                   'sudo sonic_installer list')
         pytest_assert(underscore_allowed, "command 'sudo sonic_installer list' should be allowed if"
                                           " 'sudo sonic-installer list' is banned")
 
 
-def test_ro_user_banned_command(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs):
+def test_ro_user_banned_command(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+    dutip = duthost.mgmt_ip
 
     # Run as readonly use the commands allowed by sudoers file
     commands = [
@@ -173,9 +173,9 @@ def test_ro_user_banned_command(localhost, duthosts, enum_rand_one_per_hwsku_hos
     ]
 
     # Wait until hostcfgd started and configured tacas authorization
-    wait_for_tacacs(localhost, dutip, creds_all_duts[duthost]['tacacs_ro_user'], creds_all_duts[duthost]['tacacs_ro_user_passwd'])
+    wait_for_tacacs(localhost, dutip, tacacs_creds['tacacs_ro_user'], tacacs_creds['tacacs_ro_user_passwd'])
 
     for command in commands:
-        banned = ssh_remote_ban_run(localhost, dutip, creds_all_duts[duthost]['tacacs_ro_user'],
-                                    creds_all_duts[duthost]['tacacs_ro_user_passwd'], command)
+        banned = ssh_remote_ban_run(localhost, dutip, tacacs_creds['tacacs_ro_user'],
+                                    tacacs_creds['tacacs_ro_user_passwd'], command)
         pytest_assert(banned, "command '{}' authorized".format(command))

--- a/tests/tacacs/test_rw_user.py
+++ b/tests/tacacs/test_rw_user.py
@@ -1,5 +1,4 @@
 import pytest
-import crypt
 
 from .test_ro_user import ssh_remote_run
 from .utils import check_output
@@ -11,22 +10,22 @@ pytestmark = [
 ]
 
 
-def test_rw_user(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs):
+def test_rw_user(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
     """test tacacs rw user
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    res = ssh_remote_run(localhost, dutip, creds_all_duts[duthost]['tacacs_rw_user'],
-                         creds_all_duts[duthost]['tacacs_rw_user_passwd'], "cat /etc/passwd")
+    dutip = duthost.mgmt_ip
+    res = ssh_remote_run(localhost, dutip, tacacs_creds['tacacs_rw_user'],
+                         tacacs_creds['tacacs_rw_user_passwd'], "cat /etc/passwd")
 
     check_output(res, 'testadmin', 'remote_user_su')
 
-def test_rw_user_ipv6(localhost, duthosts, enum_rand_one_per_hwsku_hostname, creds_all_duts, check_tacacs_v6):
+def test_rw_user_ipv6(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs_v6):
     """test tacacs rw user
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dutip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
-    res = ssh_remote_run(localhost, dutip, creds_all_duts[duthost]['tacacs_rw_user'],
-                         creds_all_duts[duthost]['tacacs_rw_user_passwd'], "cat /etc/passwd")
+    dutip = duthost.mgmt_ip
+    res = ssh_remote_run(localhost, dutip, tacacs_creds['tacacs_rw_user'],
+                         tacacs_creds['tacacs_rw_user_passwd'], "cat /etc/passwd")
 
     check_output(res, 'testadmin', 'remote_user_su')


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The tacacs test required credentials are originally defined in ansible group
vars that are specific to the current DUT or testbed. In case a new group
of DUTs or testbeds were added, these hard coded tacacs credentials must be
defined in var files of the new ansible group, otherwise there could be
issue like 'KeyError'.

Since the tacacs test required credentials are hard coded and created on the
fly in tacacs server running in PTF host, these credentials indeed are common
for all testbeds in all groups. It's unnecessary to define them in group
specific var files.

#### How did you do it?
This change added a new yaml file for the tacacs hard coded credentials.
Created a new fixture tacacs_creds for the tacacs tests based on the existing
creds_all_duts global fixture. The tacacs hard coded credentials are loaded
into the new tacacs_creds fixture. All the tacacs scripts have been updated to
use this new fixture. The tacacs specific credentials have been removed from
the group specific var files.

Another change is made to the creds_all_duts global fixture. This fixture is
a dict object under the hood. However, instance like duthost is used as dict
key. This is not a good practice. The improvement is to use duthost.hostname
as dict key.

All test scripts depend on the creds_all_duts have been updated to use this new
pattern too.

This commit also made some other improvements to touched scripts:
* Remove unused imports
* Use 'logger' instead of 'print'
* Use duthost.mgmt_ip and ptfhost.mgmt_ip to get DUT and PTF management IP
* Filter out unnecessary yaml files while loading 'creds_all_duts'

#### How did you verify/test it?
Tested on 202012 branch

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
