### PR TITLE
Fix force_terminate function

### DIFF
--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -95,15 +95,15 @@ def parallel_run(
                 try:
                     os.kill(p.pid, signal.SIGKILL)
                 except OSError as err:
-                    logger.debug("Unable to kill {}:{}, error:{}".format(
+                    logger.error("Unable to kill {}:{}, error:{}".format(
                         p.pid, p.name, err
                     ))
 
-            pt_assert(
-                False,
-                """Processes running target "{}" could not be terminated.
-                Tried killing them. But please check""".format(target.__name__)
-            )
+                    pt_assert(
+                        False,
+                        """Processes running target "{}" could not be terminated.
+                        Unable to kill {}:{}, error:{}""".format(target.__name__, p.pid, p.name, err)
+                    )
 
 
     workers = []


### PR DESCRIPTION
Details:
The way the function is implemented now, the function will always result in
pt_assert error whenever it is called. even if processes were killed correctly.
pt_assert should be called only during except OSError as err.

Signed-off-by: Sharon Lutati <slutati@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The way the function is implemented now, the function will always result in
pt_assert error whenever it is called. even if processes were killed correctly.
pt_assert should be called only during except OSError as err.

Summary:
fixing the force_terminate to have correct functionality

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202111
- [ ] 201911

### Approach
#### What is the motivation for this PR? 
the function will always result in pt_assert error whenever it is called, even if processes were killed correctly.

#### How did you do it?
pt_assert should be called only during except OSError as err.

#### How did you verify/test it?
run a test that use this logic 

#### Any platform specific information?
no, relevant to all platforms

