### PR TITLE
Add customized __str__ and __repr__ for device objects

### DIFF
--- a/tests/common/devices/aos.py
+++ b/tests/common/devices/aos.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 
 
 class AosHost():
@@ -48,6 +49,12 @@ class AosHost():
         os.system("rm {}".format(ansible_root + playbook_name))
 
         return res
+
+    def __str__(self):
+        return '<AosHost {}>'.format(self.hostname)
+
+    def __repr__(self):
+        return self.__str__()
 
     def shutdown(self, interface_name):
         task_name = 'Shutdown interface {}'.format(interface_name)

--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -93,3 +93,6 @@ class AnsibleHostBase(object):
 class NeighborDevice(dict):
     def __str__(self):
         return str(self["host"])
+
+    def __repr__(self):
+        return self.__str__()

--- a/tests/common/devices/ixia.py
+++ b/tests/common/devices/ixia.py
@@ -27,6 +27,12 @@ class IxiaHost (AnsibleHostBase):
         self.device_type   = device_type
         super().__init__(IxiaHost, self)
 
+    def __str__(self):
+        return '<IxiaHost {}>'.format(self.hostname)
+
+    def __repr__(self):
+        return self.__str__()
+
     def get_host_name (self):
         """Returns the Ixia hostname
 

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -45,8 +45,11 @@ class MultiAsicSonicHost(object):
 
         self.critical_services_tracking_list()
 
+    def __str__(self):
+        return '<MultiAsicSonicHost {}>'.format(self.hostname)
+
     def __repr__(self):
-        return '<MultiAsicSonicHost> {}'.format(self.hostname)
+        return self.__str__()
 
     def critical_services_tracking_list(self):
         """Get the list of services running on the DUT
@@ -469,7 +472,7 @@ class MultiAsicSonicHost(object):
     def check_bgp_default_route(self, ipv4=True,  ipv6=True):
         """
         @summary: check if bgp default route is present.
-        
+
         @param ipv4: check ipv4 default
         @param ipv6: check ipv6 default
         """

--- a/tests/common/devices/onyx.py
+++ b/tests/common/devices/onyx.py
@@ -27,6 +27,12 @@ class OnyxHost(AnsibleHostBase):
         self.host.options['variable_manager'].extra_vars.update(evars)
         self.localhost = ansible_adhoc(inventory='localhost', connection='local', host_pattern="localhost")["localhost"]
 
+    def __str__(self):
+        return '<OnyxHost {}>'.format(self.hostname)
+
+    def __repr__(self):
+        return self.__str__()
+
     def shutdown(self, interface_name):
         out = self.host.onyx_config(
             lines=['shutdown'],
@@ -80,7 +86,7 @@ class OnyxHost(AnsibleHostBase):
         """
         show_int_result = self.host.onyx_command(
             commands=['show interfaces {} | include "Supported speeds"'.format(interface_name)])[self.hostname]
-        
+
         if 'failed' in show_int_result and show_int_result['failed']:
             logger.error('Failed to get supported speed for {} - {}'.format(interface_name, show_int_result['msg']))
             return None
@@ -89,7 +95,7 @@ class OnyxHost(AnsibleHostBase):
         logger.debug('Get supported speeds for port {} from onyx: {}'.format(interface_name, out))
         if not out:
             return None
-        
+
         # The output should be something like: "Supported speeds:1G 10G 25G 50G"
         speeds = out.split(':')[-1].split()
         return list(set([x.split('G')[0] + '000' for x in speeds]))
@@ -125,12 +131,12 @@ class OnyxHost(AnsibleHostBase):
             interface_name (str): Interface name
 
         Returns:
-            boolean: True if auto negotiation mode is enabled else False. Return None if 
+            boolean: True if auto negotiation mode is enabled else False. Return None if
             the auto negotiation mode is unknown or unsupported.
         """
         show_int_result = self.host.onyx_command(
             commands=['show interfaces {} | include "Auto-negotiation"'.format(interface_name)])[self.hostname]
-        
+
         if 'failed' in show_int_result and show_int_result['failed']:
             logger.error('Failed to get auto neg mode for port {} - {}'.format(interface_name, show_int_result['msg']))
             return None
@@ -139,7 +145,7 @@ class OnyxHost(AnsibleHostBase):
         logger.debug('Get auto negotiation mode for port {} from onyx: {}'.format(interface_name, out))
         if not out:
             return None
-        
+
         # The output should be something like: "Auto-negotiation:Enabled"
         return 'Enabled' in out
 
@@ -196,12 +202,12 @@ class OnyxHost(AnsibleHostBase):
         if 'failed' in show_int_result and show_int_result['failed']:
             logger.error('Failed to get speed for port {} - {}'.format(interface_name, show_int_result['msg']))
             return False
-        
+
         out = show_int_result['stdout'][0].strip()
         logger.debug('Get speed for port {} from onyx: {}'.format(interface_name, out))
         if not out:
             return None
-        
+
         # The output should be something like: "Actual speed:50G"
         speed = out.split(':')[-1].strip()
         pos = speed.find('G')

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -75,8 +75,11 @@ class SonicHost(AnsibleHostBase):
         self.is_multi_asic = True if self.facts["num_asic"] > 1 else False
         self._kernel_version = self._get_kernel_version()
 
-    def __repr__(self):
+    def __str__(self):
         return '<SonicHost {}>'.format(self.hostname)
+
+    def __repr__(self):
+        return self.__str__()
 
     @property
     def facts(self):

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -42,6 +42,12 @@ class SonicAsic(object):
         self.sonic_db_cli = "sonic-db-cli {}".format(self.cli_ns_option)
         self.ip_cmd = "sudo ip {}".format(self.cli_ns_option)
 
+    def __str__(self):
+        return '<SonicAsic {}>'.format(self.asic_index)
+
+    def __repr__(self):
+        return self.__str__()
+
     def get_critical_services(self):
         """This function returns the list of the critical services
            for the namespace(asic)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Without customized __str__ and __repr__, name of the device objects is not
user friendly, for example:
  <tests.common.devices.eos.EosHost object at 0x7ff5c0a4e750>

#### How did you do it?
This change added customized __str__ and __repr__ methods to the device object
classes. With this change, the device object name may look like:
  <EosHost VM0100>

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
