### PR TITLE
Unblock PR testing

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -107,7 +107,6 @@ test_t0() {
       bgp/test_bgp_fact.py \
       bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved \
       bgp/test_bgp_speaker.py \
-      bgp/test_bgp_slb.py \
       bgp/test_bgp_update_timer.py \
       cacl/test_ebtables_application.py \
       cacl/test_cacl_application.py \

--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 import time
+from tests.common.helpers.assertions import pytest_require
 
 logger = logging.getLogger(__name__)
 
@@ -41,8 +42,9 @@ def test_restore_container_autorestart(duthosts, enum_dut_hostname, enable_conta
     time.sleep(SNMP_RELOADING_TIME)
 
 def test_recover_rsyslog_rate_limit(duthosts, enum_dut_hostname):
-
     duthost = duthosts[enum_dut_hostname]
+    # We don't need to recover the rate limit on vs testbed
+    pytest_require(duthost.facts['asic_type'] != 'vs', "Skip on vs testbed")
     features_dict, succeed = duthost.get_feature_status()
     if not succeed:
         # Something unexpected happened.


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to unblock PR testing.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to unblock PR testing.

#### How did you do it?
1. Remove `test_bgp_slb.py` from kvmtest temporarily as it's flaky
2. Disable `test_recover_rsyslog_rate_limit` on vs testbed as it's unnecessary and flaky because telemetry container is not running.

#### How did you verify/test it?

#### Any platform specific information?
VS testbed specific.
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
