### PR TITLE
[Decap] Skip decap test case for specific vendor and release

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -31,7 +31,7 @@ decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe]:
   skip:
     reason: "Not supported on broadcom after 201911 release and mellanox all releases"
     conditions:
-      - "(asic_type in ['broadcom'] and release in ['202012', 'master']) or (asic_type in ['mellanox'])"
+      - "(asic_type in ['broadcom'] and release not in ['201811', '201911']) or (asic_type in ['mellanox'])"
 
 decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform]:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -27,11 +27,17 @@ copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
 #######################################
 #####            decap            #####
 #######################################
+decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe]:
+  skip:
+    reason: "Not supported on broadcom after 201911 release and mellanox all releases"
+    conditions:
+      - "(asic_type in ['broadcom'] and release in ['202012', 'master']) or (asic_type in ['mellanox'])"
+
 decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform]:
   skip:
-    reason: "Not supported on backend"
+    reason: "Not supported on backend and broadcom before 202012 release"
     conditions:
-      - "topo_name in ['t1-backend', 't0-backend']"
+      - "(topo_name in ['t1-backend', 't0-backend']) or (asic_type in ['broadcom'] and release in ['201811', '201911'])"
 
 #######################################
 #####         dhcp_relay          #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To skip decap test case for specific vendor and release

#### How did you do it?
1. ttl=pipe, dscp=pipe, skip on broadcom after 201911 release
and mellanox all releases
2. ttl=pipe, dscp=uniform, skip on backend and broadcom before 202012
release

#### How did you verify/test it?
Run test in a loop

#### Any platform specific information?
1. ttl=pipe, dscp=pipe, not supported on broadcom after 201911 release
and mellanox all releases
2. ttl=pipe, dscp=uniform, not supported on backend and broadcom before
202012 release

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
