### PR TITLE
Disable loganalyzer for platform_tests.test_memory_exhaustion

### DIFF
--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -6,6 +6,7 @@ from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.reboot import SONIC_SSH_PORT, SONIC_SSH_REGEX
 
 pytestmark = [
+    pytest.mark.disable_loganalyzer,
     pytest.mark.topology('any')
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #5386 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case improvement


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

Disable loganalyzer for test case `platform_tests.test_memory_exhaustion`.

Loganalyzer is used to analyze whether one test case affects the others. Since test case `platform_tests.test_memory_exhaustion` expects DUT reboot, affecting other test cases is as expected. So we should disable loganalyzer for it.
  
#### How did you do it?

Add `pytest.mark.disable_loganalyzer` to this test case.

#### How did you verify/test it?

Verified on physical DUTs

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
