### PR TITLE
[Mellanox/Nvidia] Fixed logic which starts platform_api_server to use correct python version

### DIFF
--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -24,7 +24,8 @@ def start_platform_api_service(duthosts, enum_rand_one_per_hwsku_hostname, local
                              module_ignore_errors=True)
     if 'exception' in res:
         # TODO: Remove this check once we no longer need to support Python 2
-        if request.cls.__name__ == "TestSfpApi" and duthost.facts.get("asic_type") == "mellanox":
+        if request.cls.__name__ == "TestSfpApi" and duthost.facts.get("asic_type") == "mellanox" \
+                and duthost.sonic_release in ['202012', '202106']:
             # On Mellanox platform, the SFP APIs are not migrated to python3 yet,
             # thus we have to make it as an exception here.
             py3_platform_api_available = False


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Fixed logic which starts platform_api_server to use correct python version

Use python2 in case when sonic_release 202012 or 202106
Use python3 in all other cases(master, 202111, etc.)

Summary: Fixed logic which starts platform_api_server to use correct python version
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
API server was not able to start due to incorrect Python version,  issue fixed

#### How did you do it?
See code

#### How did you verify/test it?
Executed tests which call this part of code

#### Any platform specific information?
Mellanox/Nvidia

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
