### PR TITLE
Add loganalyzer ignore regex for GCU

### DIFF
--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -2,15 +2,6 @@ import pytest
 
 from tests.common.utilities import skip_release
 
-# def pytest_configure(config):
-#     """ JsonPatch ordering will discard incorrect ordering and continue
-#         on next ordering. But LogAnalyzer will analyze failure on discarded
-#         ordering log, we will disable it for GCU and use our own ways of
-#         verification.
-#     """
-#     if not config.option.disable_loganalyzer:
-#         config.option.disable_loganalyzer = True
-
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
     """
@@ -24,7 +15,19 @@ def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
     # When loganalyzer is disabled, the object could be None
     if loganalyzer:
          ignoreRegex = [
-             ".*ERR sonic_yang:.*",
+             ".*ERR sonic_yang.*",
+             ".*ERR bgp#bgpcfgd.*Can't update the peer. Only 'admin_status' attribute is supported.*", # test_bgpl
+             ".*ERR bgp#bgpcfgd: BGPAllowListMgr::Received BGP ALLOWED 'SET' message with no prefixes specified: {'NULL': 'NULL'}.*", # test_bgp_prefix
+             ".*ERR.*Failed to start dhcp_relay container.*", # test_dhcp_relay
+             ".*ERR GenericConfigUpdater: Service Validator: Service has been reset.*", # test_dhcp_relay test_syslog
+             ".*Same listen range is attached to peer-group.*", # test_bgp_speaker -> real issue
+             ".*ERR swss[0-9]*#orchagent.*removeLag.*", # autorestart/test_container_autorestart.py test_portchannel_interface
+             ".*ERR swss[0-9]*#intfmgrd: :- setIntfVrf:.*", # test_portchannel_interface
+             ".*ERR teamd.*get_dump: Can't get dump for LAG.*", # test_portchannel_interface
+             ".*ERR kernel.*Reset adapter.*", # test_portchannel_interface replace mtu
+             ".*ERR swss[0-9]*#orchagent: :- getPortOperSpeed.*", # test_portchannel_interface replace mtu
+             ".*ERR.*Failed to apply Json change.*", # validator need updater submodule
+             ".*ERR GenericConfigUpdater: Change Applier: service invoked.*", # validator need updater submodule
          ]
          loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
 

--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -2,6 +2,15 @@ import pytest
 
 from tests.common.utilities import skip_release
 
+def pytest_configure(config):
+    """ JsonPatch ordering will discard incorrect ordering and continue
+        on next ordering. But LogAnalyzer will analyze failure on discarded
+        ordering log, we will disable it for GCU and use our own ways of
+        verification.
+    """
+    if not config.option.disable_loganalyzer:
+        config.option.disable_loganalyzer = True
+
 @pytest.fixture(scope="module", autouse=True)
 def check_image_version(duthost):
     """Skips this test if the SONiC image installed on DUT is older than 202112

--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -2,14 +2,31 @@ import pytest
 
 from tests.common.utilities import skip_release
 
-def pytest_configure(config):
-    """ JsonPatch ordering will discard incorrect ordering and continue
-        on next ordering. But LogAnalyzer will analyze failure on discarded
-        ordering log, we will disable it for GCU and use our own ways of
-        verification.
+# def pytest_configure(config):
+#     """ JsonPatch ordering will discard incorrect ordering and continue
+#         on next ordering. But LogAnalyzer will analyze failure on discarded
+#         ordering log, we will disable it for GCU and use our own ways of
+#         verification.
+#     """
+#     if not config.option.disable_loganalyzer:
+#         config.option.disable_loganalyzer = True
+
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
     """
-    if not config.option.disable_loganalyzer:
-        config.option.disable_loganalyzer = True
+       Ignore expected yang validation failure during test execution
+
+       GCU will try several sortings of JsonPatch until the sorting passes yang validation
+
+       Args:
+           loganalyzer: Loganalyzer utility fixture
+    """
+    # When loganalyzer is disabled, the object could be None
+    if loganalyzer:
+         ignoreRegex = [
+             ".*ERR sonic_yang:.*",
+         ]
+         loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
 
 @pytest.fixture(scope="module", autouse=True)
 def check_image_version(duthost):

--- a/tests/generic_config_updater/test_syslog.py
+++ b/tests/generic_config_updater/test_syslog.py
@@ -52,7 +52,7 @@ def syslog_config_add_default(duthost):
         add_syslog_server = duthost.shell("config syslog add {}".format(syslog_server),
             module_ignore_errors=True)
         pytest_assert(not add_syslog_server['rc'],
-            "syslog server '{}' is not deleted successfully".format(syslog_server))
+            "syslog server '{}' is not added successfully".format(syslog_server))
 
 @pytest.fixture(scope="module")
 def original_syslog_servers(duthost, tbinfo):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add LogAnalyzer ignored regex for GCU as it will report failure on incorrect ordering which is discarded by GCU
Fixes # (issue)
```
admin@vlab-01:~/loganalyzer$ sudo config apply-patch rm0.json
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "remove", "path": "/LOOPBACK_INTERFACE"}]
...

**(below sorting error will be treated as error by LogAnalyzer.)**     <===============

libyang[0]: Leafref "../../LOOPBACK_INTERFACE_LIST/name" of value "Loopback0" points to a non-existing leaf. (path: /sonic-loopback-interface:sonic-loopback-interface/LOOPBACK_INTERFACE/LOOPBACK_INTERFACE_IPPREFIX_LIST[name='Loopback0'][ip-prefix='FC00:1::32/128']/name)
sonic_yang(3):Data Loading Failed:Leafref "../../LOOPBACK_INTERFACE_LIST/name" of value "Loopback0" points to a non-existing leaf.
...
Patch Applier: The patch was sorted into 3 changes:
Patch Applier:   * [{"op": "remove", "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132"}]
Patch Applier:   * [{"op": "remove", "path": "/LOOPBACK_INTERFACE/Loopback0|FC00:1::32~1128"}]
Patch Applier:   * [{"op": "remove", "path": "/LOOPBACK_INTERFACE"}]
Patch Applier: Applying 3 changes in order:
Patch Applier:   * [{"op": "remove", "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132"}]
Patch Applier:   * [{"op": "remove", "path": "/LOOPBACK_INTERFACE/Loopback0|FC00:1::32~1128"}]
Patch Applier:   * [{"op": "remove", "path": "/LOOPBACK_INTERFACE"}]
Patch Applier: Verifying patch updates are reflected on ConfigDB.
Patch Applier: Patch application completed.
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Recent LogAnalyzer fix report failure on discarded ordering in GCU jsonpatch. However, GCU doesn't fail actually as it will explore a correct ordering and apply.
#### How did you do it?
Disable LogAnalyzer for GCU tests.
#### How did you verify/test it?
Run GCU test without flag --disable_loganalyzer and see if it works.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
