### PR TITLE
[advance-reboot] Add log_analyzer support for reboot test on small disk devices

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -18,6 +18,11 @@ from tests.common.plugins.sanity_check.recover import neighbor_vm_restore
 TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
 FMT = "%b %d %H:%M:%S.%f"
 FMT_SHORT = "%b %d %H:%M:%S"
+SMALL_DISK_SKUS = [
+    "Arista-7060CX-32S-C32",
+    "Arista-7060CX-32S-Q32"
+]
+
 
 def _parse_timestamp(timestamp):
     try:
@@ -330,6 +335,23 @@ def verify_mac_jumping(test_name, timing_data):
             pytest.fail("Mac expiry detected during the window when FDB ageing was disabled")
 
 
+def overwrite_script_to_backup_logs(duthost, reboot_type):
+    # find the fast/warm-reboot script path
+    reboot_script_path = duthost.shell('which {}'.format("{}-reboot".format(reboot_type)))['stdout']
+    # backup original script
+    duthost.shell("cp {} {}".format(reboot_script_path, reboot_script_path + ".orig"))
+    # find the anchor string inside fast/warm-reboot script
+    rebooting_log_line = "debug.*Rebooting with.*to.*"
+    # Create a backup log command to be inserted right after the anchor string defined above
+    backup_log_cmds ="cp /var/log/syslog /host/syslog.99;" +\
+        "cp /var/log/swss/sairedis.rec /host/sairedis.rec.99;" +\
+        "cp /var/log/swss/swss.rec /host/swss.rec.99;" +\
+            "cp /var/log/frr/bgpd.log /host/bgpd.log.99"
+    # Do find-and-replace on fast/warm-reboot script to insert the backup_log_cmds string
+    insert_backup_command = "sed -i '/{}/a {}' {}".format(rebooting_log_line, backup_log_cmds, reboot_script_path)
+    duthost.shell(insert_backup_command)
+
+
 @pytest.fixture()
 def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
     """
@@ -356,6 +378,14 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
         if 'vs' not in device_marks:
             pytest.skip('Testcase not supported for kvm')
 
+    hwsku = duthost.facts["hwsku"]
+    if hwsku in SMALL_DISK_SKUS:
+        # For small disk devices, /var/log in mounted in tmpfs.
+        # Hence, after reboot the preboot logs are lost.
+        # For log_analyzer to work, it needs logs from the shutdown path
+        # Below method inserts a step in reboot script to back up logs to /host/
+        overwrite_script_to_backup_logs(duthost, reboot_type)
+
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="test_advanced_reboot_{}".format(test_name),
                     additional_files={'/var/log/swss/sairedis.rec': 'recording on: /var/log/swss/sairedis.rec', '/var/log/frr/bgpd.log': ''})
 
@@ -375,6 +405,17 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
         return marker
 
     def post_reboot_analysis(marker, reboot_oper=None, log_dir=None):
+        if hwsku in SMALL_DISK_SKUS:
+            restore_backup = "mv /host/syslog.99 /var/log/; " +\
+                "mv /host/sairedis.rec.99 /var/log/swss/; " +\
+                    "mv /host/swss.rec.99 /var/log/swss/; " +\
+                        "mv /host/bgpd.log.99 /var/log/frr/"
+            # find the fast/warm-reboot script path
+            reboot_script_path = duthost.shell('which {}'.format("{}-reboot".format(reboot_type)))['stdout']
+            # restore original script
+            duthost.shell("mv {} {}".format(reboot_script_path + ".orig", reboot_script_path))
+            duthost.shell(restore_backup, module_ignore_errors=True)
+
         result = loganalyzer.analyze(marker, fail=False)
         analyze_result = {"time_span": dict(), "offset_from_kexec": dict()}
         offset_from_kexec = dict()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Backup preboot logs when not retained by DUT. This happens in small disk devices where /var/log is mouted on tmpfs. Without preboot logs, log_analyzer fails.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Presently, test_advanced_reboot cases fail on small disk device since preboot logs are not retained and log_analyzer 
fails to get start strings from the logs.

Fix this issue so that test_advanced_reboot cases can be executed on small disk devices.

#### How did you do it?
Steps:
1. Create a back of warm/fast-reboot script.
2. Before reboot - modify script and add step to copy logs from /var/log to /host before kexec.
3. After reboot - collect the backup logs from /host/ and restore the warm/fast-reboot script.

#### How did you verify/test it?
Tested on a physical testbed with small HD. Timing data for reboot analysis can be collected now.

Replacement added to the script to create backup:
```
# diff warm-reboot warm-reboot.orig 
837d836
< cp /var/log/syslog /host/syslog.99;cp /var/log/swss/sairedis.rec /host/sairedis.rec.99;cp /var/log/swss/swss.rec /host/swss.rec.99;cp /var/log/frr/bgpd.log /host/bgpd.log.99
```

From 7060 device:
```
{
    "offset_from_kexec": {
        "database": "25.884498",
        "finalizer": "25.911712",
        "init_view": "40.653907",
        "syncd_create_switch": "49.587394",
        "fpmsyncd_reconciliation": "40.02647",
        "port_init": "63.932436",
        "port_ready": "80.619207",
        "sai_create_switch": "62.352508",
        "neighbor_entry": "65.109247",
        "default_route_set": "67.238689",
        "apply_view": "73.276639",
        "lag_ready": "110.60562",
        "fdb_restore": "67.645562",
        "route_deferral_timer": "111.33099"
    },
    "controlplane": {
        "lacp_session_max_wait": 86.93564772605896,
        "arp_ping": "",
        "downtime": "75.885916"
    },
    "time_span": {
        "radv": "81.297256",
        "bgp": "70.222747",
        "syncd": "37.79012",
        "swss": "60.074086",
        "teamd": "51.530036",
        "database": "27.361914",
        "syncd_create_switch": "12.25476",
        "sai_create_switch": "0.001702",
        "apply_view": "7.324648",
        "init_view": "21.687204",
        "neighbor_entry": "0.968611",
        "port_init": "0.819528",
        "port_ready": "0.0198",
        "finalizer": "139.668489",
        "lag_ready": "0.00315",
        "fpmsyncd_reconciliation": "120.191091",
        "route_deferral_timer": "0.967482",
        "fdb_restore": "0.520848"
    },
    "reboot_type": "warm",
    "dataplane": {
        "lost_packets": "0",
        "downtime": "0.0"
    }
}
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
