### PR TITLE
[t0-56] fix ports in dir_bcast test for t0-56 topo

### DIFF
--- a/ansible/roles/test/files/ptftests/dir_bcast_test.py
+++ b/ansible/roles/test/files/ptftests/dir_bcast_test.py
@@ -59,7 +59,9 @@ class BcastTest(BaseTest):
         if self.test_params['testbed_type'] == 't0-52':
             self.src_ports = range(0, 52)
         if self.test_params['testbed_type'] == 't0-56':
-            self.src_ports = range(0, 32)
+            self.src_ports = range(0, 2) + range(4, 6) + range(8, 10) + range(12, 18) + range(20, 22) + \
+                             range(24, 26) + range(28, 30) + range(32, 34) + range(36, 38) + range(40, 46) + \
+                             range(48, 50) + range(52, 54)
         if self.test_params['testbed_type'] == 't0-64':
             self.src_ports = range(0, 2) + range(4, 18) + range(20, 33) + range(36, 43) + range(48, 49) + range(52, 59)
         if self.test_params['testbed_type'] == 't0-116':


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixed the list of src ports for t0-56 topo in test dir_bcast.
In range (0,32) exist many ports which in the down state in t0-56 topo.


show interfaces status of t0-56 topo:
```
     Interface            Lanes    Speed    MTU    FEC    Alias            Vlan    Oper    Admin             Type    Asym PFC
--------------  ---------------  -------  -----  -----  -------  --------------  ------  -------  ---------------  ----------
     Ethernet0              0,1      50G   9100    N/A    etp1a           trunk      up       up   QSFP+ or later         off
     Ethernet2              2,3      50G   9100    N/A    etp1b           trunk      up       up   QSFP+ or later         off
     Ethernet4              4,5      50G   9100    N/A    etp2a          routed    down     down   QSFP+ or later         off
     Ethernet6              6,7      50G   9100    N/A    etp2b          routed    down     down   QSFP+ or later         off
     Ethernet8              8,9      50G   9100    N/A    etp3a           trunk      up       up   QSFP+ or later         off
    Ethernet10            10,11      50G   9100    N/A    etp3b           trunk      up       up   QSFP+ or later         off
    Ethernet12            12,13      50G   9100    N/A    etp4a          routed    down     down   QSFP+ or later         off
    Ethernet14            14,15      50G   9100    N/A    etp4b          routed    down     down   QSFP+ or later         off
    Ethernet16            16,17      50G   9100    N/A    etp5a           trunk      up       up   QSFP+ or later         off
    Ethernet18            18,19      50G   9100    N/A    etp5b           trunk      up       up   QSFP+ or later         off
    Ethernet20            20,21      50G   9100    N/A    etp6a          routed    down     down   QSFP+ or later         off
    Ethernet22            22,23      50G   9100    N/A    etp6b          routed    down     down   QSFP+ or later         off
    Ethernet24      24,25,26,27     100G   9100     rs     etp7  PortChannel101      up       up   QSFP+ or later         off
    Ethernet28      28,29,30,31     100G   9100     rs     etp8  PortChannel102      up       up   QSFP+ or later         off
    Ethernet32      32,33,34,35     100G   9100     rs     etp9  PortChannel103      up       up   QSFP+ or later         off
    Ethernet36      36,37,38,39     100G   9100     rs    etp10  PortChannel104      up       up   QSFP+ or later         off
    Ethernet40            40,41      50G   9100    N/A   etp11a           trunk      up       up   QSFP+ or later         off
    Ethernet42            42,43      50G   9100    N/A   etp11b           trunk      up       up   QSFP+ or later         off
    Ethernet44            44,45      50G   9100    N/A   etp12a          routed    down     down   QSFP+ or later         off
    Ethernet46            46,47      50G   9100    N/A   etp12b          routed    down     down   QSFP+ or later         off
    Ethernet48            48,49      50G   9100    N/A   etp13a           trunk      up       up   QSFP+ or later         off
    Ethernet50            50,51      50G   9100    N/A   etp13b           trunk      up       up   QSFP+ or later         off
    Ethernet52            52,53      50G   9100    N/A   etp14a          routed    down     down   QSFP+ or later         off
    Ethernet54            54,55      50G   9100    N/A   etp14b          routed    down     down   QSFP+ or later         off
    Ethernet56            56,57      50G   9100    N/A   etp15a           trunk      up       up   QSFP+ or later         off
    Ethernet58            58,59      50G   9100    N/A   etp15b           trunk      up       up   QSFP+ or later         off
    Ethernet60            60,61      50G   9100    N/A   etp16a          routed    down     down   QSFP+ or later         off
    Ethernet62            62,63      50G   9100    N/A   etp16b          routed    down     down   QSFP+ or later         off
    Ethernet64            64,65      50G   9100    N/A   etp17a           trunk      up       up  QSFP28 or later         off
    Ethernet66            66,67      50G   9100    N/A   etp17b           trunk      up       up  QSFP28 or later         off
    Ethernet68            68,69      50G   9100    N/A   etp18a          routed    down     down   QSFP+ or later         off
    Ethernet70            70,71      50G   9100    N/A   etp18b          routed    down     down   QSFP+ or later         off
    Ethernet72            72,73      50G   9100    N/A   etp19a           trunk      up       up   QSFP+ or later         off
    Ethernet74            74,75      50G   9100    N/A   etp19b           trunk      up       up   QSFP+ or later         off
    Ethernet76            76,77      50G   9100    N/A   etp20a          routed    down     down   QSFP+ or later         off
    Ethernet78            78,79      50G   9100    N/A   etp20b          routed    down     down   QSFP+ or later         off
    Ethernet80            80,81      50G   9100    N/A   etp21a           trunk      up       up   QSFP+ or later         off
    Ethernet82            82,83      50G   9100    N/A   etp21b           trunk      up       up   QSFP+ or later         off
    Ethernet84            84,85      50G   9100    N/A   etp22a          routed    down     down   QSFP+ or later         off
    Ethernet86            86,87      50G   9100    N/A   etp22b          routed    down     down   QSFP+ or later         off
    Ethernet88      88,89,90,91     100G   9100     rs    etp23  PortChannel105      up       up   QSFP+ or later         off
    Ethernet92      92,93,94,95     100G   9100     rs    etp24  PortChannel106      up       up   QSFP+ or later         off
    Ethernet96      96,97,98,99     100G   9100     rs    etp25  PortChannel107      up       up   QSFP+ or later         off
   Ethernet100  100,101,102,103      10G   9100    N/A    etp26  PortChannel108      up       up   SFP/SFP+/SFP28         off
   Ethernet104          104,105      50G   9100    N/A   etp27a           trunk      up       up   QSFP+ or later         off
   Ethernet106          106,107      50G   9100    N/A   etp27b           trunk      up       up   QSFP+ or later         off
   Ethernet108          108,109      50G   9100    N/A   etp28a          routed    down     down   QSFP+ or later         off
   Ethernet110          110,111      50G   9100    N/A   etp28b          routed    down     down   QSFP+ or later         off
   Ethernet112          112,113      50G   9100    N/A   etp29a           trunk      up       up   QSFP+ or later         off
   Ethernet114          114,115      50G   9100    N/A   etp29b           trunk      up       up   QSFP+ or later         off
   Ethernet116          116,117      50G   9100    N/A   etp30a          routed    down     down   QSFP+ or later         off
   Ethernet118          118,119      50G   9100    N/A   etp30b          routed    down     down   QSFP+ or later         off
   Ethernet120          120,121      50G   9100    N/A   etp31a           trunk      up       up   QSFP+ or later         off
   Ethernet122          122,123      50G   9100    N/A   etp31b           trunk      up       up   QSFP+ or later         off
   Ethernet124          124,125      50G   9100    N/A   etp32a          routed    down     down   QSFP+ or later         off
   Ethernet126          126,127      50G   9100    N/A   etp32b          routed    down     down   QSFP+ or later         off
PortChannel101              N/A     100G   9100    N/A      N/A          routed      up       up              N/A         N/A
PortChannel102              N/A     100G   9100    N/A      N/A          routed      up       up              N/A         N/A
PortChannel103              N/A     100G   9100    N/A      N/A          routed      up       up              N/A         N/A
PortChannel104              N/A     100G   9100    N/A      N/A          routed      up       up              N/A         N/A
PortChannel105              N/A     100G   9100    N/A      N/A          routed      up       up              N/A         N/A
PortChannel106              N/A     100G   9100    N/A      N/A          routed      up       up              N/A         N/A
PortChannel107              N/A     100G   9100    N/A      N/A          routed      up       up              N/A         N/A
PortChannel108              N/A      10G   9100    N/A      N/A          routed      up       up              N/A         N/A
```



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
test stabilization

#### How did you do it?
update list of available ports

#### How did you verify/test it?
executed test on testbed with t0-56 topo

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
old test

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
