### PR TITLE
[sensors] updated x86_64-arista_7170_64c sensors sku data

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -3196,24 +3196,24 @@ sensors_checks:
       - \[a-zA-Z0-9]*\-i2c-6-58/iin/curr1_max_alarm
       - \[a-zA-Z0-9]*\-i2c-6-58/iout1/curr2_crit_alarm
       - \[a-zA-Z0-9]*\-i2c-6-58/iout1/curr2_max_alarm
-      - \[a-zA-Z0-9]*\-i2c-6-58/vin/in1_alarm
-      - \[a-zA-Z0-9]*\-i2c-6-58/vout1/in2_crit_alarm
-      - \[a-zA-Z0-9]*\-i2c-6-58/vout1/in2_lcrit_alarm
+      - \[a-zA-Z0-9]*\-i2c-6-58/vin/in1_min_alarm
+      - \[a-zA-Z0-9]*\-i2c-6-58/vout1/in3_crit_alarm
+      - \[a-zA-Z0-9]*\-i2c-6-58/vout1/in3_lcrit_alarm
       - \[a-zA-Z0-9]*\-i2c-7-58/iin/curr1_max_alarm
       - \[a-zA-Z0-9]*\-i2c-7-58/iout1/curr2_crit_alarm
       - \[a-zA-Z0-9]*\-i2c-7-58/iout1/curr2_max_alarm
-      - \[a-zA-Z0-9]*\-i2c-7-58/vin/in1_alarm
-      - \[a-zA-Z0-9]*\-i2c-7-58/vout1/in2_crit_alarm
-      - \[a-zA-Z0-9]*\-i2c-7-58/vout1/in2_lcrit_alarm
+      - \[a-zA-Z0-9]*\-i2c-7-58/vin/in1_min_alarm
+      - \[a-zA-Z0-9]*\-i2c-7-58/vout1/in3_crit_alarm
+      - \[a-zA-Z0-9]*\-i2c-7-58/vout1/in3_lcrit_alarm
       temp:
         # to specify regular expression use backslash '\' at the beginning and end of expression
       - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit_alarm
       - coretemp-isa-0000/Core 0/temp2_crit_alarm
       - coretemp-isa-0000/Core 1/temp3_crit_alarm
-      - \[a-zA-Z0-9]*\-i2c-6-58/PSU1 primary hotspot temp/temp1_alarm
-      - \[a-zA-Z0-9]*\-i2c-6-58/PSU1 inlet temp/temp2_alarm
-      - \[a-zA-Z0-9]*\-i2c-7-58/PSU2 primary hotspot temp/temp1_alarm
-      - \[a-zA-Z0-9]*\-i2c-7-58/PSU2 inlet temp/temp2_alarm
+      - \[a-zA-Z0-9]*\-i2c-6-58/PSU1 primary hotspot temp/temp1_crit_alarm
+      - \[a-zA-Z0-9]*\-i2c-6-58/PSU1 inlet temp/temp2_crit_alarm
+      - \[a-zA-Z0-9]*\-i2c-7-58/PSU2 primary hotspot temp/temp1_crit_alarm
+      - \[a-zA-Z0-9]*\-i2c-7-58/PSU2 inlet temp/temp2_crit_alarm
       - lm73-i2c-96-48/Front air temp/temp1_max_alarm
       - lm73-i2c-96-48/Front air temp/temp1_min_alarm
       - max6658-i2c-8-4c/Temp sensor near ASIC/temp1_crit_alarm


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
After SONiC [master](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=79661) sensors case started failing with errors:
`"temp_reasons": [
E               "Path \\[a-zA-Z0-9]*\\-i2c-6-58/PSU1 primary hotspot temp/temp1_alarm is not exist", 
E               "Path \\[a-zA-Z0-9]*\\-i2c-6-58/PSU1 inlet temp/temp2_alarm is not exist", 
E               "Path \\[a-zA-Z0-9]*\\-i2c-7-58/PSU2 primary hotspot temp/temp1_alarm is not exist", 
E               "Path \\[a-zA-Z0-9]*\\-i2c-7-58/PSU2 inlet temp/temp2_alarm is not exist"
E           ], 
E           "fan_reasons": [], 
E           "fan": false, 
E           "temp": true, 
E           "power": true, 
E           "power_reasons": [
E               "Path \\[a-zA-Z0-9]*\\-i2c-6-58/vin/in1_alarm is not exist", 
E               "Path \\[a-zA-Z0-9]*\\-i2c-6-58/vout1/in2_crit_alarm is not exist", 
E               "Path \\[a-zA-Z0-9]*\\-i2c-6-58/vout1/in2_lcrit_alarm is not exist", 
E               "Path \\[a-zA-Z0-9]*\\-i2c-7-58/vin/in1_alarm is not exist", 
E               "Path \\[a-zA-Z0-9]*\\-i2c-7-58/vout1/in2_crit_alarm is not exist", 
E               "Path \\[a-zA-Z0-9]*\\-i2c-7-58/vout1/in2_lcrit_alarm is not exist"`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Make sensors case working for x86_64-arista_7170_64c platform
#### How did you do it?
Updated sensors data in community
#### How did you verify/test it?
Run sensors case, TC passed
#### Any platform specific information?
SONiC Software Version: SONiC.master.79661-dirty-20220309.124216
Distribution: Debian 11.2
Kernel: 5.10.0-8-2-amd64
Build commit: 3fa18d18d
Build date: Wed Mar  9 16:36:08 UTC 2022
Built by: AzDevOps@sonic-build-workers-0018RF

Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
