### PR TITLE
[acl] Fix some issues in acl test

### DIFF
--- a/tests/acl/templates/acltb_test_rules.j2
+++ b/tests/acl/templates/acltb_test_rules.j2
@@ -31,7 +31,7 @@
                                 },
                                 "ip": {
                                     "config": {
-                                        "destination-ip-address": "192.168.0.4/32"
+                                        "destination-ip-address": "192.168.0.252/32"
                                     }
                                 }
                             },
@@ -228,7 +228,7 @@
                                 },
                                 "ip": {
                                     "config": {
-                                        "destination-ip-address": "192.168.0.8/32"
+                                        "destination-ip-address": "192.168.0.251/32"
                                     }
                                 }
                             },

--- a/tests/acl/templates/acltb_test_rules_part_2.j2
+++ b/tests/acl/templates/acltb_test_rules_part_2.j2
@@ -31,7 +31,7 @@
                                 },
                                 "ip": {
                                     "config": {
-                                        "destination-ip-address": "192.168.0.4/32"
+                                        "destination-ip-address": "192.168.0.252/32"
                                     }
                                 }
                             },
@@ -228,7 +228,7 @@
                                 },
                                 "ip": {
                                     "config": {
-                                        "destination-ip-address": "192.168.0.8/32"
+                                        "destination-ip-address": "192.168.0.251/32"
                                     }
                                 }
                             },

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -21,6 +21,7 @@ from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py, run_garp_service, change_mac_addresses
 from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr
+from tests.common.helpers.assertions import pytest_assert
 
 logger = logging.getLogger(__name__)
 
@@ -58,17 +59,19 @@ DEFAULT_SRC_IP = {
 # TODO: These routes don't match the VLAN interface from the T0 topology.
 # This needs to be addressed before we can enable the v6 tests for T0
 DOWNSTREAM_DST_IP = {
-    "ipv4": "192.168.0.2",
+    "ipv4": "192.168.0.253",
     "ipv6": "20c0:a800::2"
 }
 DOWNSTREAM_IP_TO_ALLOW = {
-    "ipv4": "192.168.0.4",
+    "ipv4": "192.168.0.252",
     "ipv6": "20c0:a800::4"
 }
 DOWNSTREAM_IP_TO_BLOCK = {
-    "ipv4": "192.168.0.8",
+    "ipv4": "192.168.0.251",
     "ipv6": "20c0:a800::8"
 }
+
+DOWNSTREAM_IP_PORT_MAP = {}
 
 UPSTREAM_DST_IP = {
     "ipv4": "192.168.128.1",
@@ -244,6 +247,7 @@ def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname, i
         port = random.choice(setup["vlan_ports"])
         addr = addr_list[i]
         vlan_host_map[port][str(addr)] = mac
+        DOWNSTREAM_IP_PORT_MAP[addr] = port
 
     arp_responder_conf = {}
     for port in vlan_host_map:
@@ -260,12 +264,13 @@ def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname, i
     ptfhost.shell("supervisorctl restart arp_responder")
 
     def populate_arp_table():
-        duthost.command("sonic-clear fdb all")
-        duthost.command("sonic-clear arp")
-        # Wait some time to ensure the async call of clear is completed
-        time.sleep(20)
-        for addr in addr_list:
-            duthost.command("ping {} -c 3".format(addr), module_ignore_errors=True)
+        for dut in duthosts:
+            dut.command("sonic-clear fdb all")
+            dut.command("sonic-clear arp")
+            # Wait some time to ensure the async call of clear is completed
+            time.sleep(20)
+            for addr in addr_list:
+                dut.command("ping {} -c 3".format(addr), module_ignore_errors=True)
 
     populate_arp_table()
 
@@ -860,11 +865,21 @@ class BaseAclTest(object):
 
         ptfadapter.dataplane.flush()
         testutils.send(ptfadapter, self.src_port, pkt)
+        if direction == "uplink->downlink":
+            dst_port = DOWNSTREAM_IP_PORT_MAP.get(pkt[packet.IP].dst)
+            pytest_assert(dst_port != None,
+                          "Can't find dst port for IP {}".format(pkt[packet.IP].dst))
 
-        if dropped:
-            testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=self.get_dst_ports(setup, direction))
+            if dropped:
+                testutils.verify_no_packet(ptfadapter, exp_pkt, dst_port)
+            else:
+                testutils.verify_packet(ptfadapter, exp_pkt, dst_port)
         else:
-            testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=self.get_dst_ports(setup, direction), timeout=20)
+            if dropped:
+                testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=self.get_dst_ports(setup, direction))
+            else:
+                testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=self.get_dst_ports(setup, direction),
+                                                 timeout=20)
 
 
 class TestBasicAcl(BaseAclTest):


### PR DESCRIPTION
What is the motivation for this PR?
1.Current the preset downstream dest IP "192.168.0.2", "192.168.0.4" and "192.168.0.8" are duplicated in Garp service. It will trigger ARP flapping during the test if garp and arp work together.
2.This case will send ping pkts to set up the arp table at the beginning of the case. But on dual-tor system, the ping pkts will be dropped if we randomly pick up the standby tor.
3.As we already know the dest port for downstream traffic, so we just need to poll that dedicated interface rather than poll all interfaces, to make the test more efficient and accurate.

How did you do it?
1.Use "192.168.0.253", "192.168.0.252" and "192.168.0.251" as the downstream dest IP to avoid IP confliction with garp service.
2.Send the ping pkts from both tors.
3.Use verify_packet() rather  than verify_packet_any_port()

How did you verify/test it?
Run the test_acl.py

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
