### PR TITLE
[fdb] Poll the dedicated dest port

### DIFF
--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -160,8 +160,12 @@ def send_recv_eth(ptfadapter, source_ports, source_mac, dest_ports, dest_mac, sr
         exp_pkt.set_do_not_care_scapy(scapy.Dot1Q, "prio")
     logger.debug('send packet src port {} smac: {} dmac: {} vlan: {} verifying on dst port {}'.format(
         source_ports, source_mac, dest_mac, src_vlan, dest_ports))
+    ptfadapter.dataplane.flush()
     testutils.send(ptfadapter, source_ports[0], pkt)
-    testutils.verify_packet_any_port(ptfadapter, exp_pkt, dest_ports, timeout=FDB_WAIT_EXPECTED_PACKET_TIMEOUT)
+    if len(dest_ports) == 1:
+        testutils.verify_packet(ptfadapter, exp_pkt, dest_ports[0], timeout=FDB_WAIT_EXPECTED_PACKET_TIMEOUT)
+    else:
+        testutils.verify_packet_any_port(ptfadapter, exp_pkt, dest_ports, timeout=FDB_WAIT_EXPECTED_PACKET_TIMEOUT)
 
 
 def setup_fdb(ptfadapter, vlan_table, router_mac, pkt_type, dummy_mac_count):


### PR DESCRIPTION
What is the motivation for this PR?
The Fdb test case is flaky on some platforms as it can't poll all pkts within timeout.

How did you do it?
if possible, poll from one dedicated dest port rather than poll all ports

How did you verify/test it?
Run test_fdb.py.

Signed-off-by: Kevin(Shengkai) Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
