### PR TITLE
[VNET_VXLAN] Fix 'Neighbor is unreachable' failure in test_vnet_vxlan

### DIFF
--- a/tests/vxlan/test_vnet_vxlan.py
+++ b/tests/vxlan/test_vnet_vxlan.py
@@ -132,7 +132,7 @@ def vxlan_status(setup, request, duthosts, rand_one_dut_hostname, ptfhost, vnet_
 
         apply_dut_config_files(duthost, vnet_test_params)
         # Check arp table status in a loop with delay.
-        pytest_assert(wait_until(60, 10, 10, is_neigh_reachable, duthost, vnet_config), "Neighbor is unreachable")
+        pytest_assert(wait_until(120, 20, 10, is_neigh_reachable, duthost, vnet_config), "Neighbor is unreachable")
         vxlan_enabled = True
     elif request.param == "Cleanup" and vnet_test_params[CLEANUP_KEY]:
         if vlan_tagging_mode != "":


### PR DESCRIPTION
### Description of PR

Checked that it sometimes takes more than 60s to wait for neighbors to come up. So need to increase this time to 120s.
This is an addition to this PR: https://github.com/Azure/sonic-mgmt/pull/5311

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To fix the vnet_vxlan_3k test

#### How did you do it?
Increased timeout for checking neighbors from 60s to 120s

#### How did you verify/test it?
By running the test

