### PR TITLE
[test_macsec] Add testcase interop with protocols

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -329,7 +329,9 @@ class EosHost(AnsibleHostBase):
         try:
             command = 'show mac security interface {} | json'.format(interface_name)
             output = self.eos_command(commands=[command])['stdout'][0]
-            return output["interfaces"][interface_name]["controlledPort"]
+            if interface_name in output["interfaces"]:
+                return output["interfaces"][interface_name]["controlledPort"]
+            return False
         except Exception as e:
             logger.error('Failed to get macsec status for interface "{}", exception: {}'.format(interface_name, repr(e)))
             return False

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -329,7 +329,7 @@ class EosHost(AnsibleHostBase):
         try:
             command = 'show mac security interface {} | json'.format(interface_name)
             output = self.eos_command(commands=[command])['stdout'][0]
-            return output["interfaces"][interface_name]["controlledPort"] == "true"
+            return output["interfaces"][interface_name]["controlledPort"]
         except Exception as e:
             logger.error('Failed to get macsec status for interface "{}", exception: {}'.format(interface_name, repr(e)))
             return False

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -319,3 +319,17 @@ class EosHost(AnsibleHostBase):
         except Exception as e:
             logger.error('Failed to get MAC address for interface "{}", exception: {}'.format(interface_name, repr(e)))
             return None
+
+    def iface_macsec_ok(self, interface_name):
+        """
+        Check if macsec is functional on specified interface.
+
+        Returns: True or False
+        """
+        try:
+            command = 'show mac security interface {} | json'.format(interface_name)
+            output = self.eos_command(commands=[command])['stdout'][0]
+            return output["interfaces"][interface_name]["controlledPort"] == "true"
+        except Exception as e:
+            logger.error('Failed to get macsec status for interface "{}", exception: {}'.format(interface_name, repr(e)))
+            return False

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -303,3 +303,19 @@ class EosHost(AnsibleHostBase):
         def extract_speed_only(v):
             return re.match('\d+', v.strip()).group() + '000'
         return list(map(extract_speed_only, speed_list))
+
+    def get_dut_iface_mac(self, interface_name):
+        """
+        Gets the MAC address of specified interface.
+
+        Returns:
+            str: The MAC address of the specified interface, or None if it is not found.
+        """
+        try:
+            command = 'show interfaces {} | json'.format(interface_name)
+            output = self.eos_command(commands=[command])['stdout'][0]
+            mac = output["interfaces"][interface_name]["physicalAddress"]
+            return mac
+        except Exception as e:
+            logger.error('Failed to get MAC address for interface "{}", exception: {}'.format(interface_name, repr(e)))
+            return None

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1193,6 +1193,20 @@ Totals               6450                 6449
             logger.error('Failed to get MAC address for interface "{}", exception: {}'.format(iface_name, repr(e)))
             return None
 
+    def iface_macsec_ok(self, interface_name):
+        """
+        Check if macsec is functional on specified interface.
+
+        Returns: True or False
+        """
+        try:
+            cmd = 'sonic-db-cli STATE_DB HGET \"MACSEC_PORT_TABLE|{}\" state'.format(interface_name)
+            state = self.shell(cmd)['stdout'].strip()
+            return state == 'ok'
+        except Exception as e:
+            logger.error('Failed to get macsec status for interface "{}", exception: {}'.format(interface_name, repr(e)))
+            return False
+
     def get_container_autorestart_states(self):
         """
         @summary: Get container names and their autorestart states by analyzing

--- a/tests/common/plugins/ptfadapter/__init__.py
+++ b/tests/common/plugins/ptfadapter/__init__.py
@@ -176,7 +176,7 @@ def nbr_ptfadapter(request, nbrhosts, nbr_device_numbers, ptfadapter):
     Start the ptf nn services in neighbor devices and register them in ptfadapter.
     """
     if request.config.getoption("--neighbor_type") != "sonic":
-        pytest.fail("Neighbor devices aren't SONiC so that the ptf nn service cannot be started")
+        pytest.skip("Neighbor devices aren't SONiC so that the ptf nn service cannot be started")
     device_sockets = ptf.config['device_sockets']
     current_file_dir = os.path.dirname(os.path.realpath(__file__))
     for name, attr in nbrhosts.items():

--- a/tests/macsec/conftest.py
+++ b/tests/macsec/conftest.py
@@ -44,9 +44,10 @@ def profile_name():
 def default_priority():
     return 64
 
-#@pytest.fixture(scope="module", params=["GCM-AES-128", "GCM-AES-256", "GCM-AES-XPN-128", "GCM-AES-XPN-256"])
-@pytest.fixture(scope="module", params=["GCM-AES-128"])
+@pytest.fixture(scope="module", params=["GCM-AES-128", "GCM-AES-256", "GCM-AES-XPN-128", "GCM-AES-XPN-256"])
 def cipher_suite(request):
+    if request.config.getoption("--neighbor_type") == "eos" and "XPN" in request.param:
+        pytest.skip("{} is not supported on neighbor EOS".format(request.param))
     return request.param
 
 

--- a/tests/macsec/conftest.py
+++ b/tests/macsec/conftest.py
@@ -29,7 +29,7 @@ def enable_macsec_feature(duthost, nbrhosts):
             if len(nbr.shell("ps -ef | grep macsecmgrd | grep -v grep")["stdout_lines"]) != 1:
                 return False
         return True
-    assert wait_until(180, 1, 1, check_macsec_enabled)
+    assert wait_until(180, 5, 5, check_macsec_enabled)
     logger.info("Enable MACsec feature")
     yield
     global_cmd(duthost, nbrhosts, "sudo config feature state macsec disabled")

--- a/tests/macsec/macsec_config_helper.py
+++ b/tests/macsec/macsec_config_helper.py
@@ -1,4 +1,5 @@
 from tests.common.utilities import wait_until
+from tests.common.devices.eos import EosHost
 from macsec_helper import *
 
 

--- a/tests/macsec/macsec_config_helper.py
+++ b/tests/macsec/macsec_config_helper.py
@@ -3,6 +3,22 @@ from macsec_helper import *
 
 
 def set_macsec_profile(host, profile_name, priority, cipher_suite, primary_cak, primary_ckn, policy, send_sci):
+    if isinstance(host, EosHost):
+        eos_cipher_suite = {
+            "GCM-AES-128": "aes128-gcm",
+            "GCM-AES-256": "aes256-gcm",
+            "GCM-AES-XPN-128": "aes128-gcm-xpn",
+            "GCM-AES-XPN-256": "aes256-gcm-xpn"
+        }
+        host.eos_config(
+            lines = [
+                'cipher {}'.format(eos_cipher_suite[cipher_suite]),
+                'key {} 0 {}'.format(primary_ckn, primary_cak),
+                'sci'
+                ],
+            parents=['mac security', 'profile {}'.format(profile_name)])
+        return
+
     macsec_profile = {
         "priority": priority,
         "cipher_suite": cipher_suite,
@@ -19,17 +35,35 @@ def set_macsec_profile(host, profile_name, priority, cipher_suite, primary_cak, 
 
 
 def delete_macsec_profile(host, profile_name):
+    if isinstance(host, EosHost):
+        host.eos_config(
+            lines=['no profile {}'.format(profile_name)],
+            parents=['mac security'])
+        return
+
     cmd = "sonic-db-cli CONFIG_DB DEL 'MACSEC_PROFILE|{}'".format(profile_name)
     host.command(cmd)
 
 
 def enable_macsec_port(host, port, profile_name):
+    if isinstance(host, EosHost):
+        host.eos_config(
+            lines=['mac security profile {}'.format(profile_name)],
+            parents=['interface {}'.format(port)])
+        return
+
     cmd = "sonic-db-cli CONFIG_DB HSET 'PORT|{}' 'macsec' '{}'".format(
         port, profile_name)
     host.command(cmd)
 
 
 def disable_macsec_port(host, port):
+    if isinstance(host, EosHost):
+        host.eos_config(
+            lines=['no mac security profile'],
+            parents=['interface {}'.format(port)])
+        return
+
     cmd = "sonic-db-cli CONFIG_DB HDEL 'PORT|{}' 'macsec'".format(port)
     host.command(cmd)
 
@@ -45,6 +79,8 @@ def cleanup_macsec_configuration(duthost, ctrl_links, profile_name):
     delete_macsec_profile(duthost, profile_name)
     # Waiting for all mka session were cleared in all devices
     for d in devices:
+        if isinstance(d, EosHost):
+            continue
         assert wait_until(30, 1, 0, lambda: not get_mka_session(d))
 
 
@@ -69,6 +105,8 @@ def startup_all_ctrl_links(ctrl_links):
     # The ctrl links may be shutdowned by unexpected exit on the TestFaultHandling
     # So, startup all ctrl links
     for _, nbr in ctrl_links.items():
+        if isinstance(nbr["host"], EosHost):
+            continue
         nbr_eth_port = get_eth_ifname(
             nbr["host"], nbr["port"])
         nbr["host"].shell("ifconfig {} up".format(nbr_eth_port))

--- a/tests/macsec/macsec_helper.py
+++ b/tests/macsec/macsec_helper.py
@@ -9,10 +9,10 @@ import ptf.mask as mask
 import ptf.packet as packet
 import scapy.all as scapy
 import scapy.contrib.macsec as scapy_macsec
+from tests.common.devices.eos import EosHost
 
 from macsec_common_helper import *
 from macsec_platform_helper import *
-
 
 def check_wpa_supplicant_process(host, ctrl_port_name):
     cmd = "ps aux | grep 'wpa_supplicant' | grep '{}' | grep -v 'grep'".format(

--- a/tests/macsec/macsec_helper.py
+++ b/tests/macsec/macsec_helper.py
@@ -9,7 +9,6 @@ import ptf.mask as mask
 import ptf.packet as packet
 import scapy.all as scapy
 import scapy.contrib.macsec as scapy_macsec
-from tests.common.devices.eos import EosHost
 
 from macsec_common_helper import *
 from macsec_platform_helper import *

--- a/tests/macsec/macsec_helper.py
+++ b/tests/macsec/macsec_helper.py
@@ -13,6 +13,7 @@ import scapy.contrib.macsec as scapy_macsec
 from macsec_common_helper import *
 from macsec_platform_helper import *
 
+
 def check_wpa_supplicant_process(host, ctrl_port_name):
     cmd = "ps aux | grep 'wpa_supplicant' | grep '{}' | grep -v 'grep'".format(
         ctrl_port_name)

--- a/tests/macsec/macsec_platform_helper.py
+++ b/tests/macsec/macsec_platform_helper.py
@@ -130,3 +130,25 @@ def find_portchannel_from_member(port_name, portchannel_list):
         if port_name in v["members"]:
             return v
     return None
+
+def get_lldp_list(host):
+    '''
+        Here is an output example of `show lldp table`
+            Capability codes: (R) Router, (B) Bridge, (O) Other
+            LocalPort    RemoteDevice    RemotePortID    Capability    RemotePortDescr
+            -----------  --------------  --------------  ------------  -----------------
+            Ethernet112  ARISTA01T1      Ethernet1       BR
+            Ethernet116  ARISTA02T1      Ethernet1       BR
+            Ethernet120  ARISTA03T1      Ethernet1       BR
+            Ethernet124  ARISTA04T1      Ethernet1       BR
+            --------------------------------------------------
+            Total entries displayed:  4
+    '''
+    lines = host.command("show lldp table")["stdout_lines"]
+    lines = lines[3:-2]  # Remove the output header
+    lldp_list = {}
+    for line in lines:
+        items = line.split()
+        lldp = items[1]
+        lldp_list[lldp] = {"name": lldp, "localport": items[0], "remoteport": items[2]}
+    return lldp_list

--- a/tests/macsec/macsec_platform_helper.py
+++ b/tests/macsec/macsec_platform_helper.py
@@ -131,6 +131,7 @@ def find_portchannel_from_member(port_name, portchannel_list):
             return v
     return None
 
+
 def get_lldp_list(host):
     '''
         Here is an output example of `show lldp table`

--- a/tests/macsec/macsec_platform_helper.py
+++ b/tests/macsec/macsec_platform_helper.py
@@ -63,12 +63,13 @@ def get_all_ifnames(host):
 
 
 def get_eth_ifname(host, port_name):
-    if u"x86_64-kvm_x86_64" not in get_platform(host):
-        logging.info("Can only get the eth ifname on the virtual SONiC switch")
-        return None
-    ports = get_all_ifnames(host)
-    assert port_name in ports["Ethernet"]
-    return ports["eth"][ports["Ethernet"].index(port_name)]
+    if u"x86_64-kvm_x86_64" in get_platform(host):
+        logging.info("Get the eth ifname on the virtual SONiC switch")
+        ports = get_all_ifnames(host)
+        assert port_name in ports["Ethernet"]
+        return ports["eth"][ports["Ethernet"].index(port_name)]
+    # Same as port_name
+    return port_name
 
 
 def get_macsec_ifname(host, port_name):
@@ -85,6 +86,8 @@ def get_macsec_ifname(host, port_name):
 
 
 def get_platform(host):
+    if isinstance(host, EosHost):
+        return "Arista"
     for line in host.command("show platform summary")["stdout_lines"]:
         if "Platform" == line.split(":")[0]:
             return line.split(":")[1].strip()

--- a/tests/macsec/macsec_platform_helper.py
+++ b/tests/macsec/macsec_platform_helper.py
@@ -5,11 +5,15 @@ from multiprocessing.pool import ThreadPool
 
 import pytest
 
+from tests.common.devices.eos import EosHost
+
 
 def global_cmd(duthost, nbrhosts, cmd):
     pool = ThreadPool(1 + len(nbrhosts))
     pool.apply_async(duthost.command, args=(cmd,))
     for nbr in nbrhosts.values():
+        if isinstance(nbr["host"], EosHost):
+            continue
         pool.apply_async(nbr["host"].command, args=(cmd, ))
     pool.close()
     pool.join()

--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -81,7 +81,7 @@ class TestControlPlane():
                                   nbr_mka_session[nbr_macsec_port], nbr_sci,
                                   policy, cipher_suite, send_sci)
             return True
-        assert wait_until(300, 1, 1, _test_mka_session)
+        assert wait_until(300, 5, 3, _test_mka_session)
 
 
 class TestDataPlane():

--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -145,7 +145,7 @@ class TestDataPlane():
     def test_dut_to_neighbor(self, duthost, ctrl_links, upstream_links):
         for up_port, up_link in upstream_links.items():
             ret = duthost.command(
-                "ping -c {} {}".format(4, up_link['ipv4_addr']))
+                "ping -c {} {}".format(4, up_link['local_ipv4_addr']))
             assert not ret['failed']
 
     def test_neighbor_to_neighbor(self, duthost, ctrl_links, upstream_links, nbr_device_numbers, nbr_ptfadapter):
@@ -329,7 +329,7 @@ class TestInteropProtocol():
 
         def check_bgp_established(up_link):
             command = "sonic-db-cli STATE_DB HGETALL 'NEIGH_STATE_TABLE|{}'".format(
-                up_link["ipv4_addr"])
+                up_link["local_ipv4_addr"])
             fact = sonic_db_cli(duthost, command)
             logger.info("bgp state {}".format(fact))
             return fact["state"] == "Established"
@@ -380,5 +380,5 @@ class TestInteropProtocol():
             up_link = upstream_links[ctrl_port]
             sysDescr = ".1.3.6.1.2.1.1.1.0"
             command = "docker exec snmp snmpwalk -v 2c -c {} {} {}".format(
-                community, up_link["ipv4_addr"], sysDescr)
+                community, up_link["local_ipv4_addr"], sysDescr)
             assert not duthost.command(command)["failed"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1/ Add neighbor cEOS support 
2/ Add Testcase TestInteropProtocol

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Implement testcase macsec interop with protocols in [MACsec testplan](https://github.com/judyjoseph/sonic-mgmt/blob/macsec_tests/docs/testplan/MACsec-test-plan.md#testcase--macsec-interop-with-other-slow-protocols).

#### How did you do it?
Add macsec test with lacp, lldp, bgp and snmp

#### How did you verify/test it?

Verify it in DUT `str2-a7280cr3-4` with t0 topo:
```
junhuazhai@e25918d5b081:/var/src/sonic-mgmt-int/tests$ ./run_tests.sh -u -n vms28-t0-7280-4 -d str2-a7280cr3-4 -c macsec/test_macsec.py -f ../ansible/testbed.yaml -i ../ansible/str2,../ansible/veos -e "--skip_sanity --disable_loganalyzer -vvl" 
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
===================================================================================================================== test session starts ======================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.11.0, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
metadata: {'Python': '2.7.17', 'Platform': 'Linux-4.10.0-42-generic-x86_64-with-Ubuntu-18.04-bionic', 'Packages': {'py': '1.11.0', 'pytest': '4.6.5', 'pluggy': '0.13.1'}, 'Plugins': {u'repeat': u'0.9.1', u'ansible': u'2.2.2', u'xdist': u'1.28.0', u'allure-pytest': u'2.8.22', u'html': u'1.22.1', u'forked': u'1.3.0', u'metadata': u'1.11.0'}}
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, allure-pytest-2.8.22, ansible-2.2.2
collecting ... /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 96 items                                                                                                                                                                                                                                             

macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[GCM-AES-128-security-true] PASSED                                                                                                                                                 [  1%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[security-GCM-AES-128-true] PASSED                                                                                                                                                                  [  2%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[security-GCM-AES-128-true] PASSED                                                                                                                                                              [  3%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[GCM-AES-128-security-true] SKIPPED                                                                                                                                                         [  4%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[GCM-AES-128-security-true] PASSED                                                                                                                                                             [  5%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[GCM-AES-128-security-true] SKIPPED                                                                                                                                                       [  6%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[GCM-AES-128-security-true] PASSED                                                                                                                                                               [  7%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[GCM-AES-128-security-true] PASSED                                                                                                                                           [  8%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[GCM-AES-128-security-true] PASSED                                                                                                                                                          [  9%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[GCM-AES-128-security-true] PASSED                                                                                                                                                                  [ 10%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[GCM-AES-128-security-true] PASSED                                                                                                                                                                   [ 11%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[GCM-AES-128-security-true] PASSED                                                                                                                                                                  [ 12%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[GCM-AES-128-security-false] SKIPPED                                                                                                                                               [ 13%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[security-GCM-AES-128-false] SKIPPED                                                                                                                                                                [ 14%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[security-GCM-AES-128-false] SKIPPED                                                                                                                                                            [ 15%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[GCM-AES-128-security-false] SKIPPED                                                                                                                                                        [ 16%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[GCM-AES-128-security-false] SKIPPED                                                                                                                                                           [ 17%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[GCM-AES-128-security-false] SKIPPED                                                                                                                                                      [ 18%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[GCM-AES-128-security-false] SKIPPED                                                                                                                                                             [ 19%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[GCM-AES-128-security-false] SKIPPED                                                                                                                                         [ 20%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[GCM-AES-128-security-false] SKIPPED                                                                                                                                                        [ 21%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[GCM-AES-128-security-false] SKIPPED                                                                                                                                                                [ 22%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[GCM-AES-128-security-false] SKIPPED                                                                                                                                                                 [ 23%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[GCM-AES-128-security-false] SKIPPED                                                                                                                                                                [ 25%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[GCM-AES-256-security-false] SKIPPED                                                                                                                                               [ 26%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[security-GCM-AES-256-false] SKIPPED                                                                                                                                                                [ 27%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[security-GCM-AES-256-false] SKIPPED                                                                                                                                                            [ 28%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[GCM-AES-256-security-false] SKIPPED                                                                                                                                                        [ 29%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[GCM-AES-256-security-false] SKIPPED                                                                                                                                                           [ 30%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[GCM-AES-256-security-false] SKIPPED                                                                                                                                                      [ 31%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[GCM-AES-256-security-false] SKIPPED                                                                                                                                                             [ 32%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[GCM-AES-256-security-false] SKIPPED                                                                                                                                         [ 33%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[GCM-AES-256-security-false] SKIPPED                                                                                                                                                        [ 34%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[GCM-AES-256-security-false] SKIPPED                                                                                                                                                                [ 35%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[GCM-AES-256-security-false] SKIPPED                                                                                                                                                                 [ 36%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[GCM-AES-256-security-false] SKIPPED                                                                                                                                                                [ 37%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[GCM-AES-256-security-true] PASSED                                                                                                                                                 [ 38%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[security-GCM-AES-256-true] PASSED                                                                                                                                                                  [ 39%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[security-GCM-AES-256-true] PASSED                                                                                                                                                              [ 40%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[GCM-AES-256-security-true] SKIPPED                                                                                                                                                         [ 41%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[GCM-AES-256-security-true] PASSED                                                                                                                                                             [ 42%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[GCM-AES-256-security-true] SKIPPED                                                                                                                                                       [ 43%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[GCM-AES-256-security-true] PASSED                                                                                                                                                               [ 44%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[GCM-AES-256-security-true] PASSED                                                                                                                                           [ 45%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[GCM-AES-256-security-true] PASSED                                                                                                                                                          [ 46%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[GCM-AES-256-security-true] PASSED                                                                                                                                                                  [ 47%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[GCM-AES-256-security-true] PASSED                                                                                                                                                                   [ 48%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[GCM-AES-256-security-true] PASSED                                                                                                                                                                  [ 50%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[GCM-AES-XPN-128-security-false] SKIPPED                                                                                                                                           [ 51%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[security-GCM-AES-XPN-128-false] SKIPPED                                                                                                                                                            [ 52%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[security-GCM-AES-XPN-128-false] SKIPPED                                                                                                                                                        [ 53%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[GCM-AES-XPN-128-security-false] SKIPPED                                                                                                                                                    [ 54%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[GCM-AES-XPN-128-security-false] SKIPPED                                                                                                                                                       [ 55%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[GCM-AES-XPN-128-security-false] SKIPPED                                                                                                                                                  [ 56%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[GCM-AES-XPN-128-security-false] SKIPPED                                                                                                                                                         [ 57%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[GCM-AES-XPN-128-security-false] SKIPPED                                                                                                                                     [ 58%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[GCM-AES-XPN-128-security-false] SKIPPED                                                                                                                                                    [ 59%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[GCM-AES-XPN-128-security-false] SKIPPED                                                                                                                                                            [ 60%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[GCM-AES-XPN-128-security-false] SKIPPED                                                                                                                                                             [ 61%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[GCM-AES-XPN-128-security-false] SKIPPED                                                                                                                                                            [ 62%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[GCM-AES-XPN-128-security-true] SKIPPED                                                                                                                                            [ 63%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[security-GCM-AES-XPN-128-true] SKIPPED                                                                                                                                                             [ 64%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[security-GCM-AES-XPN-128-true] SKIPPED                                                                                                                                                         [ 65%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[GCM-AES-XPN-128-security-true] SKIPPED                                                                                                                                                     [ 66%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[GCM-AES-XPN-128-security-true] SKIPPED                                                                                                                                                        [ 67%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[GCM-AES-XPN-128-security-true] SKIPPED                                                                                                                                                   [ 68%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[GCM-AES-XPN-128-security-true] SKIPPED                                                                                                                                                          [ 69%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[GCM-AES-XPN-128-security-true] SKIPPED                                                                                                                                      [ 70%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[GCM-AES-XPN-128-security-true] SKIPPED                                                                                                                                                     [ 71%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[GCM-AES-XPN-128-security-true] SKIPPED                                                                                                                                                             [ 72%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[GCM-AES-XPN-128-security-true] SKIPPED                                                                                                                                                              [ 73%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[GCM-AES-XPN-128-security-true] SKIPPED                                                                                                                                                             [ 75%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[GCM-AES-XPN-256-security-false] SKIPPED                                                                                                                                           [ 76%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[security-GCM-AES-XPN-256-false] SKIPPED                                                                                                                                                            [ 77%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[security-GCM-AES-XPN-256-false] SKIPPED                                                                                                                                                        [ 78%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[GCM-AES-XPN-256-security-false] SKIPPED                                                                                                                                                    [ 79%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[GCM-AES-XPN-256-security-false] SKIPPED                                                                                                                                                       [ 80%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[GCM-AES-XPN-256-security-false] SKIPPED                                                                                                                                                  [ 81%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[GCM-AES-XPN-256-security-false] SKIPPED                                                                                                                                                         [ 82%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[GCM-AES-XPN-256-security-false] SKIPPED                                                                                                                                     [ 83%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[GCM-AES-XPN-256-security-false] SKIPPED                                                                                                                                                    [ 84%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[GCM-AES-XPN-256-security-false] SKIPPED                                                                                                                                                            [ 85%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[GCM-AES-XPN-256-security-false] SKIPPED                                                                                                                                                             [ 86%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[GCM-AES-XPN-256-security-false] SKIPPED                                                                                                                                                            [ 87%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[GCM-AES-XPN-256-security-true] SKIPPED                                                                                                                                            [ 88%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[security-GCM-AES-XPN-256-true] SKIPPED                                                                                                                                                             [ 89%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[security-GCM-AES-XPN-256-true] SKIPPED                                                                                                                                                         [ 90%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[GCM-AES-XPN-256-security-true] SKIPPED                                                                                                                                                     [ 91%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[GCM-AES-XPN-256-security-true] SKIPPED                                                                                                                                                        [ 92%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[GCM-AES-XPN-256-security-true] SKIPPED                                                                                                                                                   [ 93%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[GCM-AES-XPN-256-security-true] SKIPPED                                                                                                                                                          [ 94%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[GCM-AES-XPN-256-security-true] SKIPPED                                                                                                                                      [ 95%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[GCM-AES-XPN-256-security-true] SKIPPED                                                                                                                                                     [ 96%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[GCM-AES-XPN-256-security-true] SKIPPED                                                                                                                                                             [ 97%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[GCM-AES-XPN-256-security-true] SKIPPED                                                                                                                                                              [ 98%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[GCM-AES-XPN-256-security-true] SKIPPED                                                                                                                                                             [100%]

------------------------------------------------------------------------------------------------ generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------------------------------------
=================================================================================================================== short test summary info ====================================================================================================================
SKIPPED [24] /var/src/sonic-mgmt-int/tests/macsec/conftest.py:51: GCM-AES-XPN-128 is not supported on neighbor EOS
SKIPPED [24] /var/src/sonic-mgmt-int/tests/macsec/conftest.py:51: GCM-AES-XPN-256 is not supported on neighbor EOS
SKIPPED [24] /var/src/sonic-mgmt-int/tests/macsec/conftest.py:83: EOS with send_sci false does not work due to portchannel mac not matching ether port mac!
SKIPPED [4] /var/src/sonic-mgmt-int/tests/common/plugins/ptfadapter/__init__.py:180: Neighbor devices aren't SONiC so that the ptf nn service cannot be started
=========================================================================================================== 20 passed, 76 skipped in 1852.72 seconds ===========================================================================================================
```

#### Any platform specific information?
vSonic, Arista 7280

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
