### PR TITLE
disable skip for testQosSaiDscpToPgMapping testcase since supported on cisco-8000 platforms

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -839,6 +839,8 @@ class TestQosSai(QosSaiBase):
                 RunAnsibleModuleFail if ptf test fails
         """
         disableTest = request.config.getoption("--disable_test")
+        if dutTestParams["basicParams"]["sonic_asic_type"] == 'cisco-8000':
+            disableTest = False
         if disableTest:
             pytest.skip("DSCP to PG mapping test disabled")
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Currently the testcase testQosSaiDscpToPgMapping in test_qos_sai.py in sonic-mgmt is skipping by default .
--disable_test is set to True by default .
Since cisco-8000 platform supports this testcase , so setting disableTest to False to run this testcase .


#### How did you verify/test it?
Verified by setting disableTest to False and running the testcase for cisco platforms . The testcase passes .

