### PR TITLE
Add cleanup between testcases in `test_restapi`

### DIFF
--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -79,11 +79,18 @@ def check_reset_status_after_reboot(reboot_type, pre_reboot_status, post_reboot_
     response = r.json()
     pytest_assert(response['reset_status'] == post_reboot_status)
 
+@pytest.fixture
+def cleanup_after_testing(rand_selected_dut):
+    """
+    Cleanup DUT by config reload after test running.
+    """
+    yield
+    config_reload(rand_selected_dut)
 
 '''
 This test creates a default VxLAN Tunnel and two VNETs. It adds VLAN, VLAN member, VLAN neighbor and routes to each VNET
 '''
-def test_data_path(construct_url, vlan_members):
+def test_data_path(construct_url, vlan_members, cleanup_after_testing):
     # Create Default VxLan Tunnel
     if restapi.get_config_tunnel_decap_tunnel_type(construct_url, 'vxlan').status_code == 404:
         params = '{"ip_addr": "10.1.0.32"}'
@@ -311,7 +318,7 @@ def test_data_path(construct_url, vlan_members):
     logger.info("Routes with incorrect CIDR addresses with vnid: 7036002 to VNET vnet-guid-3 have not been added successfully")
 
 
-def test_data_path_sad(construct_url, vlan_members):
+def test_data_path_sad(construct_url, vlan_members, cleanup_after_testing):
     # Create Default VxLan Tunnel
     if restapi.get_config_tunnel_decap_tunnel_type(construct_url, 'vxlan').status_code == 404:
         params = '{"ip_addr": "10.1.0.32"}'
@@ -461,7 +468,7 @@ def test_data_path_sad(construct_url, vlan_members):
 '''
 This test creates a VNET. It adds routes to the VNET and deletes them
 '''
-def test_create_vrf(construct_url):
+def test_create_vrf(construct_url, cleanup_after_testing):
     # Create Default VxLan Tunnel
     if restapi.get_config_tunnel_decap_tunnel_type(construct_url, 'vxlan').status_code == 404:
         params = '{"ip_addr": "10.1.0.32"}'
@@ -528,7 +535,7 @@ def test_create_vrf(construct_url):
 '''
 This test creates a default VxLAN Tunnel and two VNETs. It adds VLAN, VLAN member, VLAN neighbor and routes to each VNET
 '''
-def test_create_interface(construct_url, vlan_members):
+def test_create_interface(construct_url, vlan_members, cleanup_after_testing):
     # Create Default VxLan Tunnel
     if restapi.get_config_tunnel_decap_tunnel_type(construct_url, 'vxlan').status_code == 404:
         params = '{"ip_addr": "10.1.0.32"}'
@@ -643,7 +650,7 @@ def test_create_interface(construct_url, vlan_members):
     logger.info(r.json())
     logger.info("VNET with vnet_id: vnet-guid-4 has been successfully deleted")
 
-def test_create_interface_sad(construct_url, vlan_members):
+def test_create_interface_sad(construct_url, vlan_members, cleanup_after_testing):
     # Create Default VxLan Tunnel
     if restapi.get_config_tunnel_decap_tunnel_type(construct_url, 'vxlan').status_code == 404:
         params = '{"ip_addr": "10.1.0.32"}'


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The vnet, vxlan, vlan and neighbors are not cleared between test cases in `test_restapi`, which results in test failures.
This PR addressed the issue by adding `config reload` between each test case.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to add a config reload` between testcases in `test_restapi`.

#### How did you do it?
This PR addressed the issue by adding `config reload` between each test case.

#### How did you verify/test it?
Verified by running on SN4600c platform. All test passed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
