### PR TITLE
Fix test failure of `test_data_path` in `test_restapi`

### DIFF
--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -85,7 +85,7 @@ This test creates a default VxLAN Tunnel and two VNETs. It adds VLAN, VLAN membe
 '''
 def test_data_path(construct_url, vlan_members):
     # Create Default VxLan Tunnel
-    if restapi.get_config_tunnel_decap_tunnel_type(construct_url, 'vxlan').status_code == 409:
+    if restapi.get_config_tunnel_decap_tunnel_type(construct_url, 'vxlan').status_code == 404:
         params = '{"ip_addr": "10.1.0.32"}'
         logger.info("Creating Default VxLan Tunnel with ip_addr: 10.1.0.32")
         r = restapi.post_config_tunnel_decap_tunnel_type(construct_url, 'vxlan', params)


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to fix test failure of `test_data_path` in `test_restapi`.

According the defination of interface of restapi service, the return code for an not found object is supposed to be `404` rather than `409`
https://github.com/Azure/sonic-restapi/blob/a1830c1761087bdc1f7433ebbb8d0bdc419da0d3/sonic_api.yaml#L1012
```
#----------------------------------------------
# route object
#----------------------------------------------
  '/config/vrouter/{vnet_id}/routes':
    get:
      responses:
        '200':
          description: OK
          schema:
            type: array
            items:
              $ref: '#/definitions/RouteEntry'
        '400':
          description: Malformed arguments for API call
          schema:
            $ref: '#/definitions/Error'
        '401':
          description: Invalid authentication credentials
          schema:
            $ref: '#/definitions/Error'
        '404':
          description: Object not found
          schema:
            $ref: '#/definitions/Error'
        '500':
          description: Internal service error
          schema:
            $ref: '#/definitions/Error'
        '503':
          description: Maintanence mode
          schema:
            $ref: '#/definitions/Error'
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix test failure of `test_data_path` in `test_restapi`.

#### How did you do it?
Correct the return code of prior check.

#### How did you verify/test it?
Verified on SN4600 T0 testbed.
```
collected 1 item                                                                                                                                                                                      

restapi/test_restapi.py::test_data_path PASSED                                                                                                                                                  [100%] ^H

=============================================================================== 1 passed, 1 warnings in 352.46 seconds ================================================================================
```
#### Any platform specific information?
Only run on Mellanox platform.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
