### PR TITLE
Test script to accommodate 16k nexthop scale in cisco-8000 platform

### DIFF
--- a/tests/ipfwd/test_nhop_count.py
+++ b/tests/ipfwd/test_nhop_count.py
@@ -7,6 +7,7 @@ import time
 from collections import namedtuple
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.cisco_data import is_cisco_device
 from tests.common.mellanox_data import is_mellanox_device
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import skip_release


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--

-->
Current test script had an issue where it did not scale beyond 1K nexthops and in case of Cisco-8000 platform, it has to go up to 16K nexthops to cause CRM resource exhaustion. We have done modification in wait time and how it is called to accommodate this scaled nexthop number. We have kept the changes specific to Cisco-8000 platform so that it does not affect other platforms. 


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Test case(new/improvement)


### Approach
#### What is the motivation for this PR?
This testcase expects all crm next_hop_groups to be exhausted but because Cisco supports 16k groups and 192k members and the script is designed to add just 1024 next hop groups. This causes failure, so we had to make changes in the script to add 16k groups


#### How did you verify/test it?
Ran the script on T1 testbed

