### PR TITLE
[platform][Mellanox] Fix issue: the PSU capability for Mellanox ACS-MSN3420 is wrong

### DIFF
--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -596,7 +596,7 @@ SWITCH_MODELS = {
         "psus": {
             "number": 2,
             "hot_swappable": True,
-            "capabilities": PSU_CAPABILITIES[1]
+            "capabilities": PSU_CAPABILITIES[0]
         },
         "cpu_pack": {
             "number": 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix issue: the PSU capability for Mellanox ACS-MSN3420 is wrong

Signed-off-by: Stephen Sun <stephens@nvidia.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

Fix bug

#### How did you do it?

#### How did you verify/test it?

Run platform test on ACS-MSN3420 platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
