### PR TITLE
[Syslog] Skip IPv6 test cases on SONiC 201911

### DIFF
--- a/tests/syslog/test_syslog.py
+++ b/tests/syslog/test_syslog.py
@@ -92,9 +92,13 @@ def test_syslog(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server
     logger.info("Configuring the DUT")
     # Add dummy rsyslog destination for testing
     if dummy_syslog_server_ip_a is not None:
+        if "201911" in duthost.os_version and ":" in dummy_syslog_server_ip_a:
+                pytest.skip("IPv6 syslog server IP not supported on 201911")
         duthost.shell("sudo config syslog add {}".format(dummy_syslog_server_ip_a))
         logger.debug("Added new rsyslog server IP {}".format(dummy_syslog_server_ip_a))
     if dummy_syslog_server_ip_b is not None:
+        if "201911" in duthost.os_version and ":" in dummy_syslog_server_ip_b:
+                pytest.skip("IPv6 syslog server IP not supported on 201911")
         duthost.shell("sudo config syslog add {}".format(dummy_syslog_server_ip_b))
         logger.debug("Added new rsyslog server IP {}".format(dummy_syslog_server_ip_b))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
On 201911 SONiC image, we do not support syslog IPv6 servers and hence skipping cases which involve IPv6 syslog server IPs

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [-] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
