### PR TITLE
[warm-reboot]Fix warm-reboot stuck issue

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -558,6 +558,9 @@ class Arista(object):
                     .get("Ethernet1", {})\
                         .get("details", {})\
                             .get("lastRxTime")
+        if last_lacp_pdu_time == None:
+            last_lacp_pdu_time = 0
+            self.log("Warn: the lastRxTime does not exist!")
         return last_lacp_pdu_time
 
 

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -174,11 +174,13 @@ class Arista(object):
                     continue
                 if cmd == 'cpu_down':
                     last_lacppdu_time_before_reboot = self.check_last_lacppdu_time()
-                    self.lacp_pdu_time_on_down.append(last_lacppdu_time_before_reboot)
+                    if last_lacppdu_time_before_reboot is not None:
+                        self.lacp_pdu_time_on_down.append(last_lacppdu_time_before_reboot)
                 if (cmd == 'cpu_going_up' or cmd == 'cpu_up') and self.collect_lacppdu_time:
                     # control plane is back up, start polling for new lacp-pdu
                     last_lacppdu_time_after_reboot = self.check_last_lacppdu_time()
-                    if int(last_lacppdu_time_after_reboot) > int(last_lacppdu_time_before_reboot):
+                    if last_lacppdu_time_before_reboot is not None and last_lacppdu_time_after_reboot is not None and \
+                            int(last_lacppdu_time_after_reboot) > int(last_lacppdu_time_before_reboot):
                         self.lacp_pdu_time_on_up.append(last_lacppdu_time_after_reboot)
                         self.collect_lacppdu_time = False # post-reboot lacp-pdu is received, stop the polling
 
@@ -558,9 +560,6 @@ class Arista(object):
                     .get("Ethernet1", {})\
                         .get("details", {})\
                             .get("lastRxTime")
-        if last_lacp_pdu_time is None:
-            last_lacp_pdu_time = 0
-            self.log("Warn: the lastRxTime does not exist!")
         return last_lacp_pdu_time
 
 

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -558,7 +558,7 @@ class Arista(object):
                     .get("Ethernet1", {})\
                         .get("details", {})\
                             .get("lastRxTime")
-        if last_lacp_pdu_time == None:
+        if last_lacp_pdu_time is None:
             last_lacp_pdu_time = 0
             self.log("Warn: the lastRxTime does not exist!")
         return last_lacp_pdu_time

--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -558,7 +558,7 @@ class Arista(object):
                     .get("Ethernet1", {})\
                         .get("details", {})\
                             .get("lastRxTime")
-        if last_lacp_pdu_time is None:
+        if last_lacp_pdu_time == None:
             last_lacp_pdu_time = 0
             self.log("Warn: the lastRxTime does not exist!")
         return last_lacp_pdu_time


### PR DESCRIPTION
In self.check_last_lacppdu_time() function, it will get the lastRxTime from the command "show lacp internal detailed | json" on arista, and sometimes the cli command will not return the info includ lastRxTime, then self.check_last_lacppdu_time() will return None, in the arista ssh thread, it will use the return value with converting it to int, if the return value is None, then the "int(last_lacppdu_time_after_reboot) > int(last_lacppdu_time_before_reboot)" will give exception, since this function is executed in the thread queue, then this thread will killed, then in the following code, when call q.put('quit'), the code is stuck.

Example for unexpected command output:
    show lacp internal detailed | json
    {
        "orphanPorts": {},
        "systemId": "8000,a6-21-d5-41-4a-3a",
        "portChannels": {
            "Port-Channel1": {
                "interfaces": {}
            }
        },
        "miscLacpSysIds": []
    }

Example for expected command output:
    show lacp internal detailed | json
    {
        "orphanPorts": {},
        "systemId": "8000,46-ef-1e-ef-4e-53",
        "portChannels": {
            "Port-Channel1": {
                "interfaces": {
                    "Ethernet1": {
                        "actorPortState": {
                            "collecting": true,
                            "distributing": true,
                            "synchronization": true,
                            "defaulted": false,
                            "timeout": false,
                            "activity": true,
                            "expired": false,
                            "aggregation": true
                        },
                        "partnerSystemId": "FFFF,50-6b-4b-a3-53-80",
                        "actorPortPriority": 32768,
                        "actorPortStatus": "bundled",
                        "actorOperKey": "0x0001",
                        "actorPortId": 1,
                        "details": {
                            "actorChurnState": "noChurn",
                            "lastRxTime": 1646835407.7603946,
                            "allowToWarmup": false,
                            "actorRxSmState": "rxSmCurrent",
                            "actorMuxReason": "muxActorCollectingDistributing",
                            "actorAdminKey": "0x0001",
                            "actorMuxSmState": "muxSmCollectingDistributing",
                            "actorTimeoutMultiplier": 3,
                            "aggSelectionState": "selectedStateSelected"
                        }
                    }
                }
            }
        },
        "miscLacpSysIds": []
    }

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix warm-reboot stuck issue
Fixes # (issue)
In sonic-mgmt/ansible/roles/test/files/ptftests/arista.py::run(), it will check the "lastRxTime" with "show lacp internal detailed | json", in sonic-mgmt/ansible/roles/test/files/ptftests/arista.py::check_last_lacppdu_time(), but after the reboot, sometimes, it output of "show lacp internal detailed | json" will not include "lastRxTime", so it means that the return of check_last_lacppdu_time() will be None, and in sonic-mgmt/ansible/roles/test/files/ptftests/arista.py::run(), it will compare the return value of check_last_lacppdu_time() with coverting the value to int:
```
                if cmd == 'cpu_down':
                    last_lacppdu_time_before_reboot = self.check_last_lacppdu_time()
                    self.lacp_pdu_time_on_down.append(last_lacppdu_time_before_reboot)
                if (cmd == 'cpu_going_up' or cmd == 'cpu_up') and self.collect_lacppdu_time:
                    # control plane is back up, start polling for new lacp-pdu
                    last_lacppdu_time_after_reboot = self.check_last_lacppdu_time()
                    if **int(last_lacppdu_time_after_reboot) > int(last_lacppdu_time_before_reboot)**:
                        self.lacp_pdu_time_on_up.append(last_lacppdu_time_after_reboot)
                        self.collect_lacppdu_time = False # post-reboot lacp-pdu is received, stop the polling
```

if the value is None, then the expection will happen in sonic-mgmt/ansible/roles/test/files/ptftests/arista.py::run(), since this run function is executed in one thread, in this time, the thread will stuck, and will not repsond to anything. And it will cause the warm-reboot can not be finished. in the following code is: due to the exception, the code will stuck when execute the q.put('quit')
```
    def handle_post_reboot_health_check(self):
        # wait until all bgp session are established
        self.log("Wait until bgp routing is up on all devices")
        for _, q in self.ssh_jobs:
            **q.put('quit')**

        def wait_for_ssh_threads(signal):
            while any(thr.is_alive() for thr, _ in self.ssh_jobs) and not signal.is_set():
                self.log('Waiting till SSH threads stop')
                time.sleep(self.TIMEOUT)

            for thr, _ in self.ssh_jobs:
                thr.join()

        self.timeout(wait_for_ssh_threads, self.task_timeout, "SSH threads haven't finished for %d seconds" % self.task_timeout)
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix warm-reboot stuck issue
#### How did you do it?

#### How did you verify/test it?
Run the warm-reboot in advanced-reboot.py, and the test will not stuch even there is no expected info in output of "show lacp internal detailed | json" 
#### Any platform specific information?
NO
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
