### PR TITLE
[platform][multi ASIC] Skip tests involving thermalctld, LEDd restart, pcied on Multi ASIC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -510,6 +510,12 @@ platform_tests/cli/test_show_platform.py::test_show_platform_ssdhealth:
 #######################################
 #####  daemon/test_syseepromd.py  #####
 #######################################
+platform_tests/daemon/test_ledd.py::test_pmon_ledd_kill_and_start_status:
+  skip:
+    reason: "LEDD daemon auto restart not included in 201911"
+    conditions:
+      - "release in ['201911']"
+
 platform_tests/daemon/test_syseepromd.py::test_pmon_syseepromd_running_status:
   xfail:
     reason: "Image issue on Arista platforms"
@@ -526,6 +532,12 @@ platform_tests/fwutil/test_fwutil.py::test_fwutil_auto:
 #######################################
 #####    test_platform_info.py    #####
 #######################################
+platform_tests/test_platform_info.py::test_thermal_control_fan_status:
+  skip:
+    reason: "Thermal control daemon is not present"
+    conditions:
+      - "is_multi_asic==True and release in ['201911']"
+
 platform_tests/test_platform_info.py::test_thermal_control_load_invalid_format_json:
   #Thermal policies are implemented as part of BSP layer in Cisco 8000 platform, so there is no need for loading JSON file,
   #hence the test case needs to be skipped
@@ -533,6 +545,10 @@ platform_tests/test_platform_info.py::test_thermal_control_load_invalid_format_j
     reason: "Cisco platforms use different mechanism to generate thermal policy, current method is not applicable"
     conditions:
       - "asic_type=='cisco-8000'"
+  skip:
+    reason: "Multi ASIC platfrom running 201911 release doesn't have thermalctld"
+    conditions:
+      - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/test_platform_info.py::test_thermal_control_load_invalid_value_json:
   xfail:
@@ -546,6 +562,10 @@ platform_tests/test_platform_info.py::test_thermal_control_load_invalid_value_js
     reason: "Cisco platforms use different mechanism to generate thermal policy, current method is not applicable"
     conditions:
       - "asic_type=='cisco-8000'"
+  skip:
+    reason: "Multi ASIC platfrom running 201911 release doesn't have thermalctld"
+    conditions:
+      - "is_multi_asic==True and release in ['201911']"
 
 #######################################
 #####        test_reboot.py       #####

--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -74,6 +74,7 @@ def check_daemon_status(duthosts, rand_one_dut_hostname):
 @pytest.fixture(scope="module", autouse=True)
 def get_pcie_devices_tbl_key(duthosts,rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
+    skip_release(duthost, ["201811", "201911"])
     command_output = duthost.shell("redis-cli -n 6 keys '*' | grep PCIE_DEVICES")
     
     global pcie_devices_status_tbl_key

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -265,6 +265,9 @@ def restart_thermal_control_daemon(dut):
     :param dut: DUT object representing a SONiC switch under test.
     :return:
     """
+    if dut.is_multi_asic and dut.sonic_release in ["201911"]:
+        logging.info("thermalctl daemon is not present")
+        return
     logging.info('Restarting thermal control daemon on {}...'.format(dut.hostname))
     find_thermalctld_pid_cmd = 'docker exec -i pmon bash -c \'pgrep -f thermalctld\' | sort'
     output = dut.shell(find_thermalctld_pid_cmd)


### PR DESCRIPTION
…201911

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Some of the platform tests are failing on multi ASIC platform running 201911 release as either the release doesn't support the test case or the multi ASIC platform doesn't support the test case.

#### How did you do it?
Skipped and added exemptions based on the test case.

#### How did you verify/test it?
```
samaddik@svcstr-server-2:/var/sonic-mgmt/tests$  pytest platform_tests/daemon/  --testbed=vmsvc1-t1-nmasic-acs-1 --inventory=../ansible/strsvc,../ansible/veos  --testbed_file=../ansible/testbed.csv --host-pattern=svcstr-nmasic-acs-1  --mod
ule-path=../ansible/library --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: html-1.22.1, repeat-0.9.1, forked-1.3.0, xdist-1.28.0, metadata-1.11.0, ansible-2.2.2
collecting ... ['conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut', 'inv_name', 'auto_recover', 'comment']
Finished testbed info generating.
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 24 items

platform_tests/daemon/test_fancontrol.py ssss                                                                                                                                                                                         [ 16%]
platform_tests/daemon/test_ledd.py ..ss                                                                                                                                                                                               [ 33%]
platform_tests/daemon/test_pcied.py ssss                                                                                                                                                                                              [ 50%]
platform_tests/daemon/test_psud.py ..ss                                                                                                                                                                                               [ 66%]
platform_tests/daemon/test_syseepromd.py ssss                                                                                                                                                                                         [ 83%]
platform_tests/daemon/test_thermalctld.py ssss                                                                                                                                                                                        [100%]

============================================================================================================= warnings summary ==============================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================================================================ 4 passed, 20 skipped, 1 warnings in 398.03 seconds =============================================================================================
s
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
