### PR TITLE
[dualtor][test_server_failure] Incrementing PAUSE_TIME after server shutdown 

### DIFF
--- a/tests/dualtor/test_server_failure.py
+++ b/tests/dualtor/test_server_failure.py
@@ -1,9 +1,9 @@
 import pytest
-import time
 from tests.common.dualtor.mux_simulator_control import toggle_simulator_port_to_upper_tor, simulator_flap_counter, simulator_server_down
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.dualtor.dual_tor_utils import show_muxcable_status, rand_selected_interface
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses, run_garp_service, run_icmp_responder
+from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.topology('t0'),
@@ -24,23 +24,27 @@ def test_server_down(duthosts, tbinfo, rand_selected_interface, simulator_flap_c
         
     upper_tor = duthosts[tbinfo['duts'][0]]
     lower_tor = duthosts[tbinfo['duts'][1]]
-    PAUSE_TIME = 10
+    
+    def upper_tor_mux_state_verification(state, health):
+        mux_state_upper_tor = show_muxcable_status(upper_tor)
+        return mux_state_upper_tor[itfs]['status'] == state and mux_state_upper_tor[itfs]['health'] == health
+    
+    def lower_tor_mux_state_verfication(state, health):
+        mux_state_lower_tor = show_muxcable_status(lower_tor)
+        return mux_state_lower_tor[itfs]['status'] == state and mux_state_lower_tor[itfs]['health'] == health
 
     itfs, _ = rand_selected_interface
     # Set upper_tor as active
     toggle_simulator_port_to_upper_tor(itfs)
-    time.sleep(PAUSE_TIME)
+    wait_until(10, 1, 0, upper_tor_mux_state_verification, 'active', 'healthy')
     mux_flap_counter_0 = simulator_flap_counter(itfs)
     # Server down
     simulator_server_down(itfs)
-    time.sleep(PAUSE_TIME)
     # Verify mux_cable state on upper_tor is active
-    mux_state_upper_tor = show_muxcable_status(upper_tor)
-    pytest_assert(mux_state_upper_tor[itfs]['status'] == 'active' and mux_state_upper_tor[itfs]['health'] == 'unhealthy', 
+    pytest_assert(wait_until(10, 1, 0, upper_tor_mux_state_verification, 'active', 'unhealthy'), 
                     "mux_cable status is unexpected. Should be (active, unhealthy)")
     # Verify mux_cable state on lower_tor is standby
-    mux_state_lower_tor = show_muxcable_status(lower_tor)
-    pytest_assert(mux_state_lower_tor[itfs]['status'] == 'standby' and mux_state_lower_tor[itfs]['health'] == 'unhealthy', 
+    pytest_assert(wait_until(10, 1, 0, lower_tor_mux_state_verfication, 'standby', 'unhealthy'), 
                     "mux_cable status is unexpected. Should be (standby, unhealthy)")
     # Verify that mux_cable flap_counter should be no larger than 3
     # lower_tor(standby) -> active -> standby

--- a/tests/dualtor/test_server_failure.py
+++ b/tests/dualtor/test_server_failure.py
@@ -36,7 +36,8 @@ def test_server_down(duthosts, tbinfo, rand_selected_interface, simulator_flap_c
     itfs, _ = rand_selected_interface
     # Set upper_tor as active
     toggle_simulator_port_to_upper_tor(itfs)
-    wait_until(30, 1, 0, upper_tor_mux_state_verification, 'active', 'healthy')
+    pytest_assert(wait_until(30, 1, 0, upper_tor_mux_state_verification, 'active', 'healthy'), 
+                    "mux_cable status is unexpected. Should be (active, healthy). Test can't proceed. ")
     mux_flap_counter_0 = simulator_flap_counter(itfs)
     # Server down
     simulator_server_down(itfs)

--- a/tests/dualtor/test_server_failure.py
+++ b/tests/dualtor/test_server_failure.py
@@ -24,7 +24,7 @@ def test_server_down(duthosts, tbinfo, rand_selected_interface, simulator_flap_c
         
     upper_tor = duthosts[tbinfo['duts'][0]]
     lower_tor = duthosts[tbinfo['duts'][1]]
-    PAUSE_TIME = 5
+    PAUSE_TIME = 10
 
     itfs, _ = rand_selected_interface
     # Set upper_tor as active

--- a/tests/dualtor/test_server_failure.py
+++ b/tests/dualtor/test_server_failure.py
@@ -36,15 +36,15 @@ def test_server_down(duthosts, tbinfo, rand_selected_interface, simulator_flap_c
     itfs, _ = rand_selected_interface
     # Set upper_tor as active
     toggle_simulator_port_to_upper_tor(itfs)
-    wait_until(10, 1, 0, upper_tor_mux_state_verification, 'active', 'healthy')
+    wait_until(30, 1, 0, upper_tor_mux_state_verification, 'active', 'healthy')
     mux_flap_counter_0 = simulator_flap_counter(itfs)
     # Server down
     simulator_server_down(itfs)
     # Verify mux_cable state on upper_tor is active
-    pytest_assert(wait_until(10, 1, 0, upper_tor_mux_state_verification, 'active', 'unhealthy'), 
+    pytest_assert(wait_until(20, 1, 0, upper_tor_mux_state_verification, 'active', 'unhealthy'), 
                     "mux_cable status is unexpected. Should be (active, unhealthy)")
     # Verify mux_cable state on lower_tor is standby
-    pytest_assert(wait_until(10, 1, 0, lower_tor_mux_state_verfication, 'standby', 'unhealthy'), 
+    pytest_assert(wait_until(20, 1, 0, lower_tor_mux_state_verfication, 'standby', 'unhealthy'), 
                     "mux_cable status is unexpected. Should be (standby, unhealthy)")
     # Verify that mux_cable flap_counter should be no larger than 3
     # lower_tor(standby) -> active -> standby


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Since we incremented link prober interval from 100ms to 1000ms, the PAUSE_TIME before verifying mux state should also be increased. 

The expected mux state changes are: 
lower_tor(standby) -> active -> standby
upper_tor(active) -> active

After server is shutdown, it takes 3 intervals to for link prober to post Unknown event. Then it's 4 intervals for heartbeat suspender to timeout (then linkmgrd will probe the updated mux state). 

Sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
1. Tested with pytest_assert both ToRs to be active, with PAUSE_TIME = 5, test case passed. 
2. Tested with PAUSE_TIME  = 10, test case passed. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
