### PR TITLE
There is no xfails info in the test report summary, this PR is to fix this issue.

### DIFF
--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -47,7 +47,8 @@ REQUIRED_TESTSUITE_ATTRIBUTES = {
     ("tests", int),
     ("skipped", int),
     ("failures", int),
-    ("errors", int)
+    ("errors", int),
+    ("xfails", int)
 }
 
 # Fields found in the metadata/properties section of the JUnit XML file.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: There is no xfails info in the test report summary, this PR is to fix this issue.
Fixes # (issue)
To add the xfails keyword when process the test summary data. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
