### PR TITLE
Adding Cisco-8000 to vendor id

### DIFF
--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -9,6 +9,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.broadcom_data import is_broadcom_device
 from tests.common.mellanox_data import is_mellanox_device
 from tests.common.errors import RunAnsibleModuleFail
+from tests.common.cisco_data import is_cisco_device
 
 logger = logging.getLogger(__name__)
 
@@ -215,6 +216,8 @@ def _get_vendor_id(duthost):
         vendor_id = "brcm"
     elif is_mellanox_device(duthost):
         vendor_id = "mlnx"
+    elif is_cisco_device(duthost):
+        vendor_id = "cisco"
     else:
         error_message = '"{}" does not currently support swap_syncd'.format(duthost.facts["asic_type"])
         logger.error(error_message)


### PR DESCRIPTION
### Description of PR
Adding Cisco to _get_vendor_id. The proc checks if it is a cisco device and returns vendor_id back.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Adding Cisco to _get_vendor_id. The proc checks if it is a cisco device and returns vendor_id back.

#### How did you do it?

#### How did you verify/test it?
Verified against Cisco-8000 platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
