### PR TITLE
Use different flask versions for pip and pip3

### DIFF
--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -11,8 +11,17 @@
 - name: Start mux simulator
   block:
 
+  - name: Set default Flask version
+    set_fact:
+      flask_version: "1.1.2"
+
+  - name: Use newer Flask version for pip3
+    set_fact:
+      flask_version: "2.0.3"
+    when: pip_executable == "pip3"
+
   - name: Install flask
-    pip: name=flask version=2.0.3 state=forcereinstall executable={{ pip_executable }}
+    pip: name=flask version={{ flask_version }} state=forcereinstall executable={{ pip_executable }}
     become: yes
     environment: "{{ proxy_env | default({}) }}"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
PR https://github.com/Azure/sonic-mgmt/pull/5202 upgraded flask version
to 2.0.3 to workaround a compatibility issue introduced by upgrading of its
dependent package.

However, on server running older Ubuntu like 18.04, pip instead of pip3
is used for deploying testbed. If install flask 2.0.3 using pip, it will fail
with error like:

Could not find a version that satisfies the requirement flask==2.0.3 (from versions: 0.1, 0.2, 0.3, 0.3.1, 0.4, 0.5, 0.5.1, 0.5.2, 0.6, 0.6.1, 0.7, 0.7.1, 0.7.2, 0.8, 0.8.1, 0.9, 0.10, 0.10.1, 0.11, 0.11.1, 0.12, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5, 1.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.1.4)

#### How did you do it?
This PR addressed this issue by using different flask versions for different pip.
If pip_executable is "pip3", use flask version 2.0.3. Otherwise, use default 1.1.2.
If install flask 1.1.2 using pip, there is no compatibility issue of its dependent
package.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
