### PR TITLE
[qos] Skip checking BUFFER_PG table if lossless profile is not defined

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -2427,7 +2427,7 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts):
         else:
             if is_mellanox_device(duthost):
                 buffer_items_to_check = buffer_items_to_check_dict["down"]
-            elif is_broadcom_device(duthost) and (asic_type in ['td2'] or speed == '10000'):
+            elif is_broadcom_device(duthost) and (asic_type in ['td2'] or speed <= '10000'):
                 buffer_items_to_check = [(None, None, None)]
             else:
                 buffer_items_to_check = [('BUFFER_PG_TABLE', '3-4', profile_wrapper.format(expected_profile))]

--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -2427,7 +2427,7 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts):
         else:
             if is_mellanox_device(duthost):
                 buffer_items_to_check = buffer_items_to_check_dict["down"]
-            elif is_broadcom_device(duthost) and asic_type in ['td2']:
+            elif is_broadcom_device(duthost) and (asic_type in ['td2'] or speed == '10000'):
                 buffer_items_to_check = [(None, None, None)]
             else:
                 buffer_items_to_check = [('BUFFER_PG_TABLE', '3-4', profile_wrapper.format(expected_profile))]


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In some platforms, 10g ports do not have pg profile defined. Skip checking the BUFFER_PG table for such platforms if the port speed is 10g

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

#### How did you verify/test it?
Ran the test on the platform it was failing before. The test passed with the changes