### PR TITLE
Fix test_psu.py to only run on Supervisor card if it is chassis. change does not impact pizzabox

### DIFF
--- a/tests/platform_tests/daemon/test_psud.py
+++ b/tests/platform_tests/daemon/test_psud.py
@@ -42,16 +42,16 @@ STATE_DB = 6
 psud_tbl_key = ""
 
 @pytest.fixture(scope="module", autouse=True)
-def setup(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
+def setup(duthosts, enum_supervisor_dut_hostname):
+    duthost = duthosts[enum_supervisor_dut_hostname]
     daemon_en_status = check_pmon_daemon_enable_status(duthost, daemon_name)
     if daemon_en_status is False:
         pytest.skip("{} is not enabled in {}".format(daemon_name, duthost.facts['platform'], duthost.os_version))
 
 
 @pytest.fixture(scope="module", autouse=True)
-def teardown_module(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
+def teardown_module(duthosts, enum_supervisor_dut_hostname):
+    duthost = duthosts[enum_supervisor_dut_hostname]
     yield
 
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
@@ -63,8 +63,8 @@ def teardown_module(duthosts, rand_one_dut_hostname):
 
 
 @pytest.fixture
-def check_daemon_status(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
+def check_daemon_status(duthosts, enum_supervisor_dut_hostname):
+    duthost = duthosts[enum_supervisor_dut_hostname]
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     if daemon_status is not "RUNNING":
         duthost.start_pmon_daemon(daemon_name)
@@ -96,18 +96,18 @@ def wait_data(duthost):
     return shared_scope.data_after_restart
 
 @pytest.fixture(scope='module')
-def data_before_restart(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
+def data_before_restart(duthosts, enum_supervisor_dut_hostname):
+    duthost = duthosts[enum_supervisor_dut_hostname]
 
     data = collect_data(duthost)
     return data
 
 
-def test_pmon_psud_running_status(duthosts, rand_one_dut_hostname, data_before_restart):
+def test_pmon_psud_running_status(duthosts, enum_supervisor_dut_hostname, data_before_restart):
     """
     @summary: This test case is to check psud status on dut
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_supervisor_dut_hostname]
     daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     logger.info("{} daemon is {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
     pytest_assert(daemon_status == expected_running_status,
@@ -119,11 +119,11 @@ def test_pmon_psud_running_status(duthosts, rand_one_dut_hostname, data_before_r
     pytest_assert(data_before_restart['data'], "DB data is not availale on daemon running")
 
 
-def test_pmon_psud_stop_and_start_status(check_daemon_status, duthosts, rand_one_dut_hostname, data_before_restart):
+def test_pmon_psud_stop_and_start_status(check_daemon_status, duthosts, enum_supervisor_dut_hostname, data_before_restart):
     """
     @summary: This test case is to check the psud stopped and restarted status 
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_supervisor_dut_hostname]
     pre_daemon_status, pre_daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
     logger.info("{} daemon is {} with pid {}".format(daemon_name, pre_daemon_status, pre_daemon_pid))
 
@@ -156,11 +156,11 @@ def test_pmon_psud_stop_and_start_status(check_daemon_status, duthosts, rand_one
     pytest_assert(data_after_restart == data_before_restart, 'DB data present before and after restart does not match')
 
 
-def test_pmon_psud_term_and_start_status(check_daemon_status, duthosts, rand_one_dut_hostname, data_before_restart):
+def test_pmon_psud_term_and_start_status(check_daemon_status, duthosts, enum_supervisor_dut_hostname, data_before_restart):
     """
     @summary: This test case is to check the psud terminated and restarted status
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_supervisor_dut_hostname]
 
     skip_release(duthost, ["201811", "201911"])
 
@@ -182,11 +182,11 @@ def test_pmon_psud_term_and_start_status(check_daemon_status, duthosts, rand_one
     pytest_assert(data_after_restart == data_before_restart, 'DB data present before and after restart does not match')
 
 
-def test_pmon_psud_kill_and_start_status(check_daemon_status, duthosts, rand_one_dut_hostname, data_before_restart):
+def test_pmon_psud_kill_and_start_status(check_daemon_status, duthosts, enum_supervisor_dut_hostname, data_before_restart):
     """
     @summary: This test case is to check the psud killed unexpectedly (automatically restarted) status
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_supervisor_dut_hostname]
 
     skip_release(duthost, ["201811", "201911"])
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
When running platform_tests/daemon/test_psu.py on a chassis, it randomly pick a device and it could end up picking up an LC which doe not support the PMON PSU functionality.
This PR is to change it from randomly picking a DUT_HOST by picking only the host that is SUP (in case of chassis) or the only DUT_HOST if it is a pizzabox DUT.

Here are sample output of the tests ran after the change is in place:
```
gechiang@059a8a2512ce:/var/src/sonic-mgmt-int/tests$ sudo ./run_tests.sh -c platform_tests/daemon/test_psud.py -i ../ansible/str2,../ansible/veos -n vms29-t2-8800-2 -u -e --skip_sanity -e --disable_loganalyzer
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/cryptography/__init__.py:39: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  CryptographyDeprecationWarning,
========================================================================================================== test session starts ==========================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collecting ... /usr/local/lib/python2.7/dist-packages/cryptography/__init__.py:39: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  CryptographyDeprecationWarning,
collected 4 items                                                                                                                                                                                                                       

platform_tests/daemon/test_psud.py::test_pmon_psud_running_status[str2-8800-sup-2] PASSED                                                                                                                                         [ 25%]
platform_tests/daemon/test_psud.py::test_pmon_psud_stop_and_start_status[str2-8800-sup-2] PASSED                                                                                                                                  [ 50%]
platform_tests/daemon/test_psud.py::test_pmon_psud_term_and_start_status[str2-8800-sup-2] PASSED                                                                                                                                  [ 75%]
platform_tests/daemon/test_psud.py::test_pmon_psud_kill_and_start_status[str2-8800-sup-2] PASSED                                                                                                                                  [100%]

------------------------------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------------------------
====================================================================================================== 4 passed in 386.77 seconds =======================================================================================================
INFO:root:Can not get Allure report URL. Please check logs
gechiang@059a8a2512ce:/var/src/sonic-mgmt-int/tests$ 
```
Have validate the test works if one specify specific deivice sucha s SUP or even LC which it will honor user specified parameter.  Here is a sample test run where I specified it to run on LC which expected it to fail:
```
gechiang@059a8a2512ce:/var/src/sonic-mgmt-int/tests$ sudo ./run_tests.sh -c platform_tests/daemon/test_psud.py::test_pmon_psud_running_status -i ../ansible/str2,../ansible/veos -n vms29-t2-8800-2 -d str2-8800-lc1-2 -u -e --skip_sanity -e --disable_loganalyzer
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/cryptography/__init__.py:39: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  CryptographyDeprecationWarning,
========================================================================================================== test session starts ==========================================================================================================
platform linux2 -- Python 2.7.12, pytest-4.6.5, py-1.9.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: ansible-2.2.2, forked-1.3.0, xdist-1.28.0, html-1.22.1, repeat-0.8.0, metadata-1.10.0
collecting ... /usr/local/lib/python2.7/dist-packages/cryptography/__init__.py:39: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
  CryptographyDeprecationWarning,
collected 1 item                                                                                                                                                                                                                        

platform_tests/daemon/test_psud.py::test_pmon_psud_running_status[str2-8800-lc1-2] FAILED                                                                                                                                         [100%]

=============================================================================================================== FAILURES ================================================================================================================
____________________________________________________________________________________________ test_pmon_psud_running_status[str2-8800-lc1-2] _____________________________________________________________________________________________

duthosts = [<MultiAsicSonicHost str2-8800-lc1-2>], enum_supervisor_dut_hostname = 'str2-8800-lc1-2', data_before_restart = {'data': {}, 'keys': []}

    def test_pmon_psud_running_status(duthosts, enum_supervisor_dut_hostname, data_before_restart):
        """
        @summary: This test case is to check psud status on dut
        """
        duthost = duthosts[enum_supervisor_dut_hostname]
        daemon_status, daemon_pid = duthost.get_pmon_daemon_status(daemon_name)
        logger.info("{} daemon is {} with pid {}".format(daemon_name, daemon_status, daemon_pid))
        pytest_assert(daemon_status == expected_running_status,
                              "{} expected running status is {} but is {}".format(daemon_name, expected_running_status, daemon_status))
        pytest_assert(daemon_pid != -1,
                              "{} expected pid is a positive integer but is {}".format(daemon_name, daemon_pid))
    
>       pytest_assert(data_before_restart['keys'], "DB keys is not availale on daemon running")
E       Failed: DB keys is not availale on daemon running

daemon_pid = 11524
daemon_status = 'RUNNING'
data_before_restart = {'data': {}, 'keys': []}
duthost    = <MultiAsicSonicHost str2-8800-lc1-2>
duthosts   = [<MultiAsicSonicHost str2-8800-lc1-2>]
enum_supervisor_dut_hostname = 'str2-8800-lc1-2'

platform_tests/daemon/test_psud.py:118: Failed
------------------------------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------------------------
======================================================================================================== short test summary info ========================================================================================================
FAILED platform_tests/daemon/test_psud.py::test_pmon_psud_running_status[str2-8800-lc1-2] - Failed: DB keys is not availale on daemon running
====================================================================================================== 1 failed in 127.54 seconds =======================================================================================================
INFO:root:Can not get Allure report URL. Please check logs
gechiang@059a8a2512ce:/var/src/sonic-mgmt-int/tests$
```

Summary:

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To not accidentally pick the LC to run which will fail the test case

#### How did you verify/test it?
Ensure that the DUT_HOST picked with new logic is always from SUP for chassis.
Also tried specify the DUT_HOST to ensure that is still honored.
Also ran it against a pizzabox DUT and it works fine.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
