### PR TITLE
Increase timeout for t0 jobs and balance test cases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ stages:
   - job: t0_part1
     pool: sonictest
     displayName: "kvmtest-t0-part1"
-    timeoutInMinutes: 200
+    timeoutInMinutes: 240
 
     steps:
     - template: .azure-pipelines/run-test-template.yml
@@ -36,7 +36,7 @@ stages:
   - job: t0_part2
     pool: sonictest
     displayName: "kvmtest-t0-part2"
-    timeoutInMinutes: 200
+    timeoutInMinutes: 240
 
     steps:
     - template: .azure-pipelines/run-test-template.yml

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -128,7 +128,13 @@ test_t0() {
       snmp/test_snmp_pfc_counters.py \
       snmp/test_snmp_queue.py \
       snmp/test_snmp_loopback.py \
-      snmp/test_snmp_default_route.py"
+      snmp/test_snmp_default_route.py \
+      tacacs/test_rw_user.py \
+      tacacs/test_ro_user.py \
+      tacacs/test_ro_disk.py \
+      tacacs/test_jit_user.py \
+      tacacs/test_authorization.py \
+      tacacs/test_accounting.py"
 
       pushd $SONIC_MGMT_DIR/tests
       ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname
@@ -138,12 +144,6 @@ test_t0() {
       ssh/test_ssh_stress.py \
       ssh/test_ssh_ciphers.py \
       syslog/test_syslog.py\
-      tacacs/test_rw_user.py \
-      tacacs/test_ro_user.py \
-      tacacs/test_ro_disk.py \
-      tacacs/test_jit_user.py \
-      tacacs/test_authorization.py \
-      tacacs/test_accounting.py \
       telemetry/test_telemetry.py \
       test_features.py \
       test_procdockerstatsd.py \


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Currently, t0-part2 runs almost for 200 mins, it nearly fails due to timeout. Increase timeout of two t0 jobs to 240min.
t0-part2 runs for 3h13m, t0-part1 runs for 2h17m previously. t0-part2 is a little over weighted.
Move some test cases from part2 to part1 to make sure their running time balanced.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Increase timeout of two t0 jobs to 240min to avoid timeout failure.
t0-part2 is a little over weighted, move some test cases from part2 to part1 to make sure their running time balanced.

#### How did you do it?
Increase timeout of two t0 jobs
move some test cases from part2 to part1

#### How did you verify/test it?
Every PR will trigger the pipeline.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
