### PR TITLE
Adding skip for testQosSaiPgHeadroomWatermark testcase

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -184,7 +184,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
   skip:
     reason: "Priority Group Headroom Watermark is not supported on cisco asic. PG drop counter stat is covered as a part of testQosSaiPfcXoffLimit"
     conditions:
-      - "asic_type=='cisco-8000'"
+      - "asic_type in ['cisco-8000']"
 #######################################
 #####         restapi             #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -180,6 +180,11 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[None-wm_pg_shared_l
     conditions:
       - "platform in ['x86_64-arista_7050cx3_32s']"
 
+qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
+  skip:
+    reason: "Priority Group Headroom Watermark is not supported on cisco asic. PG drop counter stat is covered as a part of testQosSaiPfcXoffLimit"
+    conditions:
+      - "asic_type=='cisco-8000'"
 #######################################
 #####         restapi             #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Adding skip for testcase testQosSaiPgHeadroomWatermark in test_qos_sai.py script, since it is not supported on cisco platforms . 


### Type of change
Skipping unsupported testcase for cisco platforms .


#### How did you do it?
Adding skip condition in sonic-mgmt/tests/common/plugins/conditional_marktests_mark_conditions.yaml file 
#### How did you verify/test it?
Verified on the cisco platforms that testcase is skipped
