### PR TITLE
[TestbedProcessing] Fix for warnings when deploy-mg script parse a lab file

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -687,7 +687,7 @@ def makeLabYAML(data, devices, testbed, outfile):
                                 }
                             },
                         'ptf': {'hosts': ptfDict},
-                        'server': serverDict
+                        'server': {'hosts': serverDict}
                         }
                     }
     })


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In PR https://github.com/Azure/sonic-mgmt/pull/4886 that merged in sonic-mgmt was not added a 'hosts' variable. Now we got few warnings when deploy-mg script parse a lab file.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 201911

#### What is the motivation for this PR?
In PR https://github.com/Azure/sonic-mgmt/pull/4886 that merged in sonic-mgmt was not added a 'hosts' variable. Now we got few warnings when deploy-mg script parse a lab file.
```
[WARNING]: Skipping unexpected key (ServerName) in group (server), only
"vars", "children" and "hosts" are valid
```
#### How did you do it?
Add 'hosts' variable to servers
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
