### PR TITLE
fixed PFCWD cleanup after test_default_cfg_after_load_mg

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -165,6 +165,3 @@ def setup_pfc_test(
     # set poll interval
     duthost.command("pfcwd interval {}".format(setup_info['pfc_timers']['pfc_wd_poll_time']))
     yield setup_info
-
-    logger.info("--- Starting Pfcwd ---")
-    duthost.command("pfcwd start_default")


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fixed PFCWD cleanup after test_default_cfg_after_load_mg
Fixes # (issue)

PFCWD test, test_default_cfg_after_load_mg checks an option `default_pfcwd_status` which is responsible for the feature state by default. When it's set in /etc/sonic/init_cfg.json and minigraph gets deployed, the PFCWD should be enabled with a default config, and disabled otherwise.
After test execution PFCWD remains enabled in running-config and in persistent config since `default_pfcwd_status` gets set in config_db.json too if the property is enabled in /etc/sonic/init_cfg.json while minigraph gets deployed . The PR fixes this issue so PFCWD is disabled after test execution


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Cleanup PFCWD after test_default_cfg_after_load_mg test
#### How did you do it?
Disabled the feature in running and permanent config
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t1,any pfcwd/test_pfc_config.py -k test_default_cfg_after_load_mg
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
