### PR TITLE
[portstat] fix the portstat test issue

### DIFF
--- a/tests/portstat/test_portstat.py
+++ b/tests/portstat/test_portstat.py
@@ -44,10 +44,14 @@ def test_portstat_clear(duthosts, enum_rand_one_per_hwsku_frontend_hostname, com
     """
     COUNT_THRES = 10
     for intf in before_portstat:
-        rx_ok_before = int(before_portstat[intf]['rx_ok'].replace(',',''))
-        rx_ok_after = int(after_portstat[intf]['rx_ok'].replace(',',''))
-        tx_ok_before = int(before_portstat[intf]['tx_ok'].replace(',',''))
-        tx_ok_after = int(after_portstat[intf]['tx_ok'].replace(',',''))
+        tmp_ok_cnt = before_portstat[intf]['rx_ok'].replace(',','')
+        rx_ok_before = int(0 if tmp_ok_cnt == 'N/A' else tmp_ok_cnt)
+        tmp_ok_cnt = after_portstat[intf]['rx_ok'].replace(',','')
+        rx_ok_after = int(0 if tmp_ok_cnt == 'N/A' else tmp_ok_cnt)
+        tmp_ok_cnt = before_portstat[intf]['tx_ok'].replace(',','')
+        tx_ok_before = int(0 if tmp_ok_cnt == 'N/A' else tmp_ok_cnt)
+        tmp_ok_cnt = after_portstat[intf]['tx_ok'].replace(',','')
+        tx_ok_after = int(0 if tmp_ok_cnt == 'N/A' else tmp_ok_cnt)
         if int(rx_ok_before >= COUNT_THRES):
             pytest_assert(rx_ok_before >= rx_ok_after,
                           'Value of RX_OK after clear should be lesser')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
There is a change in portstat script, the count of rx_ok would be 'N/A' when the port is in down status. 
Change this testcase to support this.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Enhance portstat test for the change of image.
#### How did you do it?
To check if there is 'N/A', convert 'N/A' to 0.
#### How did you verify/test it?
Run portstat test with master image.
#### Any platform specific information?
7050cx3
#### Supported testbed topology if it's a new test case?
No.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
