### PR TITLE
[unknown_mac] Add pkt string to the dict instead of the actual packet

### DIFF
--- a/tests/pfc/test_unknown_mac.py
+++ b/tests/pfc/test_unknown_mac.py
@@ -285,7 +285,7 @@ class TrafficSendVerify(object):
             self.exp_pkts.append(tmp_pkt)
             # if inft is a sub interface, tuple be like ("Eth0.10", "Eth0")
             # if inft is a general interface, tuple be like ("Eth0", "Eth0")
-            self.pkt_map[pkt] = (intf, get_intf_by_sub_intf(intf, vlan_id))
+            self.pkt_map[str(pkt)] = (intf, get_intf_by_sub_intf(intf, vlan_id), pkt)
 
     def _parseCntrs(self):
         """
@@ -333,7 +333,7 @@ class TrafficSendVerify(object):
         self._verifyIntfCounters(pretest=True)
         for pkt, exp_pkt in zip(self.pkts, self.exp_pkts):
             self.ptfadapter.dataplane.flush()
-            out_intf = self.pkt_map[pkt][0]
+            out_intf = self.pkt_map[str(pkt)][0]
             src_port = self.ptf_ports[out_intf][0]
             logger.info("Sending traffic on intf {}".format(out_intf))
             testutils.send(self.ptfadapter, src_port, pkt, count=TEST_PKT_CNT)


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The following errors are seen in nightly run for this testcase. Though there isn't a repro available, this could be due to scapy version difference. 
```
>           self.pkt_map[pkt] = (intf, get_intf_by_sub_intf(intf, vlan_id))
E           TypeError: unhashable type: 'Ether'
```
Hence instead of adding the pkt as a key, converting it into a string and using that as the dict key. This change might fix the issue

Summary:
Fixes #5211

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

#### How did you verify/test it?
Ran the test with the changes and it passed