### PR TITLE
Always remove docker-py package 

### DIFF
--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -56,6 +56,7 @@
   pip: name=docker-py state=absent executable={{ pip_executable }}
   become: yes
   environment: "{{ proxy_env | default({}) }}"
+  ignore_errors: yes
 
 - name: Install python packages
   pip: name=docker version=4.1.0 state=forcereinstall executable={{ pip_executable }}

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -111,6 +111,12 @@
     pip_executable: pip3
   when: pip_executable is not defined and host_distribution_version.stdout == "20.04"
 
+- name: remove old python packages
+  pip: name=docker-py state=absent executable={{ pip_executable }}
+  become: yes
+  environment: "{{ proxy_env | default({}) }}"
+  ignore_errors: yes
+  
 - include_tasks: docker.yml
   when: package_installation|bool
 

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -113,7 +113,6 @@
 
 - name: remove old python packages
   pip: name=docker-py state=absent executable={{ pip_executable }}
-  become: yes
   environment: "{{ proxy_env | default({}) }}"
   ignore_errors: yes
   


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to ensure package `docker-py` is always uninstalled to avoid possible package conflict.
We saw below error when running `restart-ptf` task
```
TASK [vm_set : Get infos of ptf container] *************************************

Monday 08 November 2021 13:03:52 +0000 (0:00:01.292) 0:00:12.600 *******

fatal: [STR-ACS-SERV-07]: FAILED! => {"changed": false, "msg": "Cannot have both the docker-py and docker python modules (old and new version of Docker SDK for Python) installed together as they use the same namespace and cause a corrupt installation. Please uninstall both packages, and re-install only the docker-py or docker python module (for STR-ACS-SERV-07's Python /usr/bin/python). It is recommended to install the docker module if no support for Python 2.6 is required. Please note that simply uninstalling one of the modules can leave the other module in a broken state."}
```
It was because package `docker-py` will be install on vm_host when deploying with 201811 branch. To avoid this issue, we always remove `docker-py` package to ensure a clean environment.

There is no document to clarify if it's safe to run `pip uninstall` simutaneous in multi Ansible tasks. To verify this, I manually ran 3 Ansible tasks to do a `pip uninstall` for several times, and saw no errors. 
Besides, I set `ignore_errors: yes` to ignore the possible errors.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
This PR is to ensure package `docker-py` is always uninstalled to avoid possible package conflict.

#### How did you do it?
Remove `docker-py` package.

#### How did you verify/test it?
Verified by running `restart-ptf` Ansible task.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
