### PR TITLE
Output full information when test case test_service_checker fails

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -109,8 +109,9 @@ def test_service_checker(duthosts, enum_rand_one_per_hwsku_hostname):
 
         expect_summary = SUMMARY_OK if not expect_error_dict else SUMMARY_NOT_OK
         result = wait_until(WAIT_TIMEOUT, 10, 2, check_system_health_info, duthost, 'summary', expect_summary)
-        summary = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, 'summary')
-        assert result == True, 'Expect summary {}, got {}'.format(expect_summary, summary)
+        # Output the content of whole SYSTEM_HEALTH_INFO table for easy debug when test case failed.
+        table_output = redis_get_system_health_info(duthost, STATE_DB, HEALTH_TABLE_NAME)
+        assert result == True, 'Expect summary {}, got {}'.format(expect_summary, table_output)
 
 
 @pytest.mark.disable_loganalyzer
@@ -136,7 +137,7 @@ def test_service_checker_with_process_exit(duthosts, enum_rand_one_per_hwsku_hos
                 result = wait_until(WAIT_TIMEOUT, 10, 2, check_system_health_info, duthost, category, expected_value)
                 assert result == True, '{} is not recorded'.format(critical_process)
                 summary = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, 'summary')
-                assert summary == SUMMARY_NOT_OK
+                assert summary == SUMMARY_NOT_OK, 'Expect summary {}, got {}'.format(SUMMARY_NOT_OK, summary)
             break
 
 
@@ -357,6 +358,11 @@ def redis_get_field_value(duthost, db_id, key, field_name):
     output = duthost.shell(cmd)
     content = output['stdout'].strip()
     return content
+
+def redis_get_system_health_info(duthost, db_id, key):
+    cmd = 'redis-cli --raw -n {} HGETALL \"{}\"'.format(db_id, key)
+    output = duthost.shell(cmd)['stdout'].strip()
+    return output
 
 def check_system_health_info(duthost, category, expected_value):
     value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, category)


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

When test case test_service_checker fails, it just reports "Summary Not OK", it doesn't show why test case fails.
Output the content of whole SYSTEAM_HEALTH_INFO table when test case fails, developers can easily know what cause this case failed, which service is not running.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
When test case test_service_checker fails, it just reports "Summary Not OK", it doesn't show why test case fails.

#### How did you do it?
Output the content of whole SYSTEAM_HEALTH_INFO table when test case fails, developers can easily know what cause this case failed, which service is not running.

#### How did you verify/test it?
run tests/system_health/test_system_health.py::test_service_checker

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
