### PR TITLE
Add sport 179 rules back for other versions, only master image remove these rules

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -367,6 +367,9 @@ def generate_expected_rules(duthost, docker_network, asic_index):
     # Allow all incoming BGP traffic
     iptables_rules.append("-A INPUT -p tcp -m tcp --dport 179 -j ACCEPT")
     ip6tables_rules.append("-A INPUT -p tcp -m tcp --dport 179 -j ACCEPT")
+    if "master" not in duthost.os_version:
+        iptables_rules.append("-A INPUT -p tcp -m tcp --sport 179 -j ACCEPT")
+        ip6tables_rules.append("-A INPUT -p tcp -m tcp --sport 179 -j ACCEPT")
 
     # Generate control plane rules from device config
     rules_applied_from_config = 0


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
#5186 fixed the cacl failure in PR testing, but for nightly testing, on other sonic versions, such 202012, it will remove these 2 rules as well, then will cause test case failed.

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Try to avoid nightly cacl test failure introduced by #5186.

#### How did you do it?
Add a os version checker before add sport 179 rules.

#### How did you verify/test it?
run tests/test_cacl_application.py::test_cacl_application

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
