### PR TITLE
Fix `test_acl_outer_vlan` on dualtor testbed

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -18,7 +18,7 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from abc import abstractmethod
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m # lgtm[py/unused-import]
 
 logger = logging.getLogger(__name__)
 

--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -18,6 +18,7 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lgtm[py/unused-import]
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from abc import abstractmethod
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m
 
 logger = logging.getLogger(__name__)
 
@@ -533,49 +534,49 @@ class AclVlanOuterTest_Base(object):
         finally:
             self._remove_acl_rules(duthost, stage, ip_version)
 
-    def test_tagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version):
+    def test_tagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):
         """
         Verify packet is forwarded by ACL rule on tagged interface
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, TYPE_TAGGED, ACTION_FORWARD)
         
-    def test_tagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version):
+    def test_tagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):
         """
         Verify packet is dropped by ACL rule on tagged interface
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, TYPE_TAGGED, ACTION_DROP)
 
-    def test_untagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version):
+    def test_untagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):
         """
         Verify packet is forwarded by ACL rule on untagged interface
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, TYPE_UNTAGGED, ACTION_FORWARD)
 
-    def test_untagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version):
+    def test_untagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):
         """
         Verify packet is dropped by ACL rule on untagged interface
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, TYPE_UNTAGGED, ACTION_DROP)
 
-    def test_combined_tagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version):
+    def test_combined_tagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):
         """
         Verify packet is forwarded by ACL rule on tagged interface, and the interface belongs to two vlans
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, TYPE_COMBINE_TAGGED, ACTION_FORWARD)
 
-    def test_combined_tagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version):
+    def test_combined_tagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):
         """
         Verify packet is dropped by ACL rule on tagged interface, and the interface belongs to two vlans
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, TYPE_COMBINE_TAGGED, ACTION_DROP)
 
-    def test_combined_untagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version):
+    def test_combined_untagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):
         """
         Verify packet is forwarded by ACL rule on untagged interface, and the interface belongs to two vlans
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, TYPE_COMBINE_UNTAGGED, ACTION_FORWARD)
 
-    def test_combined_untagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version):
+    def test_combined_untagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info, ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):
         """
         Verify packet is dropped by ACL rule on untagged interface, and the interface belongs to two vlans
         """


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix `test_acl_outer_vlan` on dualtor testbed.
Currently, the standby tor drops packets from servers by ACL rules matching `IN_PORTS`. Therefore, if the test was running on standby tor, there will be ACL rules conflicts. The packets will be dropped and result in test failure.  

This PR addressed the issue by toggling all mux to the randomly selected tor.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to fix `test_acl_outer_vlan` on dualtor testbed.

#### How did you do it?
This PR addressed the issue by toggling all mux to the randomly selected tor.

#### How did you verify/test it?
Verified on a dualtor testbed.
```
collected 16 items                                                                                                                                                                                    

acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_tagged_forwarded[ipv4] PASSED                                                                                                        [  6%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_tagged_dropped[ipv4] PASSED                                                                                                          [ 12%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_untagged_forwarded[ipv4] PASSED                                                                                                      [ 18%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_untagged_dropped[ipv4] PASSED                                                                                                        [ 25%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_tagged_forwarded[ipv4]  ^HPASSED                                                                                               [ 31%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_tagged_dropped[ipv4] PASSED                                                                                                 [ 37%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_untagged_forwarded[ipv4] PASSED                                                                                             [ 43%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_untagged_dropped[ipv4] PASSED                                                                                               [ 50%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_tagged_forwarded[ipv6] PASSED                                                                                                        [ 56%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_tagged_dropped[ipv6] PASSED                                                                                                          [ 62%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_untagged_forwarded[ipv6] PASSED                                                                                                      [ 68%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_untagged_dropped[ipv6]  ^HPASSED                                                                                                        [ 75%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_tagged_forwarded[ipv6] PASSED                                                                                               [ 81%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_tagged_dropped[ipv6] PASSED                                                                                                 [ 87%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_untagged_forwarded[ipv6] PASSED                                                                                             [ 93%]
acl/test_acl_outer_vlan.py::TestAclVlanOuter_Ingress::test_combined_untagged_dropped[ipv6] PASSED                                                                                               [100%
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
