### PR TITLE
added m flag verification

### DIFF
--- a/ansible/roles/test/files/ptftests/router_adv_mflag_test.py
+++ b/ansible/roles/test/files/ptftests/router_adv_mflag_test.py
@@ -1,0 +1,253 @@
+# Packet Test Framework imports
+import logging
+
+import ptf
+import ptf.testutils as testutils
+import scapy.layers.inet6 as inet6
+import scapy.layers.l2 as l2
+from ptf import config
+from ptf.base_tests import BaseTest
+from ptf.mask import Mask
+import scapy.all as scapy2
+Ether = l2.Ether
+IPv6 = inet6.IPv6
+RA = inet6.ICMPv6ND_RA
+RS = inet6.ICMPv6ND_RS
+PrefixInfo = inet6.ICMPv6NDOptPrefixInfo
+
+ALL_NODES_MULTICAST_MAC_ADDRESS = '33:33:00:00:00:01'
+ALL_ROUTERS_MULTICAST_MAC_ADDRESS = '33:33:00:00:00:02'
+ALL_NODES_IPV6_MULTICAST_ADDRESS = 'ff02::1'
+ALL_ROUTERS_IPV6_MULTICAST_ADDRESS = 'ff02::2'
+ICMPV6_SOLICITED_RA_TIMEOUT_SECS = 1
+
+class DataplaneBaseTest(BaseTest):
+    def __init__(self):
+        BaseTest.__init__(self)
+
+    def setUp(self):
+        # Filter for ICMPv6 RA packets
+        def is_icmpv6_ra(pkt_str):
+            try:
+                pkt = Ether(pkt_str)
+                return (IPv6 in pkt and RA in pkt)
+            except Exception:
+                return False
+
+        self.dataplane = ptf.dataplane_instance
+        self.dataplane.flush()
+        testutils.add_filter(is_icmpv6_ra)
+
+        if config["log_dir"] is not None:
+            filename = os.path.join(config["log_dir"], str(self)) + ".pcap"
+            self.dataplane.start_pcap(filename)
+
+    def tearDown(self):
+        if config["log_dir"] is not None:
+            self.dataplane.stop_pcap()
+        testutils.reset_filters()
+
+    """
+    @summary: Creates an ICMPv6 router advertisement packet with ICMPv6 prefix option
+
+    """
+    def create_icmpv6_router_advertisement_packet_send(self, dst_mac, dst_ip, src_mac, src_ip):
+        ether = Ether(dst=dst_mac, src=src_mac)
+        ip6 = IPv6(src=src_ip, dst=dst_ip, fl=0, tc=0, hlim=255)
+        icmp6 = RA(code=0,M=1,O=0)
+        #NOTE: Test expects RA packet to contain route prefix as the first option
+        icmp6 /= PrefixInfo(type=3, len=4)
+        rapkt = ether / ip6 / icmp6
+        scapy2.sendp(rapkt, iface="eth1")
+        # sleep(4)
+        logging.info(scapy2.sniff(iface='eth1',timeout=10))
+        # testutils.send_packet(self, 0, rapkt)
+        # testutils.verify_packet_any_port(self, rapkt, [self.ptf_port_index])
+        return rapkt
+
+    """
+    @summary: Mask off fields we don't care about matching in RA packet
+    Match following fields of RA packet:-
+        1. Eth src and dest
+        2. Link local IPv6 src and dest
+        3. IP6 hop limit = 255
+        4. ICMPv6 RA type == 134 and code == 0
+        5. Flag M == 1 and O == 0
+        6. ICMPv6 prefix option (i.e type == 3 and len == 4)
+
+    """
+    def mask_off_dont_care_ra_packet_fields(self, rapkt):
+        masked_rapkt = Mask(rapkt)
+        masked_rapkt.set_ignore_extra_bytes()
+
+        masked_rapkt.set_do_not_care_scapy(IPv6, "tc")
+        masked_rapkt.set_do_not_care_scapy(IPv6, "fl")
+        masked_rapkt.set_do_not_care_scapy(IPv6, "plen")
+        masked_rapkt.set_do_not_care_scapy(IPv6, "nh")
+
+        masked_rapkt.set_do_not_care_scapy(RA, "cksum")
+        masked_rapkt.set_do_not_care_scapy(RA, "chlim")
+        masked_rapkt.set_do_not_care_scapy(RA, "H")
+        masked_rapkt.set_do_not_care_scapy(RA, "prf")
+        masked_rapkt.set_do_not_care_scapy(RA, "P")
+        masked_rapkt.set_do_not_care_scapy(RA, "res")
+        masked_rapkt.set_do_not_care_scapy(RA, "routerlifetime")
+        masked_rapkt.set_do_not_care_scapy(RA, "reachabletime")
+        masked_rapkt.set_do_not_care_scapy(RA, "retranstimer")
+
+        masked_rapkt.set_do_not_care_scapy(PrefixInfo, "prefixlen")
+        masked_rapkt.set_do_not_care_scapy(PrefixInfo, "L")
+        masked_rapkt.set_do_not_care_scapy(PrefixInfo, "A")
+        masked_rapkt.set_do_not_care_scapy(PrefixInfo, "R")
+        masked_rapkt.set_do_not_care_scapy(PrefixInfo, "res1")
+        masked_rapkt.set_do_not_care_scapy(PrefixInfo, "validlifetime")
+        masked_rapkt.set_do_not_care_scapy(PrefixInfo, "preferredlifetime")
+        masked_rapkt.set_do_not_care_scapy(PrefixInfo, "res2")
+        masked_rapkt.set_do_not_care_scapy(PrefixInfo, "prefix")
+
+        return masked_rapkt
+
+"""
+@summary: This test is to validate the unsolicted router advertisements sent on
+the VLAN network of the ToR. In this test we listen on the first PTF port
+(Eg eth0) for any RA messages.
+
+"""
+
+class RadvUnSolicitedRATest(DataplaneBaseTest):
+    def __init__(self):
+        DataplaneBaseTest.__init__(self)
+
+    def setUp(self):
+        DataplaneBaseTest.setUp(self)
+
+        self.test_params = testutils.test_params_get()
+
+        self.hostname = self.test_params['hostname']
+        self.downlink_vlan_mac = self.test_params['downlink_vlan_mac']
+        self.downlink_vlan_ip6 = self.test_params['downlink_vlan_ip6']
+        self.ptf_port_index = int(self.test_params['ptf_port_index'])
+        self.ptf_port_mac = self.dataplane.get_mac(0, self.ptf_port_index)
+        self.radv_max_ra_interval = int(self.test_params['max_ra_interval'])
+
+        rapkt = self.create_icmpv6_router_advertisement_packet_send(
+                                                src_mac=self.downlink_vlan_mac,
+                                                dst_mac=ALL_NODES_MULTICAST_MAC_ADDRESS,
+                                                src_ip=self.downlink_vlan_ip6,
+                                                dst_ip=ALL_NODES_IPV6_MULTICAST_ADDRESS)
+        self.masked_rapkt = self.mask_off_dont_care_ra_packet_fields(rapkt)
+
+
+    def tearDown(self):
+        DataplaneBaseTest.tearDown(self)
+
+    """
+    @summary: Verify received RA packet
+
+    """
+
+    def verify_periodic_router_advertisement_with_m_flag(self):
+        testutils.verify_packet(self,
+                                self.masked_rapkt,
+                                self.ptf_port_index,
+                                self.radv_max_ra_interval+1)
+        logging.info("Received unsolicited RA from:%s on PTF eth%d",
+                     self.downlink_vlan_ip6,
+                     self.ptf_port_index)
+        logging.info("Received unsolicited RA from:%s on PTF eth%d having M=1",
+                     self.downlink_vlan_ip6,
+                     self.ptf_port_index)
+        sk=scapy2.sniff(iface='eth1',timeout=10)
+        logging.info(sk)
+
+    def runTest(self):
+        count = 5
+        while count > 0:
+            self.verify_periodic_router_advertisement_with_m_flag()
+            count = count - 1
+
+"""
+@summary: This test validates the solicited router advertisement sent on the VLAN network of the ToR
+We simulate the ToR sending the ICMPv6 router solicitation packet through one of the PTF port (eg eth0)
+
+"""
+
+class RadvSolicitedRATest(DataplaneBaseTest):
+    def __init__(self):
+        DataplaneBaseTest.__init__(self)
+
+    def setUp(self):
+        DataplaneBaseTest.setUp(self)
+
+        self.test_params = testutils.test_params_get()
+
+        self.hostname = self.test_params['hostname']
+        self.downlink_vlan_mac = self.test_params['downlink_vlan_mac']
+        self.downlink_vlan_ip6 = self.test_params['downlink_vlan_ip6']
+        self.ptf_port_index = int(self.test_params['ptf_port_index'])
+        self.ptf_port_mac = self.dataplane.get_mac(0, self.ptf_port_index)
+        self.ptf_port_ip6 = self.test_params['ptf_port_ip6']
+        self.radv_max_ra_interval = int(self.test_params['max_ra_interval'])
+
+        rapkt = self.create_icmpv6_router_advertisement_packet_send(
+                                    src_mac=self.downlink_vlan_mac,
+                                    dst_mac=self.ptf_port_mac,
+                                    src_ip=self.downlink_vlan_ip6,
+                                    dst_ip=self.ptf_port_ip6)
+
+        self.masked_rapkt = self.mask_off_dont_care_ra_packet_fields(rapkt)
+        self.rs_packet = self.create_icmpv6_router_solicitation_packet()
+
+    def tearDown(self):
+        DataplaneBaseTest.tearDown(self)
+
+
+    """
+    @summary: Creates a solicited RA packet originating from PTF port
+
+    """
+    def create_icmpv6_router_solicitation_packet(self):
+        ether = Ether(dst=ALL_ROUTERS_MULTICAST_MAC_ADDRESS,
+                      src=self.ptf_port_mac)
+        ip6 = IPv6(dst=ALL_ROUTERS_IPV6_MULTICAST_ADDRESS,
+                   src=self.ptf_port_ip6,
+                   fl=0,
+                   tc=0,
+                   hlim=255)
+        icmp6 = RS(code=0, res=0)
+        rspkt = ether / ip6 / icmp6
+        return rspkt
+
+    """
+    @summary: Sends ICMPv6 router solicitation packet on PTF port
+
+    """
+    def ptf_send_icmpv6_router_solicitation(self):
+        logging.info("Sending ICMPv6 router solicitation on PTF port:eth%s",
+                     self.ptf_port_index)
+        ret = testutils.send_packet(self, self.ptf_port_index, self.rs_packet)
+        assert len(self.rs_packet) == ret, \
+               "Failed to send ICMPv6 router solicitation on PTF eth%s".format(self.ptf_port_index)
+
+    """
+    @summary: Verify the received solicited RA packet from the router/DUT
+
+    """
+    def verify_solicited_router_advertisement_with_m_flag(self):
+        testutils.verify_packet(self,
+                                self.masked_rapkt,
+                                self.ptf_port_index,
+                                ICMPV6_SOLICITED_RA_TIMEOUT_SECS)
+        logging.info("Received solicited RA from:%s on PTF eth%d",
+                     self.downlink_vlan_ip6,
+                     self.ptf_port_index)
+        logging.info("Received solicited RA from:%s on PTF eth%d having M=1",
+                     self.downlink_vlan_ip6,
+                     self.ptf_port_index)
+        
+    def runTest(self):
+        count = 5
+        while count > 0:
+            self.ptf_send_icmpv6_router_solicitation()
+            self.verify_solicited_router_advertisement_with_m_flag()
+            count = count - 1

--- a/tests/router_adv_with_m_flag/test_radv_mflag.py
+++ b/tests/router_adv_with_m_flag/test_radv_mflag.py
@@ -1,0 +1,165 @@
+import ipaddress
+import logging
+import time
+
+import pytest
+
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_garp_service # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
+from tests.common.helpers.assertions import pytest_assert
+from tests.ptf_runner import ptf_runner
+
+pytestmark = [
+    pytest.mark.topology('t0'),
+    pytest.mark.device_type('vs')
+]
+
+RADV_CONF_FILE = '/etc/radvd.conf'
+RADV_BACKUP_CONF_FILE = '/tmp/radvd.conf'
+RADV_MIN_RA_INTERVAL_SECS = 3
+RADV_MAX_RA_INTERVAL_SECS = 4
+
+"""
+@summary: This fixture collects the data related to downlink VLAN port(s) and
+the connected PTF port(s) required to setup the RADV tests
+
+"""
+
+@pytest.fixture(scope="module", autouse=True)
+def radv_test_setup(request, duthosts, ptfhost, tbinfo):
+    duthost = duthosts[0]
+    logging.info("radv_test_setup() DUT {}".format(duthost.hostname))
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+
+    # RADVd is configured for each VLAN interface
+    vlan_dict = mg_facts['minigraph_vlans']
+    vlan_interfaces_list = []
+    for vlan_iface_name, vlan_info_dict in vlan_dict.items():
+        # Gather information about the downlink VLAN interface this relay agent is listening on
+        downlink_vlan_iface = {}
+        downlink_vlan_iface['name'] = vlan_iface_name
+
+        # Obtain the link-local IPv6 address of the DUT's downlink VLAN interface
+        downlink_vlan_iface['mac'] = duthost.get_dut_iface_mac(vlan_iface_name)
+        cmd = "ip -6 -o addr show dev {} scope link | sed -e's/^.*inet6 \([^ ]*\)\/.*$/\\1/;t;d'".format(vlan_iface_name)
+        res = duthost.shell(cmd)
+        ip6 = ipaddress.IPv6Address(unicode(res['stdout']))
+        pytest_assert(ip6.is_link_local,
+                "ip6 address:{} of {} is not a link-local address".format(str(ip6), downlink_vlan_iface['name']))
+        downlink_vlan_iface['ip6'] = str(ip6)
+
+        # Obtain link-local IPv6 address of the connected PTF port (Eg eth0)
+        # This PTF port maps to the first member of the TOR's VLAN
+        ptf_port = {}
+        ptf_port['port_idx'] = mg_facts['minigraph_ptf_indices'][vlan_info_dict['members'][0]]
+        ptf_port['name'] = "eth" + str(ptf_port['port_idx'])
+        cmd = "ip -6 -o addr show dev {} scope link | sed -e's/^.*inet6 \([^ ]*\)\/.*$/\\1/;t;d'".format(ptf_port['name'])
+        res = ptfhost.shell(cmd)
+        ip6 = ipaddress.IPv6Address(unicode(res['stdout']))
+        pytest_assert(ip6.is_link_local,
+                "ip6 address:{} of {} is not a link-local address".format(str(ip6), ptf_port['name']))
+        ptf_port['ip6'] = str(ip6)
+
+        vlan_intf_data = {}
+        vlan_intf_data['downlink_vlan_intf'] = downlink_vlan_iface
+        vlan_intf_data['ptf_port'] = ptf_port
+        vlan_interfaces_list.append(vlan_intf_data)
+
+    return vlan_interfaces_list
+
+"""
+@summary: Updates min/max RA interval in RADVd's config file
+
+"""
+
+def dut_update_ra_interval(duthost, ra, interval):
+    logging.info("Updating %s to %d in RADVd's config file:%s", ra, int(interval), RADV_CONF_FILE)
+    cmd = "sed -ie 's/\(.*\)\({}\) \([[:digit:]]\+\)/\\1\\2 {}/' {}".format(ra, interval, RADV_CONF_FILE)
+    duthost.shell("docker exec radv {}".format(cmd))
+
+"""
+@summary: A fixture that updates the RADVd's periodic RA update intervals and restores the
+intervals to old values after the test
+
+"""
+@pytest.fixture
+def dut_update_radv_periodic_ra_interval(duthost):
+    pytest_assert(duthost.is_service_fully_started('radv'), "radv service not running")
+
+    cmd = 'docker exec radv [ -f {} ] && echo "1" || echo "0"'.format(RADV_CONF_FILE)
+    pytest_assert(u'1' == duthost.shell(cmd)["stdout"], "radv conf file {} NOT found".format(RADV_CONF_FILE))
+
+    # Take backup of original radvd.conf before updating
+    duthost.shell('docker exec radv cp {} {}'.format(RADV_CONF_FILE, RADV_BACKUP_CONF_FILE))
+
+    dut_update_ra_interval(duthost, "MinRtrAdvInterval", RADV_MIN_RA_INTERVAL_SECS)
+    dut_update_ra_interval(duthost, "MaxRtrAdvInterval", RADV_MAX_RA_INTERVAL_SECS)
+
+    # Notify RADVd to read the updated RA intervals
+    logging.info("Notifying RADVd to read the updated config file:%s", RADV_CONF_FILE)
+    duthost.shell("docker exec radv supervisorctl signal SIGHUP radvd")
+
+    yield
+    # Restore the original radvd.conf file
+    duthost.shell('docker exec radv cp {} {}'.format(RADV_BACKUP_CONF_FILE, RADV_CONF_FILE))
+    duthost.shell('docker exec radv rm -f {}'.format(RADV_BACKUP_CONF_FILE))
+    duthost.shell("docker exec radv supervisorctl signal SIGHUP radvd")
+    logging.info("Successfully restored RADVd's config back to original")
+
+"""
+@summary: Test validates the RADVd's periodic router advertisement sent on each VLAN interface
+
+"""
+def test_unsolicited_router_advertisement(
+                    request, tbinfo,
+                    duthost, ptfhost,
+                    radv_test_setup,
+                    dut_update_radv_periodic_ra_interval):
+    if 'dualtor' in tbinfo['topo']['name']:
+        request.getfixturevalue('toggle_all_simulator_ports_to_upper_tor')
+
+    for vlan_intf in radv_test_setup:
+        # Run the RADV test on the PTF host
+        logging.info("Verifying RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
+                                                vlan_intf['downlink_vlan_intf']['name'],
+                                                vlan_intf['ptf_port']['port_idx'])
+        ptf_runner(ptfhost,
+                   "ptftests",
+                   "router_adv_mflag_test.RadvUnSolicitedRATest",
+                   platform_dir="ptftests",
+                   params={"hostname": duthost.hostname,
+                           "downlink_vlan_mac": vlan_intf['downlink_vlan_intf']['mac'],
+                           "downlink_vlan_ip6": vlan_intf['downlink_vlan_intf']['ip6'],
+                           "ptf_port_index": vlan_intf['ptf_port']['port_idx'],
+                           "max_ra_interval": RADV_MAX_RA_INTERVAL_SECS},
+                   log_file="/tmp/router_adv_mflag_test.RadvUnSolicitedRATest.log")
+
+"""
+@summary: Test validates the RADVd's solicited router advertisement sent on each VLAN interface
+
+"""
+
+def test_solicited_router_advertisement(request, tbinfo, ptfhost, duthost, radv_test_setup):
+    if 'dualtor' in tbinfo['topo']['name']:
+        request.getfixturevalue('toggle_all_simulator_ports_to_upper_tor')
+
+    for vlan_intf in radv_test_setup:
+        # Run the RADV solicited RA test on the PTF host
+        logging.info("Verifying solicited RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
+                                                        vlan_intf['downlink_vlan_intf']['name'],
+                                                        vlan_intf['ptf_port']['port_idx'])
+        ptf_runner(ptfhost,
+                   "ptftests",
+                   "router_adv_mflag_test.RadvSolicitedRATest",
+                   platform_dir="ptftests",
+                   params={"hostname": duthost.hostname,
+                           "downlink_vlan_mac": vlan_intf['downlink_vlan_intf']['mac'],
+                           "downlink_vlan_ip6": vlan_intf['downlink_vlan_intf']['ip6'],
+                           "ptf_port_index": vlan_intf['ptf_port']['port_idx'],
+                           "ptf_port_ip6": vlan_intf['ptf_port']['ip6'],
+                           "max_ra_interval": RADV_MAX_RA_INTERVAL_SECS},
+                   log_file="/tmp/router_adv_mflag_test.RadvSolicitedRATest.log")


### PR DESCRIPTION

### Description of PR
This testcase is to verify m flag in the Router Advertise packet at DHCPv6 client port coming from T0 switch 

Summary:
Fixes # (issue)
1. Create RA packets and verify those at one of  PTF interface (DHCP client).
2. sniffed RA packets  at DHCP client interface and checked for M flag.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To verify M flag setting to 1 in Router Advertisement packet sending from T0 switch
#### How did you do it?
Wrote a script to sniff Router Advertisement packet at DHCP client side.
#### How did you verify/test it?
Ran test_radv_mflag.py on T0 testbed setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
currently tested on T0 setup with CEOS Neighbors


