### PR TITLE
Added option for enable collecting DB data when TC failed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,10 @@ def pytest_addoption(parser):
     ############################
     parser.addoption("--loop_times", metavar="LOOP_TIMES", action="store", default=1, type=int,
                      help="Define the loop times of the test")
+    ############################
+    #   collect logs option    #
+    ############################
+    parser.addoption("--collect_db_data", action="store_true", default=False, help="Collect db info if test failed")
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -1501,7 +1505,8 @@ def collect_db_dump(request, duthosts):
         When test failed, teardown of this fixture will dump all the DB and collect to the test servers
     '''
     yield
-    collect_db_dump_on_duts(request, duthosts)
+    if request.config.getoption("--collect_db_data"):
+        collect_db_dump_on_duts(request, duthosts)
 
 def verify_packets_any_fixed(test, pkt, ports=[], device_number=0):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
PR [5197](https://github.com/Azure/sonic-mgmt/pull/5197/files) fixture for collection DB data when TC failed have been introduced. This is good idea, but has one major impact to test suite / regression run. It adds extra regression time to run. It will be proportionally increase execution time if number of failed cases increased.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Add ability to add option if engineer wants to collect DB data 
#### How did you do it?
Added "--collect_db_data option which enables collecting DB data if TC failed
#### How did you verify/test it?
Run cases with --collect_db_data, if TC failed - DB data collected.
Run cases without --collect_db_data, if TC failed - DB not data collected.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
