### PR TITLE
[NAT] Update PortChannel naming in NAT test suite

### DIFF
--- a/tests/nat/conftest.py
+++ b/tests/nat/conftest.py
@@ -9,6 +9,7 @@ from nat_helpers import GLOBAL_NAT_TIMEOUT
 from nat_helpers import GLOBAL_TCP_NAPT_TIMEOUT
 from nat_helpers import GLOBAL_UDP_NAPT_TIMEOUT
 from nat_helpers import FULL_CONE_TEST_SUBNET
+from nat_helpers import PORT_CHANNEL_TEMP
 from nat_helpers import conf_ptf_interfaces
 from nat_helpers import teardown_test_env
 from nat_helpers import exec_command
@@ -85,6 +86,7 @@ def setup_test_env(request, ptfhost, duthost, tbinfo):
     config_port_indices = cfg_facts['port_index_map']
     config_portchannels = cfg_facts.get('PORTCHANNEL', {})
     ptf_ports_available_in_topo = ptfhost.host.options['variable_manager'].extra_vars.get("ifaces_map")
+    port_channel_1_name = PORT_CHANNEL_TEMP.format(1)
     # Get outer port indices
     for port_id in config_portchannels.keys():
         port = config_portchannels[port_id]['members'][0]
@@ -118,8 +120,8 @@ def setup_test_env(request, ptfhost, duthost, tbinfo):
                          "indices_to_ports_config": indices_to_ports_config,
                          "ptf_ports_available_in_topo": ptf_ports_available_in_topo,
                          "config_portchannels": config_portchannels,
-                         "pch_ips": {"PortChannel0001": duthost.setup()['ansible_facts']['ansible_PortChannel0001']['ipv4']['address']},
-                         "pch_masks": {"PortChannel0001": duthost.setup()['ansible_facts']['ansible_PortChannel0001']['ipv4']['netmask']},
+                         "pch_ips": {port_channel_1_name: duthost.setup()['ansible_facts']['ansible_{}'.format(port_channel_1_name)]['ipv4']['address']},
+                         "pch_masks": {port_channel_1_name: duthost.setup()['ansible_facts']['ansible_{}'.format(port_channel_1_name)]['ipv4']['netmask']},
                          "outer_vrf": ["red"],
                          "inner_vrf": ["blue", "yellow"],
                          interface_type: {"vrf_conf": SETUP_CONF[interface_type]["vrf"],

--- a/tests/nat/nat_helpers.py
+++ b/tests/nat/nat_helpers.py
@@ -41,7 +41,8 @@ ACL_TABLE_GLOBAL_NAME = "test_acl_table"
 DYNAMIC_BINDING_NAME = "test_binding"
 ACL_SUBNET = "192.168.0.0/24"
 BR_MAC = ["22:22:22:22:22:21"]
-VRF = {"red": {"ip": "11.1.0.2", "id": "1", "mask": "30", "gw": "11.1.0.1", "dut_iface": "PortChannel0001", "port_id": {"t0": ["28"],
+PORT_CHANNEL_TEMP = 'PortChannel10{}'
+VRF = {"red": {"ip": "11.1.0.2", "id": "1", "mask": "30", "gw": "11.1.0.1", "dut_iface": PORT_CHANNEL_TEMP.format(1), "port_id": {"t0": ["28"],
                                                                                                                         "t0-64": ["0", "1"],
                                                                                                                         "t0-64-32": ["0", "1"]
                                                                                                                        }

--- a/tests/nat/test_static_nat.py
+++ b/tests/nat/test_static_nat.py
@@ -29,6 +29,7 @@ from nat_helpers import POOL_RANGE_END_PORT
 from nat_helpers import GLOBAL_NAT_TIMEOUT
 from nat_helpers import GLOBAL_UDP_NAPT_TIMEOUT
 from nat_helpers import GLOBAL_TCP_NAPT_TIMEOUT
+from nat_helpers import PORT_CHANNEL_TEMP
 from nat_helpers import get_redis_val
 from nat_helpers import get_db_rules
 from nat_helpers import configure_nat_over_cli
@@ -852,7 +853,7 @@ class TestStaticNat(object):
         setup_data = copy.deepcopy(setup_info)
         test_pool_range_start_port = 1000
         test_pool_range_end_port = 2000
-        test_public_ip = exec_command(duthost, ["/sbin/ifconfig PortChannel0002 | grep 'inet ' | awk -F'[: ]+' '{ print $3 }'"])['stdout']
+        test_public_ip = exec_command(duthost, ["/sbin/ifconfig {} | grep 'inet ' | awk -F'[: ]+' '{{ print $3 }}'".format(PORT_CHANNEL_TEMP.format(2))])['stdout']
         nat_type = 'static_napt'
         direction = 'host-tor'
         # Set static NAT configuration for test
@@ -954,8 +955,8 @@ class TestStaticNat(object):
     def test_nat_static_redis_napt(self, ptfhost, tbinfo, duthost, ptfadapter, setup_test_env, protocol_type):
         interface_type, setup_info = setup_test_env
         setup_data = copy.deepcopy(setup_info)
-        test_private_ip = exec_command(duthost, ["/sbin/ifconfig PortChannel0003 | grep 'inet ' | awk -F'[: ]+' '{ print $3 }'"])['stdout']
-        test_public_ip = exec_command(duthost, ["/sbin/ifconfig PortChannel0002 | grep 'inet ' | awk -F'[: ]+' '{ print $3 }'"])['stdout']
+        test_private_ip = exec_command(duthost, ["/sbin/ifconfig {} | grep 'inet ' | awk -F'[: ]+' '{{ print $3 }}'".format(PORT_CHANNEL_TEMP.format(3))])['stdout']
+        test_public_ip = exec_command(duthost, ["/sbin/ifconfig {} | grep 'inet ' | awk -F'[: ]+' '{{ print $3 }}'".format(PORT_CHANNEL_TEMP.format(2))])['stdout']
         test_private_port = 8000
         test_public_port = 6000
         nat_type = 'static_napt'


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: NAT test cases fail at setup stage with key error:
```
>                            "pch_ips": {"PortChannel0001": duthost.setup()['ansible_facts']['ansible_PortChannel0001']['ipv4']['address']},
                             "pch_masks": {"PortChannel0001": duthost.setup()['ansible_facts']['ansible_PortChannel0001']['ipv4']['netmask']},
                             "outer_vrf": ["red"],
                             "inner_vrf": ["blue", "yellow"],
                             interface_type: {"vrf_conf": SETUP_CONF[interface_type]["vrf"],
                                              "inner_zone_interfaces": [inner_zone_interfaces, ],
                                              "outer_zone_interfaces": outer_zone_interfaces,
                                              "inner_port_id": [int(inner_port_id)],
                                              "outer_port_id": outer_port_id,
                                              "src_ip": SETUP_CONF[interface_type]["vrf"]["blue"]["ip"],
                                              "second_src_ip": SETUP_CONF[interface_type]["vrf"]["yellow"]["ip"],
                                              "dst_ip": SETUP_CONF[interface_type]["vrf"]["red"]["ip"],
                                              "public_ip": public_ip,
                                              "gw": duthost.setup()['ansible_facts']['ansible_Vlan1000']['ipv4']['address'],
                                              "acl_subnet": SETUP_CONF[interface_type]["acl_subnet"]
                                             }
                            }
E       KeyError: 'ansible_PortChannel0001'
```
This behavior is caused by changes in PR - [4763](https://github.com/Azure/sonic-mgmt/pull/4763) which changed PortChannel naming inside of minigraph file.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix NAT test suite
#### How did you do it?

#### How did you verify/test it?
Run NAT test cases: 
```
nat/test_static_nat.py::TestStaticNat::test_nat_static_basic[loopback-TCP] PASSED
nat/test_static_nat.py::TestStaticNat::test_nat_static_basic[loopback-UDP] PASSED
nat/test_static_nat.py::TestStaticNat::test_nat_static_basic_icmp[loopback] PASSED
nat/test_static_nat.py::TestStaticNat::test_nat_static_napt[loopback-TCP] PASSED
nat/test_static_nat.py::TestStaticNat::test_nat_static_napt[loopback-UDP] 32mPASSED
nat/test_static_nat.py::TestStaticNat::test_nat_clear_statistics_static_basic[loopback-TCP] PASSED
nat/test_static_nat.py::TestStaticNat::test_nat_clear_statistics_static_basic[loopback-UDP] PASSED
```
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.71470-dirty-20220210.130057
Distribution: Debian 11.2
Kernel: 5.10.0-8-2-amd64
Build commit: 914a8a175
Build date: Thu Feb 10 17:24:57 UTC 2022
Built by: AzDevOps@sonic-build-workers-0015U1
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
ASIC: barefoot
```
#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
