### PR TITLE
FWUtil Test Bugfixes 

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -11,10 +11,6 @@ platform_tests/test_sequential_restart.py::test_restart_syncd:
   skip:
     reason: "Restarting syncd is not supported yet"
 
-platform_tests/fwutil/test_fwutil.py::test_fwutil_auto:
-  skip:
-    reason: "Command not yet merged into sonic-utilites"
-
 qos/test_pfc_pause.py::test_pfc_pause_lossless:
   # For this test, we use the fanout connected to the DUT to send PFC pause frames.
   # The fanout needs to send PFC frames fast enough so that the queue remains completely paused for the entire duration

--- a/tests/platform_tests/fwutil/conftest.py
+++ b/tests/platform_tests/fwutil/conftest.py
@@ -5,7 +5,6 @@ import logging
 
 from random import randrange
 
-from tests.common.utilities import wait_until
 from fwutil_common import show_firmware
 
 logger = logging.getLogger(__name__)
@@ -50,7 +49,6 @@ def random_component(duthost, fw_pkg):
     if len(components) == 0:
         pytest.skip("No suitable components found in config file for platform {}.".format(duthost.facts['platform']))
 
-    #return "CPLD2"
     return components[randrange(len(components))] 
 
 @pytest.fixture(scope='function')
@@ -109,7 +107,7 @@ def next_image(duthost, fw_pkg):
         )
         duthost.command(cmd)
     except Exception as e:
-        duthost.command("sonic-installer remove {}".format(target))
+        duthost.command("sonic-installer remove {} -y".format("SONiC-OS-{}".format(target)))
         pytest.fail("Failed to setup next-image.")
 
     yield overlay_mountpoint

--- a/tests/platform_tests/fwutil/conftest.py
+++ b/tests/platform_tests/fwutil/conftest.py
@@ -79,10 +79,10 @@ def next_image(duthost, fw_pkg):
 
     logger.info("Installing new image {}".format(target))
 
-    if fwpkg["images"][target].startswith("http"):
-        duthost.get_url(url=fwpkg["images"][target], dest=DUT_HOME)
+    if fw_pkg["images"][target].startswith("http"):
+        duthost.get_url(url=fw_pkg["images"][target], dest=DUT_HOME)
     else:
-        duthost.copy(src=os.path.join("firmware", fwpkg["images"][target]), dest=DUT_HOME)
+        duthost.copy(src=os.path.join("firmware", fw_pkg["images"][target]), dest=DUT_HOME)
 
     remote_path = os.path.join(DUT_HOME, os.path.basename(fw_pkg["images"][target]))
     duthost.command("sonic-installer install -y {}".format(remote_path), module_ignore_errors=True)

--- a/tests/platform_tests/fwutil/conftest.py
+++ b/tests/platform_tests/fwutil/conftest.py
@@ -78,7 +78,12 @@ def next_image(duthost, fw_pkg):
         pytest.skip("No suitable image definitions found in config")
 
     logger.info("Installing new image {}".format(target))
-    duthost.copy(src=os.path.join("firmware", fw_pkg["images"][target]), dest=DUT_HOME)
+
+    if fwpkg["images"][target].startswith("http"):
+        duthost.get_url(url=fwpkg["images"][target], dest=DUT_HOME)
+    else:
+        duthost.copy(src=os.path.join("firmware", fwpkg["images"][target]), dest=DUT_HOME)
+
     remote_path = os.path.join(DUT_HOME, os.path.basename(fw_pkg["images"][target]))
     duthost.command("sonic-installer install -y {}".format(remote_path), module_ignore_errors=True)
 

--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -72,7 +72,7 @@ def complete_install(duthost, localhost, boot_type, res, pdu_ctrl, auto_reboot=F
         
         logger.info("Waiting on switch to shutdown...")
         # Wait for ssh flap
-        localhost.wait_for(host=hn, port=22, state='stopped', delay=10, timeout=timeout)
+        localhost.wait_for(host=hn, port=22, state='stopped', delay=1, timeout=timeout)
         logger.info("Letting switch get through ONIE / BIOS before pinging....")
         time.sleep(300)
         logger.info("Waiting on switch to come up....")
@@ -253,7 +253,7 @@ def call_fwutil(duthost, localhost, pdu_ctrl, fw, component=None, next_image=Non
 
     time.sleep(2) # Give a little bit of time in case of no-op install for mounts to complete
     final_versions = show_firmware(duthost)
-    assert validate_versions(init_versions, final_versions, paths, chassis, boot_type)
+    test_result = validate_versions(init_versions, final_versions, paths, chassis, boot_type)
 
     if next_image is None:
         duthost.copy(src=os.path.join("firmware", "platform_components_backup.json"), 
@@ -270,5 +270,5 @@ def call_fwutil(duthost, localhost, pdu_ctrl, fw, component=None, next_image=Non
         logger.info("Latest firmware not installed after test. Installing....")
         call_fwutil(duthost, localhost, pdu_ctrl, update_needed, component, None, boot, os.path.join("/", DEVICES_PATH, duthost.facts['platform']) if basepath is not None else None)
 
-    return True
+    return test_result
 

--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -17,7 +17,7 @@ POWER_CYCLE = "power off"
 FAST_REBOOT = "fast"
 
 DEVICES_PATH="usr/share/sonic/device"
-TIMEOUT=600
+TIMEOUT=1200
 REBOOT_TYPES = {
     COLD_REBOOT: "reboot",
     WARM_REBOOT: "warm-reboot",

--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -9,6 +9,8 @@ from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
+TEMP_STATUS_FILE = "/tmp/firmwareupdate/fw_au_status"
+
 WARM_REBOOT = "warm"
 COLD_REBOOT = "cold"
 POWER_CYCLE = "power off"
@@ -134,7 +136,7 @@ def get_install_paths(duthost, fw, versions, chassis, target_component):
                 log.warning("Firmware is upgrade only and existing firmware {} is not present in version list. Skipping {}".format(ver[comp], comp))
                 continue
             for i, rev in enumerate(revs):
-                if "hw_revision" in r and r["hw_revision"] != get_hw_revision(duthost):
+                if "hw_revision" in rev and rev["hw_revision"] != get_hw_revision(duthost):
                     log.warning("Firmware {} only supports HW Revision {} and this chassis is {}. Skipping".format(rev["version"], rev["hw_revision"], get_hw_revision(duthost)))
                     continue
                 if rev["version"] != ver[comp]:
@@ -167,6 +169,9 @@ def generate_config(duthost, cfg, versions):
 
 def upload_platform(duthost, paths, next_image=None):
     target = next_image if next_image else "/"
+
+    # Clear auto update status file
+    duthost.command("rm -rf {}".format(TEMP_STATUS_FILE))
 
     # Backup the original platform_components.json file
     duthost.fetch(dest=os.path.join("firmware", "platform_components_backup.json"), 

--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -251,6 +251,7 @@ def call_fwutil(duthost, localhost, pdu_ctrl, fw, component=None, next_image=Non
     pdu_delay = fw["chassis"][chassis].get("power_cycle_delay", 60)
     complete_install(duthost, localhost, boot_type, res, pdu_ctrl, auto_reboot, current, next_image, timeout, pdu_delay)
 
+    time.sleep(2) # Give a little bit of time in case of no-op install for mounts to complete
     final_versions = show_firmware(duthost)
     assert validate_versions(init_versions, final_versions, paths, chassis, boot_type)
 

--- a/tests/platform_tests/fwutil/test_fwutil.py
+++ b/tests/platform_tests/fwutil/test_fwutil.py
@@ -21,8 +21,9 @@ def test_fwutil_show(duthost):
 
     show_fw_comp_set = set(versions["chassis"][chassis]["component"].keys())
     platform_comp_set = set(platform_comp["chassis"][chassis]["component"].keys())
+    comp = show_fw_comp_set == platform_comp_set
 
-    assert show_fw_comp_set == platform_comp_set
+    assert comp
 
 def test_fwutil_install_file(duthost, localhost, pdu_controller, fw_pkg, random_component):
     """Tests manually installing firmware to a component from a file."""

--- a/tests/platform_tests/fwutil/test_fwutil.py
+++ b/tests/platform_tests/fwutil/test_fwutil.py
@@ -108,12 +108,12 @@ def test_fwutil_update_bad_config(duthost, fw_pkg, random_component):
     assert found_bad_component
 
 
-@pytest.mark.parametrize("reboot_type", ["none", "warm", "fast", "cold", "power off"])
+@pytest.mark.parametrize("reboot_type", ["none", "cold"])
 def test_fwutil_auto(duthost, localhost, pdu_controller, fw_pkg, reboot_type):
     """Tests fwutil update all command ability to properly select firmware for install based on boot type."""
     assert call_fwutil(duthost,
             localhost,
             pdu_controller,
             fw_pkg,
-            reboot=reboot_type)
+            boot=reboot_type)
 


### PR DESCRIPTION
### Description of PR
Set of general fixes made during Mellanox implementation of the fwutil tests into nightly regression

- Add support for URLs in firmware file paths
- Add support for differentiating firmware installed for different hardware revisions
- Fix test cleanup such that latest firmware is always on device at end of test
- Enable `fwutil update all` tests 
- A couple timing errors / race conditions with `sonic_installer` and rebooting

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
