### PR TITLE
Load minigraph after wr_arp with vnet test to restore config_db.json

### DIFF
--- a/tests/vxlan/test_vnet_vxlan.py
+++ b/tests/vxlan/test_vnet_vxlan.py
@@ -14,6 +14,8 @@ from tests.common.fixtures.ptfhost_utils import remove_ip_addresses, change_mac_
 
 import tests.arp.test_wr_arp as test_wr_arp
 
+from tests.common.config_reload import config_reload
+
 logger = logging.getLogger(__name__)
 
 pytestmark = [
@@ -24,6 +26,14 @@ pytestmark = [
 
 vlan_tagging_mode = ""
 
+@pytest.fixture(scope='module', autouse=True)
+def load_minigraph_after_test(rand_selected_dut):
+    """
+    Restore config_db as vnet with wram-reboot will write testing config into
+    config_db.json
+    """
+    yield
+    config_reload(rand_selected_dut, config_source='minigraph')
 
 def prepare_ptf(ptfhost, mg_facts, dut_facts, vnet_config):
     """


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to add a `config load_minigraph` at the end of `test_vnet_vxlan`.
The `WR-ARP` test with vnet config issues a warm-reboot, which will write vnet config into `config_db.json`, and causes test cases running after this one to fail.
This PR addressed the issue by adding a  `config load_minigraph` at the end of test to restore config_db.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
This PR is to add a `config load_minigraph` at the end of `test_vnet_vxlan`.

#### How did you do it?
This PR addressed the issue by adding a  `config load_minigraph` at the end of test to restore config_db.

#### How did you verify/test it?
Verified on SN4600c by running `test_vnet_vxlan` and `test_vxlan_decap`. 
#### Any platform specific information?
Mellanox specific.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
