### PR TITLE
[ test show platform ] skip firmware status if not implemented

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -339,6 +339,9 @@ def verify_show_platform_firmware_status_output(raw_output_lines, hostname):
     """
     NUM_EXPECTED_COLS = 5
 
+    # Skip if command not implemented for platform
+    if len(raw_output_lines) <= 2:
+        pytest.skip("show platform firmware status not implemented")
     pytest_assert(len(raw_output_lines) > 2, "There must be at least two lines of output on '{}'".format(hostname))
     second_line = raw_output_lines[1]
     field_ranges = util.get_field_range(second_line)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
At current implementation if "show platform firmware status" returns empty output, TC fails. 
With new approach it will be skipped.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To avoid TC fail in case command returns empty output
#### How did you do it?
Add skip mark
#### How did you verify/test it?
Run TC test_verify_show_platform_firmware_status_output , TC skipped
#### Any platform specific information?
Will be skipped for platforms when test_verify_show_platform_firmware_status_output is not implemented
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
