### PR TITLE
Enhance test cases for scale cacl rules

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -143,8 +143,10 @@ def clean_scale_rules(duthosts, rand_one_dut_hostname, collect_ignored_rules):
     ignored_rules_v6 = duthost.command("ip6tables -S")["stdout_lines"]
 
     try:
-        pytest_assert(len(set(ignored_rules_v4) - set(collect_ignored_rules["v4"])) == 0 and len(set(ignored_rules_v6) - set(collect_ignored_rules["v6"])) == 0, 
-                        "Some iptables/ip6tables rules are not cleaned!")
+        uncleaned_iptables_rules = set(ignored_rules_v4) - set(collect_ignored_rules["v4"])
+        pytest_assert(len(uncleaned_iptables_rules) == 0, "Some iptables rules are not cleaned: {}".format(repr(uncleaned_iptables_rules)))
+        uncleaned_ip6tables_rules = set(ignored_rules_v6) - set(collect_ignored_rules["v6"])
+        pytest_assert(len(uncleaned_ip6tables_rules) == 0, "Some ip6tables rules are not cleaned: {}".format(repr(uncleaned_ip6tables_rules)))
     except:
         logger.info("Some iptalbes/ip6tables rules are not cleaned clearly. Config reload to recover testbed and make sure not impact the following tests.")
         config_reload(duthost, wait=60)

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -91,7 +91,7 @@ def collect_ignored_rules(duthosts, rand_one_dut_hostname, rand_one_frontend_asi
     # acl-loader delete operation only deletes acl rules, it still has to wait some time for synchronizing iptables rules
     if rand_one_frontend_asic_index is not None:
         # For multi-asic, it has to wait enough long to sync rules
-        time.sleep(120)
+        time.sleep(150)
     else:
         time.sleep(10)
 
@@ -128,8 +128,12 @@ def clean_scale_rules(duthosts, rand_one_dut_hostname, collect_ignored_rules, ra
     duthost.file(path=SCALE_ACL_FILE, state='absent')
     # recover ACL configuration
     duthost.get_asic_or_sonic_host(rand_one_frontend_asic_index).command("acl-loader delete SNMP_ACL")
+    # sleep 1s to avoid the issue on multi-asic: https://github.com/Azure/sonic-buildimage/issues/9824
+    time.sleep(1)
     duthost.get_asic_or_sonic_host(rand_one_frontend_asic_index).command("acl-loader delete NTP_ACL")
+    time.sleep(1)
     duthost.get_asic_or_sonic_host(rand_one_frontend_asic_index).command("acl-loader delete SSH_ONLY")
+    time.sleep(1)
 
     logger.info('Waiting all rules to be cleaned')
     wait_until(60, 2, 2, is_acl_rule_empty, duthost, rand_one_frontend_asic_index)
@@ -137,7 +141,7 @@ def clean_scale_rules(duthosts, rand_one_dut_hostname, collect_ignored_rules, ra
     # acl-loader delete operation only deletes acl rules, it still has to wait some time for synchronizing iptables rules
     if rand_one_frontend_asic_index is not None:
         # For multi-asic, it has to wait enough long to sync rules
-        time.sleep(120)
+        time.sleep(150)
     else:
         time.sleep(10)
 

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -76,7 +76,6 @@ def collect_ignored_rules(duthosts, rand_one_dut_hostname):
     """
     duthost = duthosts[rand_one_dut_hostname]
 
-    duthost = duthosts[rand_one_dut_hostname]
     ignored_rules_v4 = duthost.command("iptables -S")["stdout_lines"]
     ignored_rules_v6 = duthost.command("ip6tables -S")["stdout_lines"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1087,6 +1087,9 @@ def pytest_generate_tests(metafunc):
     elif "enum_rand_one_asic_index" in metafunc.fixturenames:
         asic_fixture_name = "enum_rand_one_asic_index"
         asics_selected = generate_param_asic_index(metafunc, duts_selected, ASIC_PARAM_TYPE_ALL, random_asic=True)
+    elif "rand_one_frontend_asic_index" in metafunc.fixturenames:
+        asic_fixture_name = "rand_one_frontend_asic_index"
+        asics_selected = generate_param_asic_index(metafunc, duts_selected, ASIC_PARAM_TYPE_FRONTEND, random_asic=True)
 
     # Create parameterization tuple of dut_fixture_name and asic_fixture_name to parameterize
     if dut_fixture_name and asic_fixture_name:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1087,9 +1087,6 @@ def pytest_generate_tests(metafunc):
     elif "enum_rand_one_asic_index" in metafunc.fixturenames:
         asic_fixture_name = "enum_rand_one_asic_index"
         asics_selected = generate_param_asic_index(metafunc, duts_selected, ASIC_PARAM_TYPE_ALL, random_asic=True)
-    elif "rand_one_frontend_asic_index" in metafunc.fixturenames:
-        asic_fixture_name = "rand_one_frontend_asic_index"
-        asics_selected = generate_param_asic_index(metafunc, duts_selected, ASIC_PARAM_TYPE_FRONTEND, random_asic=True)
 
     # Create parameterization tuple of dut_fixture_name and asic_fixture_name to parameterize
     if dut_fixture_name and asic_fixture_name:


### PR DESCRIPTION
Enhance test cases for testing scale control acl rules.

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3596
The previous PR #4913 are not robust enough, if test case failed, it will leave cacl rules on testbed and cause access rejection, we will lost the access to testbed. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fixes #3596
Enhance the previous PR #4913 

#### How did you do it?
I enhance test cases in this PR as below:
1. This is the whole process of test cases: 

- Add scale cacl rules into db with acl-loader command
- Generate expected iptables rules for new added cacl rules
- Compare the actual iptable rules with expected ones
- Clean testbed

2. Add clean_scale_rules fixture, it will clean added rules whatever test cases failed or not, if the clean failed, config reload and fail the case.
3. It add an ACCEPT SSH iptables rule for test cases, even somehow added rules are not cleaned we won't lost the connection to testbed.
4. How to add this ACCEPT SSH:

- 1) Add SSH ACCEPT rule into scale_cacl.json file and deploy it into cacl rules, ipv4 works fine, but cacl table only support one ip version, for IPv6 case, CACL table will ignore ipv4 SSH ACCEPT rule, the access to testbed will be rejected as well. 
- 2) Use "acl-loader update incremental" instead of "acl-loader update full", but incremental is only for existing CACL rules, it will refresh iptables as well, we can't add the ACCEPT SSH rule before acl-loader.
- 3) No1 and No2 don't work. "acl-loader update full **.json" command will refresh iptables, we have to add the ACCEPT SSH iptables rule after acl-loader command. But on multi-asic testbed, it always costs minutes to sync iptables rules after updating cacl rules, at first, I added time.sleep to make the process to wait, the default ansible SSH timeout is 30s, after sleeping for 3 mins, the process will try to add the ACCEPT SSH rule mentioned in No. 2, but SSH connection is disconnected, duthost.command will try to reconnect to DUT, at this time, next duthost.command will trigger ssh login, it will be rejected by default CACL DENY rule, test will fail. We have wait_until to solve this problem, I add wail_until to call check_iptable_rules every 10s to keep session alive, in check_iptable_rules just uses duthost.command to active ssh connection. In this way, we can active ssh connection and wait how long as we want.

5. Run scale cases on host not on asic, control acl should be applied to host, outside of asic.
6. collect_ignored_rules fixture is used to collect existing iptables/ip6tables rules on testbed before test, then we create scale rules, generate expected rules, at last, we will ignore the collected rules when comparing the actual rules and expected ones. In this way, we don't have to generate expected existing rules for each scenario, there are different existing rules for T0/DualToR active/DualToR standby/multi-asic and hardcode will make code hard to maintain.

#### How did you verify/test it?

run test case test_cacl_scale_rules_ipv4 and test_cacl_scale_rules_ipv6 in tests/cacl/test_cacl_application.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T0/DualToR/multi-asic

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
