### PR TITLE
[test_po_update] fix regex for nexthop route validation

### DIFF
--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -206,7 +206,8 @@ def check_no_routes_from_nexthop(asic, nexthop):
         ver = '-6'
     else:
         ver = '-4'
-    cmd = "ip {} route show | grep -w {} | wc -l".format(ver, nexthop)
+    special_nexthop = nexthop.replace('.', '\.')
+    cmd = "ip {} route show | grep -w {} | wc -l".format(ver, special_nexthop)
     if asic.namespace is not None:
         fullcmd = "sudo ip netns exec {} {}".format(asic.namespace, cmd)
         output = asic.sonichost.shell(fullcmd)


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the regex in check_no_routes_from_nexthop method.

By the previous "grep" parameter we can catch unexpected route:

ip -4 route show | grep -w "**10.0.0.25**"
193.**10.0.0/25** nhid 445 proto bgp src 10.1.0.32 metric 20 

Changed to 'ip -4 route show | grep -w "**10\\.0\\.0\\.25**"'


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
add stability to the test

#### How did you do it?
added "." as special character

#### How did you verify/test it?
test passed

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
