### PR TITLE
Fix test failure of `test_balancing_sub_ports`

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -441,7 +441,7 @@ def apply_tunnel_table_to_dut(duthost, apply_route_config):
 
 
 @pytest.fixture()
-def apply_balancing_config(duthost, ptfhost, ptfadapter, define_sub_ports_configuration, apply_config_on_the_dut, apply_config_on_the_ptf):
+def apply_balancing_config(duthost, ptfhost, ptfadapter, define_sub_ports_configuration, apply_config_on_the_dut, apply_config_on_the_ptf, tbinfo):
     """
     Apply balancing configuration on the DUT and remove after tests
     Args:
@@ -459,7 +459,12 @@ def apply_balancing_config(duthost, ptfhost, ptfadapter, define_sub_ports_config
     dut_ports = define_sub_ports_configuration['dut_ports']
     ptf_ports = define_sub_ports_configuration['ptf_ports']
 
-    src_ports = tuple(set(ptfhost.host.options['variable_manager'].extra_vars.get("ifaces_map").values()).difference(ptf_ports))
+    # Selectonly up ports as src_ports 
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    all_up_ports = set()
+    for port in mg_facts['minigraph_ports'].keys():
+        all_up_ports.add("eth" + str(mg_facts['minigraph_ptf_indices'][port]))
+    src_ports = tuple(all_up_ports.difference(ptf_ports))
 
     network = u'1.1.1.0/24'
     network = ipaddress.ip_network(network)


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix test failure of `test_balancing_sub_ports`.
The test failed because the randomly selected source ports for sending packets are possibly admin down ports
https://github.com/Azure/sonic-mgmt/blob/5eaeecdbe283dd76d92ee93893b84e6ef13f6c88/tests/sub_port_interfaces/conftest.py#L462

This PR fix the issue by selecting only up ports for sending packets.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix test failure of `test_balancing_sub_ports`.

#### How did you do it?
This PR fix the issue by selecting only up ports for sending packets.

#### How did you verify/test it?
Verified on SN4600 T0 testbed
```
collected 2 items                                                                                                                                                                                     

sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_balancing_sub_ports[port] PASSED                                                                                            [ 50%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_balancing_sub_ports[port_in_lag]  ^HPASSED                                                                                     [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
