### PR TITLE
[conn_graph_facts] Support up to 4 PSUs

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -391,7 +391,7 @@ class Parse_Lab_Graph():
         """
         if hostname in self.devices:
             ret = {}
-            for key in ['PSU1', 'PSU2']:
+            for key in ['PSU1', 'PSU2', 'PSU3', 'PSU4']:
                 try:
                     ret.update({key : self.devices[self.pdulinks[hostname][key]['peerdevice']]})
                 except KeyError:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is for support control up to 4 PSUs.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

Some DUTs (such as combined M0/C0) might have 4 PSUs, however current code only support control first 2 PSUs from PDU.
In future, we can try support unlimited PSUs by reverse the check condition. But as short term, this PR will be good enough.

#### How did you do it?

Add `PSU3` and `PSU4` to list.

#### How did you verify/test it?

Verified the code by using devutils command.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
