### PR TITLE
[ test_iface_namingmode ] Removed hardcoded interface speed

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -717,7 +717,8 @@ class TestConfigInterface():
         # Get supported speeds for interface
         supported_speeds = duthost.get_supported_speeds(interface)
         # Remove native speed from supported speeds
-        supported_speeds.remove(native_speed)
+        if supported_speeds != None:
+            supported_speeds.remove(native_speed)
         # Set speed to configure
         configure_speed = supported_speeds[0] if supported_speeds else native_speed
 

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -714,9 +714,15 @@ class TestConfigInterface():
         cli_ns_option = sample_intf['cli_ns_option']
         asic_index = sample_intf['asic_index']
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        # Get supported speeds for interface
+        supported_speeds = duthost.get_supported_speeds(interface)
+        # Remove native speed from supported speeds
+        supported_speeds.remove(native_speed)
+        # Set speed to configure
+        configure_speed = supported_speeds[0] if supported_speeds else native_speed
 
-        out = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config interface {} speed {} 10000'.format(
-             ifmode,cli_ns_option, test_intf))
+        out = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config interface {} speed {} {}'.format(
+             ifmode,cli_ns_option, test_intf, configure_speed))
 
         if out['rc'] != 0:
             pytest.fail()
@@ -728,7 +734,7 @@ class TestConfigInterface():
         speed = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} {}'.format(ifmode, db_cmd))['stdout']
         logger.info('speed: {}'.format(speed))
 
-        assert speed == '10000'
+        assert speed == configure_speed
 
         out = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config interface {}  speed {} {}'.format(
             ifmode, cli_ns_option, test_intf, native_speed))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Removed hardcoded iface speed from test_config_interface_speed

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
When run cases on Arista x86_64-arista_7170_64c configured supported speeds on interface are [ 40000, 100000 ]. When TC tries to configure 10000 per interface error appears and TC failed
#### How did you do it?
Added logic, that get supported speeds on interface and selects speed that are not native. If interface supports only one speed TC will select native speed for testing 
#### How did you verify/test it?
Run test_config_interface_speed on x86_64-arista_7170_64c
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
