### PR TITLE
Fix LogAnalyzer to force load regular expressions from common files

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -30,9 +30,6 @@ def analyzer_add_marker(analyzers, node=None, results=None):
     loganalyzer = analyzers[node.hostname]
     logging.info("Add start marker into DUT syslog for host {}".format(node.hostname))
     marker = loganalyzer.init()
-    logging.info("Load config and analyze log for host {}".format(node.hostname))
-    # Read existed common regular expressions located with legacy loganalyzer module
-    loganalyzer.load_common_config()
     results[node.hostname] = marker
 
 
@@ -53,7 +50,9 @@ def loganalyzer(duthosts, request):
     analyzers = {}
     parallel_run(analyzer_logrotate, [], {}, duthosts, timeout=120)
     for duthost in duthosts:
-        analyzers[duthost.hostname] = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
+        analyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
+        analyzer.load_common_config()
+        analyzers[duthost.hostname] = analyzer
     markers = parallel_run(analyzer_add_marker, [analyzers], {}, duthosts, timeout=120)
 
     yield analyzers


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Fix LogAnalyzer to force load regular expressions from common files

Looks like commit https://github.com/Azure/sonic-mgmt/pull/3235 caused issue that LA has empty list of match errors expressions. 

Summary: Fix LogAnalyzer to force load regular expressions from common files
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
LogAnalyzer did not work, this PR is fix for LA

#### How did you do it?
See code

#### How did you verify/test it?
Executed tests which using LA, checked that LA failed in case when we have errors in logs

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
