### PR TITLE
[dualtor]set allowed_disruption to 1 to avoid flaky failure

### DIFF
--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -203,8 +203,8 @@ def test_standby_tor_downlink_down_upstream(
     Verify no switchover and no disruption
     """
     send_server_to_t1_with_action(
-        upper_tor_host, verify=True,
-        allowed_disruption=0, action=shutdown_lower_tor_downlink_intfs
+        upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        allowed_disruption=1, action=shutdown_lower_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -223,8 +223,8 @@ def test_standby_tor_downlink_down_downstream_active(
     Confirm no switchover and no disruption
     """
     send_t1_to_server_with_action(
-        upper_tor_host, verify=True,
-        allowed_disruption=0, action=shutdown_lower_tor_downlink_intfs
+        upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        allowed_disruption=1, action=shutdown_lower_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -243,8 +243,8 @@ def test_standby_tor_downlink_down_downstream_standby(
     Confirm no switchover and no disruption
     """
     send_t1_to_server_with_action(
-        lower_tor_host, verify=True,
-        allowed_disruption=0, action=shutdown_lower_tor_downlink_intfs
+        lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        allowed_disruption=1, action=shutdown_lower_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixed the failure of test_standby_tor_downlink_down_downstream_standby case in test_link_failure.py.
Sometimes, it will lost 1 packet during testing, currently, allowed_disruption is 0, the case will failure.
To avoid the flaky failure, increase allowed_disruption from 0 to 1 for standby Tor cases.

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Sometimes, it will lost 1 packet during testing, currently, allowed_disruption is 0, the case will failure.

#### How did you do it?
To avoid the flaky failure, increase allowed_disruption from 0 to 1 for standby Tor cases.

#### How did you verify/test it?
run tests/dualtor/test_link_failure.py::test_standby_tor_downlink_down_downstream_standby

#### Any platform specific information?
dualtor

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
