### PR TITLE
Description of PR

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -108,9 +108,17 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
                         uplink_interfaces.append(iface_name)
                     uplink_port_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
 
+        other_client_ports_indices = []
+        for iface_name in vlan_info_dict['members'] :
+            if mg_facts['minigraph_ptf_indices'][iface_name] == client_iface['port_idx']:
+                pass
+            else :
+                other_client_ports_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
+
         dhcp_relay_data = {}
         dhcp_relay_data['downlink_vlan_iface'] = downlink_vlan_iface
         dhcp_relay_data['client_iface'] = client_iface
+        dhcp_relay_data['other_client_ports'] = other_client_ports_indices
         dhcp_relay_data['uplink_interfaces'] = uplink_interfaces
         dhcp_relay_data['uplink_port_indices'] = uplink_port_indices
         dhcp_relay_data['switch_loopback_ip'] = str(switch_loopback_ip)
@@ -261,6 +269,9 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                    platform_dir="ptftests",
                    params={"hostname": duthost.hostname,
                            "client_port_index": dhcp_relay['client_iface']['port_idx'],
+                           ## This port is introduced to test DHCP relay packet received
+                           ## on other client port
+                           "other_client_port": repr(dhcp_relay['other_client_ports']),
                            "client_iface_alias": str(dhcp_relay['client_iface']['alias']),
                            "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
                            "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs']),


### PR DESCRIPTION
Summary: Added DHCP relay packet verification for server and client ports

Fixes # it is TC enhancement test_dhcp_relay.py::dut_dhcp_relay_data for verifying DHCP packet on client and server ports.

Type of change
Bug fix
Testbed and Framework(new/improvement)
Test case(new/improvement) - Done

Approach

What is the motivation for this PR?
Issue was seen where DHCP packet was getting padded with extra bytes.
Current TC coverage was missing for verification of extra padding in DHCP packet.

How did you do it?
1. In this scenario function dut_dhcp_relay_data, we have introduced a new variable other_client_ports_indices. This variable will collect ports which are part of vlan 1000 (client vlan) and does not include sender client port

    tests/dhcp_relay/test_dhcp_relay.py
                @@ -108,9 +106,17 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
                                                                                                                uplink_interfaces.append(iface_name)
                                                                                                uplink_port_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])

                +        other_client_ports_indices = []
                +        for iface_name in vlan_info_dict['members'] :
                +            if mg_facts['minigraph_ptf_indices'][iface_name] == client_iface['port_idx']:
                +                pass
                +            else :
                +                other_client_ports_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
                +
                                                dhcp_relay_data = {}
                                                dhcp_relay_data['downlink_vlan_iface'] = downlink_vlan_iface
                                                dhcp_relay_data['client_iface'] = client_iface
                +        dhcp_relay_data['other_client_ports'] = other_client_ports_indices
                                                dhcp_relay_data['uplink_interfaces'] = uplink_interfaces
                                                dhcp_relay_data['uplink_port_indices'] = uplink_port_indices
                                                dhcp_relay_data['switch_loopback_ip'] = str(switch_loopback_ip)

2. In test case test_dhcp_relay, we are passing other_client_ports_indices as one of param to verify padding on client port and server port.

                @@ -260,6 +248,9 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                                                                                                platform_dir="ptftests",
                                                                                                params={"hostname": duthost.hostname,
                                                                                                                                "client_port_index": dhcp_relay['client_iface']['port_idx'],
                +                           ## This port is introduced to test DHCP relay packet received
                +                           ## on other client port
                +                           "other_client_port": repr(dhcp_relay['other_client_ports']),
                                                                                                                                "client_iface_alias": str(dhcp_relay['client_iface']['alias']),
                                                                                                                                "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
                                                                                                                                "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs']),

3. In PTF testcase, we have introduced 2 functions to verify whether DHCP packet received is padded or not
+            self.verify_dhcp_relay_pkt_on_other_client_port_with_no_padding(self.dest_mac_address, self.client_udp_src_port)
+            self.verify_dhcp_relay_pkt_on_server_port_with_no_padding(self.dest_mac_address, self.client_udp_src_port)

4. in above function, we are verifying the packet received should be matched with expected packet. If it is padded or not received, test case will fail.

Supported testbed topology if it's a new test case?
No

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
