### PR TITLE
skipped an everflow_per_interface test before it configures DUT

### DIFF
--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -90,7 +90,7 @@ def apply_mirror_session(rand_selected_dut):
 def ip_ver(request):
     return request.param
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope='module')
 def apply_acl_rule(rand_selected_dut, tbinfo, apply_mirror_session, ip_ver):
     """
     Apply ACL rule for matching input_ports


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: skipped an everflow_per_interface test before it configures DUT
Fixes # (issue)

everflow_per_interface has a skip condition based on the platform, but it is executed after the test configures a DUT. Fixed it so a skip condition executes on the start of the test

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Avoid redundant configuration for a test when it is skipped
#### How did you do it?
Changed fixtures order to execute test skip fixture as the first one
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t1,any everflow/test_everflow_per_interface.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
