### PR TITLE
[dualToR] Add test to cover the scenario of a port being set to admin down

### DIFF
--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -561,7 +561,9 @@ class DualTorIO:
                 continue
             if packet[scapyall.Ether].src in self.received_pkt_src_mac:
                 # This is a received packet.
-                curr_time = packet.time
+                # scapy 2.4.5 will use Decimal to calulcate time, but json.dumps
+                # can't recognize Decimal, transform to float here
+                curr_time = float(packet.time)
                 curr_payload = int(str(packet[scapyall.TCP].payload).replace('X',''))
 
                 # Look back at the previous received packet to check for gaps/duplicates

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -145,7 +145,7 @@ def test_active_tor_downlink_down_upstream(
     """
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=3, action=shutdown_upper_tor_downlink_intfs
+        allowed_disruption=0, action=shutdown_upper_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -164,7 +164,7 @@ def test_active_tor_downlink_down_downstream_active(
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=3, action=shutdown_upper_tor_downlink_intfs
+        allowed_disruption=0, action=shutdown_upper_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -184,7 +184,7 @@ def test_active_tor_downlink_down_downstream_standby(
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=3, action=shutdown_upper_tor_downlink_intfs
+        allowed_disruption=0, action=shutdown_upper_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -204,7 +204,7 @@ def test_standby_tor_downlink_down_upstream(
     """
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=2, action=shutdown_lower_tor_downlink_intfs
+        allowed_disruption=0, action=shutdown_lower_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -224,7 +224,7 @@ def test_standby_tor_downlink_down_downstream_active(
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=2, action=shutdown_lower_tor_downlink_intfs
+        allowed_disruption=0, action=shutdown_lower_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -244,7 +244,7 @@ def test_standby_tor_downlink_down_downstream_standby(
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=2, action=shutdown_lower_tor_downlink_intfs
+        allowed_disruption=0, action=shutdown_lower_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -145,7 +145,7 @@ def test_active_tor_downlink_down_upstream(
     """
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=0, action=shutdown_upper_tor_downlink_intfs
+        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -164,7 +164,7 @@ def test_active_tor_downlink_down_downstream_active(
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=0, action=shutdown_upper_tor_downlink_intfs
+        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -184,7 +184,7 @@ def test_active_tor_downlink_down_downstream_standby(
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=0, action=shutdown_upper_tor_downlink_intfs
+        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -203,7 +203,7 @@ def test_standby_tor_downlink_down_upstream(
     Verify no switchover and no disruption
     """
     send_server_to_t1_with_action(
-        upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        upper_tor_host, verify=True,
         allowed_disruption=0, action=shutdown_lower_tor_downlink_intfs
     )
     verify_tor_states(
@@ -223,7 +223,7 @@ def test_standby_tor_downlink_down_downstream_active(
     Confirm no switchover and no disruption
     """
     send_t1_to_server_with_action(
-        upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        upper_tor_host, verify=True,
         allowed_disruption=0, action=shutdown_lower_tor_downlink_intfs
     )
     verify_tor_states(
@@ -243,7 +243,7 @@ def test_standby_tor_downlink_down_downstream_standby(
     Confirm no switchover and no disruption
     """
     send_t1_to_server_with_action(
-        lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        lower_tor_host, verify=True,
         allowed_disruption=0, action=shutdown_lower_tor_downlink_intfs
     )
     verify_tor_states(

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -3,7 +3,8 @@ import pytest
 from tests.common.dualtor.control_plane_utils import verify_tor_states
 from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, send_server_to_t1_with_action                                  # lgtm[py/unused-import]
 from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, shutdown_fanout_upper_tor_intfs, \
-                                                shutdown_fanout_lower_tor_intfs, upper_tor_fanouthosts, lower_tor_fanouthosts                   # lgtm[py/unused-import]
+                                                shutdown_fanout_lower_tor_intfs, upper_tor_fanouthosts, lower_tor_fanouthosts, \
+                                                shutdown_upper_tor_downlink_intfs, shutdown_lower_tor_downlink_intfs                   # lgtm[py/unused-import]
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor                                                  # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, copy_ptftests_directory, change_mac_addresses             # lgtm[py/unused-import]
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
@@ -125,6 +126,125 @@ def test_standby_link_down_downstream_standby(
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs
+    )
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host,
+        expected_standby_health='unhealthy'
+    )
+
+
+def test_active_tor_downlink_down_upstream(
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
+    toggle_all_simulator_ports_to_upper_tor,
+    shutdown_upper_tor_downlink_intfs
+):
+    """
+    Send traffic from server to T1 and shutdown the active ToR downlink on DUT.
+    Verify switchover and disruption lasts < 1 second
+    """
+    send_server_to_t1_with_action(
+        upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        allowed_disruption=3, action=shutdown_upper_tor_downlink_intfs
+    )
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host,
+        expected_standby_health='unhealthy'
+    )
+
+def test_active_tor_downlink_down_downstream_active(
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor,
+    shutdown_upper_tor_downlink_intfs
+):
+    """
+    Send traffic from T1 to active ToR and shutdown the active ToR downlink on DUT.
+    Verify switchover and disruption lasts < 1 second
+    """
+    send_t1_to_server_with_action(
+        upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        allowed_disruption=3, action=shutdown_upper_tor_downlink_intfs
+    )
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host,
+        expected_standby_health='unhealthy'
+    )
+
+
+def test_active_tor_downlink_down_downstream_standby(
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor,
+    shutdown_upper_tor_downlink_intfs
+):
+    """
+    Send traffic from T1 to standby ToR and shutdown the active ToR downlink on DUT.
+    Verify switchover and disruption lasts < 1 second
+    """
+    send_t1_to_server_with_action(
+        lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        allowed_disruption=3, action=shutdown_upper_tor_downlink_intfs
+    )
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host,
+        expected_standby_health='unhealthy'
+    )
+
+
+def test_standby_tor_downlink_down_upstream(
+    upper_tor_host, lower_tor_host, send_server_to_t1_with_action,
+    toggle_all_simulator_ports_to_upper_tor,
+    shutdown_lower_tor_downlink_intfs
+):
+    """
+    Send traffic from server to T1 and shutdown the standby ToR downlink on DUT.
+    Verify no switchover and no disruption
+    """
+    send_server_to_t1_with_action(
+        upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        allowed_disruption=2, action=shutdown_lower_tor_downlink_intfs
+    )
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host,
+        expected_standby_health='unhealthy'
+    )
+
+
+def test_standby_tor_downlink_down_downstream_active(
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor,
+    shutdown_lower_tor_downlink_intfs
+):
+    """
+    Send traffic from T1 to active ToR and shutdown the standby ToR downlink on DUT.
+    Confirm no switchover and no disruption
+    """
+    send_t1_to_server_with_action(
+        upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        allowed_disruption=2, action=shutdown_lower_tor_downlink_intfs
+    )
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host,
+        expected_standby_health='unhealthy'
+    )
+
+
+def test_standby_tor_downlink_down_downstream_standby(
+    upper_tor_host, lower_tor_host, send_t1_to_server_with_action,
+    toggle_all_simulator_ports_to_upper_tor,
+    shutdown_lower_tor_downlink_intfs
+):
+    """
+    Send traffic from T1 to standby ToR and shutdwon the standby ToR downlink on DUT.
+    Confirm no switchover and no disruption
+    """
+    send_t1_to_server_with_action(
+        lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        allowed_disruption=2, action=shutdown_lower_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,


### PR DESCRIPTION
[dualToR] Add test to cover the scenario of a port being set to admin down

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4910
To cover the scenarios of ports being set to admin down on DUT instead of fanout.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Add test gap for #4910

#### How did you do it?
Add 2 new fixtures to shutdown downlink interfaces on upper tor or lower tor shutdown_upper_tor_downlink_intfs() and shutdown_lower_tor_downlink_intfs().
Add 6 new test cases to cover different scenarios for upstream or downstream traffic.

#### How did you verify/test it?
Run the following test cases in dualtor_io/test_link_failure.py:

test_active_tor_downlink_down_upstream
test_active_tor_downlink_down_downstream_active
test_active_tor_downlink_down_downstream_standby 
test_standby_tor_downlink_down_upstream 
test_standby_tor_downlink_down_downstream_active 
test_standby_tor_downlink_down_downstream_standby


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
DualTor topo

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
