### PR TITLE
[voq][chassis] fix snmp default route

### DIFF
--- a/tests/snmp/test_snmp_default_route.py
+++ b/tests/snmp/test_snmp_default_route.py
@@ -28,7 +28,7 @@ def test_snmp_default_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
             ip, interface = line.split('via')
             ip = ip.strip("*, ")
             interface = interface.strip("*, ")
-            if interface != "eth0" and 'Ethernet-IB' not in interface and 'Ethernet-BP' not in interface:
+            if interface != "eth0" and 'Ethernet-BP' not in interface:
                 dut_result_nexthops.append(ip)
 
     # If show ip route 0.0.0.0/0 has route only via eth0,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
Currently if the default route is learnt on linecard from another linecard, nexthops are learnt via inband interface(`Ethernet-IB0`)
The route table snmp has the these nexthops correct but the test is skipping `IB` interface which cause the test failures

Route table in CLI
```
admin@str2-sonic-lc6-1:~$ show ip route 0.0.0.0/0
Routing entry for 0.0.0.0/0
  Known via "bgp", distance 200, metric 0, best
  Last update 01:52:32 ago
    10.0.0.1 (recursive), weight 1
  *   10.0.0.1, via Ethernet-IB0 onlink, weight 1
    10.0.0.5 (recursive), weight 1
  *   10.0.0.5, via Ethernet-IB0 onlink, weight 1
    10.0.0.9 (recursive), weight 1
  *   10.0.0.9, via Ethernet-IB0 onlink, weight 1
    10.0.0.13 (recursive), weight 1
  *   10.0.0.13, via Ethernet-IB0 onlink, weight 1
    10.0.0.17 (recursive), weight 1
  *   10.0.0.17, via Ethernet-IB0 onlink, weight 1
    10.0.0.21 (recursive), weight 1
  *   10.0.0.21, via Ethernet-IB0 onlink, weight 1
    10.0.0.25 (recursive), weight 1
  *   10.0.0.25, via Ethernet-IB0 onlink, weight 1
    10.0.0.29 (recursive), weight 1
  *   10.0.0.29, via Ethernet-IB0 onlink, weight 1
    10.0.0.33 (recursive), weight 1
  *   10.0.0.33, via Ethernet-IB0 onlink, weight 1
    10.0.0.35 (recursive), weight 1
  *   10.0.0.35, via Ethernet-IB0 onlink, weight 1
    10.0.0.37 (recursive), weight 1
  *   10.0.0.37, via Ethernet-IB0 onlink, weight 1
    10.0.0.39 (recursive), weight 1
  *   10.0.0.39, via Ethernet-IB0 onlink, weight 1
    10.0.0.41 (recursive), weight 1
  *   10.0.0.41, via Ethernet-IB0 onlink, weight 1
    10.0.0.43 (recursive), weight 1
  *   10.0.0.43, via Ethernet-IB0 onlink, weight 1
    10.0.0.45 (recursive), weight 1
  *   10.0.0.45, via Ethernet-IB0 onlink, weight 1
    10.0.0.47 (recursive), weight 1
  *   10.0.0.47, via Ethernet-IB0 onlink, weight 1
    10.0.0.49 (recursive), weight 1
  *   10.0.0.49, via Ethernet-IB0 onlink, weight 1
    10.0.0.51 (recursive), weight 1
  *   10.0.0.51, via Ethernet-IB0 onlink, weight 1
    10.0.0.53 (recursive), weight 1
  *   10.0.0.53, via Ethernet-IB0 onlink, weight 1
    10.0.0.55 (recursive), weight 1
  *   10.0.0.55, via Ethernet-IB0 onlink, weight 1
    10.0.0.57 (recursive), weight 1
  *   10.0.0.57, via Ethernet-IB0 onlink, weight 1
    10.0.0.59 (recursive), weight 1
  *   10.0.0.59, via Ethernet-IB0 onlink, weight 1
    10.0.0.61 (recursive), weight 1
  *   10.0.0.61, via Ethernet-IB0 onlink, weight 1
    10.0.0.63 (recursive), weight 1
  *   10.0.0.63, via Ethernet-IB0 onlink, weight 1


```
SNMP walk for default route
```
admin@str2-sonic-lc6-1:~$ docker exec -it snmp bash
root@str2-sonic-lc6-1:/# snmpwalk -v1 -c msft localhost 1.3.6.1.2.1.4.24.4
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.1 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.5 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.9 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.13 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.17 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.21 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.25 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.29 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.33 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.35 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.37 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.39 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.41 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.43 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.45 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.47 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.49 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.51 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.53 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.55 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.57 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.59 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.61 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.1.0.0.0.0.0.0.0.0.0.10.0.0.63 = IpAddress: 0.0.0.0
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.1 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.5 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.9 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.13 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.17 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.21 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.25 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.29 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.33 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.35 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.37 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.39 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.41 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.43 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.45 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.47 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.49 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.51 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.53 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.55 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.57 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.59 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.61 = INTEGER: 1
iso.3.6.1.2.1.4.24.4.1.16.0.0.0.0.0.0.0.0.0.10.0.0.63 = INTEGER: 1
root@str2-sonic-lc6-1:/#
```
#### How did you do it?
Removed the check to ignore `IB` interface when parsing the nexthop

#### How did you verify/test it?
Run the test on vs and sonic-chassis

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
