### PR TITLE
Run the 'apt-get update' as a separate and retryable step

### DIFF
--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -47,8 +47,19 @@
   become: yes
   when: host_distribution_version.stdout == "20.04" and docker_repo.matched == 0
 
+# In ansible 2.8, there isn't update_cache_retries option in apt module, we can manually run update as a seperate and retryable step
+- name: Run the "apt-get update" as a separate and retryable step
+  apt:
+    update_cache: yes
+  become: yes
+  environment: "{{ proxy_env | default({}) }}"
+  register: apt_update_res
+  until: apt_update_res.cache_updated
+  retries: 5
+  delay: 10
+
 - name: Install docker-ce
-  apt: pkg=docker-ce update_cache=yes
+  apt: pkg=docker-ce
   become: yes
   environment: "{{ proxy_env | default({}) }}"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes update apt-cache issue during installing docker-ce
https://dev.azure.com/mssonic/build/_build/results?buildId=81373&view=logs&j=7ecf62ce-878c-5860-615d-9d0f5ab291f1&t=0a296980-122d-53ca-ae78-10e55d018eb3&l=838
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fixes update apt-cache issue during installing docker-ce
https://dev.azure.com/mssonic/build/_build/results?buildId=81373&view=logs&j=7ecf62ce-878c-5860-615d-9d0f5ab291f1&t=0a296980-122d-53ca-ae78-10e55d018eb3&l=838
#### How did you do it?
In ansible 2.8, there isn't update_cache_retries option in apt module, we can manually run update as a seperate and retryable step
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
