### PR TITLE
[test gap] Verify vlan interface autostate is disabled

### DIFF
--- a/docs/api_wiki/README.md
+++ b/docs/api_wiki/README.md
@@ -159,6 +159,8 @@ def test_fun(duthosts, rand_one_dut_hostname, ptfhost):
 
 - [get_image_info](sonichost_methods/get_image_info.md) - Get list of images installed on the DUT.
 
+- [get_interfaces_status](sonichost_methods/get_interfaces_status.md) - Get interfaces status on the DUT and parse the result into a dict.
+
 - [get_ip_route_info](sonichost_methods/get_ip_route_info.md) - Returns route information for a destionation. The destination could an ip address or ip prefix.
 
 - [get_monit_services_status](sonichost_methods/get_monit_services_status.md) - Get metadata on services monitored by Monit.

--- a/docs/api_wiki/sonichost_methods/get_interfaces_status.md
+++ b/docs/api_wiki/sonichost_methods/get_interfaces_status.md
@@ -1,0 +1,56 @@
+# get_interfaces_status
+
+- [Overview](#overview)
+- [Examples](#examples)
+- [Arguments](#arguments)
+- [Expected Output](#expected-output)
+
+## Overview
+Get interfaces status on the DUT and parse the result into a dict.
+
+## Examples
+```python
+def test_fun(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+
+    images = duthost.get_interfaces_status()
+```
+
+## Arguments
+This function takes no arguments.
+
+## Expected Output
+Returns dicitonary with the DUT interfaces status. 
+
+Example output:
+
+```json
+{
+    "Ethernet0": {
+        "oper": "down",
+        "lanes": "25,26,27,28",
+        "fec": "N/A",
+        "asym pfc": "off",
+        "admin": "down",
+        "type": "N/A",
+        "vlan": "routed",
+        "mtu": "9100",
+        "alias": "fortyGigE0/0",
+        "interface": "Ethernet0",
+        "speed": "40G"
+    },
+    "PortChannel101": {
+        "oper": "up",
+        "lanes": "N/A",
+        "fec": "N/A",
+        "asym pfc": "N/A",
+        "admin": "up",
+        "type": "N/A",
+        "vlan": "routed",
+        "mtu": "9100",
+        "alias": "N/A",
+        "interface": "PortChannel101",
+        "speed": "40G"
+    }
+}
+```

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1455,6 +1455,42 @@ Totals               6450                 6449
 
         return vlan_intfs
 
+    def get_interfaces_status(self):
+        '''
+        Get intnerfaces status by running 'show interfaces status' on the DUT, and parse the result into a dict.
+
+        Example output:
+            {
+                "Ethernet0": {
+                    "oper": "down",
+                    "lanes": "25,26,27,28",
+                    "fec": "N/A",
+                    "asym pfc": "off",
+                    "admin": "down",
+                    "type": "N/A",
+                    "vlan": "routed",
+                    "mtu": "9100",
+                    "alias": "fortyGigE0/0",
+                    "interface": "Ethernet0",
+                    "speed": "40G"
+                },
+                "PortChannel101": {
+                    "oper": "up",
+                    "lanes": "N/A",
+                    "fec": "N/A",
+                    "asym pfc": "N/A",
+                    "admin": "up",
+                    "type": "N/A",
+                    "vlan": "routed",
+                    "mtu": "9100",
+                    "alias": "N/A",
+                    "interface": "PortChannel101",
+                    "speed": "40G"
+                }
+            }
+        '''
+        return {x.get('interface'): x for x in self.show_and_parse('show interfaces status')}
+
     def get_crm_facts(self):
         """Run various 'crm show' commands and parse their output to gather CRM facts
 

--- a/tests/vlan/test_autostate_disabled.py
+++ b/tests/vlan/test_autostate_disabled.py
@@ -39,7 +39,7 @@ class TestAutostateDisabled:
         ifs_status = self.get_interface_status(duthost)
         ip_ifs = duthost.show_ip_interface()['ansible_facts']['ip_interfaces']
 
-        # Find out all vlans which meet the folloing requirements:
+        # Find out all vlans which meet the following requirements:
         #   1. The oper_state of vlan interface is 'up'
         #   2. The oper_state of at least one member in the vlan is 'up'
         vlan_available = []

--- a/tests/vlan/test_autostate_disabled.py
+++ b/tests/vlan/test_autostate_disabled.py
@@ -98,7 +98,7 @@ class TestAutostateDisabled:
         """
         Check the oper_state of all interfaces are as expected.
         """
-        ifs_status = duthost.get_interfaces_status(duthost)
+        ifs_status = duthost.get_interfaces_status()
         return all([ifs_status.get(x, {}).get('oper', '') == expected_state for x in interfaces])
 
     def shutdown_multiple_with_confirm(self, duthost, interfaces, err_handler=logging.error):

--- a/tests/vlan/test_autostate_disabled.py
+++ b/tests/vlan/test_autostate_disabled.py
@@ -95,14 +95,16 @@ class TestAutostateDisabled:
                 ifs_up.append(interface)
             elif admin_state == 'down':
                 ifs_down.append(interface)
-        res = duthost.no_shutdown_multiple(ifs_up)
-        if not res.is_successful:
-            logging.error('startup "{interfaces}" on DUT {hostname} failed'.
-                          format(interfaces=ifs_up, hostname=duthost.hostname))
-        res = duthost.shutdown_multiple(ifs_down)
-        if not res.is_successful:
-            logging.error('shutdown "{interfaces}" on DUT {hostname} failed'.
-                          format(interfaces=ifs_down, hostname=duthost.hostname))
+        if len(ifs_up) > 0:
+            res = duthost.no_shutdown_multiple(ifs_up)
+            if not res.is_successful:
+                logging.error('startup "{interfaces}" on DUT {hostname} failed'.
+                              format(interfaces=ifs_up, hostname=duthost.hostname))
+        if len(ifs_down) > 0:
+            res = duthost.shutdown_multiple(ifs_down)
+            if not res.is_successful:
+                logging.error('shutdown "{interfaces}" on DUT {hostname} failed'.
+                              format(interfaces=ifs_down, hostname=duthost.hostname))
 
     def get_interface_status(self, duthost):
         """

--- a/tests/vlan/test_autostate_disabled.py
+++ b/tests/vlan/test_autostate_disabled.py
@@ -1,0 +1,120 @@
+import logging
+import pytest
+from tests.common.helpers.assertions import pytest_assert
+
+from tests.common.utilities import wait_until
+
+
+pytestmark = [
+    pytest.mark.topology("t0")
+]
+
+
+class TestAutostateDisabled:
+    """
+    This test case is used to verify that vlan interface autostate is **disabled** on SONiC.
+
+    The autostate feature notifies a switch or routing module VLAN interface (Layer 3 interface) to transition to
+    up/up status when at least one Layer 2 port becomes active in that VLAN.
+
+    In SONiC, all vlans are bound to a single bridge interface, so the vlan interface will go down only if the bridge
+    is down. Since bridge goes down when all the associated interfaces are down, if all the vlan members across all
+    the vlans go down, the bridge will go down and the vlan interface will go down.
+
+    For more information about autostate, see:
+      * https://www.cisco.com/c/en/us/support/docs/switches/catalyst-6500-series-switches/41141-188.html
+    """
+
+    def test_autostate_disabled(self, duthosts, enum_frontend_dut_hostname):
+        """
+        Validate vlan interface autostate is disabled on SONiC.
+        """
+
+        duthost = duthosts[enum_frontend_dut_hostname]
+        dut_hostname = duthost.hostname
+
+        # Collect DUT configuration and status
+        vlan_members_facts = duthost.get_running_config_facts().get('VLAN_MEMBER')
+        if vlan_members_facts is None:
+            pytest.skip('No vlan available on DUT {hostname}'.format(hostname=dut_hostname))
+        ifs_status = self.get_interface_status(duthost)
+        ip_ifs = duthost.show_ip_interface()['ansible_facts']['ip_interfaces']
+
+        # Find out all vlans which meet folloing requirements:
+        #   1. The oper_state of vlan interface is 'up'
+        #   2. The oper_state of at least one interface in the vlan is 'up'
+        vlan_available = []
+        for vlan in vlan_members_facts:
+            if ip_ifs.get(vlan, {}).get('oper_state') == 'up':
+                for member in vlan_members_facts[vlan]:
+                    if ifs_status.get(member, {}).get('oper', '') == 'up':
+                        vlan_available.append(vlan)
+                        break
+        if len(vlan_available) == 0:
+            pytest.skip('No vlan available on DUT {hostname}'.format(hostname=dut_hostname))
+
+        # Pick a vlan for test
+        vlan = vlan_available[0]
+        vlan_members = vlan_members_facts[vlan].keys()
+        pytest_assert
+
+        # Shutdown all the members in vlan.
+        res = duthost.shutdown_multiple(vlan_members)
+        if not res.is_successful:
+            self.restore_interface_admin_state(duthost, ifs_status)
+            pytest.fail('shutdown "{vlan_members}" in {vlan} failed'.format(vlan_members=vlan_members, vlan=vlan))
+        logging.info('waiting for "{vlan_members}" shutdown in {vlan}'.format(vlan_members=vlan_members, vlan=vlan))
+        if not wait_until(60, 5, 0, self.check_interface_oper_state, duthost, vlan_members, "down"):
+            self.restore_interface_admin_state(duthost, ifs_status)
+            pytest.fail('shutdown "{vlan_members}" in {vlan} failed'.format(vlan_members=vlan_members, vlan=vlan))
+
+        # Check whether the oper_state of vlan is changed as expected.
+        ip_ifs = duthost.show_ip_interface()['ansible_facts']['ip_interfaces']
+        if len(vlan_available) > 1:
+            # If more than one vlan comply with the above test requirements, then there are members in other vlans
+            # that are still up. Therefore, the bridge is still up, and vlan interface should be up.
+            if ip_ifs.get(vlan, {}).get('oper_state') != "up":
+                self.restore_interface_admin_state(duthost, ifs_status)
+                pytest.fail('vlan interface is not up as expected')
+        else:
+            # If only one vlan comply with the above test requirements, then all the vlan members across all the vlans
+            # are down. Therefore, the bridge is down, and vlan interface should be down.
+            if ip_ifs.get(vlan, {}).get('oper_state') != "down":
+                self.restore_interface_admin_state(duthost, ifs_status)
+                pytest.fail('vlan interface is not down as expected')
+
+        # Restore all interfaces to their original admin_state.
+        self.restore_interface_admin_state(duthost, ifs_status)
+
+    def restore_interface_admin_state(self, duthost, ifs_status):
+        """
+        Restore all interfaces to their original admin_state at the end of test.
+        """
+        ifs_up, ifs_down = [], []
+        for interface in ifs_status:
+            admin_state = ifs_status[interface].get('admin', '')
+            if admin_state == 'up':
+                ifs_up.append(interface)
+            elif admin_state == 'down':
+                ifs_down.append(interface)
+        res = duthost.no_shutdown_multiple(ifs_up)
+        if not res.is_successful:
+            logging.error('startup "{interfaces}" on DUT {hostname} failed'.
+                          format(interfaces=ifs_up, hostname=duthost.hostname))
+        res = duthost.shutdown_multiple(ifs_down)
+        if not res.is_successful:
+            logging.error('shutdown "{interfaces}" on DUT {hostname} failed'.
+                          format(interfaces=ifs_down, hostname=duthost.hostname))
+
+    def get_interface_status(self, duthost):
+        """
+        Run 'show interfaces status' on DUT and parse the result into a dict
+        """
+        return {x.get("interface"): x for x in duthost.show_and_parse('show interfaces status')}
+
+    def check_interface_oper_state(self, duthost, interfaces, expected_state):
+        """
+        Check the oper_state of all interfaces are as expected.
+        """
+        ifs_status = self.get_interface_status(duthost)
+        return all([ifs_status.get(x, {}).get('oper', '') == expected_state for x in interfaces])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Verify vlan interface autostate is **disabled** on SONiC.

The autostate feature notifies a switch or routing module VLAN interface (Layer 3 interface) to transition to up/up status when at least one Layer 2 port becomes active in that VLAN.

In SONiC, all vlans are bound to a single bridge interface, so the vlan interface will go down only if the bridge is down. Since bridge goes down when all the associated interfaces are down, if all the vlan members across all the vlans go down, the bridge will go down and the vlan interface will go down.

For more information about autostate, see: [Understanding and Troubleshooting the Autostate Feature in Catalyst Switches - Cisco](https://www.cisco.com/c/en/us/support/docs/switches/catalyst-6500-series-switches/41141-188.html)

Summary:
Fixes #3601

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

Verify vlan interface autostate is **disabled** on SONiC.

#### How did you do it?

1. Find out all vlans which meet the following requirements:
    1. The `oper_state` of vlan interface is up;
    2. The `oper_state` of at least one member in the vlan is up.
2. Pick one vlan for test, and shutdown all the members in this vlan.
3. If more than one vlan was found in step 1, then we expect the vlan interface is still up. If only one vlan was found in step 1, then we expect the vlan interface is down.
4. Finally, restore all interfaces to their orignal `admin_state` (whether the test was passed, skipped, or failed).

#### How did you verify/test it?

Run this test case on vSONiC and physical DUTs.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
