### PR TITLE
Adding checks for bgp sessions and routes on VMs

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -4,6 +4,8 @@ import ipaddr as ipaddress
 from bgp_helpers import parse_rib, get_routes_not_announced_to_bgpmon,remove_bgp_neighbors,restore_bgp_neighbors
 from tests.common.helpers.constants import DEFAULT_ASIC_ID
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+from multiprocessing.dummy import Pool as ThreadPool
 import re
 
 pytestmark = [
@@ -56,7 +58,16 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver):
     all_routes = {}
     BGP_ENTRY_HEADING = r"BGP routing table entry for "
     BGP_COMMUNITY_HEADING = r"Community: "
-    for hostname, host_conf in neigh_hosts.items():
+    # Retrieve the routes on all VMs  in parallel by using a thread poll
+    neigh_host_items = neigh_hosts.items()
+    def parse_routes_process(neigh_host_item):
+        """
+        The process to parse routes on a VM.
+        :param neigh_host_item: tuple of hostname and host_conf dict
+        :return: no return value
+        """
+        hostname = neigh_host_item[0]
+        host_conf = neigh_host_item[1]
         host = host_conf['host']
         peer_ips = host_conf['conf']['bgp']['peers'][asn]
         for ip in peer_ips:
@@ -67,12 +78,18 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver):
         # The json formatter on EOS consumes too much time (over 40 seconds).
         # So we have to parse the raw output instead json.
         if 4 == ip_ver:
-            cmd = "show ip bgp neighbors {} received-routes detail | grep -E \"{}|{}\"".format(peer_ip_v4, BGP_ENTRY_HEADING, BGP_COMMUNITY_HEADING)
+            cmd = "show ip bgp neighbors {} received-routes detail | grep -E \"{}|{}\"".format(peer_ip_v4,
+                                                                                               BGP_ENTRY_HEADING,
+                                                                                               BGP_COMMUNITY_HEADING)
             cmd_backup = ""
         else:
-            cmd = "show ipv6 bgp peers {} received-routes detail | grep -E \"{}|{}\"".format(peer_ip_v6, BGP_ENTRY_HEADING, BGP_COMMUNITY_HEADING)
+            cmd = "show ipv6 bgp peers {} received-routes detail | grep -E \"{}|{}\"".format(peer_ip_v6,
+                                                                                             BGP_ENTRY_HEADING,
+                                                                                             BGP_COMMUNITY_HEADING)
             # For compatibility on EOS of old version
-            cmd_backup = "show ipv6 bgp neighbors {} received-routes detail | grep -E \"{}|{}\"".format(peer_ip_v6, BGP_ENTRY_HEADING, BGP_COMMUNITY_HEADING)
+            cmd_backup = "show ipv6 bgp neighbors {} received-routes detail | grep -E \"{}|{}\"".format(peer_ip_v6,
+                                                                                                        BGP_ENTRY_HEADING,
+                                                                                                        BGP_COMMUNITY_HEADING)
         res = host.eos_command(commands=[cmd], module_ignore_errors=True)
         if res['failed'] and cmd_backup != "":
             res = host.eos_command(commands=[cmd_backup], module_ignore_errors=True)
@@ -95,6 +112,11 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver):
         if entry:
             routes[entry] = community
         all_routes[hostname] = routes
+    pool = ThreadPool()
+    # Run the parse routes process on all VMs in parallel.
+    pool.map(parse_routes_process, neigh_host_items)
+    pool.close()
+    pool.join()
     return all_routes
 
 def verify_all_routes_announce_to_neighs(dut_host, neigh_hosts, routes_dut, ip_ver):
@@ -190,14 +212,18 @@ def test_TSB(duthost, ptfhost, nbrhosts, bgpmon_setup_teardown):
     pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 6), 6),
                   "Not all ipv6 routes are announced to neighbors")
 
-def test_TSA_B_C_with_no_neighbors(duthost, bgpmon_setup_teardown):
+def test_TSA_B_C_with_no_neighbors(duthost, bgpmon_setup_teardown, nbrhosts, tbinfo):
     """
     Test TSA, TSB, TSC with no neighbors on ASIC0 in case of multi-asic and single-asic.
     """
     bgp_neighbors = {}
     asic_index = 0 if duthost.is_multi_asic else DEFAULT_ASIC_ID
 
+
     try:
+
+        routes_4 = parse_rib(duthost, 4)
+        routes_6 = parse_rib(duthost, 6)
         # Remove the Neighbors for the particular BGP instance
         bgp_neighbors = remove_bgp_neighbors(duthost, asic_index)
 
@@ -226,3 +252,14 @@ def test_TSA_B_C_with_no_neighbors(duthost, bgpmon_setup_teardown):
 
         # Recover to Normal state
         duthost.shell("TSB")
+
+        # Wait until bgp sessions are established on DUT
+        pytest_assert(wait_until(100, 10, 0, duthost.check_bgp_session_state, bgp_neighbors.keys()),
+                      "Not all BGP sessions are established on DUT")
+
+        # Wait until all routes are announced to neighbors
+        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs,duthost, nbrhosts, routes_4, 4),
+                      "Not all ipv4 routes are announced to neighbors")
+        pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs,duthost, nbrhosts, routes_6, 6),
+                      "Not all ipv6 routes are announced to neighbors")
+


### PR DESCRIPTION
Signed-off-by: Cong Hou <congh@mtr-vdi-424.wap.labs.mlnx>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #4337 [bgp_traffic_shift] no neighbors check after restart bgp service | dependency of execution tests order
Adding checks for bgp sessions and routes on VMs, and modify parse_routes_on_eos() to run in parallel to shorten the checking time.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
This change is to fix the test issue Fixes #4337 [bgp_traffic_shift] no neighbors check after restart bgp service | dependency of execution tests order.
#### How did you do it?
When another bgp test run after test_traffic_shfit.py::test_TSA_B_C_with_no_neighbors, there is a chance that the routes used in the test have not yet  been learnt by the VMs.
To resolve the issue, all routes on the VMs need to be checked at the end of test_TSA_B_C_with_no_neighbors.
It costs a lot of time if we verify routes on VMs one by one. So I changed parse_routes_on_eos() to run in parallel on all VMs to shorten the checking time.
#### How did you verify/test it?
Verified on t0 setups. 
The run time of case test_TSA_B_C_with_no_neighbors will increase by about 5 mins due to the new checks. But because parse_routes_on_eos() is also used in the other two cases of test_traffic_shift.py, the total run time of test_traffic_shift.py will decrease by about 1 minute.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
