### PR TITLE
Skip cleanup docker images in the server cleanup script

### DIFF
--- a/ansible/roles/vm_set/templates/cleanup.sh.j2
+++ b/ansible/roles/vm_set/templates/cleanup.sh.j2
@@ -22,6 +22,3 @@ test -z "$(docker ps -q)" || docker stop $(docker ps -q)
 
 # remove all docker containers
 test -z "$(docker ps -a -q)" || docker rm -f $(docker ps -a -q)
-
-# remove all docker images
-test -z "$(docker images -q)" || docker rmi -f $(docker images -q|uniq)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
One of the step in test server cleanup script is to delete all docker images.
This is not really necessary and may bite us in some scenarios. If
docker images are deleted, deploying a topology need to download the
docker image again. If something went wrong with docker registry,
deploying topology may be stuck.

#### How did you do it?
This change removed the step of deleting docker images in the
server cleanup script.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
