### PR TITLE
[system-health] Disable logger analyzer for test_system_health_config

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -262,6 +262,7 @@ def test_external_checker(duthosts, enum_rand_one_per_hwsku_hostname):
         assert value == 'Device is broken', 'External checker does not work, value={}'.format(value)
 
 
+@pytest.mark.disable_loganalyzer
 def test_system_health_config(duthosts, enum_rand_one_per_hwsku_hostname, device_mocker_factory):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     device_mocker = device_mocker_factory(duthost)

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -78,7 +78,7 @@ def ignore_log_analyzer_by_vendor(request, duthosts, enum_rand_one_per_hwsku_hos
     asic_type = duthost.facts["asic_type"]
     ignore_asic_list = request.param
     if asic_type not in ignore_asic_list:
-        loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix='turn_on_off_psu_and_check_psustatus')
+        loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
         loganalyzer.load_common_config()
         marker = loganalyzer.init()
         yield


### PR DESCRIPTION
Change-Id: I47ded16d59e71c4bda03da2447b31a2a444cab28

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Disable logger analyzer for test_system_health_config test case

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

In case test_system_health_config, it mocks fan absence which removes sysfs node. There is chance that thermalctld would access the sysfs node while test case is removing it. In order to avoid such conflict, the log analyzer should be disabled for this test case like other cases in test_system_health.py

#### How did you do it?

Disable logger analyzer for test_system_health_config

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
