### PR TITLE
[Vrf] Update PortChannel namming in Vrf TCs

### DIFF
--- a/tests/vrf/vrf_config_db.j2
+++ b/tests/vrf/vrf_config_db.j2
@@ -66,17 +66,17 @@
 {%        for pc in cfg_t0['PORTCHANNEL_INTERFACE'] | sort %}
 {#     each pc have 3 keys: pc, pc|ipv4 and pc|ipv6 #}
 {%             if cfg_t0['PORTCHANNEL_INTERFACE'] | length == 12  %}
-{%                 if pc in ['PortChannel0001', 'PortChannel0002'] %}
+{%                 if pc in ['PortChannel101', 'PortChannel102'] %}
         "{{ pc }}": {"vrf_name": "Vrf1"}
-{%-                elif pc in ['PortChannel0003', 'PortChannel0004'] %}
+{%-                elif pc in ['PortChannel103', 'PortChannel104'] %}
         "{{ pc }}": {"vrf_name": "Vrf2"}
 {%-                else %}
         "{{ pc }}": {{ cfg_t0['PORTCHANNEL_INTERFACE'][pc] }}
 {%-                endif %}
 {%-            else %}
-{%                 if pc in ['PortChannel0001', 'PortChannel0002', 'PortChannel0003', 'PortChannel0004'] %}
+{%                 if pc in ['PortChannel101', 'PortChannel102', 'PortChannel103', 'PortChannel104'] %}
         "{{ pc }}": {"vrf_name": "Vrf1"}
-{%-                elif pc in ['PortChannel0005', 'PortChannel0006', 'PortChannel0007', 'PortChannel0008'] %}
+{%-                elif pc in ['PortChannel105', 'PortChannel106', 'PortChannel107', 'PortChannel108'] %}
         "{{ pc }}": {"vrf_name": "Vrf2"}
 {%-                else %}
         "{{ pc }}": {{ cfg_t0['PORTCHANNEL_INTERFACE'][pc] }}


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Vrf test cases fail at setup stage with message `Failed: VRF testing setup failed`.
```
        except Exception as e:
            # Ensure that config_db is restored.
            # If exception is raised in setup, the teardown code won't be executed. That's why we need to capture
            # exception and do cleanup here in setup part (code before 'yield').
            logger.error("Exception raised in setup: {}".format(repr(e)))
            logger.error(json.dumps(traceback.format_exception(*sys.exc_info()), indent=2))
    
            restore_config_db(localhost, duthost, ptfhost)
    
            # Setup failed. There is no point to continue running the cases.
>           pytest.fail("VRF testing setup failed")    # If this line is hit, script execution will stop here
E           Failed: VRF testing setup failed

vrf/test_vrf.py:458: Failed
------------------------------ Captured log setup ------------------------------
[1m[31mERROR   [0m test_vrf:test_vrf.py:452 Exception raised in setup: KeyError('vrf_name',)
```
This behavior is caused by changes in PR - [4763](https://github.com/Azure/sonic-mgmt/pull/4763) which changed PortChannel naming inside of minigraph file from PortChannel0001 to PortChannel101. Below changes will fix **test_vrf** and **test_vrf_attr** test cases. 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix Vrf test cases. 
#### How did you do it?

#### How did you verify/test it?
Run test_vrf.py on t0 topology:
```
vrf/test_vrf.py::TestVrfCreateAndBind::test_vrf_in_kernel PASSED                                                                                                  
vrf/test_vrf.py::TestVrfCreateAndBind::test_vrf_in_appl_db PASSED                                                                                                 
vrf/test_vrf.py::TestVrfCreateAndBind::test_vrf_in_asic_db PASSED                                                                                                 
vrf/test_vrf.py::TestVrfNeigh::test_ping_lag_neigh PASSED                                                                                                         
vrf/test_vrf.py::TestVrfNeigh::test_ping_vlan_neigh PASSED                                                                                                        
vrf/test_vrf.py::TestVrfNeigh::test_vrf1_neigh_ip_fwd PASSED                                                                                            
vrf/test_vrf.py::TestVrfNeigh::test_vrf2_neigh_ip_fwd PASSED                                                                                       
vrf/test_vrf.py::TestVrfFib::test_show_bgp_summary PASSED                                                                                                         
vrf/test_vrf.py::TestVrfFib::test_vrf1_fib PASSED                                                                                                                 
vrf/test_vrf.py::TestVrfFib::test_vrf2_fib PASSED                                                                                                               
```    
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.71470-dirty-20220210.193335
Distribution: Debian 11.2
Kernel: 5.10.0-8-2-amd64
Build commit: 914a8a175
Build date: Thu Feb 10 19:42:04 UTC 2022
Built by: AzDevOps@sonic-build-workers-0015U1
Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
ASIC: barefoot
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
