### PR TITLE
Collect and archive PTF script logs and pcap files in nightly run

### DIFF
--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -7,8 +7,8 @@ logger = logging.getLogger(__name__)
 
 def ptf_collect(host, log_file):
     host.fetch(src=log_file, dest='./logs/ptf_collect/', flat=True, fail_on_missing=False)
-    pos = log_file.rfind('.') + 1
-    pcap_file = log_file[0:pos] + 'pcap'
+    pos = log_file.rfind('.')
+    pcap_file = (log_file[0:pos] if pos > -1 else log_file) + '.pcap'
     output = host.shell("[ -f {} ] && echo exist || echo null".format(pcap_file))['stdout']
     if output == 'exist':
         host.fetch(src=pcap_file, dest='./logs/ptf_collect/', flat=True, fail_on_missing=False)

--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -7,8 +7,11 @@ logger = logging.getLogger(__name__)
 
 def ptf_collect(host, log_file):
     host.fetch(src=log_file, dest='./logs/ptf_collect/', flat=True, fail_on_missing=False)
-    pcap_file = log_file[0:-3] + 'pcap'
-    host.fetch(src=pcap_file, dest='./logs/ptf_collect/', flat=True, fail_on_missing=False)
+    pos = log_file.rfind('.') + 1
+    pcap_file = log_file[0:pos] + 'pcap'
+    output = host.shell("[ -f {} ] && echo exist || echo null".format(pcap_file))['stdout']
+    if output == 'exist':
+        host.fetch(src=pcap_file, dest='./logs/ptf_collect/', flat=True, fail_on_missing=False)
 
 def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                platform="remote", qlen=0, relax=True, debug_level="info",

--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -5,6 +5,11 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def ptf_collect(host, log_file):
+    host.fetch(src=log_file, dest='./logs/ptf_collect/', flat=True, fail_on_missing=False)
+    pcap_file = log_file[0:-3] + 'pcap'
+    host.fetch(src=pcap_file, dest='./logs/ptf_collect/', flat=True, fail_on_missing=False)
+
 def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                platform="remote", qlen=0, relax=True, debug_level="info",
                socket_recv_size=None, log_file=None, device_sockets=[], timeout=0,
@@ -33,6 +38,7 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
 
     if log_file:
         cmd += " --log-file {}".format(log_file)
+        ptf_collect(host, log_file)
 
     if socket_recv_size:
         cmd += " --socket-recv-size {}".format(socket_recv_size)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
PTF script logs and pcap files were stored in /tmp/ of PTF, which is not convenient to get logs and pcap files for analyse.
#### How did you do it?
Fetch PTF script logs and pcap files to sonic-mgmt docker in tests/logs/
#### How did you verify/test it?
Run a test and check tests/logs/ content
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
