### PR TITLE
Configlet: AddRack: Use port name, instead of hardcoded value, which is a copy/paste error

### DIFF
--- a/tests/configlet/util/common.py
+++ b/tests/configlet/util/common.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+import inspect
 import json
 import os
 import re
@@ -158,7 +159,8 @@ def init_global_data():
 
 
 def report_error(m):
-    log_error("failure: {}".format(m))
+    log_error("failure: {}:{}: {}".format(inspect.stack()[1][1],
+        inspect.stack()[1][2], m))
     assert False, m
 
 

--- a/tests/configlet/util/configlet.py
+++ b/tests/configlet/util/configlet.py
@@ -194,7 +194,8 @@ def get_port_related_data(is_mlnx, is_storage_backend):
         cable[local_port] = orig_config["CABLE_LENGTH|AZURE"]['value'][local_port]
 
         # "BUFFER_PG"
-        buffer_pg["{}|0".format(local_port)] = orig_config["BUFFER_PG|Ethernet64|0"]['value']
+        buffer_pg["{}|0".format(local_port)] = orig_config["BUFFER_PG|{}|0".format(
+            local_port)]['value']
 
         # "QUEUE"
         for i in range(7):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix a copy/paste error, which had a hardcoded value for port name.
Fixes # [5212](https://github.com/Azure/sonic-mgmt/issues/5212)

### Type of change
Change hardcoded portname to one from variable.

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix the configlet/AddRack test failure in some switches (_where First TOR/T0 is not on Ethernet64 port_).

#### How did you do it?
Switch hardcoded portname to one found from minigraph at run time.

#### How did you verify/test it?
Ran the test in the same switch where it failed and watchit succeed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
