### PR TITLE
[Vxlan Decap] Clear FDB and ARP only during the first step

### DIFF
--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -137,8 +137,6 @@ def setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
 @pytest.fixture(params=["NoVxLAN", "Enabled", "Removed"])
 def vxlan_status(setup, request, duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
-    #clear FDB and arp cache on DUT
-    duthost.shell('sonic-clear arp; fdbclear')
     if request.param == "Enabled":
         duthost.shell("sonic-cfggen -j /tmp/vxlan_db.tunnel.json --write-to-db")
         duthost.shell("sonic-cfggen -j /tmp/vxlan_db.maps.json --write-to-db")
@@ -149,6 +147,8 @@ def vxlan_status(setup, request, duthosts, rand_one_dut_hostname):
         duthost.shell('docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL|tunnelVxlan"')
         return False, request.param
     else:
+        #clear FDB and arp cache on DUT
+        duthost.shell('sonic-clear arp; fdbclear')
         return False, request.param
 
 


### PR DESCRIPTION
### Description of PR
In dualtor case, by clearing fdb and arp before the test step, the entries were not re-learned and resulting in traffic blackhole. Upon review, the clear is ideally required only during the first step (NoVxlan) and the rest of the test can continue with the learned entries.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
