### PR TITLE
Test for DHCPv6 Relay relaying Relay-Forward message

### DIFF
--- a/ansible/roles/test/files/ptftests/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcpv6_relay_test.py
@@ -8,7 +8,6 @@ import ptf.testutils as testutils
 from ptf import config
 from ptf.base_tests import BaseTest
 from ptf.mask import Mask
-import time
 
 IPv6 = scapy.layers.inet6.IPv6
 
@@ -377,7 +376,6 @@ class DHCPTest(DataplaneBaseTest):
 
         # Mask off fields we don't care about matching
         masked_packet = Mask(relayed_relay_forward_count)
-        masked_packet.set_do_not_care_scapy(packet.Ether, "src")
         masked_packet.set_do_not_care_scapy(packet.Ether, "dst")
         masked_packet.set_do_not_care_scapy(IPv6, "src")
         masked_packet.set_do_not_care_scapy(IPv6, "dst")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Test that dhcp6relay relays Relay-Forward message

#### How did you do it?
Send relay-forward message and verify that a new relay-forward message that encapsulates the relay-forward message is sent to the server

#### How did you verify/test it?
Verify packet received matches expected packet

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
