### PR TITLE
Skip the pfc_asym tests for non-Mellanox platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -43,7 +43,7 @@ dhcp_relay/test_dhcpv6_relay.py:
     conditions:
       - "asic_type in ['broadcom']"
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
-      
+
 #######################################
 #####           dualtor           #####
 #######################################
@@ -121,6 +121,15 @@ ntp/test_ntp.py::test_ntp_long_jump_disabled:
   xfail:
     strict: True
     reason: "Known NTP bug"
+
+#######################################
+#####         pfc_asym            #####
+#######################################
+pfc_asym/test_pfc_asym.py:
+  skip:
+    reason: 'pfc_asym test is only supported on Mellanox platform'
+    conditions:
+      - "asic_type not in ['mellanox']"
 
 #######################################
 #####         pfcwd               #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The pfc_asym tests are only for the Mellanox platform.

#### How did you do it?
This PR added conditional mark to skip the pfc_asym tests on
non-Mellanox platforms.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
