### PR TITLE
Skip GCU test on dut version that older than 202112

### DIFF
--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -4,7 +4,7 @@ from tests.common.utilities import skip_release
 
 @pytest.fixture(scope="module", autouse=True)
 def check_image_version(duthost):
-    """Skips this test if the SONiC image installed on DUT is older than 202106
+    """Skips this test if the SONiC image installed on DUT is older than 202112
 
     Args:
         duthost: Hostname of DUT.
@@ -12,7 +12,7 @@ def check_image_version(duthost):
     Returns:
         None.
     """
-    skip_release(duthost, ["201811", "201911", "202012"])
+    skip_release(duthost, ["201811", "201911", "202012", "202106"])
 
 @pytest.fixture(scope="module")
 def cfg_facts(duthosts, rand_one_dut_hostname):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip duts that dont have config apply-patch support
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix Nightly test issue
#### How did you do it?
Skip DUTs that don't have apply-patch support
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
