### PR TITLE
Added code to account for the absence of platform.json

### DIFF
--- a/tests/platform_tests/api/test_psu_fans.py
+++ b/tests/platform_tests/api/test_psu_fans.py
@@ -116,14 +116,14 @@ class TestPsuFans(PlatformApiTestBase):
                     platform_file_check = {}
                     try:
                         #
-                        # Check if the JSON file exists in the specific path. Return 0 if it DOES NOT exist.
+                        # Check if the JSON file exists in the specific path. Return 0 if it DOES exist.
                         # The command function throws exception if rc is non-zero, so handle it.
                         #
-                        platform_file_check = duthost.command("[ ! -f {} ]".format(platform_file_path))
+                        platform_file_check = duthost.command("[ -f {} ]".format(platform_file_path))
                     except:
-                        # The JSON file exists.. so set rc to 1.
+                        # The JSON file does not exist, so set rc to 1.
                         platform_file_check['rc'] = 1
-                    if platform_file_check.get('rc') != 0:
+                    if platform_file_check.get('rc') == 0:
                         logging.info("{} has a platform.json file. Running comparison with platform facts.".format(duthost._facts.get("platform")))
                         self.compare_value_with_platform_facts(duthost, 'name', name, j, i)
                     else:

--- a/tests/platform_tests/api/test_psu_fans.py
+++ b/tests/platform_tests/api/test_psu_fans.py
@@ -107,7 +107,27 @@ class TestPsuFans(PlatformApiTestBase):
 
                 if self.expect(name is not None, "Unable to retrieve psu {} fan {} name".format(j, i)):
                     self.expect(isinstance(name, STRING_TYPE), "psu {} fan {} name appears incorrect".format(j, i))
-                    self.compare_value_with_platform_facts(duthost, 'name', name, j, i)
+		    self.expect(duthost._facts.get("platform") is not None, "Unable to retrieve platform name")
+                    #
+                    # Check whether platform.json file exists for this specific platform. If yes compare names.
+                    # If not, skip comparison.
+                    #
+                    platform_file_path = os.path.join("/usr/share/sonic/device", duthost._facts.get("platform"), "platform.json")
+                    platform_file_check = {}
+                    try:
+                        #
+                        # Check if the JSON file exists in the specific path. Return 0 if it DOES NOT exist.
+                        # The command function throws exception if rc is non-zero, so handle it.
+                        #
+                        platform_file_check = duthost.command("[ ! -f {} ]".format(platform_file_path))
+                    except:
+                        # The JSON file exists.. so set rc to 1.
+                        platform_file_check['rc'] = 1
+                    if platform_file_check.get('rc') != 0:
+                        logging.info("{} has a platform.json file. Running comparison with platform facts.".format(duthost._facts.get("platform")))
+                        self.compare_value_with_platform_facts(duthost, 'name', name, j, i)
+                    else:
+                        logging.info("{} does not have a platform.json file. Skipping comparison with platform facts.".format(duthost._facts.get("platform")))
 
         self.assert_expectations()
 


### PR DESCRIPTION
### Description of PR
Added code to account for the absence of platform.json within the device folder that was causing false failures on the PSU Fans test.


Summary:
The test as it stands currently does not account for the fact that 201911 OS does not have the platform.json file within each platform folder in '/usr/share/sonic/device'. The platform.json file contains, among many things, information about each PSU. The absence of this file meant that the test was failing at the point where a comparison needed to be made between the expected PSU info (contained in the file) and actual info received from the device. This is why devices running 201911 were throwing false failures.

### Type of change

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Motivation was to stop the false failures on 2700 and 3800 platforms running 201911 SONiC.

#### How did you do it?
Added a check to see if platform.json was present and only run the comparison test if the file was present

#### How did you verify/test it?
I verified by running the tests on 2700 and 3800 platforms, each running 201911 and 202012 OSes and verifying that the test behaved as expected

#### Any platform specific information?
Only 2700 and 3800 platforms were tested.