### PR TITLE
Enhance sanity check recovery to support recovering bgp sessions on neighbor VMs

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 def _raise_err(msg):
         logger.error(msg)
         raise Exception(msg)
-        
+
 class EosHost(AnsibleHostBase):
     """
     @summary: Class for Eos switch
@@ -94,8 +94,8 @@ class EosHost(AnsibleHostBase):
         out = self.eos_config(
             lines=['lacp rate %s' % mode],
             parents='interface %s' % interface_name)
-            
-        # FIXME: out['failed'] will be False even when a command is deprecated, so we have to check out['changed'] 
+
+        # FIXME: out['failed'] will be False even when a command is deprecated, so we have to check out['changed']
         # However, if the lacp rate is already in expected state, out['changed'] will be False and treated as
         # error.
         if out['failed'] == True or out['changed'] == False:
@@ -125,6 +125,17 @@ class EosHost(AnsibleHostBase):
             lines=['no shut'],
             parents=['router bgp {}'.format(asn)])
         logging.info('No shut BGP [%s]' % asn)
+        return out
+
+    def no_shutdown_bgp_neighbors(self, asn, neighbors=[]):
+        if not neighbors:
+            return
+
+        out = self.eos_config(
+            lines=['no neighbor {} shutdown'.format(neighbor) for neighbor in neighbors],
+            parents=['router bgp {}'.format(asn)]
+        )
+        logging.info('No shut BGP neighbors: {}'.format(json.dumps(neighbors)))
         return out
 
     def check_bgp_session_state(self, neigh_ips, neigh_desc, state="established"):
@@ -199,7 +210,7 @@ class EosHost(AnsibleHostBase):
         return self.eos_command(commands=[{
             'command': '{} {}'.format(cmd, prefix),
             'output': 'json'
-        }])['stdout'][0]        
+        }])['stdout'][0]
 
     def get_auto_negotiation_mode(self, interface_name):
         output = self.eos_command(commands=[{
@@ -221,7 +232,7 @@ class EosHost(AnsibleHostBase):
     def set_auto_negotiation_mode(self, interface_name, enabled):
         if self.get_auto_negotiation_mode(interface_name) == enabled:
             return True
-        
+
         if enabled:
             speed_to_advertise = self.get_supported_speeds(interface_name)[-1]
             speed_to_advertise = speed_to_advertise[:-3] + 'gfull'
@@ -231,8 +242,8 @@ class EosHost(AnsibleHostBase):
             logger.debug('Set auto neg to {} for port {}: {}'.format(enabled, interface_name, out))
             return not self._has_cli_cmd_failed(out)
         return self._reset_port_speed(interface_name)
-        
-        
+
+
     def get_speed(self, interface_name):
         output = self.eos_command(commands=['show interfaces %s transceiver properties' % interface_name])
         found_txt = re.search(r'Operational Speed: (\S+)', output['stdout'][0])
@@ -246,13 +257,13 @@ class EosHost(AnsibleHostBase):
         return 'failed' in cmd_output_obj and cmd_output_obj['failed']
 
     def set_speed(self, interface_name, speed):
-        
+
         if not speed:
             # other set_speed implementations advertise port speeds when speed=None
             # but in EOS autoneg activation and speeds advertisement is done via a single CLI cmd
             # so this branch left nop intentionally
             return True
-            
+
         speed_mode = 'auto' if self.get_auto_negotiation_mode(interface_name) else 'forced'
         speed = speed[:-3] + 'gfull'
         out = self.host.eos_config(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
While debugging on a testbed, we may shutdown BGP sessions on neighbor VMs and
forget to restore them. This change is to enhance the sanity check recovery
to support recovering BGP sessions on neighbor VMs. This PR is based on the work
of PR #4866.

#### How did you do it?
Changes:
* Add method `no_shutdown_bgp_neighbors` to the EosHost class
* Call the new method in function `neighbor_vm_recover_bgpd` which is defined in
  `recovery.py` of the sanity check plugin.

#### How did you verify/test it?
* Manually shutdown BGP neighbor on neighbor VMs.
* Run any test script with `--allow_recover` and sanity check enabled.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
