### PR TITLE
[advance-reboot] Provide warmboot-SAD cases as a list argument

### DIFF
--- a/tests/platform_tests/args/advanced_reboot_args.py
+++ b/tests/platform_tests/args/advanced_reboot_args.py
@@ -1,6 +1,6 @@
 import pytest
 from tests.common.utilities import str2bool
-
+from tests.platform_tests.warmboot_sad_cases import SAD_CASE_LIST
 
 def add_advanced_reboot_args(parser):
     '''
@@ -122,7 +122,7 @@ def add_advanced_reboot_args(parser):
     )
 
     parser.addoption("--sad_case_list",
-        default="sad, multi_sad, sad_bgp, sad_lag_member, sad_lag, sad_vlan_port, sad_inboot",
+        default=", ".join(SAD_CASE_LIST),
         help="Specify the list of warmboot SAD cases (case-insensitive). Useful if SAD cases are alternated daily " +\
             "which helps to keep total runtime within desired limits. Avg time per case: " +\
             "sad(3h45m), multi_sad(5h), sad_bgp(1h5m), sad_lag_member(1h15m), sad_lag(1h15m), sad_vlan_port(1h10m), sad_inboot(1h20m)",

--- a/tests/platform_tests/args/advanced_reboot_args.py
+++ b/tests/platform_tests/args/advanced_reboot_args.py
@@ -120,3 +120,10 @@ def add_advanced_reboot_args(parser):
         default="",
         help="Specify the target image to restore to, or stay in target image if empty",
     )
+
+    parser.addoption("--sad_case_list",
+        default="sad, multi_sad, sad_bgp, sad_lag_member, sad_lag, sad_vlan_port, sad_inboot",
+        help="Specify the list of warmboot SAD cases (case-insensitive). Useful if SAD cases are alternated daily " +\
+            "which helps to keep total runtime within desired limits. Avg time per case: " +\
+            "sad(3h45m), multi_sad(5h), sad_bgp(1h5m), sad_lag_member(1h15m), sad_lag(1h15m), sad_vlan_port(1h10m), sad_inboot(1h20m)",
+    )

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # lgtm[py/unused-import]
@@ -14,8 +15,16 @@ pytestmark = [
 
 
 def pytest_generate_tests(metafunc):
+    input_sad_cases = metafunc.config.getoption("sad_case_list")
+    input_sad_list = list()
+    for input_case in input_sad_cases.split(","):
+        input_case = input_case.strip()
+        if input_case.lower() not in SAD_CASE_LIST:
+            logging.warn("Unknown SAD case ({}) - skipping it.".format(input_case))
+            continue
+        input_sad_list.append(input_case.lower())
     if "sad_case_type" in metafunc.fixturenames:
-        sad_cases = SAD_CASE_LIST
+        sad_cases = input_sad_list
         metafunc.parametrize("sad_case_type", sad_cases, scope="module")
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Provide SAD case list as an argument to pytest. This is to handle running SAD cases selectively.
Benefit is to control the test duration. All SAD cases combined take ~15 hours.
With this change the SAD cases can be alternated in subsequent runs.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To provide ability to selectively run SAD cases to avoid a full 15HR run at once.

#### How did you do it?
Provide SAD case list as an comma-separated input to argument `sad_case_list`. The inputs are case-insensitive.

White spaces are allowed between two testcases. Delimiter is still comma.
If the input SAD case is not accepted, it will be ignored and logic will still proceed with only acceptable list of case.


#### How did you verify/test it?
Executed tests on physical testbed with different SAD cases as input.

Example (mock run):
```
./run_tests.sh -n vms7-t0-7260-1 -i ../ansible/str,../ansible/veos -m individual -l INFO -e "--sad_case_list=sad, multi_Sad" -c "platform_tests/test_advanced_reboot.py::test_warm_reboot_sad"

------------------------------------------------------------------------------------------------------------------------ live log setup ------------------------------------------------------------------------------------------------------------------------
20:08:24 __init__.set_default                     L0049 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
20:08:24 __init__.check_test_completeness         L0138 INFO   | Test has no defined levels. Continue without test completeness checks
20:08:25 facts_cache.read                         L0093 INFO   | Load cache file "/var/src/sonic-mgmt-int/tests/_cache/str-7260cx3-acs-1/basic_facts.pickle" failed with exception: IOError(2, 'No such file or directory')
20:08:30 facts_cache.write                        L0120 INFO   | Cached facts "str-7260cx3-acs-1.basic_facts" to /var/src/sonic-mgmt-int/tests/_cache/str-7260cx3-acs-1/basic_facts.pickle
20:08:34 __init__._fixture_func_decorator         L0059 INFO   | -------------------- fixture change_mac_addresses setup starts --------------------
20:08:34 ptfhost_utils.change_mac_addresses       L0122 INFO   | Change interface MAC addresses on ptfhost 'vms7-7'
20:08:36 __init__._fixture_func_decorator         L0066 INFO   | -------------------- fixture change_mac_addresses setup ends --------------------
20:08:36 __init__._fixture_generator_decorator    L0071 INFO   | -------------------- fixture copy_ptftests_directory setup starts --------------------
20:08:36 ptfhost_utils.copy_ptftests_directory    L0067 INFO   | Copy PTF test files to PTF host 'vms7-7'
20:08:49 __init__._fixture_generator_decorator    L0075 INFO   | -------------------- fixture copy_ptftests_directory setup ends --------------------
20:08:51 conftest.generate_params_dut_hostname    L0931 INFO   | Using DUTs ['str-7260cx3-acs-1'] in testbed 'vms7-t0-7260-1'
20:08:51 conftest.rand_one_dut_hostname           L0307 INFO   | Randomly select dut str-7260cx3-acs-1 for testing
20:08:51 conftest.creds_on_dut                    L0556 INFO   | dut str-7260cx3-acs-1 belongs to groups [u'sonic', u'sonic_arista64_100', u'str', 'fanout']
20:08:51 conftest.creds_on_dut                    L0579 INFO   | skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
20:08:51 conftest.creds_on_dut                    L0579 INFO   | skip empty var file ../ansible/group_vars/all/README.yml
20:09:00 __init__.sanity_check                    L0106 INFO   | Prepare sanity check
20:09:00 __init__.sanity_check                    L0116 INFO   | Found marker: m.name=disable_loganalyzer, m.args=(), m.kwargs={}
20:09:00 __init__.sanity_check                    L0116 INFO   | Found marker: m.name=topology, m.args=('t0',), m.kwargs={}
20:09:00 __init__.sanity_check                    L0142 INFO   | Skip sanity check according to command line argument or configuration of test script.
20:09:00 __init__.loganalyzer                     L0048 INFO   | Log analyzer is disabled
PASSED                                                                                                                                                                                                                                                   [ 50%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad[multi_sad]
------------------------------------------------------------------------------------------------------------------------ live log setup ------------------------------------------------------------------------------------------------------------------------
20:09:00 __init__.set_default                     L0049 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
20:09:00 __init__.check_test_completeness         L0138 INFO   | Test has no defined levels. Continue without test completeness checks
20:09:00 __init__.loganalyzer                     L0048 INFO   | Log analyzer is disabled
PASSED                                                                                                                                                                                                                                                   [100%]
---------------------------------------------------------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------------------------------------------------------
20:09:00 __init__._fixture_generator_decorator    L0083 INFO   | -------------------- fixture copy_ptftests_directory teardown starts --------------------
20:09:00 ptfhost_utils.copy_ptftests_directory    L0072 INFO   | Delete PTF test files from PTF host 'vms7-7'
20:09:01 __init__._fixture_generator_decorator    L0092 INFO   | -------------------- fixture copy_ptftests_directory teardown ends --------------------


------------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/platform_tests/test_advanced_reboot.py::test_warm_reboot_sad.xml --------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------------------------------------
20:09:01 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
========================== 2 passed in 47.12 seconds ===========================

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
