### PR TITLE
Workaround code bug in verify_packets_any

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ from tests.common.utilities import str2bool
 from tests.platform_tests.args.advanced_reboot_args import add_advanced_reboot_args
 from tests.platform_tests.args.cont_warm_reboot_args import add_cont_warm_reboot_args
 from tests.platform_tests.args.normal_reboot_args import add_normal_reboot_args
-
+from ptf import testutils # lgtm[py/unused-import]
 
 logger = logging.getLogger(__name__)
 cache = FactsCache()
@@ -1485,3 +1485,41 @@ def collect_db_dump(request, duthosts):
     '''
     yield
     collect_db_dump_on_duts(request, duthosts)
+
+def verify_packets_any_fixed(test, pkt, ports=[], device_number=0):
+    """
+    Check that a packet is received on _any_ of the specified ports belonging to
+    the given device (default device_number is 0).
+
+    Also verifies that the packet is not received on any other ports for this
+    device, and that no other packets are received on the device (unless --relax
+    is in effect).
+
+    The function is redefined here to workaround code bug in testutils.verify_packets_any
+    """
+    received = False
+    failures = []
+    for device, port in testutils.ptf_ports():
+        if device != device_number:
+            continue
+        if port in ports:
+            logging.debug("Checking for pkt on device %d, port %d", device_number, port)
+            result = testutils.dp_poll(test, device_number=device, port_number=port, exp_pkt=pkt)
+            if isinstance(result, test.dataplane.PollSuccess):
+                received = True
+            else:
+                failures.append((port, result))
+        else:
+            testutils.verify_no_packet(test, pkt, (device, port))
+    testutils.verify_no_other_packets(test)
+
+    if not received:
+        def format_failure(port, failure):
+            return "On port %d:\n%s" % (port, failure.format())
+        failure_report = "\n".join([format_failure(*f) for f in failures])
+        test.fail("Did not receive expected packet on any of ports %r for device %d.\n%s"
+                    % (ports, device_number, failure_report))
+
+# Hack testutils.verify_packets_any to workaround code bug
+# Todo: delete me when ptf version is advanced than https://github.com/p4lang/ptf/pull/139
+testutils.verify_packets_any = verify_packets_any_fixed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1520,6 +1520,6 @@ def verify_packets_any_fixed(test, pkt, ports=[], device_number=0):
         test.fail("Did not receive expected packet on any of ports %r for device %d.\n%s"
                     % (ports, device_number, failure_report))
 
-# Hack testutils.verify_packets_any to workaround code bug
-# Todo: delete me when ptf version is advanced than https://github.com/p4lang/ptf/pull/139
+# HACK: testutils.verify_packets_any to workaround code bug
+# TODO: delete me when ptf version is advanced than https://github.com/p4lang/ptf/pull/139
 testutils.verify_packets_any = verify_packets_any_fixed


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to add a hot fix for code bug in https://github.com/chestercheng/ptf/blob/f8b201918263d2e292e6ec3f40638ede618715bd/src/ptf/testutils.py#L2666
The error message would be 
```
TypeError: format_failure() takes exactly 2 arguments (1 given)
```
if the bug is hit.
Actually, the bug has been fixed by PR https://github.com/p4lang/ptf/pull/139. But a hot fix is required until the integrated ptf is updated.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
This PR is to add a hotfix for a ptf code bug.

#### How did you do it?
Replace `testutils.verify_packets_any` with a fixed version. The hack is applied at `conftest.py`, so it has a global effect.

#### How did you verify/test it?
1. Verified by running `test_vlan_tc4_tagged_unicast` and confirmed the test can pass
2. Verified by manually triggering the exception, and confirm the custom code is in place by backtrace
```
File "/data/sonic-mgmt/tests/vlan/test_vlan.py", line 400, in test_vlan_tc4_tagged_unicast
    verify_unicast_packets(ptfadapter, transmit_tagged_pkt, transmit_tagged_pkt, src_port[0], dst_port)
  File "/data/sonic-mgmt/tests/vlan/test_vlan.py", line 280, in verify_unicast_packets
    testutils.verify_packets_any(ptfadapter, exp_pkt, ports=dst_ports)
  File "/data/sonic-mgmt/tests/conftest.py", line 1456, in verify_packets_any_fixed
    % (ports, device_number, failure_report))
  File "/usr/lib/python2.7/unittest/case.py", line 410, in fail
    raise self.failureException(msg)
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
