### PR TITLE
adding start index for cisco-8000 to respond to arp request 

### DIFF
--- a/tests/arp/files/ferret.py
+++ b/tests/arp/files/ferret.py
@@ -199,6 +199,9 @@ class Responder(object):
                 # References: https://tools.ietf.org/html/rfc1701
                 #             https://tools.ietf.org/html/draft-foschiano-erspan-00
                 arp_request = data[0x2E:]
+            elif ASIC_TYPE == "cisco-8000":
+                # Ethernet(14) + IP(20) + GRE(8) + ERSPAN(8) = 50 = 0x32
+                arp_request = data[0x32:]
 
         elif gre_type_r == 0x8949: # Mellanox
             arp_request = data[0x3c:]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
For ferret to parse arp requests and respond appropriately, we need to start at right offset for arp. For cisco platforms its at 0x32, considering GRE and ERSPAN header .
We have ERSPAN with version 2 which is on top of GRE with sequence number enabled.
In case of cisco platforms, GRE header has 4 bytes sequence number additional ,so GRE header in total is 8 bytes. 
Hence, the staring header offset would be as below :
Ethernet(14) + IP(20) + GRE(8) + ERSPAN(8) = 50 = 0x32

### Type of change
This is additional check for cisco platforms .

#### What is the motivation for this PR?
The change was made in order to update the ferret.py to match the arp response for cisco platforms . This will pass testcase under sonic-mgmt/tests/arp/test_wr_arp.py script .


