### PR TITLE
Fixing ptf port index in mg_facts for asics  in a multi-asic linecard

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -221,8 +221,8 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
 
 
 def get_port_indices_for_asic(asic_id, port_name_list_sorted):
-    front_end_port_name_list = [p for p in port_name_list_sorted if 'BP' not in p]
-    back_end_port_name_list = [p for p in port_name_list_sorted if 'BP' in p]
+    front_end_port_name_list = [p for p in port_name_list_sorted if 'BP' not in p or 'IB' not in p or 'Rec' not in p]
+    back_end_port_name_list = [p for p in port_name_list_sorted if 'BP' in p or 'IB' in p or 'Rec' in p]
     index_offset = 0
    # Create mapping between port alias and physical index
     port_index_map = {}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
In the minigraph_facts, minigraph_ptf_indices are derived by mapping this port_index of the device to device ports defined in the topology file that start with 0.
- PR #5011  introduced getting port index for ports on the device dynamically from the port_index defined in the port_config.ini file.
- PR #5223 fixed this to only doing so for a defined list of HWSKU's - https://github.com/Azure/sonic-mgmt/blob/master/ansible/module_utils/port_utils.py#L19

The minigraph_ptf_indices mapping for an asic (asichost.get_extended_minigraph_facts()) is wrong if we have a HWSKU like Nokia-IXR7250E-36x400G where the port_index in the port_config.ini starts with 1 and is a multi-asic linecard with Inband and Recycle Port - like Nokia-IXR7250E-36x400G.

- If we add this HWSKU to a the defined list of HWSKU to use port_config.ini, then the minigraph_ptf_indices mapping is off by 1 for asic0.
- If we don't add this HWSKU to a defined list of HWSKU's to use port_config_ini, then we revert to using port_utils.get_port_indices_for_asic (https://github.com/Azure/sonic-mgmt/blob/master/ansible/module_utils/port_utils.py#L223) method to get the device port index.
   - In this approach, we assume that the Inband and Recyle ports are frontend ports, and thus the starting port index for asic1 is off by 2. So, the minigraph_ptf_indices for asic1 is off by 2.

Because of the above, we fail ipfwd/test_dip_sip.py, ipfwd/test_mtu.py and arp/test_arpall.py when run on any asic other than asic0 our such linecards.



#### How did you do it?

To fix this issue, we assume that the port index of the Inband and the Recyle ports are after all the front panel ports across the whole device. Then we can treat the Inband and Recycle ports similar to backend ports

With the above fix, the minigraph_ptf_indices mapping is correct for all asics.

#### How did you verify/test it?

Ran the failing tests against Nokia-IXR7250E-36x400G card and make sure that they pass.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
