### PR TITLE
[chassis] Fix test_bgp_update_timer for T2 topologies

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -353,13 +353,9 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
                         used_subnets.add(ipaddress.ip_network(intf["subnet"]))
 
             subnet_prefixlen = list(used_subnets)[0].prefixlen
-            if "t2" in tbinfo["topo"]["name"]:
-                # in T2 topologies the IP subnet could conflict with interfaces on other linecards. 
-                # use a complete different subnet
-                subnets = ipaddress.ip_network(u"20.0.0.0/24").subnets(new_prefix=subnet_prefixlen)
-            else:
-                _subnets = ipaddress.ip_network(u"10.0.0.0/24").subnets(new_prefix=subnet_prefixlen)
-                subnets = (_ for _ in _subnets if _ not in used_subnets)
+            # Use a subnet which doesnt conflict with other subnets used in minigraph
+            subnets = ipaddress.ip_network(u"20.0.0.0/24").subnets(new_prefix=subnet_prefixlen)
+
 
             loopback_ip = None
             for intf in mg_facts["minigraph_lo_interfaces"]:

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -54,9 +54,9 @@ def log_bgp_updates(duthost, iface, save_path):
 
 
 @pytest.fixture
-def is_quagga(duthosts, rand_one_dut_hostname):
+def is_quagga(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """Return True if current bgp is using Quagga."""
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     show_res = duthost.shell("vtysh -c 'show version'")
     return "Quagga" in show_res["stdout"]
 
@@ -67,9 +67,9 @@ def is_dualtor(tbinfo):
 
 
 @pytest.fixture
-def common_setup_teardown(duthosts, rand_one_dut_hostname, is_dualtor, is_quagga, ptfhost, setup_interfaces):
-    duthost = duthosts[rand_one_dut_hostname]
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+def common_setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname, is_dualtor, is_quagga, ptfhost, setup_interfaces, tbinfo):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     conn0, conn1 = setup_interfaces
     dut_asn = mg_facts["minigraph_bgp_asn"]
 
@@ -136,7 +136,7 @@ def constants(is_quagga, setup_interfaces):
     return _constants
 
 
-def test_bgp_update_timer(common_setup_teardown, constants, duthosts, rand_one_dut_hostname,
+def test_bgp_update_timer(common_setup_teardown, constants, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                           toggle_all_simulator_ports_to_rand_selected_tor_m):
 
     def bgp_update_packets(pcap_file):
@@ -190,7 +190,7 @@ def test_bgp_update_timer(common_setup_teardown, constants, duthosts, rand_one_d
         else:
             return False
 
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
     n0, n1 = common_setup_teardown
     try:


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshminarasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #5176

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
Update the `test_bgp_update_timer` to run on T2 topologies

#### How did you do it?
The following changes are done.
- Change the test and conftest to use `enum_rand_one_per_hwsku_frontend_hostname`, to avoid the test from running on supervisor
- Change the subnet used to setup bgp session from `10.0.0.0/24` to `20.0.0.0/24`
- use `minigraph_ptf_indices` to get the correct PTF interfaces in the t2 topology.

#### How did you verify/test it?
Run the `test_bgp_update_timer` on T2 topology
```
arlakshm@2ec4d0fd85f8:/data/repos/my_mgmt/tests$ ./run_tests.sh -c bgp/test_bgp_update_timer.py -i '../ansible/str2,../ansible/veos'  -n vms26-t2-sonic-1  -u -e '--skip_sanity'
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================================ test session starts ============================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /data/repos/my_mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collecting ... /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 2 items

bgp/test_bgp_update_timer.py::test_bgp_update_timer[str2-sonic-lc6-1] PASSED                                                                                                                                                                                           [ 50%]
bgp/test_bgp_update_timer.py::test_bgp_update_timer[str2-sonic-lc7-1] PASSED                                                                                                                                                                                           [100%]

--------------------------------------------------------------------------------------------------------- generated xml file: /data/repos/my_mgmt/tests/logs/tr.xml ---------------------------------------------------------------------------------------------------------
======================================================================================================================== 2 passed in 487.44 seconds =========================================================================================================================
INFO:root:Can not get Allure report URL. Please check logs
arlakshm@2ec4d0fd85f8:/data/repos/my_mgmt/tests$
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
