### PR TITLE
[qos] Identify buffer type before yielding from setup for non Mellanox platforms

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -293,6 +293,7 @@ def setup_module(duthosts, rand_one_dut_hostname, request):
     global DEFAULT_OVER_SUBSCRIBE_RATIO
 
     duthost = duthosts[rand_one_dut_hostname]
+    detect_buffer_model(duthost)
     if not is_mellanox_device(duthost):
         yield
         return
@@ -312,7 +313,6 @@ def setup_module(duthosts, rand_one_dut_hostname, request):
         logging.info("Shutting down BGP neighbors and waiting for all routing entries withdrawn")
         time.sleep(60)
 
-    detect_buffer_model(duthost)
     enable_shared_headroom_pool = request.config.getoption("--enable_shared_headroom_pool")
     need_to_disable_shared_headroom_pool_after_test = False
     if BUFFER_MODEL_DYNAMIC:


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
The change to yield early from the setup fixture for non Mellanox platforms done in #5146 prevented from identifying the correct buffer type for a platform and hence dynamic buffer model tests were getting executed for traditional buffer model systems.

#### How did you do it?
Identify the buffer type early on before yielding

#### How did you verify/test it?
Ran the test on a non Mellanox system and dynamic buffer model tests are skipped

```
================================================================================== test session starts ===================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.9, py-1.8.1, pluggy-0.13.1
ansible: 2.8.7
rootdir: /var/nejo/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: ansible-2.2.2
collecting ... [WARNING]: While constructing a mapping from /var/nejo/sonic-mgmt-
int/ansible/str2, line 17, column 9, found a duplicate dict key (vms28-6).
Using last defined value only.
collected 17 items                                                                                                                                                                       

qos/test_buffer.py::test_change_speed_cable[50000-1500-15m] SKIPPED                                                                                                                [  5%]
qos/test_buffer.py::test_change_speed_cable[50000-1500-40m] SKIPPED                                                                                                                [ 11%]
qos/test_buffer.py::test_change_speed_cable[50000-9100-15m] SKIPPED                                                                                                                [ 17%]
qos/test_buffer.py::test_change_speed_cable[50000-9100-40m] SKIPPED                                                                                                                [ 23%]
qos/test_buffer.py::test_change_speed_cable[10000-1500-15m] SKIPPED                                                                                                                [ 29%]
qos/test_buffer.py::test_change_speed_cable[10000-1500-40m] SKIPPED                                                                                                                [ 35%]
qos/test_buffer.py::test_change_speed_cable[10000-9100-15m] SKIPPED                                                                                                                [ 41%]
qos/test_buffer.py::test_change_speed_cable[10000-9100-40m] SKIPPED                                                                                                                [ 47%]
qos/test_buffer.py::test_headroom_override SKIPPED                                                                                                                                 [ 52%]
qos/test_buffer.py::test_shared_headroom_pool_configure SKIPPED                                                                                                                    [ 58%]
qos/test_buffer.py::test_lossless_pg[3-4] SKIPPED                                                                                                                                  [ 64%]
qos/test_buffer.py::test_lossless_pg[6] SKIPPED                                                                                                                                    [ 70%]
qos/test_buffer.py::test_port_admin_down SKIPPED                                                                                                                                   [ 76%]
qos/test_buffer.py::test_port_auto_neg SKIPPED                                                                                                                                     [ 82%]
qos/test_buffer.py::test_exceeding_headroom SKIPPED                                                                                                                                [ 88%]
qos/test_buffer.py::test_buffer_model_test SKIPPED                                                                                                                                 [ 94%]
qos/test_buffer.py::test_buffer_deployment PASSED                                                                                                                                  [100%]
```
