### PR TITLE
Improve TACACS UT to support test LD command on all Arch and ABI.

### DIFF
--- a/tests/tacacs/tac_plus.conf.j2
+++ b/tests/tacacs/tac_plus.conf.j2
@@ -56,10 +56,7 @@ user = {{ tacacs_authorization_user }} {
         deny   -exec
         permit .*
     }
-    cmd = /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 {
-        deny .*
-    }
-    cmd = /lib/arm-linux-gnueabihf/ld-linux-armhf.so.3 {
+    cmd = /lib/arch-linux-abi/ld-linux-arch.so {
         deny .*
     }
     cmd = /usr/bin/dash {

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import paramiko
 import pytest
 
@@ -290,14 +289,8 @@ def test_bypass_authorization(duthosts, enum_rand_one_per_hwsku_hostname, tacacs
             /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 sh
     """
     ld_path = get_ld_path(duthost)
-    if os.path.isfile(ld_path):
+    if not ld_path:
         exit_code, stdout, stderr = ssh_run_command(remote_user_client, ld_path + " sh")
-        pytest_assert(exit_code == 1)
-        check_ssh_output(stdout, 'authorize failed by TACACS+ with given arguments, not executing')
-
-    ld_path_arm = "/lib/arm-linux-gnueabihf/ld-linux-armhf.so.3"
-    if os.path.isfile(ld_path_arm):
-        exit_code, stdout, stderr = ssh_run_command(remote_user_client, ld_path_arm + " sh")
         pytest_assert(exit_code == 1)
         check_ssh_output(stdout, 'authorize failed by TACACS+ with given arguments, not executing')
 

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -3,7 +3,7 @@ import os
 import paramiko
 import pytest
 
-from .utils import stop_tacacs_server, start_tacacs_server, per_command_check_skip_versions, remove_all_tacacs_server
+from .utils import stop_tacacs_server, start_tacacs_server, per_command_check_skip_versions, remove_all_tacacs_server, get_ld_path
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release
 
@@ -288,12 +288,10 @@ def test_bypass_authorization(duthosts, enum_rand_one_per_hwsku_hostname, tacacs
     """
         Verify user can't run command with loader:
             /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 sh
-        Or
-            /lib/arm-linux-gnueabihf/ld-linux-armhf.so.3 sh
     """
-    ld_path_x86 = "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
-    if os.path.isfile(ld_path_x86):
-        exit_code, stdout, stderr = ssh_run_command(remote_user_client, ld_path_x86 + " sh")
+    ld_path = get_ld_path(duthost)
+    if os.path.isfile(ld_path):
+        exit_code, stdout, stderr = ssh_run_command(remote_user_client, ld_path + " sh")
         pytest_assert(exit_code == 1)
         check_ssh_output(stdout, 'authorize failed by TACACS+ with given arguments, not executing')
 

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -66,7 +66,7 @@ def setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip):
     # setup local user
     setup_local_user(duthost, tacacs_creds)
 
-def fix_symbolic_link_in_config(duthost, ptfhost, symbolic_link_path):
+def fix_symbolic_link_in_config(duthost, ptfhost, symbolic_link_path, path_to_be_fix = None):
     """
         Fix symbolic link in tacacs config
         Because tac_plus server not support regex in command name, and SONiC will send full path to tacacs server side for authorization, so the 'python' and 'ld' path in tac_plus config file need fix.
@@ -74,9 +74,29 @@ def fix_symbolic_link_in_config(duthost, ptfhost, symbolic_link_path):
     read_link_command = "readlink -f {0}".format(symbolic_link_path)
     target_path = duthost.shell(read_link_command)['stdout']
     # Escape path string, will use it as regex in sed command.
+    
     link_path_regex = re.escape(symbolic_link_path)
+    if path_to_be_fix != None:
+        link_path_regex = re.escape(path_to_be_fix)
+
     target_path_regex = re.escape(target_path)
     ptfhost.shell("sed -i 's/{0}/{1}/g' /etc/tacacs+/tac_plus.conf".format(link_path_regex, target_path_regex))
+
+def get_ld_path(duthost):
+    """
+        Fix symbolic link in tacacs config
+        Because tac_plus server not support regex in command name, and SONiC will send full path to tacacs server side for authorization, so the 'python' and 'ld' path in tac_plus config file need fix.
+    """
+    find_ld_command = "find /lib/ -type f,l -regex '\/lib\/.*-linux-.*/ld-linux-.*\.so\.[0-9]*'"
+    return duthost.shell(find_ld_command)['stdout']
+
+def fix_ld_path_in_config(duthost, ptfhost):
+    """
+        Fix ld path in tacacs config
+    """
+    ld_symbolic_link_path = get_ld_path(duthost)
+    if os.path.isfile(ld_symbolic_link_path):
+        fix_symbolic_link_in_config(duthost, ptfhost, ld_symbolic_link_path, "/lib/arch-linux-abi/ld-linux-arch.so")
 
 def setup_tacacs_server(ptfhost, tacacs_creds, duthost):
     """setup tacacs server"""
@@ -100,13 +120,7 @@ def setup_tacacs_server(ptfhost, tacacs_creds, duthost):
     fix_symbolic_link_in_config(duthost, ptfhost, "/usr/bin/python")
 
     # Find ld lib symbolic link target, and fix the tac_plus config file
-    ld_path_x86 = "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
-    if os.path.isfile(ld_path_x86):
-        fix_symbolic_link_in_config(duthost, ptfhost, ld_path_x86)
-
-    ld_path_arm = "/lib/arm-linux-gnueabihf/ld-linux-armhf.so.3"
-    if os.path.isfile(ld_path_arm):
-        fix_symbolic_link_in_config(duthost, ptfhost, ld_path_arm)
+    fix_ld_path_in_config(duthost, ptfhost)
 
     ptfhost.lineinfile(path="/etc/default/tacacs+", line="DAEMON_OPTS=\"-d 10 -l /var/log/tac_plus.log -C /etc/tacacs+/tac_plus.conf\"", regexp='^DAEMON_OPTS=.*')
     check_all_services_status(ptfhost)

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -1,6 +1,5 @@
 import crypt
 import logging
-import os
 import re
 
 from tests.common.errors import RunAnsibleModuleFail
@@ -95,7 +94,7 @@ def fix_ld_path_in_config(duthost, ptfhost):
         Fix ld path in tacacs config
     """
     ld_symbolic_link_path = get_ld_path(duthost)
-    if os.path.isfile(ld_symbolic_link_path):
+    if not ld_symbolic_link_path:
         fix_symbolic_link_in_config(duthost, ptfhost, ld_symbolic_link_path, "/lib/arch-linux-abi/ld-linux-arch.so")
 
 def setup_tacacs_server(ptfhost, tacacs_creds, duthost):


### PR DESCRIPTION
### Description of PR
     Improve TACACS UT to support new Arch and ABI, because currently we hard code LD path for test UT will not run when it run on not supported Arch and ABI.

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [] Test case(new/improvement)


### Back port request

### Approach
#### What is the motivation for this PR?
    Improve TACACS UT to support new Arch and ABI.

#### How did you do it?
   Fix code bug and pass all UT.

#### How did you verify/test it?
   Run all UT make sure they are all pass.

#### Any platform specific information?
   N/A

#### Supported testbed topology if it's a new test case?

### Documentation 
https://github.com/Azure/SONiC/blob/master/doc/aaa/TACACS%2B%20Design.md