### PR TITLE
Revert "[chassis] Enhance Fib and IP Decap test case"

### DIFF
--- a/ansible/roles/test/files/ptftests/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/IP_decap_test.py
@@ -93,6 +93,7 @@ class DecapPacketTest(BaseTest):
 
         self.lo_ips = self.test_params.get('lo_ips')
         self.lo_ipv6s = self.test_params.get('lo_ipv6s')
+        self.router_macs = self.test_params.get('router_macs')
         self.dscp_mode = self.test_params.get('dscp_mode')
         self.ttl_mode = self.test_params.get('ttl_mode')
         self.ignore_ttl = self.test_params.get('ignore_ttl', False)
@@ -203,7 +204,8 @@ class DecapPacketTest(BaseTest):
 
         src_mac =  self.dataplane.get_mac(0, src_port)
         dst_mac = '00:11:22:33:44:55'
-        router_mac = target_mac = self.ptf_test_port_map[str(src_port)]['target_dest_mac']  # Outer dest mac
+        router_mac = self.router_macs[dut_index]
+        target_mac = self.ptf_test_port_map[str(src_port)]['target_mac']  # Outer dest mac
 
         active_dut_index = int(self.ptf_test_port_map[str(src_port)]['target_dut'])
         lo_ip = self.lo_ips[active_dut_index]

--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -36,7 +36,8 @@ class HashTest(BaseTest):
 
     _required_params = [
         'fib_info_files',
-        'ptf_test_port_map'
+        'ptf_test_port_map',
+        'router_macs'
     ]
 
     def __init__(self):
@@ -66,6 +67,7 @@ class HashTest(BaseTest):
         with open(ptf_test_port_map) as f:
             self.ptf_test_port_map = json.load(f)
 
+        self.router_macs = self.test_params.get('router_macs')
         self.src_ip_range = [unicode(x) for x in self.test_params['src_ip_range'].split(',')]
         self.dst_ip_range = [unicode(x) for x in self.test_params['dst_ip_range'].split(',')]
         self.src_ip_interval = lpm.LpmDict.IpInterval(ip_address(self.src_ip_range[0]), ip_address(self.src_ip_range[1]))
@@ -197,7 +199,7 @@ class HashTest(BaseTest):
         src_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
             if hash_key == 'src-mac' else self.base_mac
 
-        router_mac = self.ptf_test_port_map[str(src_port)]['target_dest_mac']
+        router_mac = self.ptf_test_port_map[str(src_port)]['target_mac']
 
         vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
         ip_proto = self._get_ip_proto() if hash_key == 'ip-proto' else None
@@ -250,7 +252,7 @@ class HashTest(BaseTest):
                     dport))
 
         rcvd_port, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
-        exp_src_mac = self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_src_mac']
+        exp_src_mac = self.router_macs[self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_dut']]
         actual_src_mac = Ether(rcvd_pkt).src
         if exp_src_mac != actual_src_mac:
             raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
@@ -274,7 +276,7 @@ class HashTest(BaseTest):
 
         src_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
             if hash_key == 'src-mac' else self.base_mac
-        router_mac = self.ptf_test_port_map[str(src_port)]['target_dest_mac']
+        router_mac = self.ptf_test_port_map[str(src_port)]['target_mac']
 
         vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
         ip_proto = self._get_ip_proto(ipv6=True) if hash_key == "ip-proto" else None
@@ -328,7 +330,7 @@ class HashTest(BaseTest):
                     dport))
 
         rcvd_port, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
-        exp_src_mac = self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_src_mac']
+        exp_src_mac = self.router_macs[self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_dut']]
         actual_src_mac = Ether(rcvd_pkt).src
         if exp_src_mac != actual_src_mac:
             raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -302,8 +302,7 @@ def bgp_speaker_announce_routes_common(common_setup_teardown,
             target_mac = duthost.facts['router_mac']
         ptf_test_port_map[str(port)] = {
             'target_dut': 0,
-            'target_dest_mac': target_mac,
-            'target_src_mac': duthost.facts['router_mac']
+            'target_mac': target_mac
         }
     ptfhost.copy(content=json.dumps(ptf_test_port_map), dest=PTF_TEST_PORT_MAP)
 
@@ -313,7 +312,8 @@ def bgp_speaker_announce_routes_common(common_setup_teardown,
                 "ptftests",
                 "fib_test.FibTest",
                 platform_dir="ptftests",
-                params={"ptf_test_port_map": PTF_TEST_PORT_MAP,
+                params={"router_macs": [duthost.facts['router_mac']],
+                        "ptf_test_port_map": PTF_TEST_PORT_MAP,
                         "fib_info_files": ["/root/bgp_speaker_route_%s.txt" % family],
                         "ipv4": ipv4,
                         "ipv6": ipv6,

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -181,7 +181,6 @@ class SonicHost(AnsibleHostBase):
         facts["router_mac"] = self._get_router_mac()
         facts["modular_chassis"] = self._get_modular_chassis()
         facts["mgmt_interface"] = self._get_mgmt_interface()
-        facts["switch_type"] = self._get_switch_type()
 
         logging.debug("Gathered SonicHost facts: %s" % json.dumps(facts))
         return facts
@@ -244,13 +243,6 @@ class SonicHost(AnsibleHostBase):
     def _get_router_mac(self):
         return self.command("sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac'")["stdout_lines"][0].encode().decode(
             "utf-8").lower()
-   
-    def _get_switch_type(self):
-       try:
-           return self.command("sonic-cfggen -d -v 'DEVICE_METADATA.localhost.switch_type'")["stdout_lines"][0].encode().decode(
-                  "utf-8").lower()
-       except Exception:
-           return ''
 
     def _get_platform_info(self):
         """

--- a/tests/common/fixtures/fib_utils.py
+++ b/tests/common/fixtures/fib_utils.py
@@ -37,23 +37,19 @@ def get_t2_fib_info(duthosts, duts_cfg_facts, duts_mg_facts):
 
     # Collect system neighbors, inband intf and port channel info to resolve ptf ports
     # for system neigh or lags.
+    voq_db = VoqDbCli(duthosts.supervisor_nodes[0])
+    sys_neigh = {}
+    for entry in voq_db.dump_neighbor_table():
+        neigh_key = entry.split('|')
+        neigh_ip = neigh_key[-1]
+        sys_neigh[neigh_ip] = {'duthost_name' : neigh_key[-4], 'intf' : neigh_key[-2]}
     dut_inband_intfs = {}
     dut_port_channels = {}
-    switch_type = ''
     for duthost in duthosts.frontend_nodes:
         cfg_facts = duts_cfg_facts[duthost.hostname]
         for asic_cfg_facts in cfg_facts:
-            if duthost.facts['switch_type'] == "voq":
-                switch_type = "voq"
-                dut_inband_intfs.setdefault(duthost.hostname,[]).extend(asic_cfg_facts['VOQ_INBAND_INTERFACE'])
+            dut_inband_intfs.setdefault(duthost.hostname,[]).extend(asic_cfg_facts['VOQ_INBAND_INTERFACE'])
             dut_port_channels.setdefault(duthost.hostname,{}).update(asic_cfg_facts.get('PORTCHANNEL', {}))
-    sys_neigh = {}
-    if switch_type == "voq":
-        voq_db = VoqDbCli(duthosts.supervisor_nodes[0])
-        for entry in voq_db.dump_neighbor_table():
-            neigh_key = entry.split('|')
-            neigh_ip = neigh_key[-1]
-            sys_neigh[neigh_ip] = {'duthost_name' : neigh_key[-4], 'intf' : neigh_key[-2]}
 
     for duthost in duthosts.frontend_nodes:
         cfg_facts = duts_cfg_facts[duthost.hostname]
@@ -86,7 +82,7 @@ def get_t2_fib_info(duthosts, duts_cfg_facts, duts_mg_facts):
                                     if len(oports) == 0:
                                         skip = True
                                 else:
-                                    oports.append([str(mg_facts[asic_index]['minigraph_ptf_indices'][x]) for x in po[ifname]['members']])
+                                    oports.append([str(mg_facts['minigraph_ptf_indices'][x]) for x in po[ifname]['members']])
                                     skip = False
                         else:
                             if ports.has_key(ifname):
@@ -120,7 +116,7 @@ def get_t2_fib_info(duthosts, duts_cfg_facts, duts_mg_facts):
                                         # The nexthop is a system neighbor.
                                         oports.append([str(remote_dut_mg_facts['minigraph_ptf_indices'][remote_neigh_intf])])
                                 else:
-                                    oports.append([str(mg_facts[asic_index]['minigraph_ptf_indices'][ifname])])
+                                    oports.append([str(mg_facts['minigraph_ptf_indices'][ifname])])
                                     skip = False
                             else:
                                 logger.info("Route point to non front panel port {}:{}".format(k, v))
@@ -325,12 +321,9 @@ def fib_info_files_per_function(duthosts, ptfhost, duts_running_config_facts, du
 
 
 @pytest.fixture(scope="module")
-def single_fib_for_duts(tbinfo, duthosts):
+def single_fib_for_duts(tbinfo):
     # For a T2 topology, we are generating a single fib file across all asics, but have multiple frontend nodes (DUTS).
     if tbinfo['topo']['type'] == "t2":
-        if duthosts[0].facts['switch_type'] == "voq":
-            return "single-fib-single-hop"
-        else:
-            return "single-fib-multi-hop"
-    return "multiple-fib"
+        return True
+    return False
  

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -277,7 +277,7 @@ def run_garp_service(duthost, ptfhost, tbinfo, change_mac_addresses, request):
         ptfhost.shell('supervisorctl stop garp_service')
 
 
-def ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_config_facts, duts_minigraph_facts):
+def ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url):
     active_dut_map = {}
     if 'dualtor' in tbinfo['topo']['name']:
         res = requests.get(mux_server_url)
@@ -296,8 +296,7 @@ def ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_co
     logger.info('active_dut_map={}'.format(active_dut_map))
     logger.info('disabled_ptf_ports={}'.format(disabled_ptf_ports))
     logger.info('router_macs={}'.format(router_macs))
-    
-    asic_idx = 0
+
     ports_map = {}
     for ptf_port, dut_intf_map in tbinfo['topo']['ptf_dut_intf_map'].items():
         if str(ptf_port) in disabled_ptf_ports:
@@ -311,26 +310,14 @@ def ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_co
             target_dut_index = int(active_dut_map[ptf_port])
             ports_map[ptf_port] = {
                 'target_dut': target_dut_index,
-                'target_dest_mac': tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']['one_vlan_a']['Vlan1000']['mac'],
-                'target_src_mac': router_macs[target_dut_index],
-                'asic_idx': asic_idx
+                'target_mac': tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']['one_vlan_a']['Vlan1000']['mac']
             }
         else:
             # PTF port is mapped to single DUT
             target_dut_index = int(dut_intf_map.keys()[0])
-            target_dut_port = int(dut_intf_map.values()[0])
-            router_mac = router_macs[target_dut_index]
-            if len(duts_minigraph_facts[duthosts[target_dut_index].hostname]) > 1:
-                for idx, mg_facts in enumerate(duts_minigraph_facts[duthosts[target_dut_index].hostname]):
-                    if target_dut_port in mg_facts['minigraph_port_indices'].values():
-                        router_mac = duts_running_config_facts[duthosts[target_dut_index].hostname][idx]['DEVICE_METADATA']['localhost']['mac'].lower()
-                        asic_idx = idx
-                        break
             ports_map[ptf_port] = {
                 'target_dut': target_dut_index,
-                'target_dest_mac': router_mac,
-                'target_src_mac': router_mac,
-                'asic_idx': asic_idx
+                'target_mac': router_macs[target_dut_index]
             }
 
     logger.debug('ptf_test_port_map={}'.format(json.dumps(ports_map, indent=2)))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1425,17 +1425,7 @@ def duts_minigraph_facts(duthosts, tbinfo):
             <dut hostname>: {dut_minigraph_facts}
         }
     """
-    mg_facts = {}
-    for duthost in duthosts:
-        mg_facts[duthost.hostname] = []
-        for asic in duthost.asics:
-            if asic.is_it_backend():
-                continue
-            asic_mg_facts = asic.get_extended_minigraph_facts(tbinfo)
-            mg_facts[duthost.hostname].append(asic_mg_facts)
-
- 
-    return mg_facts
+    return duthosts.get_extended_minigraph_facts(tbinfo)
 
 @pytest.fixture(scope="module", autouse=True)
 def get_reboot_cause(duthost):

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -78,8 +78,6 @@ def loopback_ips(duthosts, duts_running_config_facts):
     lo_ips = []
     lo_ipv6s = []
     for duthost in duthosts:
-        if duthost.is_supervisor_node():
-            continue
         cfg_facts = duts_running_config_facts[duthost.hostname]
         lo_ip = None
         lo_ipv6 = None
@@ -104,7 +102,8 @@ def setup_teardown(request, duthosts, duts_running_config_facts, ip_ver, loopbac
         "fib_info_files": fib_info_files[:3],  # Test at most 3 DUTs in case of multi-DUT
         "single_fib_for_duts": single_fib_for_duts,
         "ignore_ttl": True if is_multi_asic else False,
-        "max_internal_hops": 3 if is_multi_asic else 0
+        "max_internal_hops": 3 if is_multi_asic else 0,
+        'router_macs': [duthost.facts['router_mac'] for duthost in duthosts]
     }
 
     setup_info.update(ip_ver)
@@ -126,8 +125,6 @@ def apply_decap_cfg(duthosts, ip_ver, loopback_ips, ttl_mode, dscp_mode, ecn_mod
 
     # apply test decap configuration (SET or DEL)
     for idx, duthost in enumerate(duthosts):
-        if duthost.is_supervisor_node():
-            continue
         decap_conf_vars = {
             'lo_ip': loopback_ips['lo_ips'][idx],
             'lo_ipv6': loopback_ips['lo_ipv6s'][idx],
@@ -182,7 +179,7 @@ def set_mux_random(tbinfo, mux_server_url):
     return set_mux_side(tbinfo, mux_server_url, 'random')
 
 
-def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, decap_config, mux_server_url, set_mux_random, duts_running_config_facts, duts_minigraph_facts):
+def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, decap_config, mux_server_url, set_mux_random):
 
     setup_info = setup_teardown
 
@@ -202,13 +199,14 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, decap_config, mux_serv
                         "inner_ipv6": setup_info["inner_ipv6"],
                         "lo_ips": setup_info["lo_ips"],
                         "lo_ipv6s": setup_info["lo_ipv6s"],
+                        "router_macs": setup_info["router_macs"],
                         "ttl_mode": ttl_mode,
                         "dscp_mode": dscp_mode,
                         "ignore_ttl": setup_info["ignore_ttl"],
                         "max_internal_hops": setup_info["max_internal_hops"],
                         "fib_info_files": setup_info["fib_info_files"],
                         "single_fib_for_duts": setup_info["single_fib_for_duts"],
-                        "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_config_facts, duts_minigraph_facts)
+                        "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url)
                         },
                 qlen=PTFRUNNER_QLEN,
                 log_file=log_file)

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -44,6 +44,11 @@ DEFAULT_MUX_SERVER_PORT = 8080
 PTF_TEST_PORT_MAP = '/root/ptf_test_port_map.json'
 
 
+@pytest.fixture(scope='module')
+def router_macs(duthosts):
+    return [duthost.facts['router_mac'] for duthost in duthosts]
+
+
 @pytest.fixture(scope="module")
 def ignore_ttl(duthosts):
     # on the multi asic devices, the packet can have different ttl based on how the packet is routed
@@ -58,8 +63,8 @@ def ignore_ttl(duthosts):
 def test_basic_fib(duthosts, ptfhost, ipv4, ipv6, mtu,
                    toggle_all_simulator_ports_to_random_side,
                    fib_info_files_per_function,
-                   tbinfo, mux_server_url,
-                   ignore_ttl, single_fib_for_duts, duts_running_config_facts, duts_minigraph_facts):
+                   tbinfo, mux_server_url, router_macs,
+                   ignore_ttl, single_fib_for_duts):
 
     if 'dualtor' in tbinfo['topo']['name']:
         wait(30, 'Wait some time for mux active/standby state to be stable after toggled mux state')
@@ -81,7 +86,8 @@ def test_basic_fib(duthosts, ptfhost, ipv4, ipv6, mtu,
                 "fib_test.FibTest",
                 platform_dir="ptftests",
                 params={"fib_info_files": fib_info_files_per_function[:3],  # Test at most 3 DUTs
-                        "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_config_facts, duts_minigraph_facts),
+                        "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url),
+                        "router_macs": router_macs,
                         "ipv4": ipv4,
                         "ipv6": ipv6,
                         "testbed_mtu": mtu,
@@ -245,8 +251,8 @@ def add_default_route_to_dut(duts_running_config_facts, duthosts, tbinfo):
 
 def test_hash(add_default_route_to_dut, duthosts, fib_info_files_per_function, setup_vlan, hash_keys, ptfhost, ipver,
               toggle_all_simulator_ports_to_rand_selected_tor_m,
-              tbinfo, mux_server_url,
-              ignore_ttl, single_fib_for_duts, duts_running_config_facts, duts_minigraph_facts):
+              tbinfo, mux_server_url, router_macs,
+              ignore_ttl, single_fib_for_duts):
 
     if 'dualtor' in tbinfo['topo']['name']:
         wait(30, 'Wait some time for mux active/standby state to be stable after toggled mux state')
@@ -265,10 +271,11 @@ def test_hash(add_default_route_to_dut, duthosts, fib_info_files_per_function, s
             "hash_test.HashTest",
             platform_dir="ptftests",
             params={"fib_info_files": fib_info_files_per_function[:3],   # Test at most 3 DUTs
-                    "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_config_facts, duts_minigraph_facts),
+                    "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url),
                     "hash_keys": hash_keys,
                     "src_ip_range": ",".join(src_ip_range),
                     "dst_ip_range": ",".join(dst_ip_range),
+                    "router_macs": router_macs,
                     "vlan_ids": VLANIDS,
                     "ignore_ttl":ignore_ttl,
                     "single_fib_for_duts": single_fib_for_duts


### PR DESCRIPTION
Reverts Azure/sonic-mgmt#5027

This change updated the format of fixture `duts_minigraph_facts` defined in `tests/conftests.py`. Not all the code using this fixture are adapted to the new format. 
Sanity check on dualtor testbed failed with error:

```
    def _check_dut_mux_status(duthosts, duts_minigraph_facts):                                                                                                                                                                          
        dut_upper_tor = duthosts[0]                                                                                                                                                                                                     
        dut_lower_tor = duthosts[1]                                                                                                                                                                                                     
                                                                                                                                                                                                                                        
        # Run "show mux status" on dualtor DUTs to collect mux status                                                                                                                                                                   
        duts_mux_status = duthosts.show_and_parse('show mux status')                                                                                                                                                                    
                                                                                                                                                                                                                                        
        # Parse and basic check                                                                                                                                                                                                         
        duts_parsed_mux_status = {}                                                                                                                                                                                                     
        for dut_hostname, dut_mux_status in duts_mux_status.items():                                                                                                                                                                    
                                                                                                                                                                                                                                        
            logger.info('Verify that "show mux status" has output ON {}'.format(dut_hostname))                                                                                                                                          
            if len(dut_mux_status) == 0:                                                                                                                                                                                                
                err_msg = 'No mux status in output of "show mux status"'                                                                                                                                                                
                return False, err_msg, {}                                                                                                                                                                                                                                                                                                                                                                                                                                                   logger.info('Verify that mux ports match vlan interfaces of DUT.')                                                                                                                                                                      vlan_intf_names = set()                                                                                                                                                                                                     >           for vlan in duts_minigraph_facts[dut_hostname]['minigraph_vlans'].values():                                                                                                                                                 E           TypeError: list indices must be integers, not str                                                                                                                                                                                                                                                                                                                                                                                                                   dut_hostname = 'str2-7050cx3-acs-08'
```

Here `duts_minigraph_facts[dut_hostname]` is a list now.

@abdosi, since sanity check is broken by PR #5027, I have to revert this PR for now. Can you fix the issue and submit a new one?