### PR TITLE
[qos][traditional buffer][masic] Skip buffer traditional test on multi ASIC platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -129,6 +129,12 @@ qos/test_pfc_pause.py::test_pfc_pause_lossless:
   skip:
     reason: "Fanout needs to send PFC frames fast enough to completely pause the queue"
 
+qos/test_buffer_traditional.py:
+  skip:
+    reason: "buffer traditional test is not yet supported on multi-ASIC platform"
+    conditions:
+      - "is_multi_asic==True"
+
 qos/test_qos_sai.py:
   skip:
     reason: "qos_sai tests not supported on t1 topo"
@@ -152,12 +158,6 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[None-wm_pg_shared_l
     reason: "Image issue on Arista platforms"
     conditions:
       - "platform in ['x86_64-arista_7050cx3_32s']"
-
-qos/test_buffer_traditional.py:
-  skip:
-    reason: "buffer traditional test is not yet supported on multi-ASIC platform"
-    conditions:
-      - "is_multi_asic==True"
 
 #######################################
 #####         restapi             #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -153,6 +153,12 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[None-wm_pg_shared_l
     conditions:
       - "platform in ['x86_64-arista_7050cx3_32s']"
 
+qos/test_buffer_traditional.py:
+  skip:
+    reason: "buffer traditional test is not yet supported on multi-ASIC platform"
+    conditions:
+      - "is_multi_asic==True"
+
 #######################################
 #####         restapi             #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The test fails on multi-ASIC platform since it's not compatible for multi ASIC platform. API calls are made assuming single ASIC platform

#### How did you do it?
SKip using marker

#### How did you verify/test it?
```
samaddik@svcstr-server-2:/var/sonic-mgmt/tests$  pytest qos/test_buffer_traditional.py --testbed=vmsvc1-t1-nmasic-acs-1 --inventory=../ansible/strsvc,../ansible/veos  --testbed_file=../ansible/testbed.csv --host-pattern=svcstr-nmasic-acs-1  --module-path=../ansible/library  --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: html-1.22.1, repeat-0.9.1, forked-1.3.0, xdist-1.28.0, metadata-1.11.0, ansible-2.2.2
collecting ... ['conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut', 'inv_name', 'auto_recover', 'comment']
Finished testbed info generating.
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 1 item

qos/test_buffer_traditional.py s                                                                                                                                                                                                      [100%]

============================================================================================================= warnings summary ==============================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================================================================================== 1 skipped, 1 warnings in 4.66 seconds ===================================================================================================
sa
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
