### PR TITLE
[test] skip/xfail unmerged copp feature temporarily

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -9,6 +9,22 @@ cacl/test_cacl_application.py::test_cacl_application:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
 
 #######################################
+#####            copp             #####
+#######################################
+copp/test_copp.py::TestCOPP::test_add_new_trap:
+  xfail:
+    reason: "'Add always_enabled field to coppmgr' is not merged into 202012 yet, a 'strict' param will remind us to remove this mark condition by setting 'xpass' as 'fail'"
+    strict: True
+    conditions:
+      - "release in ['202012']"
+
+copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
+  skip:
+    reason: "'Add always_enabled field to coppmgr' is not merged into 202012 yet"
+    conditions:
+      - "release in ['202012']"
+
+#######################################
 #####            decap            #####
 #######################################
 decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #5106 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
skip/xfail unmerged feature of CoPP

#### How did you do it?
Add skip/xfail in tests_mark_conditions.yaml.
Set the 'strict' flag to True, once the feature has been merged in the future, the 'xpass' will be considered as 'fail', then we can remove the mark conditions.

#### How did you verify/test it?
Run them on physical testbeds, successfully skipped/xfailed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
