### PR TITLE
[VXLAN_ECMP] DUT to PTF port mapping fix

### DIFF
--- a/ansible/roles/test/files/ptftests/vxlan_traffic.py
+++ b/ansible/roles/test/files/ptftests/vxlan_traffic.py
@@ -93,22 +93,15 @@ class VXLAN(BaseTest):
             # find the list of neigh addresses for the t0_ports. For each neigh address(Addr1):
             # for each destination address(Addr2) in the same Vnet as t0_intf,
             # send traffic from Add1 to it. If there
-            # are multiple nexthops for the Addr2, then send that many different 
+            # are multiple nexthops for the Addr2, then send that many different
             # streams(different tcp ports).
             neighbors = [self.config_data['neighbors'][t0_intf]]
-            ptf_port = self.get_ptf_port(t0_intf)
+            ptf_port = self.topo_data['minigraph_facts']['minigraph_ptf_indices'][t0_intf]
             vnet = self.config_data['vnet_intf_map'][t0_intf]
             vni  = self.config_data['vnet_vni_map'][vnet]
             for addr in neighbors:
                 for destination,nh in self.config_data['dest_to_nh_map'][vnet].iteritems():
                     self.test_encap(ptf_port, vni, addr, destination, nh, test_ecn=TEST_ECN)
-
-    def get_ptf_port(self, dut_port):
-        m = re.search('Ethernet([0-9]+)', dut_port)
-        if m:
-            return self.topo_data['tbinfo']['topo']['ptf_dut_intf_map'][m.group(1)]['0']
-        else:
-            raise RuntimeError("dut_intf:{} doesn't match 'EthernetNNN'".format(dut_port))
 
     def cmd(self, cmds):
         process = subprocess.Popen(cmds,

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -439,15 +439,15 @@ def get_t2_ports(duthost, minigraph_data):
     '''
     list_of_portchannels_to_T2 = get_portchannels_to_neighbors(duthost, "T2", minigraph_data)
     list_of_interfaces = []
-    for pc_name in list_of_portchannels_to_T2:
-        list_of_interfaces.extend(list_of_portchannels_to_T2[pc_name])
+    if list_of_portchannels_to_T2:
+        for pc_name in list_of_portchannels_to_T2:
+            list_of_interfaces.extend(list_of_portchannels_to_T2[pc_name])
+    else:
+        list_of_interfaces = get_ethernet_to_neighbors("T2", minigraph_data)
 
-    ret_list = [int(x[8:]) for x in list_of_interfaces]
-    if ret_list:
-        return ret_list
-
-    list_of_ethernet_to_T2 = get_ethernet_to_neighbors("T2", minigraph_data)
-    ret_list.extend([int(x[8:]) for x in list_of_ethernet_to_T2])
+    ret_list = []
+    for iface in list_of_interfaces:
+        ret_list.append(minigraph_data["minigraph_ptf_indices"][iface])
     return ret_list
 
 def bgp_established(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Test failed because of incorrect DUT to PTF port mapping

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To get correct t0 and t2 ports and make the test work. The test was failing with KeyError. 

#### How did you do it?
Reworked logic of getting ports. Now it takes them from correct dictionary.

#### How did you verify/test it?
Ran test in a loop

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
T1

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
