### PR TITLE
fixed mgmt VRF setup on DUT

### DIFF
--- a/tests/mvrf/config_vrf_del.sh
+++ b/tests/mvrf/config_vrf_del.sh
@@ -1,2 +1,0 @@
-sudo config vrf del mgmt
-time.sleep(5)

--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -45,7 +45,8 @@ def setup_mvrf(duthosts, rand_one_dut_hostname, localhost, check_ntp_sync):
 
     try:
         logger.info("Configure mgmt vrf")
-        duthost.command("sudo config vrf add mgmt")
+        duthost.command("sudo config vrf add mgmt", module_async=True)
+        time.sleep(5)
         verify_show_command(duthost, mvrf=True)
     except Exception as e:
         logger.error("Exception raised in setup, exception: {}".format(repr(e)))
@@ -56,13 +57,8 @@ def setup_mvrf(duthosts, rand_one_dut_hostname, localhost, check_ntp_sync):
 
     try:
         logger.info("Unconfigure  mgmt vrf")
-        duthost.copy(src="mvrf/config_vrf_del.sh", dest="/tmp/config_vrf_del.sh", mode=0755)
-        duthost.shell("nohup /tmp/config_vrf_del.sh < /dev/null > /dev/null 2>&1 &")
-        localhost.wait_for(host=duthost.mgmt_ip,
-                        port=SONIC_SSH_PORT,
-                        state="stopped",
-                        search_regex=SONIC_SSH_REGEX,
-                        timeout=90)
+        duthost.shell("sudo config vrf del mgmt", module_async=True)
+        time.sleep(5)
 
         localhost.wait_for(host=duthost.mgmt_ip,
                         port=SONIC_SSH_PORT,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fixed mgmt VRF setup on DUT
Fixes # (issue)

The test setups a management VRF via Ansible CLI call on a DUT using the corresponding command (`config vrf add mgmt`). When the command executes a mgmt interface restarts for a short period of time and this is expected, as per [feature doc](https://github.com/Azure/SONiC/blob/master/doc/mgmt/sonic_stretch_management_vrf_design.md#management-vrf-create-configuration-sequence). While it's done the test fails waiting for a CLI command to finish. Fixed it by making a call to the mgmt VRF config command be async and inserting a short delay before executing other DUT commands.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix test issue
#### How did you do it?
Made the test to account a connection loss when executing mgmt VRF config command.

#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t1,any mvrf
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
