### PR TITLE
[advanced-reboot] Verify LACP session timeout after warmboot

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -122,6 +122,7 @@ class ReloadTest(BaseTest):
         self.info = {}
         self.cli_info = {}
         self.logs_info = {}
+        self.lacp_pdu_times = {}
         self.log_lock = threading.RLock()
         self.vm_handle = None
         self.sad_handle = None
@@ -833,8 +834,10 @@ class ReloadTest(BaseTest):
         self.total_disrupt_packets = None
         self.total_disrupt_time = None
         self.ssh_jobs = []
+        self.lacp_session_pause = dict()
         for addr in self.ssh_targets:
             q = Queue.Queue(1)
+            self.lacp_session_pause[addr] = None
             thr = threading.Thread(target=self.peer_state_check, kwargs={'ip': addr, 'queue': q})
             thr.setDaemon(True)
             self.ssh_jobs.append((thr, q))
@@ -1169,6 +1172,7 @@ class ReloadTest(BaseTest):
             controlplane_downtime = ""
         controlplane_report["downtime"] = str(controlplane_downtime)
         controlplane_report["arp_ping"] = "" # TODO
+        controlplane_report["lacp_sessions"] = self.lacp_session_pause
         self.report["dataplane"] = dataplane_report
         self.report["controlplane"] = controlplane_report
         with open(self.report_file_name, 'w') as reportfile:
@@ -1309,22 +1313,43 @@ class ReloadTest(BaseTest):
     def peer_state_check(self, ip, queue):
         self.log('SSH thread for VM {} started'.format(ip))
         ssh = Arista(ip, queue, self.test_params, log_cb=self.log)
-        self.fails[ip], self.info[ip], self.cli_info[ip], self.logs_info[ip] = ssh.run()
+        self.fails[ip], self.info[ip], self.cli_info[ip], self.logs_info[ip], self.lacp_pdu_times[ip] = ssh.run()
         self.log('SSH thread for VM {} finished'.format(ip))
+
+        lacp_pdu_times = self.lacp_pdu_times[ip]
+        lacp_pdu_down_times = lacp_pdu_times.get("lacp_down")
+        lacp_pdu_up_times = lacp_pdu_times.get("lacp_up")
+        lacp_pdu_before_reboot = float(lacp_pdu_down_times[-1]) if\
+            lacp_pdu_down_times and len(lacp_pdu_down_times) > 0 else None
+        lacp_pdu_after_reboot = float(lacp_pdu_up_times[-1]) if\
+            lacp_pdu_up_times and len(lacp_pdu_up_times) > 0 else None
+        if 'warm-reboot' in self.reboot_type and lacp_pdu_before_reboot and lacp_pdu_after_reboot:
+            lacp_time_diff = lacp_pdu_after_reboot - lacp_pdu_before_reboot
+            if lacp_time_diff >= 90:
+                self.fails['dut'].add("LACP session likely terminated by neighbor ({})".format(ip) +\
+                    " post-reboot lacpdu came after {}s of lacpdu pre-boot".format(lacp_time_diff))
+        else:
+            lacp_time_diff = None
+        self.lacp_session_pause[ip] = lacp_time_diff
+
 
     def wait_until_cpu_port_down(self, signal):
         while not signal.is_set():
             for _, q in self.ssh_jobs:
-                self.put_nowait(q, 'cpu_down')
+                self.put_nowait(q, 'cpu_going_down')
             if self.cpu_state.get() == 'down':
+                for _, q in self.ssh_jobs:
+                    q.put('cpu_down')
                 break
             time.sleep(self.TIMEOUT)
 
     def wait_until_cpu_port_up(self, signal):
         while not signal.is_set():
             for _, q in self.ssh_jobs:
-                self.put_nowait(q, 'cpu_up')
+                self.put_nowait(q, 'cpu_going_up')
             if self.cpu_state.get() == 'up':
+                for _, q in self.ssh_jobs:
+                    q.put('cpu_up')
                 break
             time.sleep(self.TIMEOUT)
 

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1325,7 +1325,7 @@ class ReloadTest(BaseTest):
             lacp_pdu_up_times and len(lacp_pdu_up_times) > 0 else None
         if 'warm-reboot' in self.reboot_type and lacp_pdu_before_reboot and lacp_pdu_after_reboot:
             lacp_time_diff = lacp_pdu_after_reboot - lacp_pdu_before_reboot
-            if lacp_time_diff >= 90:
+            if lacp_time_diff >= 90 and not self.kvm_test:
                 self.fails['dut'].add("LACP session likely terminated by neighbor ({})".format(ip) +\
                     " post-reboot lacpdu came after {}s of lacpdu pre-boot".format(lacp_time_diff))
         else:

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -85,14 +85,6 @@ REBOOT_CAUSE_HISTORY_TITLE = ["name", "cause", "time", "user", "comment"]
 MAX_RETRIES = 3
 RETRY_BACKOFF_TIME = 15
 
-def get_warmboot_finalizer_state(duthost):
-    try:
-        res = duthost.command('systemctl is-active warmboot-finalizer.service',module_ignore_errors=True)
-        finalizer_state = res['stdout'].strip() if 'stdout' in res else ""
-    except RunAnsibleModuleFail as err:
-        finalizer_state = err.results
-    return finalizer_state
-
 def reboot(duthost, localhost, reboot_type='cold', delay=10, \
     timeout=0, wait=0, wait_for_ssh=True, reboot_helper=None, reboot_kwargs=None):
     """
@@ -175,35 +167,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10, \
 
     logger.info('waiting for switch {} to initialize'.format(hostname))
 
-    if reboot_type == 'warm':
-        logger.info('waiting for warmboot-finalizer service to become activating on {}'.format(hostname))
-        # Check if finalizer state reaches "activating" before the "wait" period,
-        # the default wait is 90s since issue of warm-reboot).
-        # If the finalizer state is activating, however time passed is greater than "wait",
-        # then fail the testcase. Start with empty value to verify time passed before
-        # checking finalizer state for the first time.
-        finalizer_state = ''
-        while finalizer_state != 'activating':
-            dut_datetime_after_ssh = duthost.get_now_time()
-            time_passed = float(dut_datetime_after_ssh.strftime("%s")) - float(dut_datetime.strftime("%s"))
-            if time_passed > wait:
-                raise Exception('warmboot-finalizer never reached state "activating" on {}'.format(hostname))
-            time.sleep(1)
-            finalizer_state = get_warmboot_finalizer_state(duthost)
-        logger.info('waiting for warmboot-finalizer service to finish on {}'.format(hostname))
-        finalizer_state = get_warmboot_finalizer_state(duthost)
-        logger.info('warmboot finalizer service state {} on {}'.format(finalizer_state, hostname))
-        count = 0
-        while finalizer_state == 'activating':
-            finalizer_state = get_warmboot_finalizer_state(duthost)
-            logger.info('warmboot finalizer service state {} on {}'.format(finalizer_state, hostname))
-            time.sleep(delay)
-            if count * delay > timeout:
-                raise Exception('warmboot-finalizer.service did not finish on {}'.format(hostname))
-            count += 1
-        logger.info('warmboot-finalizer service finished on {}'.format(hostname))
-    else:
-        time.sleep(wait)
+    time.sleep(wait)
 
     DUT_ACTIVE.set()
     logger.info('{} reboot finished on {}'.format(reboot_type, hostname))

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -3,7 +3,6 @@ import time
 import re
 import logging
 from multiprocessing.pool import ThreadPool, TimeoutError
-from tests.common.errors import RunAnsibleModuleFail
 from collections import deque
 
 logger = logging.getLogger(__name__)

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -131,10 +131,19 @@ def get_report_summary(analyze_result, reboot_type):
                               _parse_timestamp(marker_first_time)).total_seconds()
         time_spans_summary.update({entity.lower(): str(time_taken)})
 
+    lacp_sessions_waittime = analyze_result.get(\
+        "controlplane", {"lacp_sessions": []}).pop("lacp_sessions")
+    controlplane_summary = {"downtime": "", "arp_ping": "", "lacp_session_max_wait": ""}
+    if len(lacp_sessions_waittime) > 0:
+        max_lacp_session_wait = max(list(lacp_sessions_waittime.values()))
+        analyze_result.get(\
+            "controlplane", controlplane_summary).update(
+                {"lacp_session_max_wait": max_lacp_session_wait})
+
     result_summary = {
         "reboot_type": reboot_type,
         "dataplane": analyze_result.get("dataplane", {"downtime": "", "lost_packets": ""}),
-        "controlplane": analyze_result.get("controlplane", {"downtime": "", "arp_ping": ""}),
+        "controlplane": analyze_result.get("controlplane", controlplane_summary),
         "time_span": time_spans_summary,
         "offset_from_kexec": kexec_offsets_summary
     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Improve LAG flap  detection - measure LACP session wait time during warmboot.

Fix https://github.com/Azure/sonic-mgmt/issues/4817

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

The present test_reboot.py::test_warm_reboot has inaccurate mechanism to verify 90s timeout for control plane downtime.

Problem with present code in test_reboot.py:

1. Start anchor for 90s timeout is at the time of issuing the warmboot command.
2. End anchor for 90s timeout is when FINALIZER state has reached `activating` state.

This leads to false positives as the timer starts much earlier than last LACP PDU is sent, and the timer ends much later than when first LACP PDU is received.

#### How did you do it?

Fix this issues by:

1. Do not run a timer.
2. Catch the timestamp of last LACPDU sent by DUT (t0) to neighbors (t1) before warmboot kexec.
3. Catch the timestamp of first LACPDU after warmboot.
4. Measure the time difference between two LACPDUs from each T1, and verify if they are under 90s.
5. If the difference is >=90s, then the neighbors will initiate LACP session teardown, causing to LAGs flap.

Since these checks involve interacting with neighbors and do advanced checks, moving this check from `test_reboot.py` to `test_advanced_reboot.py`.

#### How did you verify/test it?
Tested on  physical DUTs.

Now if the LACPDUs are sent too late, test fails with:
```
2022-02-06 08:07:23 : --------------------------------------------------
2022-02-06 08:07:23 : Fails:
2022-02-06 08:07:23 : --------------------------------------------------
2022-02-06 08:07:23 : FAILED:172.16.142.127:bgp ipv4 graceful restart is not enabled
2022-02-06 08:07:23 : FAILED:172.16.142.127:bgp graceful restart timeout is less then 120 seconds
2022-02-06 08:07:23 : FAILED:172.16.142.126:bgp ipv4 graceful restart is not enabled
2022-02-06 08:07:23 : FAILED:172.16.142.126:bgp graceful restart timeout is less then 120 seconds
2022-02-06 08:07:23 : FAILED:172.16.142.125:bgp ipv4 graceful restart is not enabled
2022-02-06 08:07:23 : FAILED:172.16.142.125:bgp graceful restart timeout is less then 120 seconds
2022-02-06 08:07:23 : FAILED:172.16.142.124:bgp ipv4 graceful restart is not enabled
2022-02-06 08:07:23 : FAILED:172.16.142.124:bgp graceful restart timeout is less then 120 seconds
2022-02-06 08:07:23 : FAILED:dut:LACP session terminated by Neighbor (172.16.142.126) post-reboot lacpdu came after 91.9960591793s of lacpdu pre-boot
2022-02-06 08:07:23 : FAILED:dut:LACP session terminated by Neighbor (172.16.142.124) post-reboot lacpdu came after 91.710517168s of lacpdu pre-boot
2022-02-06 08:07:23 : FAILED:dut:LACP session terminated by Neighbor (172.16.142.127) post-reboot lacpdu came after 92.1095261574s of lacpdu pre-boot
2022-02-06 08:07:23 : FAILED:dut:LACP session terminated by Neighbor (172.16.142.125) post-reboot lacpdu came after 91.9090697765s of lacpdu pre-boot
2022-02-06 08:07:23 : ==================================================
```
Also this is captured in the timing data reporT:
```
{
	"controlplane": {
		"arp_ping": "",
		"downtime": "82.739583"
	},
	"lacp_sessions": {
		"172.16.142.127": 92.10952615737915,
		"172.16.142.126": 91.99605917930603,
		"172.16.142.125": 91.90906977653503,
		"172.16.142.124": 91.71051716804504
	},
	"dataplane": {
		"lost_packets": "0",
		"downtime": "0.0"
	}
}
```


Otherwise, if PDUs are received in time, the timing is captured in the test report:
```
    "lacp_sessions": {
        "172.16.142.127": 83.43812203407288,
        "172.16.142.126": 83.38292264938354,
        "172.16.142.125": 83.26467967033386,
        "172.16.142.124": 83.12556576728821
    },
    "dataplane": {
        "lost_packets": "0",
        "downtime": "0.0"
    },
    "controlplane": {
        "arp_ping": "",
        "downtime": "74.469363"
    },
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
