### PR TITLE
Fix duplicated "skip" in the mark conditions yaml file for platform tests

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -563,13 +563,11 @@ platform_tests/test_platform_info.py::test_thermal_control_load_invalid_format_j
   #Thermal policies are implemented as part of BSP layer in Cisco 8000 platform, so there is no need for loading JSON file,
   #hence the test case needs to be skipped
   skip:
-    reason: "Cisco platforms use different mechanism to generate thermal policy, current method is not applicable"
+    # Cisco platforms use different mechanism to generate thermal policy, current method is not applicable
+    # Multi ASIC platform running 201911 release doesn't have thermalctld
+    reason: "Skip on Cisco platform and multi-asic platform running 201911 release"
     conditions:
-      - "asic_type=='cisco-8000'"
-  skip:
-    reason: "Multi ASIC platfrom running 201911 release doesn't have thermalctld"
-    conditions:
-      - "is_multi_asic==True and release in ['201911']"
+      - "asic_type=='cisco-8000' or (is_multi_asic==True and release in ['201911'])"
 
 platform_tests/test_platform_info.py::test_thermal_control_load_invalid_value_json:
   xfail:
@@ -580,13 +578,11 @@ platform_tests/test_platform_info.py::test_thermal_control_load_invalid_value_js
   #Thermal policies are implemented as part of BSP layer in Cisco 8000 platform, so there is no need for loading JSON file,
   #hence the test case needs to be skipped
   skip:
-    reason: "Cisco platforms use different mechanism to generate thermal policy, current method is not applicable"
+    # Cisco platforms use different mechanism to generate thermal policy, current method is not applicable
+    # Multi ASIC platform running 201911 release doesn't have thermalctld
+    reason: "Skip on Cisco platform and multi-asic platform running 201911 release"
     conditions:
-      - "asic_type=='cisco-8000'"
-  skip:
-    reason: "Multi ASIC platfrom running 201911 release doesn't have thermalctld"
-    conditions:
-      - "is_multi_asic==True and release in ['201911']"
+      - "asic_type=='cisco-8000' or (is_multi_asic==True and release in ['201911'])"
 
 #######################################
 #####        test_reboot.py       #####


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
PR #5163 added conditional mark to skip 2 platform test cases on multi-asic running 201911 release.
The problem is that the change introduced duplicated entry to the yaml file and broke the existing
skip mark condition.

#### How did you do it?
This change merged the conditions using "or" logic.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
