### PR TITLE
Added support of barefoot asic in incremental_qos test case

### DIFF
--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -11,7 +11,7 @@ from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfi
 
 pytestmark = [
     pytest.mark.topology('t0'),
-    pytest.mark.asic('mellanox')
+    pytest.mark.asic('mellanox', 'barefoot')
 ]
 
 logger = logging.getLogger(__name__)
@@ -32,7 +32,7 @@ def ensure_dut_readiness(duthost):
     verify_orchagent_running_or_assert(duthost)
 
     yield
- 
+
     verify_orchagent_running_or_assert(duthost)
     logger.info("Restoring config_db.json")
     duthost.shell("sudo cp {} /etc/sonic/config_db.json".format(config_tmpfile))
@@ -44,7 +44,7 @@ def ensure_dut_readiness(duthost):
 
 def prepare_configdb_field(duthost, configdb_field, value):
     """
-    Prepares config db by setting BUFFER_POOL key and field to specified value. If value is empty string or None, delete the current entry. 
+    Prepares config db by setting BUFFER_POOL key and field to specified value. If value is empty string or None, delete the current entry.
 
     Args:
         duthost: DUT host object
@@ -58,12 +58,12 @@ def prepare_configdb_field(duthost, configdb_field, value):
     key = configdb_field_elements[0]
     field = configdb_field_elements[1]
     logger.info("Setting configdb key: {} field: {} to value: {}".format(key, field, value))
-   
+
     if value:
         cmd = "sonic-db-cli CONFIG_DB hset \"BUFFER_POOL|{}\" \"{}\" \"{}\" ".format(key, field, value)
     else:
         cmd = "sonic-db-cli CONFIG_DB del \"BUFFER_POOL|{}\" \"{}\" ".format(key, field)
-   
+
     verify_orchagent_running_or_assert(duthost)
 
 
@@ -73,16 +73,16 @@ def prepare_configdb_field(duthost, configdb_field, value):
 def test_incremental_qos_config_updates(duthost, ensure_dut_readiness, configdb_field, operation, field_pre_status):
     operation_to_new_value_map = {"add": "678", "replace": "789", "remove": ""}
     field_pre_status_to_value_map = {"existing": "567", "nonexistent": ""}
-    
-    prepare_configdb_field(duthost, configdb_field, field_pre_status_to_value_map[field_pre_status]) 
+
+    prepare_configdb_field(duthost, configdb_field, field_pre_status_to_value_map[field_pre_status])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {} created for json patch of field: {} and operation: {}".format(tmpfile, configdb_field, operation))
 
     json_patch = [
         {
-            "op": "{}".format(operation), 
-            "path": "/BUFFER_POOL/{}".format(configdb_field), 
+            "op": "{}".format(operation),
+            "path": "/BUFFER_POOL/{}".format(configdb_field),
             "value": "{}".format(operation_to_new_value_map[operation])
         }
     ]


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added support of barefoot asic in incremental_qos test case of generic_config_updater test suite.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Updated `pytest.mark.asic` in incremental_qos test case of generic_config_updater test suite.
#### How did you verify/test it?
```
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[existing-add-ingress_lossless_pool/xoff] PASSED                                                 [  5%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[existing-add-ingress_lossless_pool/size] PASSED                                                 [ 11%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[existing-add-egress_lossy_pool/size] PASSED                                                     [ 16%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[existing-replace-ingress_lossless_pool/xoff] PASSED                                             [ 22%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[existing-replace-ingress_lossless_pool/size] PASSED                                             [ 27%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[existing-replace-egress_lossy_pool/size] PASSED                                                 [ 33%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[existing-remove-ingress_lossless_pool/xoff] PASSED                                              [ 38%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[existing-remove-ingress_lossless_pool/size] PASSED                                              [ 44%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[existing-remove-egress_lossy_pool/size] PASSED                                                  [ 50%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[nonexistent-add-ingress_lossless_pool/xoff] PASSED                                              [ 55%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[nonexistent-add-ingress_lossless_pool/size] PASSED                                              [ 61%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[nonexistent-add-egress_lossy_pool/size] PASSED                                                  [ 66%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[nonexistent-replace-ingress_lossless_pool/xoff] PASSED                                          [ 72%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[nonexistent-replace-ingress_lossless_pool/size] PASSED                                          [ 77%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[nonexistent-replace-egress_lossy_pool/size] PASSED                                              [ 83%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[nonexistent-remove-ingress_lossless_pool/xoff] PASSED                                           [ 88%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[nonexistent-remove-ingress_lossless_pool/size] PASSED                                           [ 94%]
generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[nonexistent-remove-egress_lossy_pool/size] PASSED                                               [100%]
```
#### Any platform specific information?
SONiC Software Version: SONiC.master.67698-dirty-20220125.180710
Distribution: Debian 11.2
Kernel: 5.10.0-8-2-amd64
Build commit: 49a036e90
Build date: Tue Jan 25 18:15:01 UTC 2022
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
