### PR TITLE
[test] [show tech support] Remove -r option on older releases

### DIFF
--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -264,9 +264,7 @@ def execute_command(duthost, since):
     :param duthost: DUT
     :param since: since string enterd by user
     """
-    opt = ""
-    if duthost.sonic_release not in ["201811", "201911"]:
-        opt = "-r"
+    opt = "-r" if duthost.sonic_release not in ["201811", "201911"] else ""
     result = duthost.command(
         "show techsupport {} --since={}".format(opt, '"' + since + '"'),
         module_ignore_errors=True

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -264,7 +264,13 @@ def execute_command(duthost, since):
     :param duthost: DUT
     :param since: since string enterd by user
     """
-    result = duthost.command("show techsupport -r --since={}".format('"' + since + '"'), module_ignore_errors=True)
+    opt = ""
+    if duthost.sonic_release not in ["201811", "201911"]:
+        opt = "-r"
+    result = duthost.command(
+        "show techsupport {} --since={}".format(opt, '"' + since + '"'),
+        module_ignore_errors=True
+    )
     if result['rc'] != SUCCESS_CODE:
         pytest.fail('Failed to create techsupport. \nstdout:{}. \nstderr:{}'.format(result['stdout'], result['stderr']))
     pytest.tar_stdout = result['stdout']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
'show techsupport' test was failing in 201911 release as the command option is not supported

#### How did you do it?
Do not add command option in older releases

#### How did you verify/test it?
Ran pytest on 201911 release

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
