### PR TITLE
fixed T0 patch preparation in add_rack test

### DIFF
--- a/tests/configlet/util/configlet.py
+++ b/tests/configlet/util/configlet.py
@@ -188,14 +188,16 @@ def get_port_related_data(is_mlnx, is_storage_backend):
         return ret
 
     for local_port in sonic_local_ports:
-        # Hard coded as 300m per discussion with Neetha
 
         #  "CABLE_LENGTH"
         cable[local_port] = orig_config["CABLE_LENGTH|AZURE"]['value'][local_port]
 
+        def filter_cfg_keys(target_key):
+            return [key for key in orig_config.keys() if target_key in key]
+
         # "BUFFER_PG"
-        buffer_pg["{}|0".format(local_port)] = orig_config["BUFFER_PG|{}|0".format(
-            local_port)]['value']
+        for pg in filter_cfg_keys("BUFFER_PG|" + local_port):
+            buffer_pg[pg.partition('BUFFER_PG|')[-1]] = orig_config[pg]['value']
 
         # "QUEUE"
         for i in range(7):
@@ -203,14 +205,8 @@ def get_port_related_data(is_mlnx, is_storage_backend):
                 local_port, i)]["value"]
 
         # "BUFFER_QUEUE"
-        buffer_q["{}|0-2".format(local_port)] = orig_config["BUFFER_QUEUE|{}|0-2".
-                format(local_port)]['value']
-
-        buffer_q["{}|3-4".format(local_port)] = orig_config["BUFFER_QUEUE|{}|3-4".
-                format(local_port)]['value']
-
-        buffer_q["{}|5-6".format(local_port)] = orig_config["BUFFER_QUEUE|{}|5-6".
-                format(local_port)]['value']
+        for q in filter_cfg_keys("BUFFER_QUEUE|" + local_port):
+            buffer_q[q.partition('BUFFER_QUEUE|')[-1]] = orig_config[q]['value']
 
         if is_mlnx:
             # "BUFFER_PORT_INGRESS_PROFILE_LIST"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fixed T0 patch preparation in add_rack test
Fixes # (issue)

The test removes one T0 from config and restores it using configlet. When preparing T0 config for restore, the test makes a wrong assumption about a config present for T0 and thus fails. The mentioned config is queue profile assignment for an interface queues 5-6. It is listed in [the default config](https://github.com/Azure/sonic-buildimage/blob/master/files/build_templates/buffers_config.j2) but vendors may redefine it [like Barefoot does](https://github.com/Azure/sonic-buildimage/blob/master/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/buffers_defaults_t1.j2).
The PR fixes the issue removing explicit config reference and collects present queue-profile assignments only.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Make the test work on more platforms
#### How did you do it?
Removed an explicit reference to the config that may vary
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t1,any configlet/test_add_rack.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
