### PR TITLE
Surface Xfail info to test summary report

### DIFF
--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -47,8 +47,7 @@ REQUIRED_TESTSUITE_ATTRIBUTES = {
     ("tests", int),
     ("skipped", int),
     ("failures", int),
-    ("errors", int),
-    ("xfails", int)
+    ("errors", int)
 }
 EXTRA_XML_SUMMARY_ATTRIBUTES = {
     ("xfails", int)

--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -47,7 +47,8 @@ REQUIRED_TESTSUITE_ATTRIBUTES = {
     ("tests", int),
     ("skipped", int),
     ("failures", int),
-    ("errors", int)
+    ("errors", int),
+    ("xfails", int)
 }
 
 # Fields found in the metadata/properties section of the JUnit XML file.

--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -50,7 +50,9 @@ REQUIRED_TESTSUITE_ATTRIBUTES = {
     ("errors", int),
     ("xfails", int)
 }
-
+EXTRA_XML_SUMMARY_ATTRIBUTES = {
+    ("xfails", int)
+}
 # Fields found in the metadata/properties section of the JUnit XML file.
 # FIXME: These are specific to pytest, needs to be extended to support spytest.
 PROPERTIES_TAG = "properties"
@@ -418,6 +420,9 @@ def _update_test_summary(current, update):
 
     new_summary = {}
     for attribute, attr_type in REQUIRED_TESTSUITE_ATTRIBUTES:
+        new_summary[attribute] = str(round(attr_type(current.get(attribute, 0)) + attr_type(update.get(attribute, 0)), 3))
+
+    for attribute, attr_type in EXTRA_XML_SUMMARY_ATTRIBUTES:
         new_summary[attribute] = str(round(attr_type(current.get(attribute, 0)) + attr_type(update.get(attribute, 0)), 3))
 
     return new_summary


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Surface Xfail info to test summary report
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Surface xfail info to the test summary report.
#### How did you do it?
Before uploading the summary report, the code would only pick up predefined items REQUIRED_TESTSUITE_ATTRIBUTES, in order to have the xfail info in the summary report, one new set, EXTRA_XML_SUMMARY_ATTRIBUTES is added.
Why don't add the xfail to the REQUIRED_TESTSUITE_ATTRIBUTES? There are multi usage for REQUIRED_TESTSUITE_ATTRIBUTES, like test report result validation, since the xfail info is not directly in the test report, add xfail to the EXTRA_XML_SUMMARY_ATTRIBUTES  will fail the validation. 
#### How did you verify/test it?
Run a full nightly to verify the report parse and uploader.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
