### PR TITLE
DB dump fix and improvement

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1438,7 +1438,7 @@ def collect_db_dump_on_duts(request, duthosts):
     if hasattr(request.node, 'rep_call') and request.node.rep_call.failed:
         dut_file_path = "/tmp/db_dump"
         docker_file_path = "./logs/db_dump"
-        db_dump_tarfile = "{}.tar.gz".format(dut_file_path)
+        db_dump_tarfile = "{}-{}.tar.gz".format(dut_file_path, request.node.name)
 
         # Collect DB config
         dbs = set()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1442,7 +1442,7 @@ def collect_db_dump_on_duts(request, duthosts):
 
         # Collect DB config
         dbs = set()
-        result = duthosts[0].shell("cat /var/run/redis/sonic-db/database_config.json")
+        result = duthosts[0].command(argv=["cat", "/var/run/redis/sonic-db/database_config.json"])
         db_config = json.loads(result['stdout'])
         state_db_id = db_config['DATABASES']['STATE_DB']['id']
         for db in db_config['DATABASES']:
@@ -1461,22 +1461,22 @@ def collect_db_dump_on_duts(request, duthosts):
         if namespace_list:
             for namespace in namespace_list:
                 # Collect DB dump
-                db_dump_path = os.path.join(dut_file_path + "/" + namespace, request.module.__name__, request.node.name)
+                db_dump_path = os.path.join(dut_file_path, namespace, request.module.__name__, request.node.name)
                 duthosts.file(path=db_dump_path, state="directory")
                 for i in dbs:
-                    duthosts.shell("ip netns exec {} redis-ducmp -d {} -y -o {}/{}".format(namespace, i, db_dump_path, i))
+                    duthosts.command(argv=["ip", "netns", "exec", namespace, "redis-dump", "-d", "{}".format(i), "-y", "-o", "{}/{}".format(db_dump_path, i)])
         else:
             # Collect DB dump
             db_dump_path = os.path.join(dut_file_path, request.module.__name__, request.node.name)
             duthosts.file(path = db_dump_path, state="directory")
             for i in dbs:
-                duthosts.shell("redis-dump -d {} -y -o {}/{}".format(i, db_dump_path, i))
+                duthosts.command(argv=["redis-dump", "-d", "{}".format(i), "-y", "-o", "{}/{}".format(db_dump_path, i)])
 
         #compress dump file and fetch to docker
-        duthosts.shell("tar czf {} {}".format(db_dump_tarfile, dut_file_path))
+        duthosts.command(argv=["tar", "czf", db_dump_tarfile, dut_file_path])
         duthosts.fetch(src = db_dump_tarfile, dest = docker_file_path)
         #remove dump file from dut
-        duthosts.shell("rm -rf {} {}".format(dut_file_path, db_dump_tarfile))
+        duthosts.command(argv=["rm", "-rf", db_dump_tarfile, dut_file_path])
 
 @pytest.fixture(autouse=True)
 def collect_db_dump(request, duthosts):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->

### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Make a couple changes related to doing the DB dump (in the case of test failure) and file naming.

1. For the DB dump, if there's special characters used in the file name, then this code may fail due to bash parsing/expansion. To fix this, avoid the shell and execute the command directly.
2. For the DB dump file name, include the test case name in the DB dump. This avoids the DB dump from test cases that failed later from overwriting ones from earlier failed tests.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

If the container autorestart test case fails, the DB dump also fails to be collected. This might not be particularly important for debugging this category of test case failures, but it's still good to fix.

#### How did you do it?

#### How did you verify/test it?

Verified by running the container autorestart test case on VS, which fails for some containers.

New file names for the db dump:

```
$ ls -l tests/logs/db_dump/vlab-01/tmp/
total 2536
-rw-rw-r-- 1 sarcot sarcot 513986 Mar 17 10:37 'db_dump-test_containers_autorestart[vlab-01-vlab-01|dhcp_relay].tar.gz'
-rw-rw-r-- 1 sarcot sarcot 517832 Mar 17 10:37 'db_dump-test_containers_autorestart[vlab-01-vlab-01|gbsyncd].tar.gz'
-rw-rw-r-- 1 sarcot sarcot 516843 Mar 17 10:38 'db_dump-test_containers_autorestart[vlab-01-vlab-01|swss].tar.gz'
-rw-rw-r-- 1 sarcot sarcot 519364 Mar 17 10:38 'db_dump-test_containers_autorestart[vlab-01-vlab-01|syncd].tar.gz'
-rw-rw-r-- 1 sarcot sarcot 519771 Mar 17 10:35 'db_dump-test_containers_autorestart[vlab-01-vlab-01|teamd].tar.gz'
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
