### PR TITLE
Added support for 'Unknown' reboot causes

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -225,11 +225,10 @@ def check_reboot_cause(dut, reboot_cause_expected):
     return reboot_cause_got == reboot_cause_expected
 
 
-def sync_reboot_history_queue_with_dut(dut, latest_reboot_type):
+def sync_reboot_history_queue_with_dut(dut):
     """
     @summary: Sync DUT and internal history queues
     @param dut: The AnsibleHost object of DUT.
-    @param latest_reboot_type: most recent reboot type 
     """
 
     global REBOOT_TYPE_HISTOYR_QUEUE
@@ -268,6 +267,7 @@ def sync_reboot_history_queue_with_dut(dut, latest_reboot_type):
     # If retry logic did not yield reboot cause history from DUT,
     # return without clearing the existing reboot history queue.
     if not dut_reboot_history_received:
+        logging.warn("Unable to sync reboot history queue")
         return
 
     # If the reboot cause history is received from DUT,

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -19,6 +19,7 @@ REBOOT_TYPE_FAST = "fast"
 REBOOT_TYPE_POWEROFF = "power off"
 REBOOT_TYPE_WATCHDOG = "watchdog"
 REBOOT_TYPE_UNKNOWN  = "Unknown"
+REBOOT_TYPE_THERMAL_OVERLOAD = "Thermal Overload"
 
 # Event to signal DUT activeness
 DUT_ACTIVE = threading.Event()
@@ -81,8 +82,13 @@ reboot_ctrl_dict = {
         "wait": 120,
         "cause": "Unknown",
         "test_reboot_cause_only": False
+    },
+    REBOOT_TYPE_THERMAL_OVERLOAD: {
+        "timeout": 300,
+        "wait": 120,
+        "cause": "Thermal Overload",
+        "test_reboot_cause_only": False
     }
-
 }
 
 MAX_NUM_REBOOT_CAUSE_HISTORY = 10

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -249,8 +249,9 @@ def sync_reboot_history_queue_with_dut(dut, latest_reboot_type):
     REBOOT_TYPE_HISTOYR_QUEUE.append(latest_reboot_type)
 
     # Skip this function if sonic image is 201811 or 201911
-    skip_release(dut, ["201811", "201911"])
-
+    if "201811" in dut.os_version or "201911" in dut.os_version:
+        logging.info("Skip sync reboot-cause history for version before 202012")
+        return
 
     # IF control is here it means the SONiC image version is > 201911
     # Try and get the entire reboot-cause history from DUT

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -55,13 +55,12 @@ def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list, reboot_type=REB
     @param reboot_helper: The helper function used only by power off reboot
     @param reboot_kwargs: The argument used by reboot_helper
     """
- 
-    logging.info("Sync reboot cause history queue with DUT reboot cause history queue")
-    sync_reboot_history_queue_with_dut(dut)
 
     logging.info("Run %s reboot on DUT" % reboot_type)
     reboot(dut, localhost, reboot_type=reboot_type, reboot_helper=reboot_helper, reboot_kwargs=reboot_kwargs)
-    REBOOT_TYPE_HISTOYR_QUEUE.append(reboot_type)
+
+    logging.info("Sync reboot cause history queue with DUT reboot cause history queue")
+    sync_reboot_history_queue_with_dut(dut, reboot_type)
 
     check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type)
 

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -57,7 +57,7 @@ def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list, reboot_type=REB
     """
 
     logging.info("Sync reboot cause history queue with DUT reboot cause history queue")
-    sync_reboot_history_queue_with_dut(dut, reboot_type)
+    sync_reboot_history_queue_with_dut(dut)
 
     logging.info("Run %s reboot on DUT" % reboot_type)
     reboot(dut, localhost, reboot_type=reboot_type, reboot_helper=reboot_helper, reboot_kwargs=reboot_kwargs)

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -56,11 +56,15 @@ def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list, reboot_type=REB
     @param reboot_kwargs: The argument used by reboot_helper
     """
 
+    logging.info("Sync reboot cause history queue with DUT reboot cause history queue")
+    sync_reboot_history_queue_with_dut(dut, reboot_type)
+
     logging.info("Run %s reboot on DUT" % reboot_type)
     reboot(dut, localhost, reboot_type=reboot_type, reboot_helper=reboot_helper, reboot_kwargs=reboot_kwargs)
 
-    logging.info("Sync reboot cause history queue with DUT reboot cause history queue")
-    sync_reboot_history_queue_with_dut(dut, reboot_type)
+    # Append the last reboot type to the queue
+    logging.info("Append the latest reboot type to the queue")
+    REBOOT_TYPE_HISTOYR_QUEUE.append(reboot_type)
 
     check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type)
 


### PR DESCRIPTION
### Description of PR

Added support for 'Unknown' reboot causes that were causing the reboot tests to fail.
Added skip_release before syncing DUT history with local history for SONiC images <= 201911

Summary:
Fixes # (issue)

### Type of change

- [X ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

The original issue was a reboot cause mismatch, for which I added a sync function that gets the full reboot history from the DUT and syncs it with the local reboot history. The idea was that if we do this, there's no chance for a mismatch. The way I did this was to get the reboot cause history from the DUT and for each cause, find a corresponding match on the  reboot cause dictionary and then add that key to the queue.

However, the DUTs started showing reboot reasons such as 'Thermal Overload' or 'Unknown', which are not part of the reboot cause dictionary. Because of this,  two things happened:

1. Let's say the most recent reboot requested was a cold reboot but in so doing, the DUT had a thermal overload. In the scenario, the assertion that the latest reboot causes match in Ln 81 of platform_tests/test_reboot.py would fail.

2. If the most recent cause of reboot passed BUT there was an 'Unknown' reboot cause or two in  the DUT's history, those specific causes were not synced to our local queue because of the way the sync function was coded. So of the 10 causes, only 8 or 9 would be added to the queue. So even if the check_reboot_cause assertion would pass, it would cause an indexing error in the check_reboot_cause_history function.

Additionally, I didn't know that 'check reboot-cause history' wasn't supported in releases 201911 and prior, so that was causing failures too.

I have fixes for all these issues save the AssertionError, which I believe is the test behaving as intended.



#### How did you do it?

**AssertionError**: NO CHANGES. This is intended behavior. If the DUT can't remember what caused the reboot OR if rebooting it caused a Thermal Overload, it is a problem with the DUT that needs further inspection.

**IndexError**: Added code to account for previously unknown reboot causes in order to not cause an indexing mismatch between DUT's reboot cause history and the local reboot cause history queue

**Ansible Shell Exception**: Added skip_release functionality to account for SONiC images <= 201911

#### How did you verify/test it?

Ran the test on multiple testbeds exhibiting different error messages and verified that those messages (except for AssertionError) no longer occur.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
