### PR TITLE
[BGP][multipath relax] Fix bgp multipath relax test case on multi ASIC platform

### DIFF
--- a/tests/bgp/test_bgp_multipath_relax.py
+++ b/tests/bgp/test_bgp_multipath_relax.py
@@ -89,7 +89,9 @@ def test_bgp_multipath_relax(tbinfo, duthosts, rand_one_dut_hostname):
 
     vips_prefix = get_vips_prefix(dut_t0_neigh, topo_config)
 
-    logger.info("vips_prefix = {}".format(vips_prefix))
+    logger.info("vips_prefix = {}, DUT T2 neighbor = {}".format(
+        vips_prefix, dut_t2_neigh
+    ))
 
     # find all paths of the prefix for test
     vips_t0, vips_asn = get_vips_prefix_paths(dut_t0_neigh, vips_prefix, topo_config)
@@ -99,7 +101,9 @@ def test_bgp_multipath_relax(tbinfo, duthosts, rand_one_dut_hostname):
     pytest_assert((vips_t0 > 1), "Did not find preconfigured multipath for the vips prefix under test")
 
     # Get the route from the DUT for the prefix
-    bgp_route = duthost.bgp_route(prefix=vips_prefix)['ansible_facts']['bgp_route']
+    bgp_route = duthost.get_bgp_route(
+        prefix=vips_prefix
+    )['ansible_facts']['bgp_route']
 
     logger.info("Bgp route from DUT for prefix {} is {}".format(vips_prefix,bgp_route))
 
@@ -116,7 +120,9 @@ def test_bgp_multipath_relax(tbinfo, duthosts, rand_one_dut_hostname):
             pytest_assert((str(asn) in  aspath))
 
     # gather one t2 neighbor advertised routes to validate routes advertised to t2 are correct with relaxed multipath
-    bgp_route_neiadv = duthost.bgp_route(neighbor=bgp_v4nei[dut_t2_neigh[0]], direction="adv")['ansible_facts']['bgp_route_neiadv']
+    bgp_route_neiadv = duthost.get_bgp_route(
+        neighbor=bgp_v4nei[dut_t2_neigh[0]], direction="adv"
+    )['ansible_facts']['bgp_route_neiadv']
 
     logger.info("Bgp neighbor adv from DUT for neigh {} and prefix {} is {}".
                 format(bgp_v4nei[dut_t2_neigh[0]],

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -451,6 +451,32 @@ class MultiAsicSonicHost(object):
 
         return False
 
+    def get_bgp_route(self, *args, **kwargs):
+        """
+            @summary: return BGP routes information from BGP docker. On
+                      single ASIC platform ansible module is called directly.
+                      On multi ASIC platform one of the frontend ASIC is
+                      used unless a neighbor is provided, in which case it
+                      fetches from the ASIC where neighbor is present
+        """
+        if not self.sonichost.is_multi_asic:
+            return self.bgp_route(*args, **kwargs)
+
+        asic_index = self.frontend_asics[0].asic_index
+
+        if kwargs.get('neighbor') is not None:
+            #find out which ASIC has the neighbor
+            for asic in self.frontend_asics:
+                bgp_facts = asic.bgp_facts()['ansible_facts']
+                if kwargs.get('neighbor')in bgp_facts['bgp_neighbors']:
+                    asic_index = asic.asic_index
+                    break
+
+        # return from one of the frontend asics or the one where
+        # the given neighbor exists
+        kwargs['namespace_id'] = asic_index
+        return self.bgp_route(*args, **kwargs)
+
     def get_bgp_route_info(self, prefix, ns=None):
         """
         @summary: return BGP routes information.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fix bgp multipath relax test case on multi ASIC platform

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
BGP multipath relax test case was failig on multi ASIC platform as vtysh query was being run in 'bgp' docker insnace which doesn't exist in multi ASIC platform, where the dockers are bgp0, bgp1, etc.

#### How did you do it?
Update bgp_route ansible module to take namesapce ID as a parameter.

#### How did you verify/test it?

```
samaddik@svcstr-server-2:/var/sonic-mgmt/tests$  pytest bgp/test_bgp_multipath_relax.py  --testbed=vmsvc1-t1-nmasic-acs-1 --inventory=../ansible/strsvc,../ansible/veos  --testbed_file=../ansible/testbed.csv --host-pattern=svcstr-n3164-acs-1  --module-path=../ansible/library  --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: html-1.22.1, repeat-0.9.1, forked-1.3.0, xdist-1.28.0, metadata-1.11.0, ansible-2.2.2
collecting ... ['conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut', 'inv_name', 'auto_recover', 'comment']
Finished testbed info generating.
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 1 item

bgp/test_bgp_multipath_relax.py .                                                                                                                                                                                                     [100%]

============================================================================================================= warnings summary ==============================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================================================================================== 1 passed, 1 warnings in 40.39 seconds ===================================================================================================
samaddik@svcstr-server-2:/var/sonic-mgmt/tests$

```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
