### PR TITLE
[SER tests BRCM][MASIC] Add MASIC support to BRCM SER tests

### DIFF
--- a/tests/platform_tests/broadcom/test_ser.py
+++ b/tests/platform_tests/broadcom/test_ser.py
@@ -67,14 +67,17 @@ def test_setup_teardown(duthosts, rand_one_dut_hostname, localhost):
 
 @pytest.mark.disable_loganalyzer
 @pytest.mark.broadcom
-def test_ser(duthosts, rand_one_dut_hostname):
+def test_ser(duthosts, rand_one_dut_hostname, enum_asic_index):
     '''
-    @summary: Broadcom SER injection test use Broadcom SER injection utility to insert SER
-              into different memory tables. Before the SER injection, Broadcom mem/sram scanners
-              are started and syslog file location is marked.
-              The test is invoked using:
-              pytest platform/broadcom/test_ser.py --testbed=vms12-t0-s6000-1 --inventory=../ansible/str --testbed_file=../ansible/testbed.csv
-                                                   --host-pattern=vms12-t0-s6000-1 --module-path=../ansible/library
+    @summary: Broadcom SER injection test use Broadcom SER injection utility
+              to insert SER into different memory tables. Before the SER
+              injection, Broadcom mem/sram scanners are started and syslog
+              file location is marked.  The test is invoked using:
+
+              pytest platform/broadcom/test_ser.py --testbed=vms12-t0-s6000-1 \
+              --inventory=../ansible/str --testbed_file=../ansible/testbed.csv \
+              --host-pattern=vms12-t0-s6000-1 --module-path=../ansible/library
+
     @param duthost: Ansible framework testbed DUT device
     '''
     duthost = duthosts[rand_one_dut_hostname]
@@ -83,9 +86,17 @@ def test_ser(duthosts, rand_one_dut_hostname):
         pytest.skip('Skipping SER test for asic_type: %s' % asic_type)
 
     logger.info('Copying SER injector to dut: %s' % duthost.hostname)
-    duthost.copy(src=os.path.join(FILES_DIR, SER_INJECTOR_FILE), dest=DUT_WORKING_DIR)
+    duthost.copy(
+        src=os.path.join(FILES_DIR, SER_INJECTOR_FILE),
+        dest=DUT_WORKING_DIR
+    )
 
     logger.info('Running SER injector test')
-    rc = duthost.shell('python {}'.format(os.path.join(DUT_WORKING_DIR, SER_INJECTOR_FILE)), executable="/bin/bash")
+    args = "" if enum_asic_index is None else "-n {}".format(enum_asic_index)
+    rc = duthost.shell(
+        'python {} {}'.format(
+            os.path.join(DUT_WORKING_DIR, SER_INJECTOR_FILE), args
+        ),
+        executable="/bin/bash"
+    )
     logger.info('Test complete with %s: ' % rc)
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Broadcom SER tests were failing on multi ASIC platform as the ASIC ID parameter was missing to bcmcmd

#### How did you do it?
Added ASIC ID parameter to the SER test script, and updated test script to run on all ASICS

#### How did you verify/test it?

Verified on single and multi ASIC platfrom
```
samaddik@svcstr-server-2:/var/sonic-mgmt/tests$ pytest platform_tests/broadcom/test_ser.py  --testbed=vms12-t1-lag-1 --inventory=../ansible/str,../ansible/veos  --testbed_file=../ansible/testbed.csv --host-pattern=str-s6000-acs-8  --module-path=../ansible/library --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: html-1.22.1, repeat-0.9.1, forked-1.3.0, xdist-1.28.0, metadata-1.11.0, ansible-2.2.2
collecting ... ['conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut', 'inv_name', 'auto_recover', 'comment']
Finished testbed info generating.
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 1 item

platform_tests/broadcom/test_ser.py .                                                                                                                                                                                                 [100%]

============================================================================================================= warnings summary ==============================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================================== 1 passed, 1 warnings in 538.11 seconds ===================================================================================================
samaddik@svcstr-server-2:/var/sonic-mgmt/tests$ pytest platform_tests/broadcom/test_ser.py  --testbed=vmsvc1-t1-nmasic-acs-1 --inventory=../ansible/strsvc,../ansible/veos  --testbed_file=../ansible/testbed.csv --host-pattern=svcstr-nmasic-acs-1  --module-path=../ansible/library --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: html-1.22.1, repeat-0.9.1, forked-1.3.0, xdist-1.28.0, metadata-1.11.0, ansible-2.2.2
collecting ... ['conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut', 'inv_name', 'auto_recover', 'comment']
Finished testbed info generating.
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 6 items

platform_tests/broadcom/test_ser.py ......                                                                                                                                                                                            [100%]

============================================================================================================= warnings summary ==============================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================================================================================== 6 passed, 1 warnings in 49.91 seconds ===================================================================================================
s
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
