### PR TITLE
[test gap] Add memory exhaustion test

### DIFF
--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -34,8 +34,8 @@ def test_memory_exhaustion(duthosts, enum_frontend_dut_hostname, localhost):
                              delay=10,
                              timeout=120,
                              module_ignore_errors=True)
-    if res.is_failed or ('msg' in res and 'Timeout' in res['msg']):
-        raise Exception('DUT {} did not shutdown'.format(hostname))
+    pytest_assert(not res.is_failed and 'Timeout' not in res.get('msg'),
+                  'DUT {} did not shutdown'.format(hostname))
 
     logging.info('waiting for ssh to startup on {}'.format(hostname))
     res = localhost.wait_for(host=dut_ip,
@@ -45,8 +45,8 @@ def test_memory_exhaustion(duthosts, enum_frontend_dut_hostname, localhost):
                              delay=10,
                              timeout=120,
                              module_ignore_errors=True)
-    if res.is_failed or ('msg' in res and 'Timeout' in res['msg']):
-        raise Exception('DUT {} did not startup'.format(hostname))
+    pytest_assert(not res.is_failed and 'Timeout' not in res.get('msg'),
+                  'DUT {} did not startup'.format(hostname))
 
     # Wait until all critical processes are healthy.
     wait_critical_processes(duthost)

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -1,0 +1,21 @@
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
+
+def test_memory_exhaustion(duthosts, enum_frontend_dut_hostname):
+    """validate kernel will panic and reboot the DUT when runs out of memory and hits oom event"""
+
+    duthost = duthosts[enum_frontend_dut_hostname]
+    duthost.shell('tail /dev/zero')
+    pytest_assert(wait_until(300, 5, 60, check_uptime_less_than, duthost, 10),
+                  "kernel didn't reboot or no response")
+
+
+def check_uptime_less_than(dut, target):
+    return dut.get_uptime().total_seconds() < target

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -1,21 +1,56 @@
+import logging
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until
+from tests.common.platform.processes_utils import wait_critical_processes
+from tests.common.reboot import SONIC_SSH_PORT, SONIC_SSH_REGEX
 
 pytestmark = [
     pytest.mark.topology('any')
 ]
 
 
-def test_memory_exhaustion(duthosts, enum_frontend_dut_hostname):
+def test_memory_exhaustion(duthosts, enum_frontend_dut_hostname, localhost):
     """validate kernel will panic and reboot the DUT when runs out of memory and hits oom event"""
 
     duthost = duthosts[enum_frontend_dut_hostname]
-    duthost.shell('tail /dev/zero')
-    pytest_assert(wait_until(300, 5, 60, check_uptime_less_than, duthost, 10),
-                  "kernel didn't reboot or no response")
+    dut_ip = duthost.mgmt_ip
+    hostname = duthost.hostname
+    dut_datetime = duthost.get_now_time()
 
+    # Use `tail /dev/zero` to run out of memory completely. Since this command will cause DUT reboot,
+    # we need to run it in the background (using &) to avoid pytest getting stuck. We also need to
+    # add `nohup` to protect it.
+    cmd = 'nohup tail /dev/zero &'
+    res = duthost.shell(cmd)
+    if not res.is_successful:
+        raise Exception('DUT {} run command {} failed'.format(hostname, cmd))
 
-def check_uptime_less_than(dut, target):
-    return dut.get_uptime().total_seconds() < target
+    logging.info('waiting for ssh to drop on {}'.format(hostname))
+    res = localhost.wait_for(host=dut_ip,
+                             port=SONIC_SSH_PORT,
+                             state='absent',
+                             search_regex=SONIC_SSH_REGEX,
+                             delay=10,
+                             timeout=120,
+                             module_ignore_errors=True)
+    if res.is_failed or ('msg' in res and 'Timeout' in res['msg']):
+        raise Exception('DUT {} did not shutdown'.format(hostname))
+
+    logging.info('waiting for ssh to startup on {}'.format(hostname))
+    res = localhost.wait_for(host=dut_ip,
+                             port=SONIC_SSH_PORT,
+                             state='started',
+                             search_regex=SONIC_SSH_REGEX,
+                             delay=10,
+                             timeout=120,
+                             module_ignore_errors=True)
+    if res.is_failed or ('msg' in res and 'Timeout' in res['msg']):
+        raise Exception('DUT {} did not startup'.format(hostname))
+
+    # Wait until all critical processes are healthy.
+    wait_critical_processes(duthost)
+
+    # Verify DUT uptime is later than the time when the test case started running.
+    dut_uptime = duthost.get_up_time()
+    pytest_assert(dut_uptime > dut_datetime, "Device {} did not reboot".format(hostname))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Validate kernel will panic and reboot the DUT when kernel runs out of memory and hit oom event.

Summary:
Fixes #3619 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request

- [x] 202012

### Approach
#### What is the motivation for this PR?

Validate kernel will panic and reboot the DUT when kernel runs out of memory and hit oom event.

#### How did you do it?

Use `tail /dev/zero` to run out of memory completely and check the DUT reboot as expected.

#### How did you verify/test it?

Run tests on vSONiC and physical DUTs.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

*  #3619