### PR TITLE
[Vrf] Added extra check for TestVrfCapacity

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -21,6 +21,7 @@ from tests.common.storage_backend.backend_utils import skip_test_module_over_bac
 from tests.ptf_runner import ptf_runner
 from tests.common.utilities import wait_until
 from tests.common.reboot import reboot
+from tests.common.helpers.assertions import pytest_assert
 
 """
     During vrf testing, a vrf basic configuration need to be setup before any tests,
@@ -379,6 +380,16 @@ def get_dut_vlan_ptf_ports(mg_facts):
         for member in mg_facts['minigraph_vlans'][vlan]['members']:
             ports.add(mg_facts['minigraph_port_indices'][member])
     return ports
+
+def check_vlan_members(duthost, member1, member2, exp_count):
+    out1 = duthost.shell("redis-cli -n 6 keys 'VLAN_MEMBER_TABLE|*|{}' | wc -l".format(member1))['stdout']
+    out2 = duthost.shell("redis-cli -n 6 keys 'VLAN_MEMBER_TABLE|*|{}' | wc -l".format(member2))['stdout']
+    added = int(out1) + int(out2)
+    if added >= exp_count * 2:
+        logger.info('All vlan members added')
+        return True
+    logger.info('Not all vlan members are added, {} when expected => {}'.format(added, (exp_count * 2)))
+    return False
 
 # fixtures
 
@@ -1214,7 +1225,11 @@ class TestVrfCapacity():
             duthost.template(src=src_template, dest=render_file)
             duthost.shell("sonic-cfggen -j {} --write-to-db".format(render_file))
 
-            time.sleep(attrs['add_sleep_time'])
+            if cfg_name == 'vlan_member':
+                pytest_assert(wait_until(220, 10, 0, check_vlan_members, duthost, dut_port1, dut_port2, vrf_count),
+                              "Not all vlan members were added by the end of timeout")
+            else:
+                time.sleep(attrs['add_sleep_time'])
 
         # setup static routes
         duthost.template(src='vrf/vrf_capacity_route_cfg.j2', dest='/tmp/vrf_capacity_route_cfg.sh', mode="0755")


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: When executing test cases under **TestVrfCapacity**  it is seen that setup configuration may still be applying on DUT when test cases are already started, which leads to fail of test cases **test_ping** or **test_ip_fwd**. It was spotted that adding of around **2000** vlan members may still be in progress  when test case is started. In order to make sure that this setup is finished, a check for vlan members was added. 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Make TestVrfCapacity test cases more stable
#### How did you do it?

#### How did you verify/test it?
Run TestVrfCapacity on t0 topology 
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.79661-dirty-20220309.185027
Distribution: Debian 11.2
Kernel: 5.10.0-8-2-amd64
Build commit: 3fa18d18d
Build date: Wed Mar  9 18:58:08 UTC 2022
Built by: AzDevOps@sonic-build-workers-0018RF
Platform: x86_64-accton_as9516_32d-r0
HwSKU: newport
```
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
