### PR TITLE
add run_arp_responder fixture for test_tunnel_memory_leak

### DIFF
--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -79,46 +79,35 @@ def common_setup_teardown(rand_selected_dut, request, tbinfo, vmhost):
     if 'dualtor' in tbinfo['topo']['name']:
         request.getfixturevalue('run_garp_service')
 
-
-@pytest.fixture(scope="module")
-def run_arp_responder_ipv6(rand_selected_dut, ptfhost, tbinfo, apply_mock_dual_tor_tables, copy_arp_responder_py):
-    """Run arp_responder to enable ptf to respond neighbor solicitation messages"""
-    duthost = rand_selected_dut
-    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    minigraph_ptf_indices = mg_facts['minigraph_ptf_indices']
-    mux_config = mux_cable_server_ip(duthost)
-
-    arp_responder_conf = {"eth%s" % minigraph_ptf_indices[port]: [config["server_ipv6"].split("/")[0]] for port, config in mux_config.items()}
-    ptfhost.copy(content=json.dumps(arp_responder_conf, indent=4), dest="/tmp/from_t1.json")
-    ptfhost.host.options["variable_manager"].extra_vars.update({"arp_responder_args": ""})
-    ptfhost.template(src="templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
-    ptfhost.shell('supervisorctl reread && supervisorctl update')
-    ptfhost.shell('supervisorctl restart arp_responder')
-
-    yield
-
-    ptfhost.shell('supervisorctl stop arp_responder')
-
-
-@pytest.fixture(scope="module")
-def run_arp_responder(rand_selected_dut, ptfhost, tbinfo, apply_mock_dual_tor_tables, copy_arp_responder_py):
-    """Run arp_responder to enable ptf to respond neighbor solicitation messages"""
-    logging.info('Copy ARP responder to the PTF container  {}'\
+def _setup_arp_responder(rand_selected_dut, ptfhost, tbinfo, ip_type):
+    logging.info('Setup ARP responder in the PTF container  {}'\
         .format(ptfhost.hostname))
     duthost = rand_selected_dut
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     minigraph_ptf_indices = mg_facts['minigraph_ptf_indices']
     mux_config = mux_cable_server_ip(duthost)
-
-    arp_responder_conf = {"eth%s" % minigraph_ptf_indices[port]: [config["server_ipv4"].split("/")[0]] for port, config in mux_config.items()}
+    if ip_type == 'ipv4':
+        arp_responder_conf = {"eth%s" % minigraph_ptf_indices[port]: [config["server_ipv4"].split("/")[0]] for port, config in mux_config.items()}
+    else:
+        arp_responder_conf = {"eth%s" % minigraph_ptf_indices[port]: [config["server_ipv6"].split("/")[0]] for port, config in mux_config.items()}
     ptfhost.copy(content=json.dumps(arp_responder_conf, indent=4), dest="/tmp/from_t1.json")
 
-    ptfhost.copy(src='scripts/arp_responder.py', dest='/opt')
     ptfhost.host.options["variable_manager"].extra_vars.update({"arp_responder_args": ""})
     ptfhost.template(src="templates/arp_responder.conf.j2", dest="/etc/supervisor/conf.d/arp_responder.conf")
     ptfhost.shell('supervisorctl reread && supervisorctl update')
     ptfhost.shell('supervisorctl restart arp_responder')
 
+@pytest.fixture(scope="module")
+def run_arp_responder_ipv6(rand_selected_dut, ptfhost, tbinfo, apply_mock_dual_tor_tables):
+    """Run arp_responder to enable ptf to respond neighbor solicitation messages"""
+    _setup_arp_responder(rand_selected_dut, ptfhost, tbinfo, 'ipv6')
+    yield
+
+    ptfhost.shell('supervisorctl stop arp_responder')
+
+@pytest.fixture(scope="module")
+def run_arp_responder(rand_selected_dut, ptfhost, tbinfo):
+    _setup_arp_responder(rand_selected_dut, ptfhost, tbinfo, 'ipv4')
     yield
 
     ptfhost.shell('supervisorctl stop arp_responder')

--- a/tests/dualtor/test_tunnel_memory_leak.py
+++ b/tests/dualtor/test_tunnel_memory_leak.py
@@ -25,11 +25,7 @@ from tests.common.fixtures.ptfhost_utils import run_garp_service, run_icmp_respo
 
 
 pytestmark = [
-    pytest.mark.topology("dualtor"),
-    pytest.mark.usefixtures('run_garp_service',
-                            'run_arp_responder',
-                            'run_icmp_responder'
-                            )
+    pytest.mark.topology("dualtor")
 ]
 
 PACKET_COUNT = 1000
@@ -109,7 +105,8 @@ def check_memory_leak(duthost):
 def test_tunnel_memory_leak(
     toggle_all_simulator_ports_to_upper_tor,
     upper_tor_host, lower_tor_host, ptfhost, 
-    ptfadapter, conn_graph_facts, tbinfo, vmhost
+    ptfadapter, conn_graph_facts, tbinfo, vmhost,
+    run_arp_responder
 ):
     """
     Test if there is memory leak for service tunnel_packet_handler.

--- a/tests/dualtor/test_tunnel_memory_leak.py
+++ b/tests/dualtor/test_tunnel_memory_leak.py
@@ -21,15 +21,22 @@ from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.dual_tor_utils import build_packet_to_server
 from tests.common.dualtor.dual_tor_utils import flush_neighbor
 from tests.common.helpers.dut_utils import get_program_info
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service
 
 
 pytestmark = [
-    pytest.mark.topology("dualtor")
+    pytest.mark.topology("dualtor"),
+    pytest.mark.usefixtures('run_garp_service',
+                            'run_icmp_responder',
+                            'run_arp_responder'
+                            )
 ]
 
 PACKET_COUNT = 1000
 swss_mem_percent = 0
-
+# It's normal to see the mem usage increased a little bit
+# set threshold buffer to 0.01%
+MEM_THRESHOLD_BUFFER = 0.01
 
 def validate_neighbor_entry_exist(duthost, neighbor_addr):
     """Validate if neighbor entry exist on duthost
@@ -93,7 +100,7 @@ def check_memory_leak(duthost):
         logging.info("SWSS container original MEM USAGE:{} original percent: {}%"
                     .format(mem_usage, swss_mem_percent))
         return False
-    elif mem_percent > swss_mem_percent:
+    elif mem_percent > swss_mem_percent + MEM_THRESHOLD_BUFFER:
         logging.error("SWSS container MEM percent is increased. current percent:{}%, original percent: {}%"
                     .format(mem_percent, swss_mem_percent))
         return True

--- a/tests/dualtor/test_tunnel_memory_leak.py
+++ b/tests/dualtor/test_tunnel_memory_leak.py
@@ -21,6 +21,7 @@ from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.dual_tor_utils import build_packet_to_server
 from tests.common.dualtor.dual_tor_utils import flush_neighbor
 from tests.common.helpers.dut_utils import get_program_info
+from tests.common.fixtures.ptfhost_utils import run_garp_service, run_icmp_responder
 
 
 pytestmark = [
@@ -171,7 +172,7 @@ def test_tunnel_memory_leak(
 
             server_traffic_monitor = ServerTrafficMonitor(
                 upper_tor_host, ptfhost, vmhost, tbinfo, iface,
-                conn_graph_facts, exp_pkt, existing=True, is_mocked=True
+                conn_graph_facts, exp_pkt, existing=True, is_mocked=False
             )
             with rm_neighbor, server_traffic_monitor:
                 testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), pkt, count=PACKET_COUNT)
@@ -182,7 +183,6 @@ def test_tunnel_memory_leak(
                 pytest_assert(validate_neighbor_entry_exist(upper_tor_host, server_ipv4),
                             "The server ip {} doesn't exist in neighbor table on dut {}. \
                             tunnel_packet_handler isn't triggered.".format(server_ipv4, upper_tor_host.hostname))
-                time.sleep(3)
             pytest_assert(len(server_traffic_monitor.matched_packets) > PACKET_COUNT /2, 
                         "Received {} expected packets for server {}, drop more than 50%."
                         .format(len(server_traffic_monitor.matched_packets), server_ipv4))

--- a/tests/dualtor/test_tunnel_memory_leak.py
+++ b/tests/dualtor/test_tunnel_memory_leak.py
@@ -21,7 +21,6 @@ from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.dual_tor_utils import build_packet_to_server
 from tests.common.dualtor.dual_tor_utils import flush_neighbor
 from tests.common.helpers.dut_utils import get_program_info
-from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service
 
 
 pytestmark = [
@@ -35,8 +34,8 @@ pytestmark = [
 PACKET_COUNT = 1000
 swss_mem_percent = 0
 # It's normal to see the mem usage increased a little bit
-# set threshold buffer to 0.01%
-MEM_THRESHOLD_BUFFER = 0.01
+# set threshold buffer to 0.02%
+MEM_THRESHOLD_BUFFER = 0.02
 
 def validate_neighbor_entry_exist(duthost, neighbor_addr):
     """Validate if neighbor entry exist on duthost

--- a/tests/dualtor/test_tunnel_memory_leak.py
+++ b/tests/dualtor/test_tunnel_memory_leak.py
@@ -27,8 +27,8 @@ from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_ser
 pytestmark = [
     pytest.mark.topology("dualtor"),
     pytest.mark.usefixtures('run_garp_service',
-                            'run_icmp_responder',
-                            'run_arp_responder'
+                            'run_arp_responder',
+                            'run_icmp_responder'
                             )
 ]
 
@@ -183,7 +183,7 @@ def test_tunnel_memory_leak(
                 pytest_assert(validate_neighbor_entry_exist(upper_tor_host, server_ipv4),
                             "The server ip {} doesn't exist in neighbor table on dut {}. \
                             tunnel_packet_handler isn't triggered.".format(server_ipv4, upper_tor_host.hostname))
-
+                time.sleep(3)
             pytest_assert(len(server_traffic_monitor.matched_packets) > PACKET_COUNT /2, 
                         "Received {} expected packets for server {}, drop more than 50%."
                         .format(len(server_traffic_monitor.matched_packets), server_ipv4))

--- a/tests/dualtor/test_tunnel_memory_leak.py
+++ b/tests/dualtor/test_tunnel_memory_leak.py
@@ -21,7 +21,7 @@ from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.dual_tor_utils import build_packet_to_server
 from tests.common.dualtor.dual_tor_utils import flush_neighbor
 from tests.common.helpers.dut_utils import get_program_info
-from tests.common.fixtures.ptfhost_utils import run_garp_service, run_icmp_responder
+from tests.common.fixtures.ptfhost_utils import run_garp_service, run_icmp_responder # lgtm[py/unused-import]
 
 
 pytestmark = [


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Currently, test_tunnel_memory_leak always fails. It's because it doesn't set up `arp_responder ` configuration and uses the existing config file `/tmp/from_t1.json`. So some neighbors may not send correct arp respond, the expected packets may lost.

Summary:
In this PR, it has several changes:
1. add `run_arp_responder` fixture for test_tunnel_memory_leak, load correct content into `/tmp/from_t1.json` which is used by `arp_responder`
2. Add a common setup_arp_responder function for both ipv4 and ipv6 run_arp_responder fixture
3. add 0.02% memory usage buffer to avoid test case failure.
4. set is_mock to Falsue, capture packets in vmhost interface, not in ptf container.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To fix the failure of test_tunnel_memory_leak

#### How did you do it?
Add `run_arp_responder` fixture for test_tunnel_memory_leak, load correct content into `/tmp/from_t1.json` which is used by `arp_responder`. Servers can receive expected packets.

#### How did you verify/test it?
run test case: dualtor/test_tunnel_memory_leak.py

#### Any platform specific information?
Dualtor
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
