### PR TITLE
replace time.sleep with wait_until for high efficiency

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -37,6 +37,7 @@ DEFAULT_INTERVAL = 60
 FAST_INTERVAL = 10
 THERMAL_CHECK_INTERVAL = 70
 PSU_CHECK_INTERVAL = FAST_INTERVAL + 5
+WAIT_TIMEOUT = 90
 STATE_DB = 6
 
 SERVICE_EXPECT_STATUS_DICT = {
@@ -83,17 +84,17 @@ def test_service_checker(duthosts, enum_rand_one_per_hwsku_hostname):
                 for process_name in processes["exited_critical_process"]:
                     expect_error_dict[process_name] = '{}:{} is not running'.format(container_name, process_name)
 
-        logger.info('Waiting {} seconds for healthd to work'.format(DEFAULT_INTERVAL))
-        time.sleep(DEFAULT_INTERVAL)
         if expect_error_dict:
             logger.info('Verify data in redis')
             for name, error in expect_error_dict.items():
+                result = wait_until(WAIT_TIMEOUT, 10, 2, check_system_health_info, duthost, name, error)
                 value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, name)
-                assert value == error, 'Expect error {}, got {}'.format(error, value)
+                assert result == True, 'Expect error {}, got {}'.format(error, value)
 
-        summary = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, 'summary')
         expect_summary = SUMMARY_OK if not expect_error_dict else SUMMARY_NOT_OK
-        assert summary == expect_summary, 'Expect summary {}, got {}'.format(expect_summary, summary)
+        result = wait_until(WAIT_TIMEOUT, 10, 2, check_system_health_info, duthost, 'summary', expect_summary)
+        summary = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, 'summary')
+        assert result == True, 'Expect summary {}, got {}'.format(expect_summary, summary)
 
 
 @pytest.mark.disable_loganalyzer
@@ -116,7 +117,7 @@ def test_service_checker_with_process_exit(duthosts, enum_rand_one_per_hwsku_hos
                 # avoid waiting for too long or DEFAULT_INTERVAL is not long enough to refresh db
                 category = '{}:{}'.format(container, critical_process)
                 expected_value = "'{}' is not running".format(critical_process)
-                result = wait_until(90, 10, 2, check_system_health_info, duthost, category, expected_value)
+                result = wait_until(WAIT_TIMEOUT, 10, 2, check_system_health_info, duthost, category, expected_value)
                 assert result == True, '{} is not recorded'.format(critical_process)
                 summary = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, 'summary')
                 assert summary == SUMMARY_NOT_OK
@@ -261,7 +262,7 @@ def test_external_checker(duthosts, enum_rand_one_per_hwsku_hostname):
                      dest=os.path.join('/tmp', EXTERNAL_CHECKER_MOCK_FILE))
         # use wait_until to check if SYSTEM_HEALTH_INFO has expected content
         # avoid waiting for too long or DEFAULT_INTERVAL is not long enough to refresh db
-        result = wait_until(90, 10, 2, check_system_health_info, duthost, 'ExternalService', 'Service is not working')
+        result = wait_until(WAIT_TIMEOUT, 10, 2, check_system_health_info, duthost, 'ExternalService', 'Service is not working')
         assert result == True, 'External checker does not work'
         value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, 'ExternalDevice')
         assert value == 'Device is broken', 'External checker does not work, value={}'.format(value)
@@ -341,9 +342,7 @@ def redis_get_field_value(duthost, db_id, key, field_name):
 
 def check_system_health_info(duthost, category, expected_value):
     value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, category)
-    if value == expected_value:
-        return True
-    return False
+    return value == expected_value
 
 class ConfigFileContext:
     """


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Sleep DEFAULT_INTERVAL(60s) is not very efficient, actually, most of time next DB refresh is less than DEFAULT_INTERVAL.
Sometimes, DEFAULT_INTERVAL may not long enough to refresh db to cause test cases failure. test_service_checker_with_process_exit and test_external_checker sometimes failed but manual testing was success.
wait_until is more efficient and it can save test running time.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Sleep DEFAULT_INTERVAL(60s) is not very efficient, actually, most of time next DB refresh is less than DEFAULT_INTERVAL.
Sometimes, DEFAULT_INTERVAL may not long enough to refresh db to cause test cases failure. test_service_checker_with_process_exit and test_external_checker sometimes failed but manual testing was success.
wait_until is more efficient and it can save test running time.

#### How did you do it?
replace time.sleep with wait_until 

#### How did you verify/test it?
run test_service_checker_with_process_exit and test_external_checker in tests/system_health/test_system_health.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
