### PR TITLE
Adding skip some testcases in test_psu.py and Test_sfp.py for cisco-8000 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -272,7 +272,7 @@ platform_tests/api/test_psu.py::TestPsuApi::test_power:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox']"
+      - "asic_type in ['mellanox', 'cisco-8000']"
 
 #######################################
 #####    api/test_psu_fans.py     #####
@@ -338,7 +338,7 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_rx_los:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox']"
+      - "asic_type in ['mellanox'] or (asic_type in ['cisco-8000'] and release in ['202012'])"
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_get_rx_power:
   skip:
@@ -380,7 +380,7 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_tx_fault:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox']"
+      - "asic_type in ['mellanox'] or (asic_type in ['cisco-8000'] and release in ['202012'])"
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_get_tx_power:
   skip:
@@ -411,6 +411,12 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_tx_disable_channel:
     reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox']"
+
+platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_threshold_info:
+  skip:
+    reason: "Unsupported platform API"
+    conditions:
+      - "asic_type in ['cisco-8000'] and release in ['202012']"
 
 #######################################
 #####     api/test_thermal.py     #####


### PR DESCRIPTION
### Description of PR
Skipping  test_get_tx_fault, test_get_transceiver_threshold_info, test_get_rx_los in test_psu.py since sfp refactoring code is not present in 202012 branch.  Skipping test_power in Test_psu.py since it is currently unsupported.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ x] 202012

### Approach
#### What is the motivation for this PR?
Skipping  test_get_tx_fault, test_get_transceiver_threshold_info, test_get_rx_los in test_psu.py since sfp refactoring code is not present in 202012 branch. Skipping test_power in Test_psu.py since it is currently unsupported.

#### How did you do it?

#### How did you verify/test it?
Verified against cisco-8000 platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
