### PR TITLE
Fix SFP test failure in 201911

### DIFF
--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -78,7 +78,9 @@ def check_transceiver_details(dut, asic_index, interfaces, xcvr_skip_list):
     """
     asichost = dut.asic_instance(asic_index)
     logging.info("Check detailed transceiver information of each connected port")
-    if dut.sonic_release in ["202012", "202106", "202111"]:
+    # NOTE: No more releases to be added here. Platform should use SFP-refactor.
+    # 'hardware_rev' is ONLY applicable to QSFP-DD/OSFP modules
+    if dut.sonic_release in ["201811", "201911", "202012", "202106", "202111"]:
         expected_fields = ["type", "hardware_rev", "serial", "manufacturer", "model"]
     else:
         expected_fields = ["type", "vendor_rev", "serial", "manufacturer", "model"]

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -253,7 +253,9 @@ class TestSfpApi(PlatformApiTestBase):
                     actual_keys = info_dict.keys()
                     
                     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-                    if duthost.sonic_release == "202012" or duthost.sonic_release == "202111":
+                    # NOTE: No more releases to be added here. Platform should use SFP-refactor.
+                    # 'hardware_rev' is ONLY applicable to QSFP-DD/OSFP modules
+                    if duthost.sonic_release in ["201811", "201911", "202012", "202106", "202111"]:
                         EXPECTED_XCVR_INFO_KEYS = [key if key != 'vendor_rev' else 'hardware_rev' for key in
                             self.EXPECTED_XCVR_INFO_KEYS]
                         self.EXPECTED_XCVR_INFO_KEYS = EXPECTED_XCVR_INFO_KEYS


### PR DESCRIPTION
### Description of PR
Fix test failure in check_transceiver_details() due to change in xcvr_info field name

### Type of change
- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
As part of sfp-refactor, 'vendor_rev' is replaced with 'hardware_rev' as per the SFF spec. Older releases doesn't have this change and hence this fix expects the 'vendor_rev' for older releases.


#### How did you verify/test it?
Run sonic-mgmt test: test_xcvr_info_in_db.py

