### PR TITLE
[subport] Run subport only on td2

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert as py_assert
+from tests.common.helpers.assertions import pytest_require as py_require
 from tests.common.utilities import get_host_visible_vars
 from tests.common.utilities import wait_until
 from sub_ports_helpers import DUT_TMP_DIR
@@ -55,14 +56,9 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope='module', autouse=True)
 def skip_unsupported_asic_type(duthost):
-    SUBPORT_UNSUPPORTED_ASIC_LIST = ["th2"]
-    vendor = duthost.facts["asic_type"]
-    hostvars = get_host_visible_vars(duthost.host.options['inventory'], duthost.hostname)
-    for asic in SUBPORT_UNSUPPORTED_ASIC_LIST:
-        vendorAsic = "{0}_{1}_hwskus".format(vendor, asic)
-        if vendorAsic in hostvars.keys() and duthost.facts['hwsku'] in hostvars[vendorAsic]:
-            pytest.skip(
-                "Skipping test since subport is not supported on {0} {1} platforms".format(vendor, asic))
+    SUBPORT_SUPPORTED_ASIC_LIST = ["td2"]
+    asic_type = duthost.get_asic_name()
+    py_require(asic_type in SUBPORT_SUPPORTED_ASIC_LIST, "Subport tests is not supported on {}".format(asic_type))
 
 
 @pytest.fixture(params=['port', 'port_in_lag'])


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Run subport related testcases only on td2.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
```
collected 31 items

sub_port_interfaces/test_show_subinterface.py::test_subinterface_status[port] SKIPPED                                                                                                                                                                                  [  3%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_packet_routed_with_valid_vlan[port] SKIPPED                                                                                                                                                        [  6%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_packet_routed_with_valid_vlan[port_in_lag] SKIPPED                                                                                                                                                 [  9%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_packet_routed_with_invalid_vlan[port] SKIPPED                                                                                                                                                      [ 12%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_packet_routed_with_invalid_vlan[port_in_lag] SKIPPED                                                                                                                                               [ 16%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_untagged_packet_not_routed[port] SKIPPED                                                                                                                                                           [ 19%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_admin_status_down_disables_forwarding[port] SKIPPED                                                                                                                                                [ 22%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_admin_status_down_disables_forwarding[port_in_lag] SKIPPED                                                                                                                                         [ 25%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_max_numbers_of_sub_ports[port] SKIPPED                                                                                                                                                             [ 29%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_max_numbers_of_sub_ports[port_in_lag] SKIPPED                                                                                                                                                      [ 32%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_mtu_inherited_from_parent_port[port] SKIPPED                                                                                                                                                       [ 35%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_mtu_inherited_from_parent_port[port_in_lag] SKIPPED                                                                                                                                                [ 38%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_vlan_config_impact[port] SKIPPED                                                                                                                                                                   [ 41%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_vlan_config_impact[port_in_lag] SKIPPED                                                                                                                                                            [ 45%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports[same-port-TCP-UDP-ICMP] SKIPPED                                                                                                                                          [ 48%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports[same-port_in_lag-TCP-UDP-ICMP] SKIPPED                                                                                                                                   [ 51%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports[different-port-TCP-UDP-ICMP] SKIPPED                                                                                                                                     [ 54%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports[different-port_in_lag-TCP-UDP-ICMP] SKIPPED                                                                                                                              [ 58%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_unaffected_by_sub_ports_removal[same-TCP-UDP-ICMP-PORT] SKIPPED                                                                                                          [ 61%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_unaffected_by_sub_ports_removal[different-TCP-UDP-ICMP-PORT] SKIPPED                                                                                                     [ 64%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[svi-port-TCP-UDP-ICMP] SKIPPED                                                                                                                                  [ 67%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[svi-port_in_lag-TCP-UDP-ICMP] SKIPPED                                                                                                                           [ 70%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[l3-port-TCP-UDP-ICMP] SKIPPED                                                                                                                                   [ 74%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[l3-port_in_lag-TCP-UDP-ICMP] SKIPPED                                                                                                                            [ 77%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports[same-port] SKIPPED                                                                                                                                                     [ 80%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports[same-port_in_lag] SKIPPED                                                                                                                                              [ 83%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports[different-port] SKIPPED                                                                                                                                                [ 87%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports[different-port_in_lag] SKIPPED                                                                                                                                         [ 90%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_balancing_sub_ports[port] SKIPPED                                                                                                                                                                  [ 93%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_balancing_sub_ports[port_in_lag] SKIPPED                                                                                                                                                           [ 96%]
sub_port_interfaces/test_sub_port_l2_forwarding.py::test_sub_port_l2_forwarding[port] SKIPPED                                                                                                                                                                          [100%]

======================================================================================================================== 31 skipped in 49.26 seconds =========================================================================================================================
```
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
