### PR TITLE
Support vsonic VM's with t2 topology [t2_2lc_min_ports-masic]

### DIFF
--- a/ansible/roles/sonic/templates/configdb-t2_2lc_min_ports-masic-core.j2
+++ b/ansible/roles/sonic/templates/configdb-t2_2lc_min_ports-masic-core.j2
@@ -1,0 +1,75 @@
+{% set host = configuration[hostname] %}
+{
+{% set first_in_loop = true %}
+    "PORTCHANNEL": {
+{% for name, iface in host['interfaces'].items() %}
+{% if name.startswith('Port-Channel') %}
+{{ "," if not first_in_loop else "" }}
+{% set first_in_loop = false %}
+        "{{ name | replace("-", "") }}": {
+            "admin_status": "up",
+            "mtu": "9100"
+        }
+{% endif %}
+{% endfor %}
+    },
+{% set first_in_loop = true %}
+    "INTERFACE": {
+{% for name, iface in host['interfaces'].items() %}
+{% if not name.startswith('Loopback') and not name.startswith('Port-Channel') and iface['lacp'] is not defined %}
+{{ "," if not first_in_loop else "" }}
+{% set first_in_loop = false %}
+        "{{ name | replace("-", "") }}": {},
+{% if iface['ipv4'] is defined %}
+        "{{ name | replace("-", "") }}|{{ iface['ipv4'] }}": {},
+{% endif %}
+{% if iface['ipv6'] is defined %}
+        "{{ name | replace("-", "") }}|{{ iface['ipv6'] }}": {}
+{% endif %}
+{% endif %}
+{% endfor %}
+    },
+{% set first_in_loop = true %}
+    "PORTCHANNEL_INTERFACE": {
+{% for name, iface in host['interfaces'].items() %}
+{% if name.startswith('Port-Channel') %}
+{{ "," if not first_in_loop else "" }}
+{% set first_in_loop = false %}
+        "{{ name | replace("-", "") }}": {},
+{% if iface['ipv4'] is defined %}
+        "{{ name | replace("-", "") }}|{{ iface['ipv4'] }}": {},
+{% endif %}
+{% if iface['ipv6'] is defined %}
+        "{{ name | replace("-", "") }}|{{ iface['ipv6'] }}": {}
+{% endif %}
+{% endif %}
+{% endfor %}
+    },
+{% set first_in_loop = true %}
+    "PORTCHANNEL_MEMBER": {
+{% for name, iface in host['interfaces'].items() %}
+{% if iface['lacp'] is defined %}
+{{ "," if not first_in_loop else "" }}
+{% set first_in_loop = false %}
+{% set index = name | replace("Ethernet", "") | int - 1 %}
+        "PortChannel{{ iface['lacp'] }}|{{ name }}": {}
+{% endif %}
+{% endfor %}
+    },
+{% set first_in_loop = true %}
+    "LOOPBACK_INTERFACE": {
+{% for name, iface in host['interfaces'].items() %}
+{% if name.startswith('Loopback') %}
+{{ "," if not first_in_loop else "" }}
+{% set first_in_loop = false %}
+        "{{ name }}": {},
+{% if iface['ipv4'] is defined %}
+        "{{ name }}|{{ iface['ipv4'] }}": {},
+{% endif %}
+{% if iface['ipv6'] is defined %}
+        "{{ name }}|{{ iface['ipv6'] }}": {}
+{% endif %}
+{% endif %}
+{% endfor %}
+}
+}

--- a/ansible/roles/sonic/templates/configdb-t2_2lc_min_ports-masic-leaf.j2
+++ b/ansible/roles/sonic/templates/configdb-t2_2lc_min_ports-masic-leaf.j2
@@ -1,0 +1,75 @@
+{% set host = configuration[hostname] %}
+{
+{% set first_in_loop = true %}
+    "PORTCHANNEL": {
+{% for name, iface in host['interfaces'].items() %}
+{% if name.startswith('Port-Channel') %}
+{{ "," if not first_in_loop else "" }}
+{% set first_in_loop = false %}
+        "{{ name | replace("-", "") }}": {
+            "admin_status": "up",
+            "mtu": "9100"
+        }
+{% endif %}
+{% endfor %}
+    },
+{% set first_in_loop = true %}
+    "INTERFACE": {
+{% for name, iface in host['interfaces'].items() %}
+{% if not name.startswith('Loopback') and not name.startswith('Port-Channel') and iface['lacp'] is not defined %}
+{{ "," if not first_in_loop else "" }}
+{% set first_in_loop = false %}
+        "{{ name | replace("-", "") }}": {},
+{% if iface['ipv4'] is defined %}
+        "{{ name | replace("-", "") }}|{{ iface['ipv4'] }}": {},
+{% endif %}
+{% if iface['ipv6'] is defined %}
+        "{{ name | replace("-", "") }}|{{ iface['ipv6'] }}": {}
+{% endif %}
+{% endif %}
+{% endfor %}
+    },
+{% set first_in_loop = true %}
+    "PORTCHANNEL_INTERFACE": {
+{% for name, iface in host['interfaces'].items() %}
+{% if name.startswith('Port-Channel') %}
+{{ "," if not first_in_loop else "" }}
+{% set first_in_loop = false %}
+        "{{ name | replace("-", "") }}": {},
+{% if iface['ipv4'] is defined %}
+        "{{ name | replace("-", "") }}|{{ iface['ipv4'] }}": {},
+{% endif %}
+{% if iface['ipv6'] is defined %}
+        "{{ name | replace("-", "") }}|{{ iface['ipv6'] }}": {}
+{% endif %}
+{% endif %}
+{% endfor %}
+    },
+{% set first_in_loop = true %}
+    "PORTCHANNEL_MEMBER": {
+{% for name, iface in host['interfaces'].items() %}
+{% if iface['lacp'] is defined %}
+{{ "," if not first_in_loop else "" }}
+{% set first_in_loop = false %}
+{% set index = name | replace("Ethernet", "") | int - 1 %}
+        "PortChannel{{ iface['lacp'] }}|{{ name }}": {}
+{% endif %}
+{% endfor %}
+    },
+{% set first_in_loop = true %}
+    "LOOPBACK_INTERFACE": {
+{% for name, iface in host['interfaces'].items() %}
+{% if name.startswith('Loopback') %}
+{{ "," if not first_in_loop else "" }}
+{% set first_in_loop = false %}
+        "{{ name }}": {},
+{% if iface['ipv4'] is defined %}
+        "{{ name }}|{{ iface['ipv4'] }}": {},
+{% endif %}
+{% if iface['ipv6'] is defined %}
+        "{{ name }}|{{ iface['ipv6'] }}": {}
+{% endif %}
+{% endif %}
+{% endfor %}
+}
+}

--- a/ansible/roles/sonic/templates/frr-t2_2lc_min_ports-masic-core.j2
+++ b/ansible/roles/sonic/templates/frr-t2_2lc_min_ports-masic-core.j2
@@ -1,0 +1,44 @@
+{% set host = configuration[hostname] %}
+!
+hostname {{ hostname }}
+password zebra
+enable password zebra
+!
+log syslog informational
+log facility local4
+!
+router bgp {{ host['bgp']['asn'] }}
+ no bgp ebgp-requires-policy
+ bgp router-id {{ host['interfaces']['Loopback0']['ipv4'] | ipaddr('address') }}
+ !
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+{% for remote_ip in remote_ips %}
+ neighbor {{ remote_ip }} remote-as {{ asn }}
+ neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} timers 3 10
+{% if remote_ip | ipv6 %}
+ address-family ipv6 unicast
+  neighbor {{ remote_ip }} activate
+ exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+ neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv4 }} description exabgp_v4
+ neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv6 }} description exabgp_v6
+ address-family ipv6
+  neighbor {{ props.nhipv6 }} activate
+ exit
+ !
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
+ address-family ipv4 unicast
+  network {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ address-family ipv6 unicast
+  network {{ iface['ipv6'] }}
+{% endif %}
+{% endfor %}
+!

--- a/ansible/roles/sonic/templates/frr-t2_2lc_min_ports-masic-leaf.j2
+++ b/ansible/roles/sonic/templates/frr-t2_2lc_min_ports-masic-leaf.j2
@@ -1,0 +1,44 @@
+{% set host = configuration[hostname] %}
+!
+hostname {{ hostname }}
+password zebra
+enable password zebra
+!
+log syslog informational
+log facility local4
+!
+router bgp {{ host['bgp']['asn'] }}
+ no bgp ebgp-requires-policy
+ bgp router-id {{ host['interfaces']['Loopback0']['ipv4'] | ipaddr('address') }}
+ !
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+{% for remote_ip in remote_ips %}
+ neighbor {{ remote_ip }} remote-as {{ asn }}
+ neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} timers 3 10
+{% if remote_ip | ipv6 %}
+ address-family ipv6 unicast
+  neighbor {{ remote_ip }} activate
+ exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+ neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv4 }} description exabgp_v4
+ neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv6 }} description exabgp_v6
+ address-family ipv6
+  neighbor {{ props.nhipv6 }} activate
+ exit
+ !
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
+ address-family ipv4 unicast
+  network {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ address-family ipv6 unicast
+  network {{ iface['ipv6'] }}
+{% endif %}
+{% endfor %}
+!

--- a/ansible/roles/sonic/templates/zebra-t2_2lc_min_ports-masic-core.j2
+++ b/ansible/roles/sonic/templates/zebra-t2_2lc_min_ports-masic-core.j2
@@ -1,0 +1,17 @@
+{% set host = configuration[hostname] %}
+hostname {{ hostname }}
+password zebra
+enable password zebra
+!
+log syslog informational
+log facility local4
+!
+! end of template: common/daemons.common.conf.j2!
+!
+!
+! Enable link-detect (default disabled)
+{% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+link detect
+!
+{% endfor %}

--- a/ansible/roles/sonic/templates/zebra-t2_2lc_min_ports-masic-leaf.j2
+++ b/ansible/roles/sonic/templates/zebra-t2_2lc_min_ports-masic-leaf.j2
@@ -1,0 +1,17 @@
+{% set host = configuration[hostname] %}
+hostname {{ hostname }}
+password zebra
+enable password zebra
+!
+log syslog informational
+log facility local4
+!
+! end of template: common/daemons.common.conf.j2!
+!
+!
+! Enable link-detect (default disabled)
+{% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+link detect
+!
+{% endfor %}


### PR DESCRIPTION
#### What is the motivation for this PR?
Support for vsonic with t2 topology.
Starting the support with the minimal t2 topology, t2_2lc_min_ports-masic

#### How did you do it?
Update the template files matching the toplogy.

#### How did you verify/test it?
Tested with t2 minimal topology : t2_2lc_min_ports-masic, bgp sessions are up and portchannels/routed interfaces are UP.

Following commands are used to setup the topology 

```
./testbed-cli.sh -t testbed.yaml -k vsonic start-topo-vms vms29-t2-xxxx-1 str2 ../password.txt; 
./testbed-cli.sh -t testbed.yaml -k vsonic add-topo vms29-t2-xxxx-1 str2 ../password.txt ; 
./testbed-cli.sh -t testbed.yaml -k vsonic deploy-mg vms29-t2-xxxx-1 str2 ../password.txt

where, the configuration is defined with the topology "t2_2lc_min_ports-masic" -- which is a 2 multi-asic linecard topology where 6 ports from each asic is used with 8 peer vsonic VM's 

- conf-name: vms29-t2-xxxx-1
  group-name: vms29-2
  topo: t2_2lc_min_ports-masic
  ptf_image_name: docker-ptf
  ptf: vms29-2
  ptf_ip: 10.64.246.245/23
  ptf_ipv6:
  server: server_29
  vm_base: VM29072
  dut:
    - str2-xxxx-lc1-1
    - str2-xxxx-lc2-1
    - str2-xxxx-sup-1
  inv_name: str2
  auto_recover: 'True'

```


```
admin@str2--lc2-1:~$ show ip bgp summary 

IPv4 Unicast Summary:
asic0: BGP router identifier 192.0.0.6, local AS number 65100 vrf-id 0
BGP table version 6
asic1: BGP router identifier 192.0.0.8, local AS number 65100 vrf-id 0
BGP table version 6
RIB entries 22, using 4224 bytes of memory
Peers 16, using 349056 KiB of memory
Peer groups 6, using 384 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------   -----  ------  ---------  --------------  --------------
10.0.0.13      4  65000         10         10         0      0       0  00:00:13                1  ARISTA01T1
10.0.0.17      4  65001          7          7         0      0       0  00:00:04                1  ARISTA03T1
10.0.0.19      4  65002         10         10         0      0       0  00:00:14                1  ARISTA04T1
10.0.0.23      4  65003         10         10         0      0       0  00:00:15                1  ARISTA06T1

Total number of neighbors 4

Last login: Tue Mar  1 04:35:21 2022 from 10.64.247.30
admin@str2--lc1-1:~$ show ip bgp summary 

IPv4 Unicast Summary:
asic0: BGP router identifier 192.0.0.1, local AS number 65100 vrf-id 0
BGP table version 6
asic1: BGP router identifier 192.0.0.2, local AS number 65100 vrf-id 0
BGP table version 6
RIB entries 22, using 4224 bytes of memory
Peers 16, using 349056 KiB of memory
Peer groups 6, using 384 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  65200         12         13         0      0       0  00:00:23                1  ARISTA01T3
10.0.0.5       4  65200          9          9         0      0       0  00:00:13                1  ARISTA03T3
10.0.0.7       4  65200         14         15         0      0       0  00:00:22                1  ARISTA04T3
10.0.0.11      4  65200          9          9         0      0       0  00:00:14                1  ARISTA06T3


```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
