### PR TITLE
Skip span mirror test on unsupported release

### DIFF
--- a/tests/span/conftest.py
+++ b/tests/span/conftest.py
@@ -5,7 +5,7 @@ Conftest file for span tests
 import pytest
 
 from tests.common.storage_backend.backend_utils import skip_test_module_over_backend_topologies
-
+from tests.common.utilities import skip_release
 
 @pytest.fixture(scope="module")
 def cfg_facts(duthosts, rand_one_dut_hostname, skip_test_module_over_backend_topologies):
@@ -55,6 +55,12 @@ def ports_for_test(cfg_facts):
         'monitor': port_info[2],
         'vlan': vlan
     }
+
+@pytest.fixture(scope='session', autouse=True)
+def skip_unsupported_release(duthost):
+    """ Span mirror is not supported on release < 202012
+    """
+    skip_release(duthost, ["201811", "201911"])
 
 @pytest.fixture(scope='module', autouse=True)
 def skip_unsupported_asic_type(duthost):


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip span mirroring test on release prior to 202012.
The support of span mirroring was introduced by PR https://github.com/Azure/sonic-utilities/pull/936 . The change is backported into `202012` branch but not into `201811` and `201911`. Hence we are not able to run this test on `201811` and `201911`.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
This PR is to skip span mirroring test on release prior to 202012.

#### How did you do it?
Add a session level, autoused fixture to check release, and skip if not supported.

#### How did you verify/test it?
Verified on `201911` branch, and confirm the test is skipped.
```
collected 4 items                                                                                                                                                                                     

span/test_port_mirroring.py::test_mirroring_rx SKIPPED                                                                                                                                          [ 25%]
span/test_port_mirroring.py::test_mirroring_tx SKIPPED                                                                                                                                          [ 50%]
span/test_port_mirroring.py::test_mirroring_both SKIPPED                                                                                                                                        [ 75%]
span/test_port_mirroring.py::test_mirroring_multiple_source SKIPPED                                                                                                                             [100%]

```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
