### PR TITLE
[advanced-reboot] Add KVM warmboot test support for vlan oper down case

### DIFF
--- a/tests/common/helpers/sad_path.py
+++ b/tests/common/helpers/sad_path.py
@@ -129,15 +129,21 @@ class NeighVlanMemberDown(VlanMemberDown):
     """ Sad path test case to verify warm-reboot when vlan member port goes operationaly down
     by shutting down the corresponding port on the neighbor side. """
 
-    def __init__(self, duthost, fanouthosts, port_selector):
+    def __init__(self, duthost, fanouthosts, vmhost, port_selector):
         super(NeighVlanMemberDown, self).__init__(duthost, port_selector)
         self.fanouthosts = fanouthosts
+        self.vmhost = vmhost
+        self.port_info = duthost.get_running_config_facts()["PORT"]
         logger.info("Selected ports for neighbor vlan member down case {}".format(self.ports))
 
     def setup(self, test_data):
         super(NeighVlanMemberDown, self).setup(test_data)
 
         for port in self.ports:
+            if self.duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
+                index = int(self.port_info.get(port).get("index")) + 1
+                self.vmhost.shell("virsh domif-setlink {} {}-{} down".format(
+                    self.duthost.hostname, self.duthost.hostname, index))
             fanout, fanport = fanout_switch_port_lookup(self.fanouthosts, self.duthost.hostname, port)
             if fanout and fanport:
                 fanout.shutdown(fanport)
@@ -149,6 +155,10 @@ class NeighVlanMemberDown(VlanMemberDown):
 
     def revert(self):
         for port in self.ports:
+            if self.duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
+                index = int(self.port_info.get(port).get("index")) + 1
+                self.vmhost.shell("virsh domif-setlink {} {}-{} up".format(
+                    self.duthost.hostname, self.duthost.hostname, index))
             fanout, fanport = fanout_switch_port_lookup(self.fanouthosts, self.duthost.hostname, port)
             if fanout and fanport:
                 fanout.no_shutdown(fanport)

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -70,7 +70,7 @@ def test_warm_reboot_mac_jump(request, get_advanced_reboot, verify_dut_health,
 
 ### Tetcases to verify reboot procedure with SAD cases ###
 @pytest.mark.device_type('vs')
-def test_warm_reboot_sad(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts, tbinfo,
+def test_warm_reboot_sad(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts, vmhost, tbinfo,
                         get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,
                         backup_and_restore_config_db, advanceboot_neighbor_restore,
                         sad_case_type):
@@ -87,7 +87,7 @@ def test_warm_reboot_sad(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts,
     advancedReboot = get_advanced_reboot(rebootType='warm-reboot',\
         advanceboot_loganalyzer=advanceboot_loganalyzer)
 
-    sad_preboot_list, sad_inboot_list = get_sad_case_list(duthost, nbrhosts, fanouthosts, tbinfo, sad_case_type)
+    sad_preboot_list, sad_inboot_list = get_sad_case_list(duthost, nbrhosts, fanouthosts, vmhost, tbinfo, sad_case_type)
     advancedReboot.runRebootTestcase(
         prebootList=sad_preboot_list,
         inbootList=sad_inboot_list

--- a/tests/platform_tests/warmboot_sad_cases.py
+++ b/tests/platform_tests/warmboot_sad_cases.py
@@ -17,7 +17,7 @@ SAD_CASE_LIST = [
     "sad_inboot"
 ]
 
-def get_sad_case_list(duthost, nbrhosts, fanouthosts, tbinfo, sad_case_type):
+def get_sad_case_list(duthost, nbrhosts, fanouthosts, vmhost, tbinfo, sad_case_type):
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     lagMemberCnt = len(mg_facts['minigraph_portchannels'].values()[0]['members'])
 
@@ -34,7 +34,7 @@ def get_sad_case_list(duthost, nbrhosts, fanouthosts, tbinfo, sad_case_type):
             # Shutdown 1 vlan port (interface) on DUT
             DutVlanMemberDown(duthost, PhyPropsPortSelector(duthost, 1)),
             # Shutdown 1 vlan port (interface) on fanout
-            NeighVlanMemberDown(duthost, fanouthosts, PhyPropsPortSelector(duthost, 1))
+            NeighVlanMemberDown(duthost, fanouthosts, vmhost, PhyPropsPortSelector(duthost, 1))
         ],
 
         "multi_sad": [
@@ -48,7 +48,7 @@ def get_sad_case_list(duthost, nbrhosts, fanouthosts, tbinfo, sad_case_type):
                 # Shutdown 1 LAG member of 2 LAG sessions on 2 remote devices (VM) (1 each)
                 NeighLagMemberDown(duthost, nbrhosts, fanouthosts, DatetimeSelector(2), PhyPropsPortSelector(duthost, 1)),
                 DutVlanMemberDown(duthost, PhyPropsPortSelector(duthost, 4)),
-                NeighVlanMemberDown(duthost, fanouthosts, PhyPropsPortSelector(duthost, 4)),
+                NeighVlanMemberDown(duthost, fanouthosts, vmhost, PhyPropsPortSelector(duthost, 4)),
             ] + ([
                 # Shutdown <lag count> LAG member(s) of 2 LAG sessions corresponding to 2 remote
                 # devices (VM) on DUT
@@ -85,7 +85,7 @@ def get_sad_case_list(duthost, nbrhosts, fanouthosts, tbinfo, sad_case_type):
 
         "sad_vlan_port": [
                 DutVlanMemberDown(duthost, PhyPropsPortSelector(duthost, 4)),                # Shutdown 4 vlan ports (interfaces) on DUT
-                NeighVlanMemberDown(duthost, fanouthosts, PhyPropsPortSelector(duthost, 4)), # Shutdown 4 vlan ports (interfaces) on fanout
+                NeighVlanMemberDown(duthost, fanouthosts, vmhost, PhyPropsPortSelector(duthost, 4)), # Shutdown 4 vlan ports (interfaces) on fanout
             ]
     }
 

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -79,7 +79,7 @@ def test_upgrade_path(localhost, duthosts, ptfhost, rand_one_dut_hostname, nbrho
 
 
 @pytest.mark.device_type('vs')
-def test_warm_upgrade_sad_path(localhost, duthosts, ptfhost, rand_one_dut_hostname, nbrhosts, fanouthosts, tbinfo,
+def test_warm_upgrade_sad_path(localhost, duthosts, ptfhost, rand_one_dut_hostname, nbrhosts, fanouthosts, vmhost, tbinfo,
                         restore_image, get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,
                         upgrade_path_lists, backup_and_restore_config_db, advanceboot_neighbor_restore,
                         sad_case_type):
@@ -104,7 +104,7 @@ def test_warm_upgrade_sad_path(localhost, duthosts, ptfhost, rand_one_dut_hostna
             install_sonic(duthost, to_image, tbinfo)
             advancedReboot = get_advanced_reboot(rebootType=get_reboot_command(duthost, "warm"),\
                 advanceboot_loganalyzer=advanceboot_loganalyzer)
-            sad_preboot_list, sad_inboot_list = get_sad_case_list(duthost, nbrhosts, fanouthosts, tbinfo, sad_case_type)
+            sad_preboot_list, sad_inboot_list = get_sad_case_list(duthost, nbrhosts, fanouthosts, vmhost, tbinfo, sad_case_type)
             advancedReboot.runRebootTestcase(
                 prebootList=sad_preboot_list,
                 inbootList=sad_inboot_list


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Enable warmboot with vlan-oper-down testing support on KVM platform
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
To cover warmboot with SAD case scenarios on KVM platform.

SAD case with vlan port in oper-down state is not supported on KVM platform yet.
This works on physical testbed where there is fanout switch, and to simulate vlan-oper-down, mapped ports on fanout switch is shutdown.
However, on virtual testbed, there is no fanout. Hence, to simulate vlan port oper-down condition, a different mechanism is needed.

#### How did you do it?
Check if DUT is KVM platform. If yes, shutdown virsh domain ports on `vmhost` (server hosting entire testbed).

The goal is to execute down/up command on vmhost for mapped ports - 
Example:
` virsh domif-setlink vlab-01 vlab-01-3 down`
` virsh domif-setlink vlab-01 vlab-01-3 up`

The port is found via the DUT port index which is selected for the test.

#### How did you verify/test it?
Tested on KVM testbed - vlan ports now can go oper-down and UP as part of the test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
