### PR TITLE
[show][platform][tests] Fix and skip multi ASIC 'show platform' tests

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -763,7 +763,7 @@ class SonicHost(AnsibleHostBase):
                     logging.debug("Daemon %s is disabled" % key)
                     exemptions.append(key)
 
-            if self.is_multi_asic and self.sonic_release in ['201911']:
+            if self.sonic_release in ['201911']:
                 exemptions.append('platform_api_server')
         except:
             # if pmon_daemon_control.json not exist, then it's using default setting,

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -762,6 +762,9 @@ class SonicHost(AnsibleHostBase):
                 else:
                     logging.debug("Daemon %s is disabled" % key)
                     exemptions.append(key)
+
+            if self.is_multi_asic and self.sonic_release in ['201911']:
+                exemptions.append('platform_api_server')
         except:
             # if pmon_daemon_control.json not exist, then it's using default setting,
             # all the pmon daemons expected to be running after boot up.

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -45,6 +45,21 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_status_led:
       - "asic_type in ['mellanox']"
 
 #######################################
+#####  cli/test_show_platform.py  #####
+#######################################
+platform_tests/cli/test_show_platform.py::test_show_platform_fan:
+  skip:
+    reason: "Unsupported platform API"
+    conditions:
+      - "is_multi_asic==True and release in ['201911']"
+
+platform_tests/cli/test_show_platform.py::test_show_platform_firmware_status:
+  skip:
+    reason: "Unsupported platform API"
+    conditions:
+      - "is_multi_asic==True and release in ['201911']"
+
+#######################################
 #####   api/test_chassis_fans.py  #####
 #######################################
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_model:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -45,21 +45,6 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_status_led:
       - "asic_type in ['mellanox']"
 
 #######################################
-#####  cli/test_show_platform.py  #####
-#######################################
-platform_tests/cli/test_show_platform.py::test_show_platform_fan:
-  skip:
-    reason: "Unsupported platform API"
-    conditions:
-      - "is_multi_asic==True and release in ['201911']"
-
-platform_tests/cli/test_show_platform.py::test_show_platform_firmware_status:
-  skip:
-    reason: "Unsupported platform API"
-    conditions:
-      - "is_multi_asic==True and release in ['201911']"
-
-#######################################
 #####   api/test_chassis_fans.py  #####
 #######################################
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_model:
@@ -515,6 +500,18 @@ platform_tests/api/test_watchdog.py:
 #######################################
 #####  cli/test_show_platform.py  #####
 #######################################
+platform_tests/cli/test_show_platform.py::test_show_platform_fan:
+  skip:
+    reason: "Unsupported platform API"
+    conditions:
+      - "is_multi_asic==True and release in ['201911']"
+
+platform_tests/cli/test_show_platform.py::test_show_platform_firmware_status:
+  skip:
+    reason: "Unsupported platform API"
+    conditions:
+      - "is_multi_asic==True and release in ['201911']"
+
 platform_tests/cli/test_show_platform.py::test_show_platform_ssdhealth:
   xfail:
     strict: True

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -176,7 +176,10 @@ def test_show_platform_psustatus(duthosts, enum_supervisor_dut_hostname):
     """
     duthost = duthosts[enum_supervisor_dut_hostname]
     logging.info("Check pmon daemon status on dut '{}'".format(duthost.hostname))
-    assert check_pmon_daemon_status(duthost), "Not all pmon daemons running on '{}'".format(duthost.hostname)
+    pytest_assert(
+        check_pmon_daemon_status(duthost),
+        "Not all pmon daemons running on '{}'".format(duthost.hostname)
+    )
     cmd = " ".join([CMD_SHOW_PLATFORM, "psustatus"])
 
     logging.info("Verifying output of '{}' on '{}' ...".format(cmd, duthost.hostname))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
'show platform' tests were failing for multi ASIC. Fixed one, skipped for others that are not supported yet.

#### How did you do it?
Add an exemption for 'platform_api_server' for multi ASIC platform running 201911.

#### How did you verify/test it?
```
samaddik@svcstr-server-2:/var/sonic-mgmt/tests$  pytest platform_tests/cli/test_show_platform.py  --testbed=vmsvc1-t1-nmasic-acs-1 --inventory=../ansible/strsvc,../ansible/veos  --testbed_file=../ansible/testbed.csv --host-pattern=svcstr-nmasic-acs-1  --module-path=../ansible/library --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: html-1.22.1, repeat-0.9.1, forked-1.3.0, xdist-1.28.0, metadata-1.11.0, ansible-2.2.2
collecting ... ['conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut', 'inv_name', 'auto_recover', 'comment']
Finished testbed info generating.
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 8 items

platform_tests/cli/test_show_platform.py ...s.s.s                                                                                                                                                                                     [100%]

============================================================================================================= warnings summary ==============================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================================================================= 5 passed, 3 skipped, 1 warnings in 32.52 seconds ==============================================================================================
s
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
