### PR TITLE
[GCU] add ipv6, ethernet interface to kvm test suite

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -96,6 +96,15 @@ everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_e
       - "asic_type=='cisco-8000'"
 
 #######################################
+#####   generic_config_updater    #####
+#######################################
+generic_config_updater/test_eth_interface.py::test_replace_fec:
+  skip:
+    reason: 'replace_fec ethernet test is not supported on virtual switch'
+    conditions:
+      - "platform in ['x86_64-kvm_x86_64-r0']"
+
+#######################################
 #####      iface_namingmode       #####
 #######################################
 iface_namingmode/test_iface_namingmode.py::TestShowPriorityGroup:

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -144,6 +144,9 @@ def test_toggle_pfc_asym(duthost, ensure_dut_readiness, pfc_asym):
 
 @pytest.mark.parametrize("fec", ["rs", "fc"])
 def test_replace_fec(duthost, ensure_dut_readiness, fec):
+    if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
+        pytest.skip("Not supported on virtual switch")
+
     json_patch = [
         {
             "op": "replace",

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -142,11 +142,9 @@ def test_toggle_pfc_asym(duthost, ensure_dut_readiness, pfc_asym):
         delete_tmpfile(duthost, tmpfile)
 
 
+@pytest.mark.device_type('physical')
 @pytest.mark.parametrize("fec", ["rs", "fc"])
 def test_replace_fec(duthost, ensure_dut_readiness, fec):
-    if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
-        pytest.skip("Not supported on virtual switch")
-
     json_patch = [
         {
             "op": "replace",

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -157,6 +157,8 @@ test_t0() {
       generic_config_updater/test_bgp_prefix.py \
       generic_config_updater/test_bgp_speaker.py \
       generic_config_updater/test_dhcp_relay.py \
+      generic_config_updater/test_eth_interface.py \
+      generic_config_updater/test_ipv6.py \
       generic_config_updater/test_lo_interface.py \
       generic_config_updater/test_portchannel_interface.py \
       generic_config_updater/test_syslog.py \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add previous Generic Configer Updater ipv6 and ethernet interface config tests into kvm test suite
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Move GCU test into kvm daily test
#### How did you do it?
Add GCU test case into kvmtest.sh
#### How did you verify/test it?
Run test of sonic-mgmt/tests/generic_config_updater/*.py on KVM
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->