### PR TITLE
[backend] Skip `test_bgp_slb` on backend topologies

### DIFF
--- a/tests/bgp/test_bgp_slb.py
+++ b/tests/bgp/test_bgp_slb.py
@@ -16,6 +16,13 @@ PEER_COUNT = 1
 NEIGHBOR_EXABGP_PORT = 11000
 
 
+@pytest.fixture(scope="module", autouse=True)
+def skip_on_backend(tbinfo):
+    """Skip over storage backend topologies."""
+    if "backend" in tbinfo["topo"]["name"]:
+        pytest.skip("Skipping test_bgp_slb, unsupported topology %s." % tbinfo["topo"]["name"])
+
+
 @pytest.fixture(params=["warm", "fast"])
 def reboot_type(request):
     return request.param


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #5210

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Skip `test_bgp_slb` on backend topologies

#### How did you do it?
Add a fixture to check if the testbed is backend.

#### How did you verify/test it?
bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot[warm] SKIPPED                                                                                                                                                                            [ 50%]
bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot[fast] SKIPPED                                                                                                                                                                            [100%]

========================================================================================================================= 2 skipped in 76.08 seconds =========================================================================================================================

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
