### PR TITLE
[chassis][drop counters tests] Use NO_DROPS group for DNX platforms

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -182,6 +182,10 @@ class SonicHost(AnsibleHostBase):
         facts["modular_chassis"] = self._get_modular_chassis()
         facts["mgmt_interface"] = self._get_mgmt_interface()
 
+        platform_asic = self._get_platform_asic(facts["platform"])
+        if platform_asic:
+            facts["platform_asic"] = platform_asic
+
         logging.debug("Gathered SonicHost facts: %s" % json.dumps(facts))
         return facts
 
@@ -1435,6 +1439,17 @@ Totals               6450                 6449
             asic = "th3"
 
         return asic
+
+    def _get_platform_asic(self, platform):
+        platform_asic = os.path.join(
+            "/usr/share/sonic/device", platform, "platform_asic"
+        )
+        output = self.shell(
+            "cat {}".format(platform_asic), module_ignore_errors=True
+        )
+        if output["rc"] == 0:
+            return output["stdout_lines"][0]
+        return None
 
     def get_facts(self):
         return self.facts

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -181,8 +181,10 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo):
         "neighbor_sniff_ports": neighbor_sniff_ports,
         "vlans": configured_vlans,
         "mg_facts": mg_facts,
-        "intf_per_namespace": intf_per_namespace
+        "intf_per_namespace": intf_per_namespace,
+        "platform_asic": duthost.facts.get("platform_asic")
     }
+
     return setup_information
 
 
@@ -501,7 +503,12 @@ def test_not_expected_vlan_tag_drop(do_test, duthosts, rand_one_dut_hostname, pt
         vlan_vid=vlan_id,
         )
 
-    do_test("L2", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"])
+    group = "L2"
+    # DNX platform DROP counters are not there yet
+    if setup.get("platform_asic") == "broadcom-dnx":
+        group = "NO_DROPS"
+
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"])
 
 
 def test_dst_ip_is_loopback_addr(do_test, ptfadapter, setup, pkt_fields, tx_dut_ports, ports_info):
@@ -520,7 +527,12 @@ def test_dst_ip_is_loopback_addr(do_test, ptfadapter, setup, pkt_fields, tx_dut_
         tcp_sport=pkt_fields["tcp_sport"],
         tcp_dport=pkt_fields["tcp_dport"])
 
-    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    group = "L3"
+    # DNX platform DROP counters are not there yet
+    if setup.get("platform_asic") == "broadcom-dnx":
+        group = "NO_DROPS"
+
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 def test_src_ip_is_loopback_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info):
@@ -539,7 +551,12 @@ def test_src_ip_is_loopback_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_f
         tcp_sport=pkt_fields["tcp_sport"],
         tcp_dport=pkt_fields["tcp_dport"])
 
-    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    group = "L3"
+    # DNX platform DROP counters are not there yet
+    if setup.get("platform_asic") == "broadcom-dnx":
+        group = "NO_DROPS"
+
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 def test_dst_ip_absent(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info):
@@ -567,7 +584,13 @@ def test_dst_ip_absent(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, por
             tcp_sport=pkt_fields["tcp_sport"],
             tcp_dport=pkt_fields["tcp_dport"])
 
-    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    group = "L3"
+    # DNX platform DROP counters are not there yet
+    if setup.get("platform_asic") == "broadcom-dnx":
+        group = "NO_DROPS"
+
+    print("msm group {}, setup {}".format(group, setup))
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 @pytest.mark.parametrize("ip_addr", ["ipv4", "ipv6"])
@@ -602,7 +625,12 @@ def test_src_ip_is_multicast_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_
 
     log_pkt_params(ports_info["dut_iface"], ports_info["dst_mac"], ports_info["src_mac"], pkt_fields["ipv4_dst"], ip_src)
 
-    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    group = "L3"
+    # DNX platform DROP counters are not there yet
+    if setup.get("platform_asic") == "broadcom-dnx":
+        group = "NO_DROPS"
+
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 def test_src_ip_is_class_e(do_test, ptfadapter, duthosts, rand_one_dut_hostname, setup, tx_dut_ports, pkt_fields, ports_info):
@@ -627,7 +655,12 @@ def test_src_ip_is_class_e(do_test, ptfadapter, duthosts, rand_one_dut_hostname,
             tcp_sport=pkt_fields["tcp_sport"],
             tcp_dport=pkt_fields["tcp_dport"])
 
-        do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+        group = "L3"
+        # DNX platform DROP counters are not there yet
+        if setup.get("platform_asic") == "broadcom-dnx":
+            group = "NO_DROPS"
+
+        do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 @pytest.mark.parametrize("addr_type, addr_direction", [("ipv4", "src"), ("ipv6", "src"), ("ipv4", "dst"),
@@ -673,7 +706,12 @@ def test_ip_is_zero_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, a
 
     logger.info(pkt_params)
 
-    do_test("L3", pkt, ptfadapter, ports_info, setup["dut_to_ptf_port_map"].values(), tx_dut_ports)
+    group = "L3"
+    # DNX platform DROP counters are not there yet
+    if setup.get("platform_asic") == "broadcom-dnx":
+        group = "NO_DROPS"
+
+    do_test(group, pkt, ptfadapter, ports_info, setup["dut_to_ptf_port_map"].values(), tx_dut_ports)
 
 
 def test_dst_ip_link_local(do_test, ptfadapter, duthosts, rand_one_dut_hostname, setup, tx_dut_ports, pkt_fields, ports_info):
@@ -747,7 +785,12 @@ def test_ip_pkt_with_expired_ttl(duthost, do_test, ptfadapter, setup, tx_dut_por
         tcp_dport=pkt_fields["tcp_dport"],
         ip_ttl=0)
 
-    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
+    group = "L3"
+    # DNX platform DROP counters are not there yet
+    if setup.get("platform_asic") == "broadcom-dnx":
+        group = "NO_DROPS"
+
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
 
 
 @pytest.mark.parametrize("pkt_field, value", [("version", 1), ("chksum", 10), ("ihl", 1)])
@@ -767,7 +810,12 @@ def test_broken_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, 
         )
     setattr(pkt[testutils.scapy.scapy.all.IP], pkt_field, value)
 
-    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
+    group = "L3"
+    # DNX platform DROP counters are not there yet
+    if setup.get("platform_asic") == "broadcom-dnx":
+        group = "NO_DROPS"
+
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
 
 
 def test_absent_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info, sai_acl_drop_adj_enabled):
@@ -790,7 +838,12 @@ def test_absent_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, 
     pkt.type = 0x800
     pkt = pkt/tcp
 
-    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
+    group = "L3"
+    # DNX platform DROP counters are not there yet
+    if setup.get("platform_asic") == "broadcom-dnx":
+        group = "NO_DROPS"
+
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
 
 
 @pytest.mark.parametrize("eth_dst", ["01:00:5e:00:01:02", "ff:ff:ff:ff:ff:ff"])
@@ -812,7 +865,12 @@ def test_unicast_ip_incorrect_eth_dst(do_test, ptfadapter, setup, tx_dut_ports, 
         tcp_dport=pkt_fields["tcp_dport"]
         )
 
-    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    group = "L3"
+    # DNX platform DROP counters are not there yet
+    if setup.get("platform_asic") == "broadcom-dnx":
+        group = "NO_DROPS"
+
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
 @pytest.mark.parametrize("igmp_version,msg_type", [("v1", "general_query"), ("v3", "general_query"), ("v1", "membership_report"),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
On DNX platform use "NO_DROPS" group to verify packets are dropped, and not forwarded.
At this point DNX BRCM SAI has not implemented drop counters, which is not trivial to implement due to DNX forwarding pipeline architecture.
DNX may also not be able to support drop counters for all the scenarios listed in test cases.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Pass the drop counters test case on DNX platform

#### How did you do it?
Use "NO_DROPS" group to verify packets are not forwarded

#### How did you verify/test it?
```
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$ pytest -rsx drop_packets/test_drop_counters.py  --testbed=vms26-t2-7800-1 --topology="t2,any" --inventory=../ansible/str2,../ansible/veos  --testbed_file=../ansible/testbed.yaml --host-pattern=str2-7804-lc3-1  --module-path=../ansible/library  --skip_sanity
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/sonic-mgmt/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collecting ... /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 102 items

drop_packets/test_drop_counters.py ssssss.s..s..s..s...ss..sss....ssss....ssssss.s....sss....s...ss..ssssssssssssssssss.s.ssssss.s.sss.s.                                                                                             [100%]

============================================================================================================= warnings summary ==============================================================================================================
/usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538
  /usr/local/lib/python2.7/dist-packages/_pytest/config/__init__.py:538: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================================================== short test summary info ==========================================================================================================
SKIPPED [2] /var/sonic-mgmt/tests/drop_packets/test_drop_counters.py:266: Test case requires explicit fanout support
SKIPPED [2] /var/sonic-mgmt/tests/common/helpers/assertions.py:13: BRCM does not drop SIP class E packets
SKIPPED [3] drop_packets/drop_packets.py: SONiC can't enable loop-back filter feature
SKIPPED [3] drop_packets/drop_packets.py: Not supported on Broadcom platforms
SKIPPED [2] /var/sonic-mgmt/tests/drop_packets/drop_packets.py:400: Test case requires explicit fanout support
SKIPPED [32] /var/sonic-mgmt/tests/drop_packets/drop_packets.py:229: No vlan_members available
SKIPPED [2] /var/sonic-mgmt/tests/drop_packets/drop_packets.py:439: Test case requires explicit fanout support
SKIPPED [2] /var/sonic-mgmt/tests/common/helpers/assertions.py:13: BRCM does not drop DIP link local packets
SKIPPED [12] /var/sonic-mgmt/tests/drop_packets/drop_packets.py:853: Test case requires explicit fanout support
SKIPPED [2] /var/sonic-mgmt/tests/common/helpers/assertions.py:13: BRCM does not drop SIP link local packets
=========================================================================================== 40 passed, 62 skipped, 1 warnings in 1465.17 seconds ============================================================================================
Exception AttributeError: "'NoneType' object has no attribute 'close'" in <bound method EventDescriptor.__del__ of <ptf.ptfutils.EventDescriptor instance at 0x7f1472c04c30>> ignored
samaddik@str-serv-acs-14:/var/sonic-mgmt/tests$
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
