### PR TITLE
Add proxy support for setup-container.sh

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -264,7 +264,14 @@ EOF
     log_error "failed to generate a Dockerfile: ${TMP_DIR}/Dockerfile"
 
     log_info "building docker image from ${TMP_DIR}: ${LOCAL_IMAGE} ..."
-    eval "docker build -t \"${LOCAL_IMAGE}\" \"${TMP_DIR}\" ${SILENT_HOOK}" || \
+    build_args=""
+    if [[ -n ${http_proxy} ]]; then
+        build_args="--build-arg http_proxy=${http_proxy}"
+    fi
+    if [[ -n ${https_proxy} ]]; then
+        build_args="${build_args} --build-arg https_proxy=${https_proxy}"
+    fi
+    eval "docker build -t \"${LOCAL_IMAGE}\" \"${TMP_DIR}\" ${SILENT_HOOK} ${build_args}" || \
     log_error "failed to build docker image: ${LOCAL_IMAGE}"
 
     log_info "cleanup a temporary dir: ${TMP_DIR}"


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
After PR #4914, the setup-container.sh script needs to install some python
packages using pip. This means that internet access is required while
building docker image. If run this script on servers that need http_proxy
to have internet access, this script will fail at the step of pip installing while
building docker image.

#### How did you do it?
This change added the proxy support to this script. When environment
http_proxy and https_proxy are configured on the server running
setup-container.sh, the script can automatically use the proxy servers
while building docker image.

#### How did you verify/test it?
Tested on a server using http proxy to access internet.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
