### PR TITLE
[test_orchagent_slb] Add ipv6 support

### DIFF
--- a/tests/dualtor/test_orchagent_slb.py
+++ b/tests/dualtor/test_orchagent_slb.py
@@ -30,10 +30,11 @@ pytestmark = [
 TEST_DEVICE_INTERFACE = "Loopback3"
 EXABGP_PORT_UPPER_TOR = 11000
 EXABGP_PORT_LOWER_TOR = 11001
-ANNOUNCED_SUBNET = u"10.10.100.0/27"
+ANNOUNCED_SUBNET_IPV4 = u"10.10.100.0/27"
+ANNOUNCED_SUBNET_IPV6 = u"fc00:10::/64"
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def setup_interfaces(ptfhost, upper_tor_host, lower_tor_host, tbinfo):
     """Setup the interfaces used by the new BGP sessions on PTF."""
 
@@ -45,6 +46,11 @@ def setup_interfaces(ptfhost, upper_tor_host, lower_tor_host, tbinfo):
     def _find_ipv4_vlan(mg_facts):
         for vlan_intf in mg_facts["minigraph_vlan_interfaces"]:
             if is_ipv4_address(vlan_intf["addr"]):
+                return vlan_intf
+
+    def _find_ipv6_vlan(mg_facts):
+        for vlan_intf in mg_facts["minigraph_vlan_interfaces"]:
+            if not is_ipv4_address(vlan_intf["addr"]):
                 return vlan_intf
 
     # find the DUT interface ip used in the bgp session
@@ -62,6 +68,7 @@ def setup_interfaces(ptfhost, upper_tor_host, lower_tor_host, tbinfo):
     test_iface = random.choice(mux_configs.keys())
     test_server = mux_configs[test_iface]
     test_server_ip = test_server["server_ipv4"]
+    test_server_ipv6 = test_server["server_ipv6"]
     upper_tor_server_ptf_intf_idx = upper_tor_mg_facts["minigraph_port_indices"][test_iface]
     lower_tor_server_ptf_intf_idx = lower_tor_mg_facts["minigraph_port_indices"][test_iface]
     upper_tor_server_ptf_intf = "eth%s" % upper_tor_server_ptf_intf_idx
@@ -77,9 +84,19 @@ def setup_interfaces(ptfhost, upper_tor_host, lower_tor_host, tbinfo):
     vlan_intf_addr = upper_tor_vlan["addr"]
     vlan_intf_prefixlen = upper_tor_vlan["prefixlen"]
 
+    upper_tor_vlan_ipv6 = _find_ipv6_vlan(upper_tor_mg_facts)
+    lower_tor_vlan_ipv6 = _find_ipv6_vlan(lower_tor_mg_facts)
+    assert upper_tor_vlan_ipv6
+    assert lower_tor_vlan_ipv6
+    assert upper_tor_vlan_ipv6["addr"] == lower_tor_vlan_ipv6["addr"]
+    vlan_intf_prefixlen_ipv6 = upper_tor_vlan_ipv6["prefixlen"]
+
     # construct the server ip with the vlan prefix length
     upper_tor_server_ip = "%s/%s" % (test_server_ip.split("/")[0], vlan_intf_prefixlen)
     lower_tor_server_ip = "%s/%s" % (test_server_ip.split("/")[0], vlan_intf_prefixlen)
+
+    upper_tor_server_ipv6 = "%s/%s" % (test_server_ipv6.split("/")[0], vlan_intf_prefixlen_ipv6)
+    lower_tor_server_ipv6 = "%s/%s" % (test_server_ipv6.split("/")[0], vlan_intf_prefixlen_ipv6)
 
     # find ToRs' ASNs
     upper_tor_asn = upper_tor_mg_facts["minigraph_bgp_asn"]
@@ -98,6 +115,7 @@ def setup_interfaces(ptfhost, upper_tor_host, lower_tor_host, tbinfo):
             "test_intf": test_iface,
             "neighbor_intf": upper_tor_server_ptf_intf,
             "neighbor_addr": upper_tor_server_ip,
+            "neighbor_addr_ipv6": upper_tor_server_ipv6,
             "neighbor_asn": upper_tor_slb_asn,
             "exabgp_port": EXABGP_PORT_UPPER_TOR,
         },
@@ -109,6 +127,7 @@ def setup_interfaces(ptfhost, upper_tor_host, lower_tor_host, tbinfo):
             "test_intf": test_iface,
             "neighbor_intf": lower_tor_server_ptf_intf,
             "neighbor_addr": lower_tor_server_ip,
+            "neighbor_addr_ipv6": lower_tor_server_ipv6,
             "neighbor_asn": lower_tor_slb_asn,
             "exabgp_port": EXABGP_PORT_LOWER_TOR,
         }
@@ -125,7 +144,7 @@ def setup_interfaces(ptfhost, upper_tor_host, lower_tor_host, tbinfo):
             ptfhost.shell("ip route del %s" % conn["local_addr"], module_ignore_errors=True)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def bgp_neighbors(ptfhost, setup_interfaces):
     """Build the bgp neighbor objects used to start new bgp sessions."""
     # allow ebgp neighbors that are multiple hops away
@@ -146,23 +165,43 @@ def bgp_neighbors(ptfhost, setup_interfaces):
     return neighbors
 
 
+@pytest.fixture(params=['ipv4', 'ipv6'])
+def ip_version(request):
+    """Traffic IP version to test."""
+    return request.param
+
+
+@pytest.fixture(autouse=True)
+def testbed_setup(ip_version, request):
+    """Setup the testbed."""
+    if ip_version == "ipv6":
+        request.getfixturevalue("run_arp_responder_ipv6")
+
+
 @pytest.fixture
-def constants(setup_interfaces):
+def constants(setup_interfaces, ip_version):
     class _C(object):
         """Dummy class to save test constants."""
         pass
 
     connections = setup_interfaces
     assert connections["upper_tor"]["neighbor_addr"] == connections["lower_tor"]["neighbor_addr"]
-    nexthop = connections["upper_tor"]["neighbor_addr"].split("/")[0]
+    assert connections["upper_tor"]["neighbor_addr_ipv6"] == connections["lower_tor"]["neighbor_addr_ipv6"]
+
     _constants = _C()
-    _constants.route = {
-        "prefix": ANNOUNCED_SUBNET,
-        "nexthop": nexthop
-    }
+    if ip_version == "ipv4":
+        nexthop = connections["upper_tor"]["neighbor_addr"].split("/")[0]
+        _constants.route = dict(prefix=ANNOUNCED_SUBNET_IPV4, nexthop=nexthop)
+    elif ip_version == "ipv6":
+        nexthop = connections["upper_tor"]["neighbor_addr_ipv6"].split("/")[0]
+        _constants.route = dict(prefix=ANNOUNCED_SUBNET_IPV6, nexthop=nexthop)
+    else:
+        raise ValueError("Unrecognized IP version %s" % ip_version)
+
     _constants.bgp_establish_sleep_interval = 30
     _constants.bgp_update_sleep_interval = 10
     _constants.mux_state_change_sleep_interval = 5
+    _constants.ip_version = ip_version
     return _constants
 
 
@@ -193,15 +232,19 @@ def test_orchagent_slb(
 
     def verify_traffic(duthost, connection, route, is_duthost_active=True, is_route_existed=True):
         prefix = ipaddress.ip_network(route["prefix"])
-        dst_host = str(random.choice(list(prefix.hosts())))
+        dst_host = str(next(prefix.hosts()))
         pkt, exp_pkt = build_packet_to_server(duthost, ptfadapter, dst_host)
         ptf_t1_intf = random.choice(get_t1_ptf_ports(duthost, tbinfo))
         ptf_t1_intf_index = int(ptf_t1_intf.strip("eth"))
         is_tunnel_traffic_existed = is_route_existed and not is_duthost_active
         is_server_traffic_existed = is_route_existed and is_duthost_active
 
-        tunnel_innner_pkt = pkt[scapyall.IP].copy()
-        tunnel_innner_pkt[scapyall.IP].ttl -= 1
+        if isinstance(prefix, ipaddress.IPv4Network):
+            tunnel_innner_pkt = pkt[scapyall.IP].copy()
+            tunnel_innner_pkt[scapyall.IP].ttl -= 1
+        else:
+            tunnel_innner_pkt = pkt[scapyall.IPv6].copy()
+            tunnel_innner_pkt[scapyall.IPv6].hlim -= 1
         tunnel_monitor = tunnel_traffic_monitor(duthost, existing=is_tunnel_traffic_existed, inner_packet=tunnel_innner_pkt)
         server_traffic_monitor = ServerTrafficMonitor(
             duthost, ptfhost, vmhost, tbinfo, connection["test_intf"],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Add ipv6 route/traffic test.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
1. Announce ipv6 route over ipv4 dynamic BGP sessions
2. verify the route by sending downstream traffic to both ToRs

#### How did you verify/test it?
Run over a dualtor testbed.

```
dualtor/test_orchagent_slb.py::test_orchagent_slb[ipv4] PASSED                                                                                                                                                                                                         [ 50%]
dualtor/test_orchagent_slb.py::test_orchagent_slb[ipv6] FAILED                                                                                                                                                                                                         [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
