### PR TITLE
Fixed KeyError in case when port_type not available in hwsku.json

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -52,7 +52,7 @@ def xcvr_skip_list(duthosts):
             out = dut.command("cat {}".format(f_path))
             hwsku_info = json.loads(out["stdout"])
             for int_n in hwsku_info['interfaces']:
-                if hwsku_info['interfaces'][int_n]['port_type'] == "RJ45":
+                if hwsku_info['interfaces'][int_n].get('port_type') == "RJ45":
                     intf_skip_list[dut.hostname].append(int_n)
 
         except Exception:


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Key "port_type" in hwsku.json available only for RJ45 ports.
In case when try to get key "port_type" from non RJ45 ports - KeyError was raised - now issue fixed

Summary: Fixed KeyError in case when port_type not available in hwsku.json
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fixed KeyError in case when port_type not available in hwsku.json

#### How did you do it?
Changed dictionary[key] to dictionary.get(key)

#### How did you verify/test it?
Executed tests which use this logic

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
