### PR TITLE
Revert GCU cacl test due to random failure and add sleep in cacl for local test

### DIFF
--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import time
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_res_success, expect_op_failure
@@ -94,6 +95,7 @@ def expect_acl_table_match(duthost, table_name, expected_content_list):
 def expect_res_success_acl_rule(duthost, expected_content_list, unexpected_content_list):
     """Check if acl rule added as expected
     """
+    time.sleep(1) # Sleep 1 sec to ensure caclmgrd does update in case of its UPDATE_DELAY_SECS 0.5s
     cmds = "iptables -S"
     output = duthost.shell(cmds)
     pytest_assert(not output['rc'],

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -152,7 +152,6 @@ test_t0() {
       container_checker/test_container_checker.py \
       process_monitoring/test_critical_process_monitoring.py \
       system_health/test_system_status.py \
-      generic_config_updater/test_cacl.py \
       generic_config_updater/test_lo_interface.py \
       generic_config_updater/test_vlan_interface.py \
       generic_config_updater/test_portchannel_interface.py \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Revert GCU cacl test in kvm. Add sleep in cacl for local test.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To fix nightly test GCU cacl random failure.
#### How did you do it?
Revert the change. Add sleep 1 sec to make sure caclmgrd does update in local test
#### How did you verify/test it?
Keep it out of KVM tests.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
