### PR TITLE
[advanced-reboot-sad] Fix report collection and improve logging

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -175,12 +175,16 @@ class ReloadTest(BaseTest):
         else:
             self.logfile_suffix = self.sad_oper
 
-        if self.logfile_suffix:
-           self.log_file_name = '/tmp/%s-%s.log' % (self.test_params['reboot_type'], self.logfile_suffix)
-           self.report_file_name = '/tmp/%s-%s.json' % (self.test_params['reboot_type'], self.logfile_suffix)
+        if "warm-reboot" in self.test_params['reboot_type']:
+            reboot_log_prefix = "warm-reboot"
         else:
-           self.log_file_name = '/tmp/%s.log' % self.test_params['reboot_type']
-           self.report_file_name = '/tmp/%s-report.json' % self.test_params['reboot_type']
+            reboot_log_prefix = self.test_params['reboot_type']
+        if self.logfile_suffix:
+           self.log_file_name = '/tmp/%s-%s.log' % (reboot_log_prefix, self.logfile_suffix)
+           self.report_file_name = '/tmp/%s-%s-report.json' % (reboot_log_prefix, self.logfile_suffix)
+        else:
+           self.log_file_name = '/tmp/%s.log' % reboot_log_prefix
+           self.report_file_name = '/tmp/%s-report.json' % reboot_log_prefix
         self.report = dict()
         self.log_fp = open(self.log_file_name, 'w')
 

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -408,6 +408,7 @@ class AdvancedReboot:
         for host, logs in logFiles.items():
             for log in logs:
                 host.fetch(**log)
+        return log_dir
 
     def imageInstall(self, prebootList=None, inbootList=None, prebootFiles=None):
         '''
@@ -453,15 +454,15 @@ class AdvancedReboot:
                 failed_list.append(rebootOper)
             finally:
                 # always capture the test logs
-                self.__fetchTestLogs(rebootOper)
+                log_dir = self.__fetchTestLogs(rebootOper)
                 self.__clearArpAndFdbTables()
                 self.__revertRebootOper(rebootOper)
                 if self.advanceboot_loganalyzer:
-                    post_reboot_analysis(marker, reboot_oper=rebootOper)
+                    post_reboot_analysis(marker, reboot_oper=rebootOper, log_dir=log_dir)
             if len(self.rebootData['sadList']) > 1 and count != len(self.rebootData['sadList']):
                 time.sleep(TIME_BETWEEN_SUCCESSIVE_TEST_OPER)
         pytest_assert(len(failed_list) == 0,\
-            "Advanced-reboot failure. Failed cases: {}".format(failed_list))
+            "Advanced-reboot failure. Failed test: {}, sub-cases: {}".format(self.request.node.name, failed_list))
         return result
 
     def runRebootTestcase(self, prebootList=None, inbootList=None,
@@ -559,7 +560,8 @@ class AdvancedReboot:
         self.__updateAndRestartArpResponder(rebootOper)
 
 
-        logger.info('Run advanced-reboot ReloadTest on the PTF host. Case: {}'.format(str(rebootOper)))
+        logger.info('Run advanced-reboot ReloadTest on the PTF host. TestCase: {}, sub-case: {}'.format(\
+            self.request.node.name, str(rebootOper)))
         result = ptf_runner(
             self.ptfhost,
             "ptftests",

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -271,9 +271,15 @@ def analyze_sairedis_rec(messages, result, offset_from_kexec):
     result["offset_from_kexec"] = offset_from_kexec
 
 
-def get_data_plane_report(analyze_result, reboot_type):
+def get_data_plane_report(analyze_result, reboot_type, log_dir, reboot_oper):
     report = {"controlplane": {"arp_ping": "", "downtime": ""}, "dataplane": {"lost_packets": "", "downtime": ""}}
-    files = glob.glob('/tmp/{}-reboot-report.json'.format(reboot_type))
+    reboot_report_path = re.sub('([\[\]])','[\\1]',log_dir) # escaping, as glob utility does not work well with "[","]"
+    if reboot_oper:
+        reboot_report_file_name = "{}-reboot-{}-report.json".format(reboot_type, reboot_oper)
+    else:
+        reboot_report_file_name = "{}-reboot-report.json".format(reboot_type)
+    reboot_report_file = "{}/{}".format(reboot_report_path, reboot_report_file_name)
+    files = glob.glob(reboot_report_file)
     if files:
         filepath = files[0]
         with open(filepath) as json_file:
@@ -359,7 +365,7 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
         loganalyzer.match_regex = []
         return marker
 
-    def post_reboot_analysis(marker, reboot_oper=None):
+    def post_reboot_analysis(marker, reboot_oper=None, log_dir=None):
         result = loganalyzer.analyze(marker, fail=False)
         analyze_result = {"time_span": dict(), "offset_from_kexec": dict()}
         offset_from_kexec = dict()
@@ -387,7 +393,7 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
             else:
                 time_data["time_taken"] = "N/A"
 
-        get_data_plane_report(analyze_result, reboot_type)
+        get_data_plane_report(analyze_result, reboot_type, log_dir, reboot_oper)
         result_summary = get_report_summary(analyze_result, reboot_type)
         logging.info(json.dumps(analyze_result, indent=4))
         logging.info(json.dumps(result_summary, indent=4))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix report collection issue for SAD cases, and improve logging.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?



#### How did you do it?

1. Log file collection:
Recently we started collecting all the logs from ptf into a local dir for saving it as a artifact. With this change, the files don't exist inside /tmp/, but are located in logs dir. Update the path from "tmp" to "logs" by using `log_dir` path to fetch.

2. Logging improvements - Instead of printing `None` for non-SAD case, print the testcase name, and subcases as None.

To improve logging
#### How did you verify/test it?

Tested on a physical testbed, the downtime data is now updated in the test report for SAD cases.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
