### PR TITLE
REFINE: test_po_update_io_no_loss support multi-asic devices

### DIFF
--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -149,6 +149,8 @@ def test_po_update_io_no_loss(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     # THEN no packets shall loss
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asichost = duthost.asic_instance(enum_frontend_asic_index)
+    namespace = asichost.namespace
+    is_single_asic = not namespace
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     if len(mg_facts["minigraph_portchannel_interfaces"]) < 2:
@@ -163,7 +165,9 @@ def test_po_update_io_no_loss(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     # be like:[("10.0.0.56", "10.0.0.57", "PortChannel0001", ["Ethernet48", "Ethernet52"])]
     pcs = [(pair[0], pair[1], pair[2], mg_facts["minigraph_portchannels"][pair[2]]["members"]) for pair in
            peer_ip_pc_pair
-           if len(mg_facts["minigraph_portchannels"][pair[2]]["members"]) >= 2]
+           if len(mg_facts["minigraph_portchannels"][pair[2]]["members"]) >= 2 and
+           (is_single_asic or mg_facts["minigraph_portchannels"][pair[2]]["namespace"] == namespace)
+           ]
 
     if len(pcs) < 2:
         pytest.skip(

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -149,9 +149,7 @@ def test_po_update_io_no_loss(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     # THEN no packets shall loss
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asichost = duthost.asic_instance(enum_frontend_asic_index)
-    namespace = asichost.namespace
-    is_single_asic = not namespace
-    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    mg_facts = asichost.get_extended_minigraph_facts(tbinfo)
 
     if len(mg_facts["minigraph_portchannel_interfaces"]) < 2:
         pytest.skip("Skip test due to there isn't enough port channel exists in current topology.")
@@ -165,9 +163,7 @@ def test_po_update_io_no_loss(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     # be like:[("10.0.0.56", "10.0.0.57", "PortChannel0001", ["Ethernet48", "Ethernet52"])]
     pcs = [(pair[0], pair[1], pair[2], mg_facts["minigraph_portchannels"][pair[2]]["members"]) for pair in
            peer_ip_pc_pair
-           if len(mg_facts["minigraph_portchannels"][pair[2]]["members"]) >= 2 and
-           (is_single_asic or mg_facts["minigraph_portchannels"][pair[2]]["namespace"] == namespace)
-           ]
+           if len(mg_facts["minigraph_portchannels"][pair[2]]["members"]) >= 2]
 
     if len(pcs) < 2:
         pytest.skip(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #5122 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
refine test_po_update_io_no_loss to support multi-asic devices
#### How did you do it?
Assert whether the device is multi-asic, if true, only select the port channels that belong to the target ASIC.
#### How did you verify/test it?
Run on physical testbeds.
