### PR TITLE
[barefoot] remove ip_proto from hash keys for fib hash test

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -146,6 +146,8 @@ def hash_keys(duthost):
     if duthost.facts['asic_type'] in ["barefoot"]:
         if 'ingress-port' in hash_keys:
             hash_keys.remove('ingress-port')
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
     # removing ingress-port and ip-proto from hash_keys not supported by Marvell SAI
     if duthost.facts['platform'] in ['armhf-nokia_ixs7215_52x-r0']:
         if 'ip-proto' in hash_keys:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Removes 'ip-proto' from hash_keys in fib/test_fib.py::test_hash for barefoot devices

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
'ip-proto' is not supported as hash key on barefoot devices.
#### How did you do it?
Removed 'ip-proto' from hash_keys.
#### How did you verify/test it?
Run fib/test_fib.py - all tests are passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
