### PR TITLE
added PTF IPv6 generation into lab file

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -404,6 +404,12 @@ def makeLab(data, devices, testbed, outfile):
                         except:
                             print("\t\t" + host + ": ansible_host not found")
 
+                        try:
+                            ansible_hostv6 = dev.get("ansible").get("ansible_hostv6")
+                            entry += "\tansible_hostv6=" + ansible_hostv6.split("/")[0]
+                        except:
+                            print("\t\t" + host + ": ansible_hostv6 not found")
+
                         if ansible_host:
                             try: # get ansible ssh username
                                 ansible_ssh_user = dev.get("ansible").get("ansible_ssh_user")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: added PTF IPv6 generation into lab file
Fixes # (issue)

There are several TACACS tests which check connection to the server via IPv6 address. Since the server is run inside PTF an IPv6 address to PTF should be setup
The mentioned tests are:
- test_ro_user_ipv6
- test_rw_user_ipv6

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Enable TACACS IPv6 tests
#### How did you do it?
Made TestbedProcessing to generate IPv6 for PTF
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t1,any tacacs/test_ro_user.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
