### PR TITLE
Collect db dump from each asic on multi-asic DUT

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1388,8 +1388,12 @@ def collect_db_dump_on_duts(request, duthosts):
         state_db_id = db_config['DATABASES']['STATE_DB']['id']
         for db in db_config['DATABASES']:
             db_id = db_config['DATABASES'][db]['id']
-            # Skip STATE_DB dump on release 201911
-            # JINJA2_CACHE can't be dumped by "redis-dump", and it is stored in STATE_DB on 201911 release
+            # Skip STATE_DB dump on release 201911.
+            # JINJA2_CACHE can't be dumped by "redis-dump", and it is stored in STATE_DB on 201911 release.
+            # Please refer to issue: https://github.com/Azure/sonic-buildimage/issues/5587.
+            # The issue has been fixed in https://github.com/Azure/sonic-buildimage/pull/5646.
+            # However, the fix is not included in 201911 release. So we have to skip STATE_DB on release 201911
+            # to avoid raising exception when dumping the STATE_DB.
             if i == state_db_id and duthosts[0].sonic_release in ['201911']:
                 continue
             dbs.add(db_id)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Db dump use 'redis-dump' to dump files, but on multi-asic DUT, output
filename matches with the directory name within the same folder.

#### How did you do it?
Use "ip netns exec 'namespace' redis-dump" to collect dumps from each
asic on multi-asic DUT.

#### How did you verify/test it?
Run test in some loops

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
