### PR TITLE
Cisco platform: Fix to match N/A led output in show platform psustatus cli

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -30,7 +30,7 @@ def fanout_switch_port_lookup(fanout_switches, dut_name, dut_port):
 def get_dut_psu_line_pattern(dut):
     if "201811" in dut.os_version or "201911" in dut.os_version:
         psu_line_pattern = re.compile(r"PSU\s+(\d)+\s+(OK|NOT OK|NOT PRESENT)")
-    elif dut.facts['platform'] == "x86_64-dellemc_z9332f_d1508-r0":
+    elif dut.facts['platform'] == "x86_64-dellemc_z9332f_d1508-r0" or dut.facts['asic_type'] == "cisco-8000":
         psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT)\s+(N/A)")
     else:
         """

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -221,7 +221,7 @@ def test_show_platform_psustatus_json(duthosts, enum_supervisor_dut_hostname):
     psu_info_list = json.loads(psu_status_output)
 
     # TODO: Compare against expected platform-specific output
-    if duthost.facts["platform"] == "x86_64-dellemc_z9332f_d1508-r0":
+    if duthost.facts["platform"] == "x86_64-dellemc_z9332f_d1508-r0" or duthost.facts['asic_type'] == "cisco-8000":
         led_status_list = ["N/A"]
     else:
         led_status_list = ["green", "amber", "red", "off"]


### PR DESCRIPTION

### Description of PR
Cisco platforms do not display the color of the LED in the "show platform psustatus" cli.
Hence 'N/A' is a valid PSU LED status for this platform.
Including code here to accept N/A as acceptable status when "show platform psustatus" cli is executed" for the below TCs

platform_tests/cli/test_show_platform.py::test_show_platform_psustatus_json
platform_tests/cli/test_show_platform.py::test_show_platform_psustatus

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

To match N/A for psu led output in cisco platform

#### How did you do it?

Added cisco-8000 asic-type check

#### How did you verify/test it?

Verified on cisco-8000 platform and all tests passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
