### PR TITLE
[ test ssh_chiphers ] added default lab file name to ssh conftest

### DIFF
--- a/tests/ssh/conftest.py
+++ b/tests/ssh/conftest.py
@@ -41,7 +41,7 @@ def generate_ssh_ciphers(request, typename):
     tbinfo = testbed_module.TestbedInfo(testbed_file).testbed_topo.get(testbed_name, None)
 
     dut_name = tbinfo['duts'][0]
-    inv_name = tbinfo['inv_name']
+    inv_name = tbinfo['inv_name'] if 'inv_name' in tbinfo.keys() else 'lab'
 
     ansible_cmd = "ansible -m shell -i ../ansible/{} {} -a".format(inv_name, dut_name)
     cmd = ansible_cmd.split()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added default inventory name to lab file if not added in host variables

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
While running ssh_chiphers  error received 
`ssh/conftest.py m:44: in generate_ssh_ciphers
inv_name = tbinfo['inv_name']
KeyError: 'inv_name'`
#### How did you do it?
Add default name "lab" if inv_name is not present
#### How did you verify/test it?
Run test ssh_chiphers
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
