### PR TITLE
Skipping PFCWD Forward action for Cisco-8000 platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -153,7 +153,7 @@ pfcwd/test_pfc_config.py::TestPfcConfig::test_forward_action_cfg:
    skip:
      reason: "Forward action not supported in cisco-8000"
      conditions:
-        - asic_type=="cisco-8000"
+        - "asic_type in ['cisco-8000']"
 #######################################
 #####           qos               #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -149,6 +149,11 @@ pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb:
   xfail:
     reason: "Test flaky"
 
+pfcwd/test_pfc_config.py::TestPfcConfig::test_forward_action_cfg:
+   skip:
+     reason: "Forward action not supported in cisco-8000"
+     conditions:
+        - asic_type=="cisco-8000"
 #######################################
 #####           qos               #####
 #######################################

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -722,7 +722,10 @@ class TestPfcwdFunc(SetupPfcwdFunc):
              pfc_wd_restore_time_large = request.config.getoption("--restore-time")
              # wait time before we check the logs for the 'restore' signature. 'pfc_wd_restore_time_large' is in ms.
              self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)
-             for action in ['dontcare', 'drop', 'forward']:
+             actions = ['dontcare', 'drop', 'forward']
+             if duthost.sonichost._facts['asic_type']=="cisco-8000":
+                 actions = ['dontcare', 'drop']
+             for action in actions:
                  try:
                      self.stats = PfcPktCntrs(self.dut, action)
                      logger.info("{} on port {}".format(WD_ACTION_MSG_PFX[action], port))


### PR DESCRIPTION
### Description of PR
PFCWD Forward action is not supported on Cisco-8000 platforms

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
To skip cases that try to test pfcwd fwd action

#### How did you do it?
Skip these tests for cisco-8000 platform

#### How did you verify/test it?
Verified on cisco-8000 platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
