### PR TITLE
Fix TACACS UT failed because /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 not exist on ARM platform. 

### DIFF
--- a/tests/tacacs/tac_plus.conf.j2
+++ b/tests/tacacs/tac_plus.conf.j2
@@ -59,6 +59,9 @@ user = {{ tacacs_authorization_user }} {
     cmd = /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 {
         deny .*
     }
+    cmd = /lib/arm-linux-gnueabihf/ld-linux-armhf.so.3 {
+        deny .*
+    }
     cmd = /usr/bin/dash {
         deny .*
     }

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import paramiko
 import pytest
 
@@ -288,9 +289,11 @@ def test_bypass_authorization(duthosts, enum_rand_one_per_hwsku_hostname, tacacs
         Verify user can't run command with loader:
             /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 sh
     """
-    exit_code, stdout, stderr = ssh_run_command(remote_user_client, "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 sh")
-    pytest_assert(exit_code == 1)
-    check_ssh_output(stdout, 'authorize failed by TACACS+ with given arguments, not executing')
+    ld_path = "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    if os.path.isfile(ld_path):
+        exit_code, stdout, stderr = ssh_run_command(remote_user_client, ld_path + " sh")
+        pytest_assert(exit_code == 1)
+        check_ssh_output(stdout, 'authorize failed by TACACS+ with given arguments, not executing')
 
     """
         Verify user can't run command with prefix/quoting:

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -288,10 +288,18 @@ def test_bypass_authorization(duthosts, enum_rand_one_per_hwsku_hostname, tacacs
     """
         Verify user can't run command with loader:
             /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 sh
+        Or
+            /lib/arm-linux-gnueabihf/ld-linux-armhf.so.3 sh
     """
-    ld_path = "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
-    if os.path.isfile(ld_path):
-        exit_code, stdout, stderr = ssh_run_command(remote_user_client, ld_path + " sh")
+    ld_path_x86 = "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    if os.path.isfile(ld_path_x86):
+        exit_code, stdout, stderr = ssh_run_command(remote_user_client, ld_path_x86 + " sh")
+        pytest_assert(exit_code == 1)
+        check_ssh_output(stdout, 'authorize failed by TACACS+ with given arguments, not executing')
+
+    ld_path_arm = "/lib/arm-linux-gnueabihf/ld-linux-armhf.so.3"
+    if os.path.isfile(ld_path_arm):
+        exit_code, stdout, stderr = ssh_run_command(remote_user_client, ld_path_arm + " sh")
         pytest_assert(exit_code == 1)
         check_ssh_output(stdout, 'authorize failed by TACACS+ with given arguments, not executing')
 

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -100,9 +100,13 @@ def setup_tacacs_server(ptfhost, tacacs_creds, duthost):
     fix_symbolic_link_in_config(duthost, ptfhost, "/usr/bin/python")
 
     # Find ld lib symbolic link target, and fix the tac_plus config file
-    ld_path = "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
-    if os.path.isfile(ld_path):
-        fix_symbolic_link_in_config(duthost, ptfhost, "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2")
+    ld_path_x86 = "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    if os.path.isfile(ld_path_x86):
+        fix_symbolic_link_in_config(duthost, ptfhost, ld_path_x86)
+
+    ld_path_arm = "/lib/arm-linux-gnueabihf/ld-linux-armhf.so.3"
+    if os.path.isfile(ld_path_arm):
+        fix_symbolic_link_in_config(duthost, ptfhost, ld_path_arm)
 
     ptfhost.lineinfile(path="/etc/default/tacacs+", line="DAEMON_OPTS=\"-d 10 -l /var/log/tac_plus.log -C /etc/tacacs+/tac_plus.conf\"", regexp='^DAEMON_OPTS=.*')
     check_all_services_status(ptfhost)

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -1,5 +1,6 @@
 import crypt
 import logging
+import os
 import re
 
 from tests.common.errors import RunAnsibleModuleFail
@@ -99,7 +100,9 @@ def setup_tacacs_server(ptfhost, tacacs_creds, duthost):
     fix_symbolic_link_in_config(duthost, ptfhost, "/usr/bin/python")
 
     # Find ld lib symbolic link target, and fix the tac_plus config file
-    fix_symbolic_link_in_config(duthost, ptfhost, "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2")
+    ld_path = "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    if os.path.isfile(ld_path):
+        fix_symbolic_link_in_config(duthost, ptfhost, "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2")
 
     ptfhost.lineinfile(path="/etc/default/tacacs+", line="DAEMON_OPTS=\"-d 10 -l /var/log/tac_plus.log -C /etc/tacacs+/tac_plus.conf\"", regexp='^DAEMON_OPTS=.*')
     check_all_services_status(ptfhost)


### PR DESCRIPTION
### Description of PR
     Fix TACACS UT failed because /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 not exist on ARM platform. 

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)


### Back port request

### Approach
#### What is the motivation for this PR?
    TACACS UT failed because /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 not exist on ARM platform. 

#### How did you do it?
   Fix code bug and pass all UT.

#### How did you verify/test it?
   Run all UT make sure they are all pass.

#### Any platform specific information?
   N/A

#### Supported testbed topology if it's a new test case?

### Documentation 
https://github.com/Azure/SONiC/blob/master/doc/aaa/TACACS%2B%20Design.md