### PR TITLE
[Fix]Method delete_saiserver_script typo in sai_qualify

### DIFF
--- a/tests/sai_qualify/conftest.py
+++ b/tests/sai_qualify/conftest.py
@@ -98,7 +98,7 @@ def prepare_saiserver_script(duthost, request):
     _copy_saiserver_script(duthost)
     yield
     if not request.config.option.sai_test_keep_test_env:
-        delete_saiserver_script(duthost)
+        _delete_saiserver_script(duthost)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
fix the method name in sai_qualify/conftest.py
this cause the sai pipeline failed without the sai_test_keep_test_env
parameter

testing done:
checked in pipeline

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
