### PR TITLE
Upgrade flask to fix the issue of starting mux simulator

### DIFF
--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -12,7 +12,7 @@
   block:
 
   - name: Install flask
-    pip: name=flask version=1.1.2 state=forcereinstall executable={{ pip_executable }}
+    pip: name=flask version=2.0.3 state=forcereinstall executable={{ pip_executable }}
     become: yes
     environment: "{{ proxy_env | default({}) }}"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Recently we observed that starting mux simulator failed with error like below:

azure@server:~$ sudo python /home/azure/veos-vm/mux_simulator.py 8080 vms24-7 -v
Traceback (most recent call last):
  File "/home/azure/veos-vm/mux_simulator.py", line 18, in <module>
    from flask import Flask, request, abort
  File "/usr/local/lib/python3.8/dist-packages/flask/__init__.py", line 19, in <module>
    from . import json
  File "/usr/local/lib/python3.8/dist-packages/flask/json/__init__.py", line 15, in <module>
    from itsdangerous import json as _json
ImportError: cannot import name 'json' from 'itsdangerous' (/usr/local/lib/python3.8/dist-packages/itsdangerous/__init__.py)

While deploying dualtor testbed, we always tried to install Flask version 1.1.2 on test server. Flask specified one
of dependant package "itsdangerous" as:

    itsdangerous>=0.24

This means that the latest version of "itsdangerous" is always installed after "pip install Flask==1.1.2".

Recently the latest "itsdangerous" version deprecated something and caused this issue. It has been fixed in
Flask 2.0.0: https://itsdangerous.palletsprojects.com/en/2.1.x/changes

This article described the detailed reason and solutions:
https://itsmycode.com/importerror-cannot-import-name-json-from-itsdangerous/

#### How did you do it?
This PR updated the deployment code to use Flask 2.0.3 (current latest Flask version on pypi) which has the fix.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
