### PR TITLE
[backend][subport] Fix `test_balancing_sub_ports`

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -9,6 +9,8 @@ from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.utilities import get_host_visible_vars
 from tests.common.utilities import wait_until
+from tests.common import constants
+from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
 from sub_ports_helpers import DUT_TMP_DIR
 from sub_ports_helpers import TEMPLATE_DIR
 from sub_ports_helpers import SUB_PORTS_TEMPLATE
@@ -459,12 +461,12 @@ def apply_balancing_config(duthost, ptfhost, ptfadapter, define_sub_ports_config
     dut_ports = define_sub_ports_configuration['dut_ports']
     ptf_ports = define_sub_ports_configuration['ptf_ports']
 
-    # Selectonly up ports as src_ports 
-    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    all_up_ports = set()
-    for port in mg_facts['minigraph_ports'].keys():
-        all_up_ports.add("eth" + str(mg_facts['minigraph_ptf_indices'][port]))
-    src_ports = tuple(all_up_ports.difference(ptf_ports))
+    # Select src ports from uplinks
+    src_ports = get_t1_ptf_ports(duthost, tbinfo)
+    if "t0-backend" in tbinfo["topo"]["name"]:
+        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+        vlan_id = mg_facts["minigraph_vlan_sub_interfaces"][0]["vlan"]
+        src_ports = [_ + constants.VLAN_SUB_INTERFACE_SEPARATOR + vlan_id for _ in src_ports]
 
     network = u'1.1.1.0/24'
     network = ipaddress.ip_network(network)

--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -6,6 +6,7 @@ import ipaddress
 from collections import OrderedDict
 
 import pytest
+import scapy.all as scapyall
 
 import ptf.testutils as testutils
 import ptf.mask as mask
@@ -325,14 +326,23 @@ def generate_and_verify_balancing_traffic(duthost, ptfhost, ptfadapter, src_port
     ip_src = '10.0.0.1'
     ip_dst = ip_dst.split('/')[0]
 
+    vlan_vid = None
+    dl_vlan_enable = False
+    send_pkt_length = pktlen
+    if constants.VLAN_SUB_INTERFACE_SEPARATOR in src_port:
+        vlan_vid = int(src_port.split('.')[1])
+        dl_vlan_enable = True
+        send_pkt_length += len(scapyall.Dot1Q())
+
     pkt = create_packet(eth_src=src_mac,
                         eth_dst=router_mac,
                         ip_src=ip_src,
                         ip_dst=ip_dst,
-                        vlan_vid=None,
-                        dl_vlan_enable=False,
+                        vlan_vid=vlan_vid,
+                        dl_vlan_enable=dl_vlan_enable,
                         tr_type='TCP',
-                        ttl=64)
+                        ttl=64,
+                        pktlen=send_pkt_length)
 
     ptfadapter.dataplane.flush()
     time.sleep(2)
@@ -355,11 +365,15 @@ def generate_and_verify_balancing_traffic(duthost, ptfhost, ptfadapter, src_port
     config_port_indices = {v: k for k, v in ifaces_map.items()}
     dst_port_numbers = [config_port_indices[k] for k in config_port_indices if k in dst_port]
 
+    ignore_fields=[("Ether", "dst"), ("IP", "src"), ("IP", "chksum"), ("TCP", "chksum")]
+    if dl_vlan_enable:
+        ignore_fields.append(("Ether", "type"))
+
     pkt_filter = FilterPktBuffer(ptfadapter=ptfadapter,
                                  exp_pkt=exp_pkt,
                                  dst_port_numbers=dst_port_numbers,
                                  match_fields=[("Ethernet", "src"), ("IP", "dst"), ('TCP', "dport")],
-                                 ignore_fields=[("Ether", "dst"), ("IP", "src"), ("IP", "chksum"), ("TCP", "chksum")])
+                                 ignore_fields=ignore_fields)
 
     pkt_in_buffer = pkt_filter.filter_pkt_in_buffer()
 

--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -330,7 +330,7 @@ def generate_and_verify_balancing_traffic(duthost, ptfhost, ptfadapter, src_port
     dl_vlan_enable = False
     send_pkt_length = pktlen
     if constants.VLAN_SUB_INTERFACE_SEPARATOR in src_port:
-        vlan_vid = int(src_port.split('.')[1])
+        vlan_vid = int(src_port.split(constants.VLAN_SUB_INTERFACE_SEPARATOR)[1])
         dl_vlan_enable = True
         send_pkt_length += len(scapyall.Dot1Q())
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #5107

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix `test_balancing_sub_ports` on backend topology.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
1. For `src_port`, select those from uplinks
2. Enable vlan tag for to-send packets.

#### How did you verify/test it?
* `t0-backend`
```
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_balancing_sub_ports[port] PASSED                                                                                                                                                                   [ 50%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_balancing_sub_ports[port_in_lag] PASSED                                                                                                                                                            [100%]
```
* `t1-backend`
```
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_balancing_sub_ports[port] PASSED                                                                                                                                                                   [ 50%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_balancing_sub_ports[port_in_lag] SKIPPED                                                                                                                                                           [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
