### PR TITLE
[transceiver_utils] Added fix for method check_transceiver_details which allow tests pass on 202111 image

### DIFF
--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -78,7 +78,7 @@ def check_transceiver_details(dut, asic_index, interfaces, xcvr_skip_list):
     """
     asichost = dut.asic_instance(asic_index)
     logging.info("Check detailed transceiver information of each connected port")
-    if dut.sonic_release == "202012":
+    if dut.sonic_release in ["202012", "202106","202111"]:
         expected_fields = ["type", "hardware_rev", "serial", "manufacturer", "model"]
     else:
         expected_fields = ["type", "vendor_rev", "serial", "manufacturer", "model"]


### PR DESCRIPTION
Added fix for method check_transceiver_details which allow tests pass on 202111 image

Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Added fix for method check_transceiver_details which allow tests pass on 202111 image
Old logic caused fail on image 202111:
```
Failed: Transceiver 1 info does not contain field: 'vendor_rev'
Expected field vendor_rev is not found in type
```
Now test passing

Summary: Added fix for method check_transceiver_details which allow tests pass on 202111 image
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fixed test failure

#### How did you do it?
see code

#### How did you verify/test it?
executed test - sonic-mgmt/tests/platform_tests/test_xcvr_info_in_db.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
