### PR TITLE
[advanced-reboot] New small disk SKU and handle bgpd.log between upgrades

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -20,7 +20,8 @@ FMT = "%b %d %H:%M:%S.%f"
 FMT_SHORT = "%b %d %H:%M:%S"
 SMALL_DISK_SKUS = [
     "Arista-7060CX-32S-C32",
-    "Arista-7060CX-32S-Q32"
+    "Arista-7060CX-32S-Q32",
+    "Arista-7060CX-32S-D48C8"
 ]
 
 
@@ -378,14 +379,16 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
         if 'vs' not in device_marks:
             pytest.skip('Testcase not supported for kvm')
 
-    current_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
-    if 'SONiC-OS-201811' in current_os_version:
+    base_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
+    if 'SONiC-OS-201811' in base_os_version:
         bgpd_log = "/var/log/quagga/bgpd.log"
     else:
         bgpd_log = "/var/log/frr/bgpd.log"
 
     hwsku = duthost.facts["hwsku"]
-    if hwsku in SMALL_DISK_SKUS:
+    log_filesystem = duthost.shell("df -h | grep '/var/log'")['stdout']
+    logs_in_tmpfs = True if log_filesystem and "tmpfs" in log_filesystem else False
+    if hwsku in SMALL_DISK_SKUS or logs_in_tmpfs:
         # For small disk devices, /var/log in mounted in tmpfs.
         # Hence, after reboot the preboot logs are lost.
         # For log_analyzer to work, it needs logs from the shutdown path
@@ -411,7 +414,7 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
         return marker
 
     def post_reboot_analysis(marker, reboot_oper=None, log_dir=None):
-        if hwsku in SMALL_DISK_SKUS:
+        if hwsku in SMALL_DISK_SKUS or logs_in_tmpfs:
             restore_backup = "mv /host/syslog.99 /var/log/; " +\
                 "mv /host/sairedis.rec.99 /var/log/swss/; " +\
                     "mv /host/swss.rec.99 /var/log/swss/; " +\
@@ -423,11 +426,18 @@ def advanceboot_loganalyzer(duthosts, rand_one_dut_hostname, request):
             duthost.shell("mv {} {}".format(reboot_script_path + ".orig", reboot_script_path), module_ignore_errors=True)
 
         # check current OS version post-reboot. This can be different than preboot OS version in case of upgrade
-        current_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
-        if 'SONiC-OS-201811' in current_os_version:
+        target_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
+        upgrade_out_201811 = "SONiC-OS-201811" in base_os_version and "SONiC-OS-201811" not in target_os_version
+        if 'SONiC-OS-201811' in target_os_version:
             bgpd_log = "/var/log/quagga/bgpd.log"
         else:
             bgpd_log = "/var/log/frr/bgpd.log"
+        if upgrade_out_201811 and not logs_in_tmpfs:
+            # if upgrade from 201811 to future branch is done there are two cases:
+            # 1. Small disk devices: previous quagga logs don't exist anymore, handled in restore_backup.
+            # 2. Other devices: prev quagga log to be copied to a common place, for ansible extract to work:
+            duthost.shell("cp {} {}".format(
+                "/var/log/quagga/bgpd.log", "/var/log/frr/bgpd.log.99"), module_ignore_errors=True)
         additional_files={'/var/log/swss/sairedis.rec': 'recording on: /var/log/swss/sairedis.rec', bgpd_log: ''}
         loganalyzer.additional_files = list(additional_files.keys())
         loganalyzer.additional_start_str = list(additional_files.values())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Changes to small disk HKUs handling - new SKU, detect small disk and bgpd.log during upgrade path.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Previous PR added small disk SKU handling for log_analyzer- https://github.com/Azure/sonic-mgmt/pull/5126

However errors are seen for one SKU which was not added earlier. Moreover, auto detection mechanism is needed for 202012 upgrades, so that we don't just rely on hardcoded list (still needed for upgrade path).

#### How did you do it?

In this PR:
1. Add missed SKU to the list - `Arista-7060CX-32S-D48C8"` -  this list is needed for upgrade path with 201811 base.
2. Add detection of logs in tmpfs and automatically handle it. This case will still be not valid for upgrade path with 201811 base. But at least, it will cover 202012 upgrades, and will not require the hardcoded list to be updated for that path.
3. `bgpd.log` handling for SKUs with logs still present after upgrade - move quagga logs to frr dir so that ansible `extract_log` works fine.


#### How did you verify/test it?
Tested on small and large disk devices, and upgrade path proceeds fine.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
