### PR TITLE
Revert "[fwutil] Fix Various Bugs Identified in Regression"

### DIFF
--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -1,4 +1,3 @@
-import allure
 import pytest
 import os
 import json
@@ -10,15 +9,13 @@ from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
-TEMP_STATUS_FILE = "/tmp/firmwareupdate/fw_au_status"
-
 WARM_REBOOT = "warm"
 COLD_REBOOT = "cold"
 POWER_CYCLE = "power off"
 FAST_REBOOT = "fast"
 
 DEVICES_PATH="usr/share/sonic/device"
-TIMEOUT=1200
+TIMEOUT=3600
 REBOOT_TYPES = {
     COLD_REBOOT: "reboot",
     WARM_REBOOT: "warm-reboot",
@@ -30,11 +27,6 @@ def find_pattern(lines, pattern):
         if pattern.match(line):
             return True
     return False
-
-def get_hw_revision(duthost):
-    out = duthost.command("show platform summary")
-    rev_line = out["stdout"].splitlines()[6]
-    return rev_line.split(": ")[1]
 
 def power_cycle(duthost=None, pdu_ctrl=None, delay_time=60):
     if pdu_ctrl is None:
@@ -73,7 +65,7 @@ def complete_install(duthost, localhost, boot_type, res, pdu_ctrl, auto_reboot=F
         
         logger.info("Waiting on switch to shutdown...")
         # Wait for ssh flap
-        localhost.wait_for(host=hn, port=22, state='stopped', delay=1, timeout=timeout)
+        localhost.wait_for(host=hn, port=22, state='stopped', delay=10, timeout=timeout)
         logger.info("Letting switch get through ONIE / BIOS before pinging....")
         time.sleep(300)
         logger.info("Waiting on switch to come up....")
@@ -122,14 +114,11 @@ def show_firmware(duthost):
 
     return output_data
 
-def get_install_paths(duthost, fw, versions, chassis, target_component):
+def get_install_paths(duthost, fw, versions, chassis):
     component = fw["chassis"].get(chassis, {})["component"]
     ver = versions["chassis"].get(chassis, {})["component"]
     
     paths = {}
-
-    if target_component is not None:
-        component = {target_component: component[target_component]}
 
     for comp, revs in component.items():
         if comp in ver:
@@ -137,9 +126,6 @@ def get_install_paths(duthost, fw, versions, chassis, target_component):
                 log.warning("Firmware is upgrade only and existing firmware {} is not present in version list. Skipping {}".format(ver[comp], comp))
                 continue
             for i, rev in enumerate(revs):
-                if "hw_revision" in rev and rev["hw_revision"] != get_hw_revision(duthost):
-                    log.warning("Firmware {} only supports HW Revision {} and this chassis is {}. Skipping".format(rev["version"], rev["hw_revision"], get_hw_revision(duthost)))
-                    continue
                 if rev["version"] != ver[comp]:
                     paths[comp] = rev
                     break
@@ -171,9 +157,6 @@ def generate_config(duthost, cfg, versions):
 def upload_platform(duthost, paths, next_image=None):
     target = next_image if next_image else "/"
 
-    # Clear auto update status file
-    duthost.command("rm -rf {}".format(TEMP_STATUS_FILE))
-
     # Backup the original platform_components.json file
     duthost.fetch(dest=os.path.join("firmware", "platform_components_backup.json"), 
             src=os.path.join(target, DEVICES_PATH, duthost.facts["platform"], "platform_components.json"),
@@ -187,12 +170,13 @@ def upload_platform(duthost, paths, next_image=None):
         os.path.join(target, DEVICES_PATH, duthost.facts["platform"])))
 
     for comp, dat in paths.items():
-        if dat["firmware"].startswith("http"):
-            duthost.get_url(url=dat["firmware"], 
+        duthost.copy(src=os.path.join("firmware", dat["firmware"]), 
+                dest=os.path.join(target, DEVICES_PATH, duthost.facts["platform"]))
+        if "install" in dat:
+            duthost.copy(src=os.path.join("firmware", dat["install"]["firmware"]), 
                     dest=os.path.join(target, DEVICES_PATH, duthost.facts["platform"]))
-        else:
-            duthost.copy(src=os.path.join("firmware", dat["firmware"]), 
-                    dest=os.path.join(target, DEVICES_PATH, duthost.facts["platform"]))
+            logger.info("Copying {} to {}".format(os.path.join("firmware", dat["install"]["firmware"]),
+                os.path.join(target, DEVICES_PATH, duthost.facts["platform"])))
 
 def validate_versions(init, final, config, chassis, boot):
     final = final["chassis"][chassis]["component"]
@@ -205,29 +189,24 @@ def validate_versions(init, final, config, chassis, boot):
     return True
 
 def call_fwutil(duthost, localhost, pdu_ctrl, fw, component=None, next_image=None, boot=None, basepath=None):
-    allure.step("Collect firmware versions")
     logger.info("Calling fwutil with component: {} | next_image: {} | boot: {} | basepath: {}".format(component, next_image, boot, basepath))
     init_versions = show_firmware(duthost)
     logger.info("Initial Versions: {}".format(init_versions))
     chassis = init_versions["chassis"].keys()[0] # Only one chassis
-    paths = get_install_paths(duthost, fw, init_versions, chassis, component)
+    paths = get_install_paths(duthost, fw, init_versions, chassis)
     current = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
 
-    allure.step("Upload firmware to DUT")
     generate_config(duthost, paths, init_versions)
     upload_platform(duthost, paths, next_image)
 
-    allure.step("Execute fwutil command")
     command = "fwutil"
     if basepath is not None:
         command += " install"
-        auto_reboot = paths[component].get("force_reboot", False)
     else:
         command += " update"
-        auto_reboot = True
 
     if component is None:
-        command += " all fw"
+        command += " all"
     else:
         if component not in paths:
             pytest.skip("No available firmware to install on {}. Skipping".format(component))
@@ -235,7 +214,7 @@ def call_fwutil(duthost, localhost, pdu_ctrl, fw, component=None, next_image=Non
 
     if basepath is not None:
         # Install file is override if API implementation needs a different file for install / update
-        filepath = paths[component]["firmware"]
+        filepath = paths[component]["install"]["firmware"] if "install" in paths[component] else paths[component]["firmware"]
         command += " {}".format(os.path.join(basepath, os.path.basename(filepath)))
 
     if next_image is not None:
@@ -243,39 +222,39 @@ def call_fwutil(duthost, localhost, pdu_ctrl, fw, component=None, next_image=Non
 
     if boot is not None:
         command += " --boot={}".format(boot)
-        auto_reboot = False
-    else:
-        command += " -y"
+
+    command += " -y"
 
     logger.info("Running install command: {}".format(command))
     task, res = duthost.command(command, module_ignore_errors=True, module_async=True)
     boot_type = boot if boot else paths[component]["reboot"][0]
 
-    allure.step("Perform Neccesary Reboot")
+    auto_reboot = False
+    for comp in paths.keys():
+        if "install" in paths[comp] and basepath is not None:
+            if paths[comp]["install"].get("auto_reboot", False): auto_reboot = True
+        else:
+            if paths[comp].get("auto_reboot", False): auto_reboot = True
+
     timeout = max([v.get("timeout", TIMEOUT) for k, v in paths.items()])
     pdu_delay = fw["chassis"][chassis].get("power_cycle_delay", 60)
     complete_install(duthost, localhost, boot_type, res, pdu_ctrl, auto_reboot, current, next_image, timeout, pdu_delay)
 
-    allure.step("Collect Updated Firmware Versions")
-    time.sleep(2) # Give a little bit of time in case of no-op install for mounts to complete
     final_versions = show_firmware(duthost)
-    test_result = validate_versions(init_versions, final_versions, paths, chassis, boot_type)
+    assert validate_versions(init_versions, final_versions, paths, chassis, boot_type)
 
-    allure.step("Begin Switch Restoration")
-    if next_image is None:
-        duthost.copy(src=os.path.join("firmware", "platform_components_backup.json"), 
-                dest=os.path.join("/", DEVICES_PATH, duthost.facts["platform"], "platform_components.json"))
-        logger.info("Restoring backup platform_components.json to {}".format(
-            os.path.join(DEVICES_PATH, duthost.facts["platform"])))
+    duthost.copy(src=os.path.join("firmware", "platform_components_backup.json"), 
+            dest=os.path.join(target, DEVICES_PATH, duthost.facts["platform"], "platform_components.json"))
+    logger.info("Restoring backup platform_components.json to {}".format(
+        os.path.join(DEVICES_PATH, duthost.facts["platform"])))
 
-    update_needed = deepcopy(fw)
-    update_needed["chassis"][chassis]["component"] = {}
+    update_needed = copy(fw)
     for comp in paths.keys():
-        if fw["chassis"][chassis]["component"][comp][0]["version"] != final_versions["chassis"][chassis]["component"][comp] and boot in fw["chassis"][chassis]["component"][comp][0]["reboot"] + [None] and not paths[comp].get("upgrade_only", False):
-            update_needed["chassis"][chassis]["component"][comp] = fw["chassis"][chassis]["component"][comp]
+        if fw["chassis"][chassis]["component"][comp][0]["version"] == final_versions[comp] or paths[comp]["upgrade_only"]:
+            del update_needed["chassis"][chassis]["component"][comp]
     if len(update_needed["chassis"][chassis]["component"].keys()) > 0:
         logger.info("Latest firmware not installed after test. Installing....")
-        call_fwutil(duthost, localhost, pdu_ctrl, update_needed, component, None, boot, os.path.join("/", DEVICES_PATH, duthost.facts['platform']) if basepath is not None else None)
+        call_fwutil(duthost, localhost, pdu_ctrl, update_needed, component, None, boot, basepath)
 
-    return test_result
+    return True
 

--- a/tests/platform_tests/fwutil/test_fwutil.py
+++ b/tests/platform_tests/fwutil/test_fwutil.py
@@ -21,9 +21,8 @@ def test_fwutil_show(duthost):
 
     show_fw_comp_set = set(versions["chassis"][chassis]["component"].keys())
     platform_comp_set = set(platform_comp["chassis"][chassis]["component"].keys())
-    comp = show_fw_comp_set == platform_comp_set
 
-    assert comp
+    assert show_fw_comp_set == platform_comp_set
 
 def test_fwutil_install_file(duthost, localhost, pdu_controller, fw_pkg, random_component):
     """Tests manually installing firmware to a component from a file."""
@@ -108,12 +107,12 @@ def test_fwutil_update_bad_config(duthost, fw_pkg, random_component):
     assert found_bad_component
 
 
-@pytest.mark.parametrize("reboot_type", ["none", "cold"])
+@pytest.mark.parametrize("reboot_type", ["none", "warm", "fast", "cold", "power off"])
 def test_fwutil_auto(duthost, localhost, pdu_controller, fw_pkg, reboot_type):
     """Tests fwutil update all command ability to properly select firmware for install based on boot type."""
     assert call_fwutil(duthost,
             localhost,
             pdu_controller,
             fw_pkg,
-            boot=reboot_type)
+            reboot=reboot_type)
 


### PR DESCRIPTION
Reverts Azure/sonic-mgmt#5130

Need to revert this PR for the same reason as PR #5282.

The dependent pytest-allure package which is only available to user “AzDevOps” in sonic-mgmt docker because it is installed to local path of that user:

```
AzDevOps@2fb15ed04ed5:~$ python
Python 2.7.17 (default, Feb 27 2021, 15:10:58)
[GCC 7.5.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import allure
>>> allure.__file__
'/var/AzDevOps/.local/lib/python2.7/site-packages/allure.pyc'
AzDevOps@2fb15ed04ed5:~$ sudo su
root@2fb15ed04ed5:/var/AzDevOps# pip list | grep allure
DEPRECATION: The default format will switch to columns in the future. You can use --format=(legacy|columns) (or define a format=(legacy|columns) in your pip.conf under the [list] section) to disable this warning.
root@2fb15ed04ed5:/var/AzDevOps# python
Python 2.7.17 (default, Feb 27 2021, 15:10:58)
[GCC 7.5.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import allure
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named allure
>>> exit()
```

I’ll revert this PR for now to unblock testing using root account. The sonic-mgmt docker file https://github.com/Azure/sonic-buildimage/blob/master/dockers/docker-sonic-mgmt/Dockerfile.j2 needs to be updated to ensure that package pytest-allure is installed to global directory.