### PR TITLE
[bgpmon][masic] Add loopback route on PTF

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -403,9 +403,13 @@ def setup_interfaces(duthosts, rand_one_dut_hostname, ptfhost, request, tbinfo):
                 nhop_ip = re.split("/", conn["local_addr"])[0]
                 try:
                     socket.inet_aton(nhop_ip)
-                    ptfhost.shell("ip route add {}/32 via {}".format(
-                        conn["loopback_ip"], nhop_ip
+                    result = ptfhost.shell("ip route show {}/32".format(
+                        conn["loopback_ip"]
                     ))
+                    if len(result['stdout_lines']) == 0:
+                        ptfhost.shell("ip route add {}/32 via {}".format(
+                            conn["loopback_ip"], nhop_ip
+                        ))
                 except socket.error:
                     raise Exception("Invalid V4 address {}".format(nhop_ip))
 

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -6,6 +6,8 @@ import logging
 import netaddr
 import pytest
 import random
+import re
+import socket
 
 from jinja2 import Template
 from tests.common.helpers.assertions import pytest_assert as pt_assert
@@ -397,6 +399,16 @@ def setup_interfaces(duthosts, rand_one_dut_hostname, ptfhost, request, tbinfo):
                 duthost.shell("config interface %s ip add %s %s" % (namespace, conn["local_intf"], conn["local_addr"]))
                 ptfhost.shell("ifconfig %s %s" % (conn["neighbor_intf"], conn["neighbor_addr"]))
 
+                # add route to loopback address on PTF host
+                nhop_ip = re.split("/", conn["local_addr"])[0]
+                try:
+                    socket.inet_aton(nhop_ip)
+                    ptfhost.shell("ip route add {}/32 via {}".format(
+                        conn["loopback_ip"], nhop_ip
+                    ))
+                except socket.error:
+                    raise Exception("Invalid V4 address {}".format(nhop_ip))
+
             yield connections
 
         finally:
@@ -404,6 +416,10 @@ def setup_interfaces(duthosts, rand_one_dut_hostname, ptfhost, request, tbinfo):
                 namespace = '-n {}'.format(conn["namespace"]) if conn["namespace"] else ''
                 duthost.shell("config interface %s ip remove %s %s" % (namespace, conn["local_intf"], conn["local_addr"]))
                 ptfhost.shell("ifconfig %s 0.0.0.0" % conn["neighbor_intf"])
+                ptfhost.shell(
+                    "ip route del {}/32".format(conn["loopback_ip"]),
+                    module_ignore_errors=True
+                )
 
     peer_count = getattr(request.module, "PEER_COUNT", 1)
     if "dualtor" in tbinfo["topo"]["name"]:

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -403,13 +403,13 @@ def setup_interfaces(duthosts, rand_one_dut_hostname, ptfhost, request, tbinfo):
                 nhop_ip = re.split("/", conn["local_addr"])[0]
                 try:
                     socket.inet_aton(nhop_ip)
-                    result = ptfhost.shell("ip route show {}/32".format(
-                        conn["loopback_ip"]
+                    ptfhost.shell(
+                        "ip route del {}/32".format(conn["loopback_ip"]),
+                        module_ignore_errors=True
+                    )
+                    ptfhost.shell("ip route add {}/32 via {}".format(
+                        conn["loopback_ip"], nhop_ip
                     ))
-                    if len(result['stdout_lines']) == 0:
-                        ptfhost.shell("ip route add {}/32 via {}".format(
-                            conn["loopback_ip"], nhop_ip
-                        ))
                 except socket.error:
                     raise Exception("Invalid V4 address {}".format(nhop_ip))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
BGP monitor setup was failing on multi ASIC platform due to loopback unreachability. 

#### How did you do it?
Added /32 loopback route on PTF.

#### How did you verify/test it?
```
=========================================================================================== 2 passed, 1 deselected, 1 warnings in 348.86 seconds ============================================================================================
samaddik@svcstr-server-2:/var/sonic-mgmt/tests$  pytest bgp/test_traffic_shift.py  --testbed=vmsvc1-t1-nmasic-acs-1 --inventory=../ansible/strsvc,../ansible/veos  --testbed_file=../ansible/testbed.csv --host-pattern=svcstr-nmasic-acs-1  --module-path=../ansible/library  --skip_sanity -k test_TSA
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: html-1.22.1, repeat-0.9.1, forked-1.3.0, xdist-1.28.0, metadata-1.11.0, ansible-2.2.2
collecting ... ['conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut', 'inv_name', 'auto_recover', 'comment']
Finished testbed info generating.
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 3 items / 1 deselected / 2 selected

bgp/test_traffic_shift.py ..                                                                                                                                                                                                          [100%]

============================================================================================================= warnings summary ==============================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=========================================================================================== 2 passed, 1 deselected, 1 warnings in 344.04 seconds ============================================================================================
s
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
