### PR TITLE
Increase packet logging level to `info`

### DIFF
--- a/ansible/roles/test/files/ptftests/ip_in_ip_tunnel_test.py
+++ b/ansible/roles/test/files/ptftests/ip_in_ip_tunnel_test.py
@@ -219,7 +219,7 @@ class IpinIPTunnelTest(BaseTest):
                 inner_pkt = self.generate_packet_to_server(hash_key)
                 tunnel_pkt = self.generate_expected_packet(inner_pkt)
                 l3packet = inner_pkt.getlayer(IP) or inner_pkt.getlayer(IPv6)
-                self.logger.debug("Sending packet dst_mac = {} src_mac = {} dst_ip = {} src_ip = {} from port {}" \
+                self.logger.info("Sending packet dst_mac = {} src_mac = {} dst_ip = {} src_ip = {} from port {}" \
                     .format(inner_pkt[Ether].dst, inner_pkt[Ether].src, l3packet.dst, l3packet.src, src_port))
                 self.dataplane.flush()
                 send_packet(self, src_port, inner_pkt)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
for ptftest `ip_in_ip_tunnel_test.py`, increase the packet sending log from `debug` to `info` so the packet sending details could be logged.

#### How did you do it?
Increase from `debug` to `info`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
