### PR TITLE
Skip setting speed to 10G for T2 topology in test_config_interface_speed

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -715,22 +715,30 @@ class TestConfigInterface():
         asic_index = sample_intf['asic_index']
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-        if tbinfo['topo']['type'] == 't2':
-            logger.info("Dealing with T2 topology which typically has ports that don't support setting speed to 10G - causes orchagent crash. So, not setting speed to 10G")
-        else:
-            out = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config interface {} speed {} 10000'.format(
-                ifmode,cli_ns_option, test_intf))
-            if out['rc'] != 0:
-                pytest.fail()
-
-            db_cmd = 'sudo {} CONFIG_DB HGET "PORT|{}" speed'\
-            	.format(duthost.asic_instance(asic_index).sonic_db_cli,
+        db_cmd = 'sudo {} CONFIG_DB HGET "PORT|{}" speed'\
+            .format(duthost.asic_instance(asic_index).sonic_db_cli,
                     interface)
+        supported_speeds = duthost.get_supported_speeds(test_intf)
+        if supported_speeds:
+            supported_speeds.remove(native_speed)
+            if len(supported_speeds):
+                speed_to_configure = supported_speeds[0]
+                out = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config interface {} speed {} {}'.format(
+                    ifmode, cli_ns_option, test_intf, speed_to_configure))
 
-            speed = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} {}'.format(ifmode, db_cmd))['stdout']
-            logger.info('speed: {}'.format(speed))
+                if out['rc'] != 0:
+                    pytest.fail()
 
-            assert speed == '10000'
+                speed = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} {}'.format(ifmode, db_cmd))['stdout']
+                logger.info('speed: {}'.format(speed))
+
+                assert speed == speed_to_configure
+            else:
+                logger.info("{} on {} only supports one speed. So not changing speed".format(test_intf, duthost))
+
+        else:
+            logger.info("Could not get supported speed on {} on {}. So not changing speed".format(test_intf, duthost))
+
 
         out = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config interface {}  speed {} {}'.format(
             ifmode, cli_ns_option, test_intf, native_speed))


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
test_config_interface_speed gets the current, and then sets the spped to 10G and validates that the speed is set to 10G, and then sets it back to the original speed.

However, in a 'T2' topology we are typically dealing with 100G/400G that don't support setting the speed to 10G. If we sent such command, we are seeing orchagent crash.

#### How did you do it?
For a T2 topology we skip setting and validating speed of 10G.

#### How did you verify/test it?
Ran test on a T2 topology with 400G linecards 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
