### PR TITLE
Improve the devutils to exit early if no matching hosts is found

### DIFF
--- a/ansible/devutils
+++ b/ansible/devutils
@@ -251,7 +251,7 @@ def action_pdu(parameters, action):
             data.append(status)
         else:
             data.append([status[x] for x in header])
-    
+
     return header, data
 
 
@@ -368,6 +368,9 @@ def main():
             print("If you are sure to do pdu action to all devices, please use -l/--limit all.")
             return
     hosts = retrieve_hosts(args.group, args.limit)
+    if not hosts:
+        print('No matching hosts')
+        return
     get_conn_graph_facts(hosts)
     actions = {'list': action_list,
                'ping': action_ping,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The devutils tool will try to parse all the connection graph files to
find the graph files that contain the list of hosts parsed from
ansible inventory files.

When no matching hosts is found in inventory files, it is unnecessary
for the devutils tool to do rest of the steps like parsing connection
graph files.

#### How did you do it?
This change added code to check matching hosts parsed from inventory
file. If no matching hosts is found, exit early.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
