### PR TITLE
[vnet] Fix wr_arp test with vnet config

### DIFF
--- a/ansible/library/vlan_facts.py
+++ b/ansible/library/vlan_facts.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+# This ansible module is for gathering VLAN related facts from SONiC device.
+
+from ansible.module_utils.basic import *
+from collections import defaultdict
+
+
+DOCUMENTATION = '''
+---
+module: vlan_facts
+version_added: "1.0"
+author: Bing Wang (bingwang@microsoft.com)
+short_description: Retrive VLAN facts from a device.
+description:
+    - Retrieve VLAN facts for a device, the facts will be
+      inserted to the ansible_facts key.
+options:
+    N/A
+'''
+
+EXAMPLES = '''
+# Gather VLAN facts
+- name: Gathering VLAN facts from the device
+  vlan_facts:
+  {
+      "vlan1000": {
+          "name": "vlan1000",
+          "vlanid": "1000",
+          "members": [
+              "Ethernet0": {
+                  "tagging_mode": "untagged"
+              },
+              "Ethernet2": {
+                  "tagging_mode": "untagged"
+              }
+          ],
+          "interfaces": [
+              {
+                "addr": "192.168.0.1",
+                "prefixlen": 21
+                },
+                {
+                "prefixlen": 64,
+                "addr": "fc02:1000::1",  
+                }
+            ]
+      }
+  }
+'''
+
+
+def get_all_vlan(module, config):
+    """
+    @summary:  Read all running vlan with sonic-cfggen.
+    @param module: The AnsibleModule object
+    @param config: The retrieved vlan config
+    @return: None
+    """
+    rc, stdout, stderr = module.run_command('sonic-cfggen -d --var-json \"VLAN\"')
+    if rc != 0:
+        module.fail_json(msg='Failed to get DUT running config, rc=%s, stdout=%s, stderr=%s' % (rc, stdout, stderr))
+    
+    try:
+        vlan_config = module.from_json(stdout)
+        for k, v in vlan_config.items():
+            config[k] = {
+                'name': k,
+                'vlanid': v['vlanid']
+            }
+    except Exception as e:
+        module.fail_json(msg='Failed to parse config from output of "sonic-cfggen -d --var-json VLAN", err=' + str(e))
+
+def get_vlan_interfaces(module, config):
+    """
+    @summary:  Read all running vlan interface IP with sonic-cfggen.
+    @param module: The AnsibleModule object
+    @param config: The retrieved vlan config
+    @return: None
+    """
+    rc, stdout, stderr = module.run_command('sonic-cfggen -d --var-json \"VLAN_INTERFACE\"')
+    if rc != 0:
+        module.fail_json(msg='Failed to get DUT running config, rc=%s, stdout=%s, stderr=%s' % (rc, stdout, stderr))
+    
+    try:
+        vlan_config = module.from_json(stdout)
+        for k, v in vlan_config.items():
+            vlan_ip = k.split('|')
+            if len(vlan_ip) != 2:
+                continue
+            vlan = vlan_ip[0]
+            if 'interfaces' not in config[vlan]:
+                config[vlan]['interfaces'] = []
+            ip_prefix = vlan_ip[1].split('/')
+            config[vlan]['interfaces'].append(
+                {
+                "addr": ip_prefix[0],
+                "prefixlen": 32 if len(ip_prefix) < 2 else int(ip_prefix[1])
+                }
+            )
+
+    except Exception as e:
+        module.fail_json(msg='Failed to parse config from output of "sonic-cfggen -d --var-json VLAN_INTERFACE", err=' + str(e))
+
+def get_vlan_members(module, config):
+    """
+    @summary:  Read all running vlan members with sonic-cfggen.
+    @param module: The AnsibleModule object
+    @param config: The retrieved vlan config
+    @return: None
+    """
+    rc, stdout, stderr = module.run_command('sonic-cfggen -d --var-json \"VLAN_MEMBER\"')
+    if rc != 0:
+        module.fail_json(msg='Failed to get DUT running config, rc=%s, stdout=%s, stderr=%s' % (rc, stdout, stderr))
+    
+    try:
+        vlan_config = module.from_json(stdout)
+        for k, v in vlan_config.items():
+            vlan_intf = k.split('|')
+            if len(vlan_intf) < 2:
+                continue
+            if 'members' not in config[vlan_intf[0]]:
+                config[vlan_intf[0]]['members'] = {}
+            config[vlan_intf[0]]['members'].update(
+                {vlan_intf[1]: {"tagging_mode": v['tagging_mode']}}
+                )
+    
+    except Exception as e:
+        module.fail_json(msg='Failed to parse config from output of "sonic-cfggen -d --var-json VLAN_MEMBER", err=' + str(e))
+
+
+def main():
+
+    module = AnsibleModule(argument_spec=dict())
+
+    vlan_config = defaultdict(dict)
+    
+    get_all_vlan(module, vlan_config)
+    get_vlan_interfaces(module, vlan_config)
+    get_vlan_members(module, vlan_config)
+    
+    module.exit_json(ansible_facts={'ansible_vlan_facts': vlan_config})
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/roles/test/files/ptftests/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/wr_arp.py
@@ -234,7 +234,6 @@ class ArpTest(BaseTest):
             test['vlan_id'] = int(config['vlanid'])
             test['vni'] = vni_base + test['vlan_id']
 
-            gw = None
             prefixlen = None
             for d in config['interfaces']:
                 if sys.version_info < (3, 0):

--- a/ansible/roles/test/files/ptftests/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/wr_arp.py
@@ -21,10 +21,11 @@ from Queue import Queue
 import ptf
 from ptf.base_tests import BaseTest
 from ptf import config
+from ptf.mask import Mask
 import ptf.dataplane as dataplane
 import ptf.testutils as testutils
 from device_connection import DeviceConnection
-
+import ipaddress
 
 class ArpTest(BaseTest):
     def __init__(self):
@@ -145,13 +146,15 @@ class ArpTest(BaseTest):
 
         return res
 
-    def generatePkts(self, gw, port_ip, port_mac):
+    def generatePkts(self, gw, port_ip, port_mac, vlan_id):
         pkt = testutils.simple_arp_packet(
                         ip_snd=port_ip,
                         ip_tgt=gw,
                         eth_src=port_mac,
                         hw_snd=port_mac,
-                       )
+                        vlan_vid=vlan_id
+                        )
+        
         exp_pkt = testutils.simple_arp_packet(
                         ip_snd=gw,
                         ip_tgt=port_ip,
@@ -160,9 +163,12 @@ class ArpTest(BaseTest):
                         hw_snd=self.dut_mac,
                         hw_tgt=port_mac,
                         arp_op=2,
+                        vlan_vid=vlan_id
                        )
-
-        return str(pkt), str(exp_pkt)
+        masked_exp_pkt = Mask(exp_pkt)
+        # Ignore the Ethernet padding zeros
+        masked_exp_pkt.set_ignore_extra_bytes()
+        return pkt, masked_exp_pkt
 
     def generatePackets(self):
         self.gen_pkts = {}
@@ -171,7 +177,12 @@ class ArpTest(BaseTest):
                 gw = test['vlan_gw']
                 port_ip  = test['vlan_ip_prefixes'][port]
                 port_mac = self.ptf_mac_addrs['eth%d' % port]
-                self.gen_pkts[port] = self.generatePkts(gw, port_ip, port_mac)
+                tagging_mode = test['tagging_mode'][port]
+                if tagging_mode == 'tagged':
+                    vlan_id = test['vlan_id']
+                else:
+                    vlan_id = 0
+                self.gen_pkts[port] = self.generatePkts(gw, port_ip, port_mac, vlan_id)
 
         return
 
@@ -208,24 +219,35 @@ class ArpTest(BaseTest):
 
         self.tests = []
         vni_base = 0
-        for name, data in graph['minigraph_vlans'].items():
+        for vlan, config in graph['vlan_facts'].items():
             test = {}
-            test['acc_ports'] = [graph['minigraph_port_indices'][member] for member in data['members']]
-            vlan_id = int(name.replace('Vlan', ''))
-            test['vni'] = vni_base + vlan_id
+            test['acc_ports'] = []
+            test['tagging_mode'] = {}
+            for member, mode in config['members'].items():
+                ptf_port_idx = graph['minigraph_port_indices'][member]
+                test['acc_ports'].append(ptf_port_idx)
+                test['tagging_mode'].update(
+                    {
+                        ptf_port_idx: mode['tagging_mode']
+                    }
+                )
+            test['vlan_id'] = int(config['vlanid'])
+            test['vni'] = vni_base + test['vlan_id']
 
             gw = None
             prefixlen = None
-            for d in graph['minigraph_vlan_interfaces']:
-                if d['attachto'] == name:
-                    gw = d['addr']
+            for d in config['interfaces']:
+                if sys.version_info < (3, 0):
+                        ip = ipaddress.ip_address(d['addr'].decode('utf8'))
+                else:
+                        ip = ipaddress.ip_address(d['addr'])
+                if ip.version == 4:
+                    test['vlan_gw'] = d['addr']
                     prefixlen = int(d['prefixlen'])
+                    test['vlan_ip_prefixes'] = self.generate_VlanPrefixes(d['addr'], prefixlen, test['acc_ports'])
                     break
             else:
-                raise Exception("Vlan '%s' is not found" % name)
-
-            test['vlan_gw'] = gw
-            test['vlan_ip_prefixes'] = self.generate_VlanPrefixes(gw, prefixlen, test['acc_ports'])
+                raise Exception("No invalid IPv4 address found for Vlan '%s'" % vlan)
 
             self.tests.append(test)
 

--- a/tests/vxlan/test_vnet_vxlan.py
+++ b/tests/vxlan/test_vnet_vxlan.py
@@ -21,7 +21,8 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.topology("t0"),
     pytest.mark.sanity_check(post_check=True),
-    pytest.mark.asic("mellanox")
+    pytest.mark.asic("mellanox"),
+    pytest.mark.disable_loganalyzer
 ]
 
 vlan_tagging_mode = ""
@@ -98,7 +99,7 @@ def setup(duthosts, rand_one_dut_hostname, ptfhost, minigraph_facts, vnet_config
     return minigraph_facts
 
 @pytest.fixture(params=["Disabled", "Enabled", "WR_ARP", "Cleanup"])
-def vxlan_status(setup, request, duthosts, rand_one_dut_hostname, ptfhost, vnet_test_params, vnet_config, creds):
+def vxlan_status(setup, request, duthosts, rand_one_dut_hostname, ptfhost, vnet_test_params, vnet_config, creds, tbinfo):
     """
     Paramterized fixture that tests the Disabled, Enabled, and Cleanup configs for VxLAN
 
@@ -139,7 +140,11 @@ def vxlan_status(setup, request, duthosts, rand_one_dut_hostname, ptfhost, vnet_
         cleanup_vxlan_tunnels(duthost, vnet_test_params)
     elif request.param == "WR_ARP":
         testWrArp = test_wr_arp.TestWrArp()
-        test_wr_arp.TestWrArp.testWrArp(testWrArp, request, duthost, ptfhost, creds)
+        testWrArp.Setup(duthost, ptfhost, tbinfo)
+        try:
+            test_wr_arp.TestWrArp.testWrArp(testWrArp, request, duthost, ptfhost, creds)
+        finally:
+            testWrArp.Teardown(duthost)
 
     return vxlan_enabled, request.param
 


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix wr_arp test with vnet config.
Changes include
1. Add an Ansible library `vlan_facts` to retrieve running vlan config from DUT
2. Improve `test_wr_arp` to make it callable from `vnet_vxlan` test
3. Improve `ferret.py` to support ARP request with VLAN tag 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
This PR is to fix wr_arp test with vnet config.

#### How did you do it?
1. Add an Ansible library `vlan_facts` to retrieve running vlan config from DUT
2. Improve `test_wr_arp` to make it callable from `vnet_vxlan` test
3. Improve `ferret.py` to support ARP request with VLAN tag 

#### How did you verify/test it?
Verified on SN4600c testbed.
```
collected 4 items                                                                                                                                                                                     

vxlan/test_vnet_vxlan.py::test_vnet_vxlan[Disabled] PASSED                                                                                                                                      [ 25%]
vxlan/test_vnet_vxlan.py::test_vnet_vxlan[Enabled] PASSED                                                                                                                                       [ 50%]
vxlan/test_vnet_vxlan.py::test_vnet_vxlan[WR_ARP] PASSED                                                                                                                                        [ 75%]
vxlan/test_vnet_vxlan.py::test_vnet_vxlan[Cleanup] PASSED                                                                                                                                       [100%]
```
#### Any platform specific information?
`Mellanox` platform specific testcase.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
