### PR TITLE
[fanout]: Add EAPOL pass through in fanout switch template

### DIFF
--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -128,6 +128,8 @@ interface Management 1
 mac address-table reserved forward 0180.c200.0002
 # LLDP packets pass through
 mac address-table reserved forward 0180.c200.000e
+# EAPOL packets pass through
+mac address-table reserved forward 0180.c200.0003
 !
 ip route 0.0.0.0/0 {{ device_info[inventory_hostname]["ManagementGw"] }}
 ip route vrf management 0.0.0.0/0 {{ device_info[inventory_hostname]["ManagementGw"] }}

--- a/ansible/roles/fanout/templates/arista_7260_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260_deploy.j2
@@ -64,6 +64,8 @@ interface Management 1
 mac address-table reserved forward 0180.c200.0002
 # LLDP packets pass through
 mac address-table reserved forward 0180.c200.000e
+# EAPOL packets pass through
+mac address-table reserved forward 0180.c200.0003
 !
 ip route 0.0.0.0/0 {{ device_info[inventory_hostname]["ManagementGw"] }}
 ip route vrf management 0.0.0.0/0 {{ device_info[inventory_hostname]["ManagementGw"] }}

--- a/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
@@ -118,6 +118,8 @@ interface Management 1
 mac address-table reserved forward 0180.c200.0002
 # LLDP packets pass through
 mac address-table reserved forward 0180.c200.000e
+# EAPOL packets pass through
+mac address-table reserved forward 0180.c200.0003
 !
 ip route 0.0.0.0/0 {{ device_info[inventory_hostname]["ManagementGw"] }}
 ip route vrf management 0.0.0.0/0 {{ device_info[inventory_hostname]["ManagementGw"] }}


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Add EAPOL pass through rule in FANOUT switch template to make the MKA protocol in DUT and Neighbor devices can be used.

#### How did you do it?
Add `mac address-table reserved forward 0180.c200.0003` in fanout switch template

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
