### PR TITLE
Revert "There is no xfails info in the test report summary, this PR is to fix this issue."

### DIFF
--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -47,8 +47,7 @@ REQUIRED_TESTSUITE_ATTRIBUTES = {
     ("tests", int),
     ("skipped", int),
     ("failures", int),
-    ("errors", int),
-    ("xfails", int)
+    ("errors", int)
 }
 EXTRA_XML_SUMMARY_ATTRIBUTES = {
     ("xfails", int)


### PR DESCRIPTION
Reverts Azure/sonic-mgmt#5033

This PR indeed can cause issue like below while parsing XML result files.
```
could not parse results/test_vs_chassis_setup.xml: xfails not found in <testsuite> element - skipping                                                                                                                                                           could not parse results/qos/test_buffer.xml: xfails not found in <testsuite> element - skipping                                                                                                                                                                 could not parse results/ixia/pfcwd/test_pfcwd_runtime_traffic.xml: xfails not found in <testsuite> element - skipping                                                                                                                                           could not parse results/tacacs/test_ro_user.xml: xfails not found in <testsuite> element - skipping                                                                                                                                                             could not parse results/platform_tests/test_cpu_memory_usage.xml: xfails not found in <testsuite> element - skipping                                                                                                                                            could not parse results/http/test_http_copy.xml: xfails not found in <testsuite> element - skipping                                                                                                                                                             could not parse results/platform_tests/sfp/test_sfputil.xml: xfails not found in <testsuite> element - skipping                  
```