### PR TITLE
Add an option to do a safe config reload

### DIFF
--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -3,7 +3,6 @@ import pytest
 import time
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)
 

--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -77,7 +77,7 @@ class TestNeighborMacNoPtf:
         yield
 
         logger.info("Reload Config DB")
-        config_reload(duthost, config_source='config_db', wait=120)
+        config_reload(duthost, config_source='config_db', safe_reload=True)
 
     @pytest.fixture(params=[4, 6])
     def ipVersion(self, request):

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -106,7 +106,7 @@ def clean_scale_rules(duthosts, rand_one_dut_hostname, collect_ignored_rules):
     # delete the tmp file
     duthost.file(path=SCALE_ACL_FILE, state='absent')
     logger.info("Reload config to recover configuration.")
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True)
 
 def is_acl_rule_empty(duthost):
     """

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -1,6 +1,7 @@
 import time
 import logging
 
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -1,6 +1,8 @@
 import time
 import logging
 
+from tests.common.utilities import wait_until
+
 logger = logging.getLogger(__name__)
 
 config_sources = ['config_db', 'minigraph']
@@ -36,7 +38,7 @@ def config_force_option_supported(duthost):
         return True
     return False
 
-def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True):
+def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True, safe_reload=False):
     """
     reload SONiC configuration
     :param duthost: DUT host object
@@ -77,4 +79,8 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
     modular_chassis = duthost.get_facts().get("modular_chassis")
     wait = max(wait, 240) if modular_chassis else wait
 
-    time.sleep(wait)
+    if safe_reload:
+        assert wait_until(wait, 20, 0, duthost.critical_services_fully_started), \
+                "All critical services should be fully started!"
+    else:
+        time.sleep(wait)


### PR DESCRIPTION

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

When doing a config reload, test cases cannot assume that the DUT is
available immediately after `config_reload` returns. Instead, they need
to wait on `duthost.critical_services_fully_started` to be true.

Therefore, in `config_reload` add an option `safe_reload` (defaults to
False to preserve current behavior) that will block on this so that the
function returns when the DUT is ready. In addition, have two test
cases (for now; other test cases will be checked later) use safe reload
so that the DUT is guaranteed to be ready when the function returns.

Otherwise, if the setup for the next test case is running while the
DUT is still bringing up the containers, then some check there could
fail.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

Locally ran t0-part1 KVM test, and it succeeded, which suggests that at least nothing broke because of this change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
