### PR TITLE
Added sku data for x86_64-accton_as9516_32d-r0

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -2813,6 +2813,48 @@ sensors_checks:
     psu_skips: {}
     sensor_skip_per_version: {}
 
+  x86_64-accton_as9516_32d-r0:
+    alarms:
+      fan: []
+      power: []
+      temp: []
+
+    compares:
+      fan: []
+      power: []
+      temp:
+      - - tmp75-i2c-3-48/Chip Temp/temp1_input
+        - tmp75-i2c-3-48/Chip Temp/temp1_max
+      - - tmp75-i2c-3-49/Exhaust2 Temp/temp1_input
+        - tmp75-i2c-3-49/Exhaust2 Temp/temp1_max
+      - - tmp75-i2c-3-4a/Exhaust Temp/temp1_input
+        - tmp75-i2c-3-4a/Exhaust Temp/temp1_max
+      - - tmp75-i2c-3-4b/Intake Temp/temp1_input
+        - tmp75-i2c-3-4b/Intake Temp/temp1_max
+      - - tmp75-i2c-3-4c/Tofino Temp/temp1_input
+        - tmp75-i2c-3-4c/Tofino Temp/temp1_max
+      - - tmp75-i2c-3-4d/Intake2 Temp/temp1_input
+        - tmp75-i2c-3-4d/Intake2 Temp/temp1_max
+
+    non_zero:
+      fan:
+      - fancpld-i2c-8-66/Fan 1 front/fan1_input
+      - fancpld-i2c-8-66/Fan 1 rear/fan2_input
+      - fancpld-i2c-8-66/Fan 2 front/fan3_input
+      - fancpld-i2c-8-66/Fan 2 rear/fan4_input
+      - fancpld-i2c-8-66/Fan 3 front/fan5_input
+      - fancpld-i2c-8-66/Fan 3 rear/fan6_input
+      - fancpld-i2c-8-66/Fan 4 front/fan7_input
+      - fancpld-i2c-8-66/Fan 4 rear/fan8_input
+      - fancpld-i2c-8-66/Fan 5 front/fan9_input
+      - fancpld-i2c-8-66/Fan 5 rear/fan10_input
+
+      power: []
+      temp: []
+
+    psu_skips: {}
+    sensor_skip_per_version: {}
+
   x86_64-arista_7060_cx32s:
     alarms:
       fan:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added sensors data for x86_64-accton_as9516_32d-r0
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
test_sensors have been skipped for x86_64-accton_as9516_32d-r0 as data was not populated in
ansible/group_vars/sonic/sku-sensors-data.yml  for this platform
#### How did you do it?
Add data to ansible/group_vars/sonic/sku-sensors-data.yml 
#### How did you verify/test it?
Run test_sensors. TC passed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
