### PR TITLE
[MASIC][sub port tests] Skip sub port interface tests for multi ASIC platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -525,6 +525,12 @@ platform_tests/api/test_thermal.py::TestThermalApi::test_set_high_threshold:
     conditions:
       - "asic_type in ['mellanox']"
 
+sub_port_interfaces:
+  skip:
+    reason: "sub port interfaces test is not yet supported on multi-ASIC platform"
+    conditions:
+      - "is_multi_asic==True"
+
 sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports:
   skip:
     reason: "Cisco 8000 platform does not support DSCP PIPE Mode for IPinIP Tunnels"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Sub port tests are not implemented to run on multi ASIC platform. Skip tests until support is required.

#### How did you do it?
Use conditional skip for the sub port test using "is_multi_asic" variable.

#### How did you verify/test it?
verified tests are skipped
```
collected 31 items

sub_port_interfaces/test_show_subinterface.py s                                                                                                                                                                                       [  3%]
sub_port_interfaces/test_sub_port_interfaces.py sssssssssssssssssssssssssssss                                                                                                                                                         [ 96%]
sub_port_interfaces/test_sub_port_l2_forwarding.py s                                                                                                                                                                                  [100%]

============================================================================================================= warnings summary ==============================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================================== 31 skipped, 1 warnings in 4.73 seconds ===================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
