### PR TITLE
Send Jumbo MTU frames of size 9114 bytes

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -118,7 +118,7 @@ class FibTest(BaseTest):
             self.ptf_test_port_map = json.load(f)
 
         self.router_macs = self.test_params.get('router_macs')
-        self.pktlen = self.test_params.get('testbed_mtu', 1500)
+        self.pktlen = self.test_params.get('testbed_mtu', 9114)
         self.test_ipv4 = self.test_params.get('ipv4', True)
         self.test_ipv6 = self.test_params.get('ipv6', True)
         self.test_balancing = self.test_params.get('test_balancing', True)
@@ -298,6 +298,9 @@ class FibTest(BaseTest):
 
         if self.pkt_action == self.ACTION_FWD:
             rcvd_port, rcvd_pkt = verify_packet_any_port(self,masked_exp_pkt, dst_port_list)
+            len_rcvd_pkt = len(rcvd_pkt)
+            logging.info('Recieved packet at port {} and packet is {} bytes'.format(rcvd_port,len_rcvd_pkt))
+            logging.info('Recieved packet with length of {}'.format(len_rcvd_pkt))
             exp_src_mac = self.router_macs[self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_dut']]
             actual_src_mac = Ether(rcvd_pkt).src
             if exp_src_mac != actual_src_mac:
@@ -374,6 +377,9 @@ class FibTest(BaseTest):
 
         if self.pkt_action == self.ACTION_FWD:
             rcvd_port, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
+            len_rcvd_pkt = len(rcvd_pkt)
+            logging.info('Recieved packet at port {} and packet is {} bytes'.format(rcvd_port,len_rcvd_pkt))
+            logging.info('Recieved packet with length of {}'.format(len_rcvd_pkt))
             exp_src_mac = self.router_macs[self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_dut']]
             actual_src_mac = Ether(rcvd_pkt).src
             if actual_src_mac != exp_src_mac:

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -333,7 +333,7 @@ def bgp_speaker_announce_routes_common(common_setup_teardown,
     logger.info("Nexthop ip%s tests are done" % family)
 
 
-@pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(True, False, 1514)])
+@pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(True, False, 9114)])
 def test_bgp_speaker_announce_routes(common_setup_teardown, tbinfo, duthosts, rand_one_dut_hostname, ptfhost, ipv4, ipv6, mtu, vlan_mac):
     """Setup bgp speaker on T0 topology and verify routes advertised by bgp speaker is received by T0 TOR
 
@@ -343,7 +343,7 @@ def test_bgp_speaker_announce_routes(common_setup_teardown, tbinfo, duthosts, ra
     bgp_speaker_announce_routes_common(common_setup_teardown, tbinfo, duthost, ptfhost, ipv4, ipv6, mtu, "v4", "10.10.10.0/26", nexthops, vlan_mac)
 
 
-@pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(False, True, 1514)])
+@pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(False, True, 9114)])
 def test_bgp_speaker_announce_routes_v6(common_setup_teardown, tbinfo, duthosts, rand_one_dut_hostname, ptfhost, ipv4, ipv6, mtu, vlan_mac):
     """Setup bgp speaker on T0 topology and verify routes advertised by bgp speaker is received by T0 TOR
 


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # (issue)
This script includes test cases as below

1.Regular bgp_speaker tests ( test_bgp_speaker.py, ipv4 announce_route and ipv6 announce_route)
2. fib_test.py under ptftests
 

### Type of change

- [ ]  Bug fix
- [ ]  Testbed and Framework(new/improvement)
- [x]  Test case(new/improvement)

### Back port request
- [ ] 201911

Approach

What is the motivation for this PR?

Refactored the test_bgp_speaker.py to send jumbo mtu frames up to size 9114  and to ensure the traffic sent and received at the destination are the same #4841 

#### How did you do it?

Changed MTU size on ipv4 and ipv6 announce routes in test_bgp_speaker.py to 9114 bytes. After sending traffic using jumbo frames to the virtually created neighbors (3 speaker ip's created using - refer test_bgp_speaker.py) and to send traffic to those from the script fib_test.py, we have to check whether the byte count of the received packet at the destination is same as that of the sent packet, I have added few logger.info's on the /tmp/bgp_speaker_test.FibTest.log  folder of ptf logs in where I have printed the len(received_packet) , which exactly prints the number of bytes received at the destination.

#### How did you verify/test it?

I have checked /tmp/bgp_speaker_test.FibTest.log by logging in to the ptf to verify the byte count.


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 

