### PR TITLE
Restart tunnel_packet_handler if it's not running in test_tunnel_memory_leak.py

### DIFF
--- a/tests/dualtor/test_tunnel_memory_leak.py
+++ b/tests/dualtor/test_tunnel_memory_leak.py
@@ -57,6 +57,11 @@ def is_tunnel_packet_handler_running(duthost):
         bool: True if tunnel_packet_handler is running. Otherwise, return False.
     """
     status, _ = get_program_info(duthost, "swss", "tunnel_packet_handler")
+    # if tunnel_packet_handler is not running, restart it
+    if status != 'RUNNING':
+        duthost.command("docker exec swss supervisorctl restart tunnel_packet_handler")
+        time.sleep(2)
+    status, _ = get_program_info(duthost, "swss", "tunnel_packet_handler")
     return status == 'RUNNING'
 
 def check_memory_leak(duthost):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Restart tunnel_packet_handler if it's not running in test_tunnel_memory_leak.py

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Sometimes, test case will fail due to tunnel_packet_handler is not running.

#### How did you do it?
Restart tunnel_packet_handler service in swss if found it's not running at first time.
If it's still not running, the test case will fail.

#### How did you verify/test it?
run tests/dualtor/test_tunnel_memory_leak.py

#### Any platform specific information?
dualtor

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
