### PR TITLE
[conftest] Added code to account for older SONiC images

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1367,7 +1367,10 @@ def get_reboot_cause(duthost):
     yield
     uptime_end = duthost.get_up_time()
     if not uptime_end == uptime_start:
-        duthost.show_and_parse("show reboot-cause history")
+        if "201811" in duthost.os_version or "201911" in duthost.os_version:
+            duthost.show_and_parse("show reboot-cause")
+        else:
+            duthost.show_and_parse("show reboot-cause history")
 
 def collect_db_dump_on_duts(request, duthosts):
     '''


### PR DESCRIPTION
### Description of PR

Modified the get_reboot_cause function in conftest.py to only call the 'show reboot-cause history' command when testing a DUT running 202012 or greater. For devices running older OS versions, it calls 'show reboot-cause'.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)
