### PR TITLE
[multi-asic]: Fix port_alias to generate the right list of

### DIFF
--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -298,13 +298,20 @@ def main():
 
         # Sort the Interface Name needed in multi-asic
         aliases.sort(key=lambda x: int(x[1]))
+        # Get ASIC interface names list based on sorted aliases
+        front_panel_asic_ifnames_list = []
+        for k in aliases:
+            if k[0] in front_panel_asic_ifnames:
+                front_panel_asic_ifnames_list.append(front_panel_asic_ifnames[k[0]])
+
         module.exit_json(ansible_facts={'port_alias': [k[0] for k in aliases],
                                         'port_name_map': portmap,
                                         'port_alias_map': aliasmap,
                                         'port_speed': portspeed,
-                                        'front_panel_asic_ifnames': [front_panel_asic_ifnames[k[0]] for k in aliases] if front_panel_asic_ifnames else [],
+                                        'front_panel_asic_ifnames': front_panel_asic_ifnames_list,
                                         'asic_if_names': asic_if_names,
                                         'sysports': sysports})
+
     except (IOError, OSError) as e:
         fail_msg = "IO error" + str(e)
         module.fail_json(msg=fail_msg)


### PR DESCRIPTION
front panel asic interface names when the list of asic aliases
includes Inb or Rec interfaces.

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Provides fix for: https://github.com/Azure/sonic-mgmt/issues/5141
This PR https://github.com/Azure/sonic-mgmt/pull/5008 was added to ensure that the list of interfaces generated in port_alias matches with the list of interfaces generated in the show interfaces output. Show interfaces output currently displays both external and Inband/Recirc ports. So port_alias was modified to generate alias list for External/Inb/Rec ports if include_internal flag is set to false. This was causing an issue voq chassis multi-asic line card, when trying to access the dict with the list of alias to front panel asic interface names. Inb/Rec should not be present in front panel asic interfaces dict, so error was observed when trying to look for Inb/Rec port information in the front panel asic interfaces dict.

### How did you do it?
Modified code to generate front panel asic interfaces list in sorted order or aliases.
Also, ensure that key(alias) is present before accessing front panel asic interfaces dict.

## How did you verify/test it?
Able to generate minigraph for voq chassis multi-asic line card.
Change in multi-asic line card minigraph:
Ethernet-IB<> interfaces is getting added in the "EthernetInterfaces" section. Before this change Ethernet-IB<> interfaces was present only in SystemPort and VoqInbandInterfaces sections.
```
        <a:EthernetInterface>
          <ElementType>DeviceInterface</ElementType>
          <AlternateSpeeds i:nil="true"/>
          <EnableAutoNegotiation>true</EnableAutoNegotiation>
          <EnableFlowControl>true</EnableFlowControl>
          <Index>1</Index>
          <InterfaceName>Ethernet-IB0</InterfaceName>
          <InterfaceType i:nil="true"/>
          <MultiPortsInterface>false</MultiPortsInterface>
          <PortName>0</PortName>
          <Priority>0</Priority>
          <Speed>10000</Speed>
        </a:EthernetInterface>
        <a:EthernetInterface>
          <ElementType>DeviceInterface</ElementType>
          <AlternateSpeeds i:nil="true"/>
          <EnableAutoNegotiation>true</EnableAutoNegotiation>
          <EnableFlowControl>true</EnableFlowControl>
          <Index>1</Index>
          <InterfaceName>Ethernet-IB1</InterfaceName>
          <InterfaceType i:nil="true"/>
          <MultiPortsInterface>false</MultiPortsInterface>
          <PortName>0</PortName>
          <Priority>0</Priority>
          <Speed>10000</Speed>
        </a:EthernetInterface>
      </EthernetInterfaces>
```

There is no change in config_db<>.json for multi-asic Linecard.

Verified test_iface_namingmode test case works as expected.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
