### PR TITLE
[VXLAN_ECMP] Added all supported topologies "t1, t1-64-lag, t1-lag"

### DIFF
--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -62,7 +62,7 @@ SUPPORTED_ENCAP_TYPES = ['v4_in_v4', 'v4_in_v6', 'v6_in_v4', 'v6_in_v6']
 
 pytestmark = [
     # This script supports any T1 topology: t1, t1-64-lag, t1-lag.
-    pytest.mark.topology("t1"),
+    pytest.mark.topology("t1", "t1-64-lag", "t1-lag"),
     pytest.mark.sanity_check(post_check=True)
 ]
 


### PR DESCRIPTION
### Description of PR
The function in _tests/common/plugins/custom_markers/__init__.py_ which checks topology skipped the test because: 
`"'t1-lag' not in ''t1''"`. 

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To run the test_vxlan_ecmp on all supported topologies: ("t1", "t1-64-lag", "t1-lag")

#### How did you do it?
Extended the list of supported topologies

#### How did you verify/test it?
Ran the test with parameter "--topology t1-lag"

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
