### PR TITLE
change the wait time after docker service restart 10 secs to 60 secs

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -366,9 +366,9 @@
           daemon_reload: yes
           name: docker
 
-      - name: Wait 10s for docker containers to restart
+      - name: Wait 60s for docker containers to restart
         pause:
-          seconds: 10
+          seconds: 60
     become: true
     when: proxy_env is defined
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The PR https://github.com/Azure/sonic-mgmt/pull/4988 add the change  to do docker pull, restart the docker service and wait for 10 secs. On multi asic devices, which have multiple database containers, the database containers do not come up within 10 secs. This cause the load minigraph to fail.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The PR https://github.com/Azure/sonic-mgmt/pull/4988 add the change  to do docker pull, restart the docker service and wait for 10 secs. On multi asic devices, which have multiple database containers, the database containers do not come up within 10 secs. This cause the load minigraph to fail.
#### How did you do it?
 Change the wait time from `10sec` to `60secs`

#### How did you verify/test it?
Load minigraph on multi asic devices

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
