### PR TITLE
Add previous GCU tests to kvm daily test

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -156,8 +156,10 @@ test_t0() {
       generic_config_updater/test_bgpl.py \
       generic_config_updater/test_bgp_prefix.py \
       generic_config_updater/test_bgp_speaker.py \
+      generic_config_updater/test_cacl.py \
       generic_config_updater/test_dhcp_relay.py \
       generic_config_updater/test_lo_interface.py \
+      generic_config_updater/test_monitor_config.py \
       generic_config_updater/test_portchannel_interface.py \
       generic_config_updater/test_syslog.py \
       generic_config_updater/test_vlan_interface.py \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add previous Generic Configer Updater cacl and monitor config tests into kvm test suite
Need https://github.com/Azure/sonic-utilities/pull/2120 merge first for monitor test pass Log Analyer check.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Move GCU test into kvm daily test
#### How did you do it?
Add GCU test case into kvmtest.sh
#### How did you verify/test it?
Run test of sonic-mgmt/tests/generic_config_updater/*.py on KVM
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
