### PR TITLE
Specify env vm_type in start/stop-topo-vms

### DIFF
--- a/ansible/roles/vm_set/tasks/respin_vm.yml
+++ b/ansible/roles/vm_set/tasks/respin_vm.yml
@@ -15,7 +15,7 @@
   become: yes
   ignore_errors: true
 
-- name: Remove arista disk image for {{ vm_name }}
+- name: Remove {{ vm_type }} disk image for {{ vm_name }}
   file: path={{ disk_image }} state=absent
 
 - name: Copy arista disk image for {{ vm_name }}

--- a/ansible/roles/vm_set/tasks/start_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_vm.yml
@@ -35,7 +35,7 @@
   stat: path={{ disk_image }}
   register: file_stat
 
-- name: Copy arista disk image for {{ hostname }}
+- name: Copy {{ vm_type }} disk image for {{ hostname }}
   copy: src={{ src_disk_image }} dest={{ disk_image }} remote_src=True
   when: not file_stat.stat.exists
 

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -208,7 +208,8 @@ function start_topo_vms
 
   echo "Starting VMs for testbed '${testbed_name}' on server '${server}'"
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_start_VMs.yml --vault-password-file="${passwd}" -l "${server}" -e VM_base="$vm_base" -e topo="$topo" $@
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_start_VMs.yml --vault-password-file="${passwd}" -l "${server}" \
+	  -e VM_base="$vm_base" -e vm_type="$vm_type" -e topo="$topo" $@
 }
 
 function stop_topo_vms
@@ -225,7 +226,8 @@ function stop_topo_vms
 
   echo "Stopping VMs for testbed '${testbed_name}' on server '${server}'"
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_stop_VMs.yml --vault-password-file="${passwd}" -l "${server}" -e VM_base="$vm_base" -e topo="$topo" $@
+  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_stop_VMs.yml --vault-password-file="${passwd}" -l "${server}" \
+	  -e VM_base="$vm_base" -e vm_type="$vm_type" -e topo="$topo" $@
 }
 
 function add_topo


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Specify env variable vm_type in start/stop-topo-vms, regarding to testbed-cli.sh param '-k <vm-type>'

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The param `-k <vm-type>` takes no effect on command start-topo-vms and stop-topo-vms.

#### How did you do it?
Specify env variable `vm_type` in start/stop-topo-vms,

#### How did you verify/test it?
Deploy t0 testbed with vsonic vm by specifying param `-k vsonic` with  testbed-cli.sh commands:

```
start-topo-vms
add-topo
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
