### PR TITLE
Improve `test_restapi`

### DIFF
--- a/tests/restapi/conftest.py
+++ b/tests/restapi/conftest.py
@@ -95,7 +95,8 @@ def setup_restapi_server(duthosts, rand_one_dut_hostname, localhost):
     urllib3.disable_warnings()
 
     yield
-    config_reload(duthost)
+    # Perform a config load_minigraph to ensure config_db is not corrupted
+    config_reload(duthost, config_source='minigraph')
     # Delete all created certs
     local_command = "rm \
                         restapiCA.* \


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to improve `test_restapi`.
`test_check_reset_status` will issue a `warm-reboot` at the end of test case. However, the next case `test_data_path` is likely to start running before `warmboot-finalizer` service is done. As a result, the testing config will be written into `config_db.json` and cause a series of test failure.
This PR addressed the issue by
1. Add a logic in `reboot` function to wait `warmboot-finalizer` finish running
2. Add a `config load_minigraph` at the end of `test_restapi` to ensure a clean `config_db.json`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to improve `test_restapi`.

#### How did you do it?
1. Add a logic in `reboot` function to wait `warmboot-finalizer` finish running
2. Add a `config load_minigraph` at the end of `test_restapi` to ensure a clean `config_db.json`.

#### How did you verify/test it?
Verified on SN4600c
```
collected 6 items                                                                                                                                                                                     

restapi/test_restapi.py::test_check_reset_status  ^H ^H ^HPASSED                                                                                                                                         [ 16%]
restapi/test_restapi.py::test_data_path PASSED                                                                                                                                                  [ 33%] ^H
restapi/test_restapi.py::test_data_path_sad PASSED                                                                                                                                              [ 50%] ^H
restapi/test_restapi.py::test_create_vrf PASSED                                                                                                                                                 [ 66%] ^H
restapi/test_restapi.py::test_create_interface PASSED                                                                                                                                           [ 83%] ^H
restapi/test_restapi.py::test_create_interface_sad PASSED                                                                                                                                       [100%]
```
#### Any platform specific information?
MLNX specific test case.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
