### PR TITLE
[DHCP][mASIC] Fix DHCP relay test on multi ASIC platform

### DIFF
--- a/tests/dhcp_relay/test_dhcp_pkt_fwd.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_fwd.py
@@ -144,13 +144,13 @@ class DhcpPktFwdBase:
             tbinfo
         )
 
-        self.__updateRoute(duthost, self.DHCP_SERVER["ip"], upstreamPeerIp)
-        self.__updateRoute(duthost, self.DHCP_RELAY["ip"], downstreamPeerIp)
+        duthost.update_ip_route(self.DHCP_SERVER["ip"], upstreamPeerIp)
+        duthost.update_ip_route(self.DHCP_RELAY["ip"], downstreamPeerIp)
 
         yield {"upstream": upstreamLags, "downstream": downstreamLags}
 
-        self.__updateRoute(duthost, self.DHCP_SERVER["ip"], upstreamPeerIp, "no")
-        self.__updateRoute(duthost, self.DHCP_RELAY["ip"], downstreamPeerIp, "no")
+        duthost.update_ip_route(self.DHCP_SERVER["ip"], upstreamPeerIp, "no")
+        duthost.update_ip_route(self.DHCP_RELAY["ip"], downstreamPeerIp, "no")
 
     @classmethod
     def createDhcpDiscoverRelayedPacket(self, dutMac):
@@ -315,7 +315,7 @@ class TestDhcpPktFwd(DhcpPktFwdBase):
 
         # Update fields of the forwarded packet
         dhcpPacket[scapy.Ether].src = duthost.facts["router_mac"]
-        dhcpPacket[scapy.IP].ttl = dhcpPacket[scapy.IP].ttl - 1
+        dhcpPacket[scapy.IP].ttl = dhcpPacket[scapy.IP].ttl - duthost.ttl_decr_value
 
         expectedDhcpPacket = Mask(dhcpPacket)
         expectedDhcpPacket.set_do_not_care_scapy(scapy.Ether, "dst")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fix DHCP relay test on multi ASIC platform

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
DHCP relay test was failing on multi ASIC platofrm

#### How did you do it?
* program relay and server IP route on all the namespaces
* Fix TTL check on mutli ASIC platform as there are 2 more L3 hops.

#### How did you verify/test it?
```
samaddik@svcstr-server-2:/var/sonic-mgmt/tests$ pytest -vv dhcp_relay/test_dhcp_pkt_fwd.py  --testbed=vmsvc1-t1-nmasic-acs-1 --inventory=../ansible/strsvc,../ansible/veos  --testbed_file=../ansible/testbed.csv --host-pattern=svcstr-nmasic-acs-1  --module-path=../ansible/library  --topology="t1,any"   --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.17', 'Platform': 'Linux-4.15.0-163-generic-x86_64-with-Ubuntu-18.04-bionic', 'Packages': {'py': '1.10.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.9.1', u'ansible': u'2.2.2', u'xdist':
u'1.28.0', u'html': u'1.22.1', u'forked': u'1.3.0', u'metadata': u'1.11.0'}}
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: html-1.22.1, repeat-0.9.1, forked-1.3.0, xdist-1.28.0, metadata-1.11.0, ansible-2.2.2
collecting ... ['conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut', 'inv_name', 'auto_recover', 'comment']
Finished testbed info generating.
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 4 items

dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo0] PASSED                                                                                                                                            [ 25%]
dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo1] PASSED                                                                                                                                            [ 50%]
dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo2] PASSED                                                                                                                                            [ 75%]
dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo3] PASSED                                                                                                                                            [100%]

============================================================================================================= warnings summary ==============================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================================================================================== 4 passed, 1 warnings in 84.41 seconds ===================================================================================================
Exception AttributeError: "'NoneType' object has no attribute 'close'" in <bound method EventDescriptor.__del__ of <ptf.ptfutils.EventDescriptor instance at 0x7f3a5d501a50>> ignored
samaddik@svcstr-server-2:/var/sonic-mgmt/tests$

```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
