### PR TITLE
[platform_tests] Skip thermal tests if thermal manager is disabled

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -511,15 +511,7 @@ class TestChassisApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_thermal_manager(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
-        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        thermal_manager_available = True
-        if duthost.facts.get("chassis"):
-            thermal_manager_available = duthost.facts.get("chassis").get("thermal_manager", True)
-
-        if not thermal_manager_available:
-            pytest.skip("skipped as thermal manager is not available")
-
+    def test_get_thermal_manager(self, localhost, platform_api_conn, thermal_manager_enabled):
         thermal_mgr = chassis.get_thermal_manager(platform_api_conn)
         pytest_assert(thermal_mgr is not None, "Failed to retrieve thermal manager")
 

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -493,6 +493,16 @@ def capture_interface_counters(duthosts, rand_one_dut_hostname):
         outputs.append(res)
     logging.info("Counters after reboot test: dut={}, cmd_outputs={}".format(duthost.hostname,json.dumps(outputs, indent=4)))
 
+@pytest.fixture()
+def thermal_manager_enabled(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    thermal_manager_available = True
+    if duthost.facts.get("chassis"):
+        thermal_manager_available = duthost.facts.get("chassis").get("thermal_manager", True)
+    if not thermal_manager_available:
+        pytest.skip("skipped as thermal manager is not available")
+
 
 def pytest_generate_tests(metafunc):
     if 'power_off_delay' in metafunc.fixturenames:

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -306,7 +306,7 @@ def test_show_platform_temperature_mocked(duthosts, enum_rand_one_per_hwsku_host
 
 
 @pytest.mark.disable_loganalyzer
-def test_thermal_control_load_invalid_format_json(duthosts, enum_rand_one_per_hwsku_hostname):
+def test_thermal_control_load_invalid_format_json(duthosts, enum_rand_one_per_hwsku_hostname, thermal_manager_enabled):
     """
     @summary: Load a thermal policy file with invalid format, check thermal
               control daemon is up and there is an error log printed
@@ -317,7 +317,7 @@ def test_thermal_control_load_invalid_format_json(duthosts, enum_rand_one_per_hw
 
 
 @pytest.mark.disable_loganalyzer
-def test_thermal_control_load_invalid_value_json(duthosts, enum_rand_one_per_hwsku_hostname):
+def test_thermal_control_load_invalid_value_json(duthosts, enum_rand_one_per_hwsku_hostname, thermal_manager_enabled):
     """
     @summary: Load a thermal policy file with invalid value, check thermal
               control daemon is up and there is an error log printed


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skips `test_thermal_control_load_invalid_format_json` and `test_thermal_control_load_invalid_value_json` if thermal manager is disabled.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
As per [Thermal control management HLD](https://github.com/Azure/SONiC/blob/master/thermal-control-design.md#3-thermal-control-management):
"This cooling device control function can be disabled if the vendor have their own implementation in the kernel or somewhere else."
[PR 9883](https://github.com/Azure/sonic-buildimage/pull/9883
) removes thermal manager for Accton boards.
The TCs mentioned above should be skipped in case thermal manager is not supported.
#### How did you do it?
Moved logic to check if thermal manager is available to a separate fixture.
#### How did you verify/test it?
Run `platform_tests/test_platform_info.py` - test_thermal_control_load_invalid_format_json and test_thermal_control_load_invalid_value_json are skipped if thermal manager is disabled.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
