### PR TITLE
Cisco platform: xfail acl/test_acl_outer_vlan.py testcases

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -7,7 +7,7 @@ acl/test_acl_outer_vlan.py:
   xfail:
     reason: "Cisco platform does not support ACL Outer VLAN ID tests"
     conditions:
-       - asic_type=="cisco-8000"
+      - asic_type=="cisco-8000"
        
 #######################################
 #####            cacl             #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1,4 +1,15 @@
 #######################################
+#####            acl              #####
+#######################################
+acl/test_acl_outer_vlan.py:
+  #Outer VLAN id match support is planned for future release with SONIC on Cisco 8000 
+  #For the current release, will mark the related test cases as XFAIL
+  xfail:
+    reason: "Cisco platform does not support ACL Outer VLAN ID tests"
+    conditions:
+       - asic_type=="cisco-8000"
+       
+#######################################
 #####            cacl             #####
 #######################################
 cacl/test_cacl_application.py::test_cacl_application:


### PR DESCRIPTION

### Description of PR
Outer VLAN id match support is planned for future release with SONIC on Cisco 8000. For the current release, will mark the related test cases as XFAIL. This is discussed between MSFT and Cisco teams and approved

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
xfail all acl outer vlan test cases for cisco platform

#### How did you do it?
mark the related test cases as XFAIL

#### How did you verify/test it?
Verified in cisco platform and all tests xfailed
================================= 33 xfailed in 1063.46 seconds =================================
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
