### PR TITLE
[test_orchagent_slb] Use dynamic BGP sessions

### DIFF
--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -23,7 +23,8 @@ class BGPNeighbor(object):
 
     def __init__(self, duthost, ptfhost, name,
                  neighbor_ip, neighbor_asn,
-                 dut_ip, dut_asn, port, neigh_type, is_multihop=False, is_passive=False):
+                 dut_ip, dut_asn, port, neigh_type=None,
+                 is_multihop=False, is_passive=False):
         self.duthost = duthost
         self.ptfhost = ptfhost
         self.ptfip = ptfhost.mgmt_ip
@@ -34,8 +35,8 @@ class BGPNeighbor(object):
         self.peer_asn = dut_asn
         self.port = port
         self.type = neigh_type
-        self.is_multihop = is_multihop
         self.is_passive = is_passive
+        self.is_multihop = not is_passive and is_multihop
 
     def start_session(self):
         """Start the BGP session."""

--- a/tests/dualtor/test_orchagent_slb.py
+++ b/tests/dualtor/test_orchagent_slb.py
@@ -126,10 +126,9 @@ def setup_interfaces(ptfhost, upper_tor_host, lower_tor_host, tbinfo):
 
 
 @pytest.fixture
-def bgp_neighbors(upper_tor_host, lower_tor_host, ptfhost, setup_interfaces):
+def bgp_neighbors(ptfhost, setup_interfaces):
     """Build the bgp neighbor objects used to start new bgp sessions."""
     # allow ebgp neighbors that are multiple hops away
-    is_quagga = True
     connections = setup_interfaces
     neighbors = {}
     for dut, conn in connections.items():

--- a/tests/dualtor/test_orchagent_slb.py
+++ b/tests/dualtor/test_orchagent_slb.py
@@ -28,9 +28,6 @@ pytestmark = [
 
 
 TEST_DEVICE_INTERFACE = "Loopback3"
-NEIGHBOR_TYPE = "LeafRouter"
-NEIGHBOR_ASN_UPPER_TOR = 61000
-NEIGHBOR_ASN_LOWER_TOR = 61000
 EXABGP_PORT_UPPER_TOR = 11000
 EXABGP_PORT_LOWER_TOR = 11001
 ANNOUNCED_SUBNET = u"10.10.100.0/27"
@@ -89,6 +86,9 @@ def setup_interfaces(ptfhost, upper_tor_host, lower_tor_host, tbinfo):
     lower_tor_asn = lower_tor_mg_facts["minigraph_bgp_asn"]
     assert upper_tor_asn == lower_tor_asn
 
+    upper_tor_slb_asn = upper_tor_host.shell("sonic-cfggen -m -d -y /etc/sonic/constants.yml -v \"constants.deployment_id_asn_map[DEVICE_METADATA['localhost']['deployment_id']]\"")["stdout"]
+    lower_tor_slb_asn = lower_tor_host.shell("sonic-cfggen -m -d -y /etc/sonic/constants.yml -v \"constants.deployment_id_asn_map[DEVICE_METADATA['localhost']['deployment_id']]\"")["stdout"]
+
     connections = {
         "upper_tor": {
             "localhost": upper_tor_host,
@@ -98,8 +98,7 @@ def setup_interfaces(ptfhost, upper_tor_host, lower_tor_host, tbinfo):
             "test_intf": test_iface,
             "neighbor_intf": upper_tor_server_ptf_intf,
             "neighbor_addr": upper_tor_server_ip,
-            "neighbor_asn": NEIGHBOR_ASN_UPPER_TOR,
-            "neighbor_type": NEIGHBOR_TYPE,
+            "neighbor_asn": upper_tor_slb_asn,
             "exabgp_port": EXABGP_PORT_UPPER_TOR,
         },
         "lower_tor": {
@@ -110,8 +109,7 @@ def setup_interfaces(ptfhost, upper_tor_host, lower_tor_host, tbinfo):
             "test_intf": test_iface,
             "neighbor_intf": lower_tor_server_ptf_intf,
             "neighbor_addr": lower_tor_server_ip,
-            "neighbor_asn": NEIGHBOR_ASN_LOWER_TOR,
-            "neighbor_type": NEIGHBOR_TYPE,
+            "neighbor_asn": lower_tor_slb_asn,
             "exabgp_port": EXABGP_PORT_LOWER_TOR,
         }
     }
@@ -144,8 +142,7 @@ def bgp_neighbors(upper_tor_host, lower_tor_host, ptfhost, setup_interfaces):
             conn["local_addr"].split("/")[0],
             conn["local_asn"],
             conn["exabgp_port"],
-            conn["neighbor_type"],
-            is_multihop=is_quagga
+            is_passive=True
         )
     return neighbors
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
BGP slb should use dynamic sessions.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
for test `test_orchagent_slb`, use dynamic BGP sessions.

#### How did you verify/test it?
```
dualtor/test_orchagent_slb.py::test_orchagent_slb PASSED                                                                                                                                                                                                               [100%]

========================================================================================================================= 1 passed in 348.10 seconds =========================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
