### PR TITLE
increase the timeout value to wait cacl rules effective

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -683,7 +683,7 @@ def generate_scale_rules(duthost, ip_type):
     # duthost.command to active ssh connection.
     # In this way, we can active ssh connection and wait as long as we want.
 
-    # For multi-asic, it has to wait enough long
+    # It has to wait cacl rules to be effective.
     wait_until(200, 10, 2, check_iptable_rules, duthost)
     # add ACCEPT rule for SSH to make sure testbed access
     duthost.command("iptables -I INPUT 3 -p tcp -m tcp --dport 22 -j ACCEPT")

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -682,11 +682,9 @@ def generate_scale_rules(duthost, ip_type):
     # to call check_iptable_rules every 10s to keep ssh session alive, it just calls
     # duthost.command to active ssh connection.
     # In this way, we can active ssh connection and wait as long as we want.
-    if duthost.is_multi_asic:
-        # For multi-asic, it has to wait enough long
-        wait_until(200, 10, 2, check_iptable_rules, duthost)
-    else:
-        wait_until(30, 10, 2, check_iptable_rules, duthost)
+
+    # For multi-asic, it has to wait enough long
+    wait_until(200, 10, 2, check_iptable_rules, duthost)
     # add ACCEPT rule for SSH to make sure testbed access
     duthost.command("iptables -I INPUT 3 -p tcp -m tcp --dport 22 -j ACCEPT")
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_cacl_scale_rules_ipv4 and test_cacl_scale_rules_ipv6 failed on some testbed, especially T1 lag testbed.
It turns out the syncing time for scale cacl rules is much longer on these testbed. Increasing the waiting time
to make sure cacl rules are added.

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To avoid the flaky failures for test_cacl_scale_rules_ipv4 and test_cacl_scale_rules_ipv6.

#### How did you do it?
Increase the waiting time to wait cacl rules be effective.

#### How did you verify/test it?
run tests/cacl/test_cacl_application.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
