### PR TITLE
Skip platform testcases if transceiver is DAC

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -146,6 +146,13 @@ class TestSfpApi(PlatformApiTestBase):
     # Helper functions
     #
 
+    def is_xcvr_dac(self, xcvr_info_dict):
+        conn_type = xcvr_info_dict.get("connector")
+        comp_type = xcvr_info_dict.get("specification_compliance")
+        if conn_type == "No separable connector" and 'copper' in comp_type:
+            return True
+        return False
+
     def is_xcvr_optical(self, xcvr_info_dict):
         """Returns True if transceiver is optical, False if copper (DAC)"""
         #For QSFP-DD specification compliance will return type as passive or active
@@ -335,6 +342,12 @@ class TestSfpApi(PlatformApiTestBase):
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
 
         for i in self.sfp_setup["sfp_test_port_indices"]:
+            info_dict = sfp.get_transceiver_info(platform_api_conn, i)
+            # Skip if transceiver ia a dac
+            if self.is_xcvr_dac(info_dict):
+                logger.info("test_get_rx_los: Skipping transceiver {} (not supported on this platform)".format(i))
+                continue
+
             rx_los = sfp.get_rx_los(platform_api_conn, i)
             if self.expect(rx_los is not None, "Unable to retrieve transceiver {} RX loss-of-signal data".format(i)):
                 self.expect(isinstance(rx_los, list) and (all(isinstance(item, bool) for item in rx_los)),
@@ -347,6 +360,12 @@ class TestSfpApi(PlatformApiTestBase):
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
 
         for i in self.sfp_setup["sfp_test_port_indices"]:
+            info_dict = sfp.get_transceiver_info(platform_api_conn, i)
+            # Skip if transceiver ia a dac
+            if self.is_xcvr_dac(info_dict):
+                logger.info("test_get_tx_fault: Skipping transceiver {} (not supported on this platform)".format(i))
+                continue
+
             tx_fault = sfp.get_tx_fault(platform_api_conn, i)
             if self.expect(tx_fault is not None, "Unable to retrieve transceiver {} TX fault data".format(i)):
                 self.expect(isinstance(tx_fault, list) and (all(isinstance(item, bool) for item in tx_fault)),
@@ -359,6 +378,12 @@ class TestSfpApi(PlatformApiTestBase):
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
 
         for i in self.sfp_setup["sfp_test_port_indices"]:
+            info_dict = sfp.get_transceiver_info(platform_api_conn, i)
+            # Skip if transceiver ia a dac
+            if self.is_xcvr_dac(info_dict):
+                logger.info("test_get_temperature: Skipping transceiver {} (not supported on this platform)".format(i))
+                continue
+
             temp = sfp.get_temperature(platform_api_conn, i)
             if self.expect(temp is not None, "Unable to retrieve transceiver {} temperatue".format(i)):
                 self.expect(isinstance(temp, float), "Transceiver {} temperature appears incorrect".format(i))
@@ -370,6 +395,12 @@ class TestSfpApi(PlatformApiTestBase):
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
 
         for i in self.sfp_setup["sfp_test_port_indices"]:
+            info_dict = sfp.get_transceiver_info(platform_api_conn, i)
+            # Skip if transceiver ia a dac
+            if self.is_xcvr_dac(info_dict):
+                logger.info("test_get_voltage: Skipping transceiver {} (not supported on this platform)".format(i))
+                continue
+
             voltage = sfp.get_voltage(platform_api_conn, i)
             if self.expect(voltage is not None, "Unable to retrieve transceiver {} voltage".format(i)):
                 self.expect(isinstance(voltage, float), "Transceiver {} voltage appears incorrect".format(i))
@@ -421,13 +452,18 @@ class TestSfpApi(PlatformApiTestBase):
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
 
         for i in self.sfp_setup["sfp_test_port_indices"]:
+            info_dict = sfp.get_transceiver_info(platform_api_conn, i)
+            # Skip if transceiver ia a dac
+            if self.is_xcvr_dac(info_dict):
+                logger.info("test_get_tx_power: Skipping transceiver {} (not supported on this platform)".format(i))
+                continue
+
             tx_power = sfp.get_tx_power(platform_api_conn, i)
             if self.expect(tx_power is not None, "Unable to retrieve transceiver {} TX power data".format(i)):
                 continue
 
             # Determine whether the transceiver type supports RX power
             # If the transceiver is non-optical, e.g., DAC, we should receive a list of "N/A" strings
-            info_dict = sfp.get_transceiver_info(platform_api_conn, i)
             if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
                 continue
 
@@ -516,8 +552,13 @@ class TestSfpApi(PlatformApiTestBase):
     def test_lpmode(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         """This function tests both the get_lpmode() and set_lpmode() APIs"""
         for i in self.sfp_setup["sfp_test_port_indices"]:
-            # First ensure that the transceiver type supports low-power mode
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
+            # Skip if transceiver ia a dac
+            if self.is_xcvr_dac(info_dict):
+                logger.info("test_lpmod: Skipping transceiver {} (not supported on this platform)".format(i))
+                continue
+
+            # Ensure that the transceiver type supports low-power mode
             if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
                 continue
 

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -146,33 +146,13 @@ class TestSfpApi(PlatformApiTestBase):
     # Helper functions
     #
 
-
-    def get_sfp_attributes(self, duthost, sfp_idx, def_value, *keys):
-        if duthost.facts.get("chassis"):
-            sfps = duthost.facts.get("chassis").get("sfps")
-            if sfps:
-                sfp_value = sfps[sfp_idx]
-                for key in keys:
-                    value = sfp_value.get(key)
-                    if value is None:
-                        return def_value
-                return value
-        return def_value
-
-    def is_xcvr_dac(self, xcvr_info_dict):
-        conn_type = xcvr_info_dict.get("connector")
-        comp_type = xcvr_info_dict.get("specification_compliance")
-        if conn_type == "No separable connector" and 'copper' in comp_type:
-            return True
-        return False
-
-
     def is_xcvr_optical(self, xcvr_info_dict):
         """Returns True if transceiver is optical, False if copper (DAC)"""
         #For QSFP-DD specification compliance will return type as passive or active
         if xcvr_info_dict["type_abbrv_name"] == "QSFP-DD" or xcvr_info_dict["type_abbrv_name"] == "OSFP-8X" \
         or xcvr_info_dict["type_abbrv_name"] == "QSFP+C":
-            if xcvr_info_dict["specification_compliance"] == "Passive Copper Cable":
+            if xcvr_info_dict["specification_compliance"] == "Passive Copper Cable" or \
+                    xcvr_info_dict["specification_compliance"] == "passive_copper_media_interface":
                return False
         else:
             spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])
@@ -357,7 +337,7 @@ class TestSfpApi(PlatformApiTestBase):
 
         for i in self.sfp_setup["sfp_test_port_indices"]:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
-            # Skip if transceiver ia a dac
+
             if not self.is_xcvr_optical(info_dict):
                 logger.info("test_get_rx_los: Skipping transceiver {} (not supported on this platform)".format(i))
                 continue
@@ -375,7 +355,7 @@ class TestSfpApi(PlatformApiTestBase):
 
         for i in self.sfp_setup["sfp_test_port_indices"]:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
-            # Skip if transceiver ia a dac
+
             if not self.is_xcvr_optical(info_dict):
                 logger.info("test_get_tx_fault: Skipping transceiver {} (not supported on this platform)".format(i))
                 continue
@@ -393,7 +373,7 @@ class TestSfpApi(PlatformApiTestBase):
 
         for i in self.sfp_setup["sfp_test_port_indices"]:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
-            # Skip if transceiver ia a dac
+
             if not self.is_xcvr_optical(info_dict):
                 logger.info("test_get_temperature: Skipping transceiver {} (not supported on this platform)".format(i))
                 continue
@@ -410,7 +390,7 @@ class TestSfpApi(PlatformApiTestBase):
 
         for i in self.sfp_setup["sfp_test_port_indices"]:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
-            # Skip if transceiver ia a dac
+
             if not self.is_xcvr_optical(info_dict):
                 logger.info("test_get_voltage: Skipping transceiver {} (not supported on this platform)".format(i))
                 continue
@@ -467,7 +447,7 @@ class TestSfpApi(PlatformApiTestBase):
 
         for i in self.sfp_setup["sfp_test_port_indices"]:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
-            # Skip if transceiver ia a dac
+
             if not self.is_xcvr_optical(info_dict):
                 logger.info("test_get_tx_power: Skipping transceiver {} (not supported on this platform)".format(i))
                 continue
@@ -567,11 +547,6 @@ class TestSfpApi(PlatformApiTestBase):
         """This function tests both the get_lpmode() and set_lpmode() APIs"""
         for i in self.sfp_setup["sfp_test_port_indices"]:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
-            # Skip if transceiver ia a dac
-            if not self.is_xcvr_optical(info_dict):
-                logger.info("test_lpmod: Skipping transceiver {} (not supported on this platform)".format(i))
-                continue
-
             # Ensure that the transceiver type supports low-power mode
             if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
                 continue

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -339,7 +339,7 @@ class TestSfpApi(PlatformApiTestBase):
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
 
             if not self.is_xcvr_optical(info_dict):
-                logger.info("test_get_rx_los: Skipping transceiver {} (not supported on this platform)".format(i))
+                logger.info("test_get_rx_los: Skipping transceiver {} (not applicable for this transceiver type)".format(i))
                 continue
 
             rx_los = sfp.get_rx_los(platform_api_conn, i)
@@ -357,7 +357,7 @@ class TestSfpApi(PlatformApiTestBase):
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
 
             if not self.is_xcvr_optical(info_dict):
-                logger.info("test_get_tx_fault: Skipping transceiver {} (not supported on this platform)".format(i))
+                logger.info("test_get_tx_fault: Skipping transceiver {} (not applicable for this transceiver type)".format(i))
                 continue
 
             tx_fault = sfp.get_tx_fault(platform_api_conn, i)
@@ -375,7 +375,7 @@ class TestSfpApi(PlatformApiTestBase):
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
 
             if not self.is_xcvr_optical(info_dict):
-                logger.info("test_get_temperature: Skipping transceiver {} (not supported on this platform)".format(i))
+                logger.info("test_get_temperature: Skipping transceiver {} (not applicable for this transceiver type)".format(i))
                 continue
 
             temp = sfp.get_temperature(platform_api_conn, i)
@@ -392,7 +392,7 @@ class TestSfpApi(PlatformApiTestBase):
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
 
             if not self.is_xcvr_optical(info_dict):
-                logger.info("test_get_voltage: Skipping transceiver {} (not supported on this platform)".format(i))
+                logger.info("test_get_voltage: Skipping transceiver {} (not applicable for this transceiver type)".format(i))
                 continue
 
             voltage = sfp.get_voltage(platform_api_conn, i)
@@ -449,7 +449,7 @@ class TestSfpApi(PlatformApiTestBase):
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
 
             if not self.is_xcvr_optical(info_dict):
-                logger.info("test_get_tx_power: Skipping transceiver {} (not supported on this platform)".format(i))
+                logger.info("test_get_tx_power: Skipping transceiver {} (not applicable for this transceiver type)".format(i))
                 continue
 
             tx_power = sfp.get_tx_power(platform_api_conn, i)

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -146,12 +146,26 @@ class TestSfpApi(PlatformApiTestBase):
     # Helper functions
     #
 
+
+    def get_sfp_attributes(self, duthost, sfp_idx, def_value, *keys):
+        if duthost.facts.get("chassis"):
+            sfps = duthost.facts.get("chassis").get("sfps")
+            if sfps:
+                sfp_value = sfps[sfp_idx]
+                for key in keys:
+                    value = sfp_value.get(key)
+                    if value is None:
+                        return def_value
+                return value
+        return def_value
+
     def is_xcvr_dac(self, xcvr_info_dict):
         conn_type = xcvr_info_dict.get("connector")
         comp_type = xcvr_info_dict.get("specification_compliance")
         if conn_type == "No separable connector" and 'copper' in comp_type:
             return True
         return False
+
 
     def is_xcvr_optical(self, xcvr_info_dict):
         """Returns True if transceiver is optical, False if copper (DAC)"""
@@ -344,7 +358,7 @@ class TestSfpApi(PlatformApiTestBase):
         for i in self.sfp_setup["sfp_test_port_indices"]:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
             # Skip if transceiver ia a dac
-            if self.is_xcvr_dac(info_dict):
+            if not self.is_xcvr_optical(info_dict):
                 logger.info("test_get_rx_los: Skipping transceiver {} (not supported on this platform)".format(i))
                 continue
 
@@ -362,7 +376,7 @@ class TestSfpApi(PlatformApiTestBase):
         for i in self.sfp_setup["sfp_test_port_indices"]:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
             # Skip if transceiver ia a dac
-            if self.is_xcvr_dac(info_dict):
+            if not self.is_xcvr_optical(info_dict):
                 logger.info("test_get_tx_fault: Skipping transceiver {} (not supported on this platform)".format(i))
                 continue
 
@@ -380,7 +394,7 @@ class TestSfpApi(PlatformApiTestBase):
         for i in self.sfp_setup["sfp_test_port_indices"]:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
             # Skip if transceiver ia a dac
-            if self.is_xcvr_dac(info_dict):
+            if not self.is_xcvr_optical(info_dict):
                 logger.info("test_get_temperature: Skipping transceiver {} (not supported on this platform)".format(i))
                 continue
 
@@ -397,7 +411,7 @@ class TestSfpApi(PlatformApiTestBase):
         for i in self.sfp_setup["sfp_test_port_indices"]:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
             # Skip if transceiver ia a dac
-            if self.is_xcvr_dac(info_dict):
+            if not self.is_xcvr_optical(info_dict):
                 logger.info("test_get_voltage: Skipping transceiver {} (not supported on this platform)".format(i))
                 continue
 
@@ -454,7 +468,7 @@ class TestSfpApi(PlatformApiTestBase):
         for i in self.sfp_setup["sfp_test_port_indices"]:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
             # Skip if transceiver ia a dac
-            if self.is_xcvr_dac(info_dict):
+            if not self.is_xcvr_optical(info_dict):
                 logger.info("test_get_tx_power: Skipping transceiver {} (not supported on this platform)".format(i))
                 continue
 
@@ -554,7 +568,7 @@ class TestSfpApi(PlatformApiTestBase):
         for i in self.sfp_setup["sfp_test_port_indices"]:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
             # Skip if transceiver ia a dac
-            if self.is_xcvr_dac(info_dict):
+            if not self.is_xcvr_optical(info_dict):
                 logger.info("test_lpmod: Skipping transceiver {} (not supported on this platform)".format(i))
                 continue
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added code snippet to skip certain platform_tests if the transceiver is a DAC
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach

#### What is the motivation for this PR?
Make the platform test cases more robust

#### How did you do it?
- Added method to check for transceiver cable type
- Added code snippet to testcase to skip the test if transceiver type is DAC

#### How did you verify/test it?
Ran the regression tests
 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
