### PR TITLE
Fix test_thermal_state_db test case to avoid duplication of data read from redis-db

### DIFF
--- a/tests/platform_tests/test_thermal_state_db.py
+++ b/tests/platform_tests/test_thermal_state_db.py
@@ -67,7 +67,7 @@ def test_thermal_state_db(duthosts, enum_rand_one_per_hwsku_hostname, tbinfo):
     if duthost.facts['modular_chassis'] == "False":
         pytest.skip("Test skipped applicable to modular chassis only")
     num_thermals = get_expected_num_thermals(duthosts, enum_rand_one_per_hwsku_hostname)
-    thermal_out = duthost.command("redis-dump -d 6 -y -k \"*TEMP*\"")
+    thermal_out = duthost.command("redis-dump -d 6 -y -k \"TEMP*\"")
     out_dict = json.loads(thermal_out['stdout'])
     pytest_assert(len(out_dict.keys()) == num_thermals, "number of thermal sensors incorrect expected  {} but got {}".format(num_thermals, len(out_dict.keys())))
     result = check_therm_data(out_dict)
@@ -85,7 +85,7 @@ def test_thermal_global_state_db(duthosts, enum_supervisor_dut_hostname, tbinfo)
         pytest.skip("Test skipped applicable to modular chassis only")
     chassis_db_ip = get_chassis_db_ip(duthost)
     expected_num_thermals = get_expected_num_thermals(duthosts)
-    thermal_out = duthost.command("redis-dump -H {} -p 6380 -d 13 -y -k \"*TEMP*\"".format(chassis_db_ip))
+    thermal_out = duthost.command("redis-dump -H {} -p 6380 -d 13 -y -k \"TEMP*\"".format(chassis_db_ip))
     out_dict = json.loads(thermal_out['stdout'])
     actual_num_thermal_sensors = len(out_dict.keys())
     pytest_assert(actual_num_thermal_sensors == expected_num_thermals,


### PR DESCRIPTION
### Description of PR

Test case test_thermal_state_db failure because of mismatch in the number of thermal sensors read from redis-dump command and output of "show platform temperature". There is duplication of sensors read from redis command due to key match "\*TEMP\*", which causes it to pull data from a different table (PHYSICAL_ENTITY_INFO)(not needed) along with TEMPERATURE_INFO (needed) table

Summary:
Fixes #5007 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Failure of the test_thermal_state_db test case

#### How did you do it?
Change key match to "TEMP*" in redis command

#### How did you verify/test it?
Verified the fix on T2 profile

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
