### PR TITLE
Revert "Fix LogAnalyzer to force load regular expressions from common files"

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -30,6 +30,9 @@ def analyzer_add_marker(analyzers, node=None, results=None):
     loganalyzer = analyzers[node.hostname]
     logging.info("Add start marker into DUT syslog for host {}".format(node.hostname))
     marker = loganalyzer.init()
+    logging.info("Load config and analyze log for host {}".format(node.hostname))
+    # Read existed common regular expressions located with legacy loganalyzer module
+    loganalyzer.load_common_config()
     results[node.hostname] = marker
 
 
@@ -50,9 +53,7 @@ def loganalyzer(duthosts, request):
     analyzers = {}
     parallel_run(analyzer_logrotate, [], {}, duthosts, timeout=120)
     for duthost in duthosts:
-        analyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
-        analyzer.load_common_config()
-        analyzers[duthost.hostname] = analyzer
+        analyzers[duthost.hostname] = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
     markers = parallel_run(analyzer_add_marker, [analyzers], {}, duthosts, timeout=120)
 
     yield analyzers


### PR DESCRIPTION
Reverts Azure/sonic-mgmt#5193

After this fix was merged, PR test keeps failing because of errors in syslog.

We spent some effort trying to temporarily ignore the errors. However, the list seems endless.
Please refer to: 
* https://github.com/Azure/sonic-mgmt/pull/5411
* https://github.com/Azure/sonic-mgmt/pull/5391

We need a way to temporarily unblock PR testing. Let's revert this fix for now. Then I'll submit another PR to fix the 
loganalyzer issue together with a complete ignore list.
