### PR TITLE
Include Inband and recirc ports in the list of external

### DIFF
--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -161,7 +161,7 @@ class SonicPortAliasMap():
                     else:
                         alias = name
                     add_port = False
-                    if role == 'Ext' or (role == "Int" and include_internal):
+                    if role == 'Ext' or role == "Inb" or role =="Rec" or (role == "Int" and include_internal):
                         add_port = True
                         aliases.append((alias, -1 if port_index == -1 or len(mapping) <= port_index else mapping[port_index]))
                         portmap[name] = alias

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -161,7 +161,7 @@ class SonicPortAliasMap():
                     else:
                         alias = name
                     add_port = False
-                    if role == 'Ext' or role == "Inb" or role =="Rec" or (role == "Int" and include_internal):
+                    if role in {"Ext", "Inb", "Rec"} or (role == "Int" and include_internal):
                         add_port = True
                         aliases.append((alias, -1 if port_index == -1 or len(mapping) <= port_index else mapping[port_index]))
                         portmap[name] = alias


### PR DESCRIPTION
interfaces.

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Seeing failure in test_iface_namingmode testcase when running for VoQ chassis, with the below traceback:
```
18:18:16 test_iface_namingmode.test_show_interfac L0263 INFO   | show_intf_counter:
      IFACE    STATE    RX_OK      RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK      TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
-----------  -------  -------  ----------  ---------  --------  --------  --------  -------  ----------  ---------  --------  --------  --------
 TestAlias4        U      484  161.99 B/s      0.00%         0         0         0       73   50.34 B/s      0.00%         0         0         0
 TestAlias5        U       33    2.44 B/s      0.00%         0         0         0      494   81.90 B/s      0.00%         0         0         0
18:18:16 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/_pytest/python.py", line 1464, in runtest
..
  File "/var/sonic-mgmt/tests/iface_namingmode/test_iface_namingmode.py", line 274, in test_show_interfaces_counter
    assert item in setup['port_alias']
AttributeError: 'module' object has no attribute 'locals'
```
#### How did you do it?
inband and recirc ports are included in the show CLIs along with the external interfaces.
Hence, Include Inband and Recirc ports along with external ports interfaces.

#### How did you verify/test it?
- test_iface_naming_mode test case passes in VoQ chassis after this change.
- port_alias library used in minigraph generation, ensure there is no change  minigraph generated.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
