### PR TITLE
[chassis] run test_bgp_shutdown test on linecards only

### DIFF
--- a/tests/log_fidelity/test_bgp_shutdown.py
+++ b/tests/log_fidelity/test_bgp_shutdown.py
@@ -26,8 +26,8 @@ def check_syslog(duthost, prefix, trigger_action, expected_log, restore_action):
     finally:
         duthost.command(restore_action)
 
-def test_bgp_shutdown(duthosts, rand_one_dut_hostname):
-    duthost=duthosts[rand_one_dut_hostname]
+def test_bgp_shutdown(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    duthost=duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
     BGP_DOWN_EXPECTED_LOG_MESSAGE = "admin state is set to 'down'"
     BGP_DOWN_COMMAND = "config bgp shutdown all"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #5029
The `test_bgp_shutdown`  use the fixtures `rand_one_dut_hostname` 
on a chassis testbed, the supervisor node could be selected to run the test.
Since the supervisor node doesnt have bgp sessions the test fails 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix #5029
#### How did you do it?
change the test to use the fixture `enum_rand_one_per_hwsku_frontend_hostname` so that this test will be run only on the linecard in chassis testbed

#### How did you verify/test it?
run test on the chassis testbed

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
