### PR TITLE
[advanced-reboot] Fix capturing first lacpdu frame after reboot

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1319,9 +1319,11 @@ class ReloadTest(BaseTest):
         lacp_pdu_times = self.lacp_pdu_times[ip]
         lacp_pdu_down_times = lacp_pdu_times.get("lacp_down")
         lacp_pdu_up_times = lacp_pdu_times.get("lacp_up")
+        self.log('lacp_pdu_down_times: IP:{}: {}'.format(ip, lacp_pdu_down_times))
+        self.log('lacp_pdu_up_times: IP:{}: {}'.format(ip, lacp_pdu_up_times))
         lacp_pdu_before_reboot = float(lacp_pdu_down_times[-1]) if\
             lacp_pdu_down_times and len(lacp_pdu_down_times) > 0 else None
-        lacp_pdu_after_reboot = float(lacp_pdu_up_times[-1]) if\
+        lacp_pdu_after_reboot = float(lacp_pdu_up_times[0]) if\
             lacp_pdu_up_times and len(lacp_pdu_up_times) > 0 else None
         if 'warm-reboot' in self.reboot_type and lacp_pdu_before_reboot and lacp_pdu_after_reboot:
             lacp_time_diff = lacp_pdu_after_reboot - lacp_pdu_before_reboot

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -161,7 +161,7 @@ class Arista(object):
         portchannel_output = "\n".join(portchannel_output.split("\r\n")[1:-1])
         sample["po_changetime"] = json.loads(portchannel_output, strict=False)['interfaces']['Port-Channel1']['lastStatusChangeTimestamp']
         samples[cur_time] = sample
-        collect_lacppdu_time = False
+        self.collect_lacppdu_time = True
 
         while not (quit_enabled and v4_routing_ok and v6_routing_ok):
             cmd = None
@@ -175,14 +175,12 @@ class Arista(object):
                 if cmd == 'cpu_down':
                     last_lacppdu_time_before_reboot = self.check_last_lacppdu_time()
                     self.lacp_pdu_time_on_down.append(last_lacppdu_time_before_reboot)
-                if cmd == 'cpu_up' or collect_lacppdu_time:
+                if (cmd == 'cpu_going_up' or cmd == 'cpu_up') and self.collect_lacppdu_time:
                     # control plane is back up, start polling for new lacp-pdu
                     last_lacppdu_time_after_reboot = self.check_last_lacppdu_time()
-                    if last_lacppdu_time_after_reboot != last_lacppdu_time_before_reboot:
+                    if int(last_lacppdu_time_after_reboot) != int(last_lacppdu_time_before_reboot):
                         self.lacp_pdu_time_on_up.append(last_lacppdu_time_after_reboot)
-                        collect_lacppdu_time = False # post-reboot lacp-pdu is received, stop the polling
-                    else: # Until post-reboot lacp-pdu is not received, keep polling for it
-                        collect_lacppdu_time = True
+                        self.collect_lacppdu_time = False # post-reboot lacp-pdu is received, stop the polling
 
             cur_time = time.time()
             info = {}

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -178,7 +178,7 @@ class Arista(object):
                 if (cmd == 'cpu_going_up' or cmd == 'cpu_up') and self.collect_lacppdu_time:
                     # control plane is back up, start polling for new lacp-pdu
                     last_lacppdu_time_after_reboot = self.check_last_lacppdu_time()
-                    if int(last_lacppdu_time_after_reboot) != int(last_lacppdu_time_before_reboot):
+                    if int(last_lacppdu_time_after_reboot) > int(last_lacppdu_time_before_reboot):
                         self.lacp_pdu_time_on_up.append(last_lacppdu_time_after_reboot)
                         self.collect_lacppdu_time = False # post-reboot lacp-pdu is received, stop the polling
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix capturing first lacpdu frame after reboot
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
After warmboot, capture and check first LACPDU timestamp.


#### How did you do it?
Instead of catching timestamp of lacpdu when control plane is detected to be UP by test, capture the timestamp when control plane is _COMING_ up.

This enables the test to get the timestamp of FIRST LACPDU that is sent to T1 neighbors from T0 after warmboot.

#### How did you verify/test it?
Tested on a physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
