### PR TITLE
Modified IPv4 and UDP length fields for dhcp request packet

### DIFF
--- a/tests/dhcp_relay/test_dhcp_pkt_fwd.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_fwd.py
@@ -206,8 +206,8 @@ class DhcpPktFwdBase:
             packet: DHCP Request packet
         """
         ether = scapy.Ether(dst=dutMac, src=self.DHCP_RELAY["mac"], type=0x0800)
-        ip = scapy.IP(src=self.DHCP_RELAY["loopback"], dst=self.DHCP_SERVER["ip"], len=336, ttl=64)
-        udp = scapy.UDP(sport=self.DHCP_SERVER["port"], dport=self.DHCP_SERVER["port"], len=316)
+        ip = scapy.IP(src=self.DHCP_RELAY["loopback"], dst=self.DHCP_SERVER["ip"], len=328, ttl=64)
+        udp = scapy.UDP(sport=self.DHCP_SERVER["port"], dport=self.DHCP_SERVER["port"], len=308)
         bootp = scapy.BOOTP(
             op=1,
             htype=1,


### PR DESCRIPTION
### Description of PR
Seeing Issue with "dhcp_relay/test_dhcp_pkt_fwd.py " script with "request" packet .

The DHCP request packets are not even making it to the router.
And it happens only with DHCP request packets and not the others.
After taking a closer look at the DHCP request packet that is generated by the PTF, it turned out that IPv4 and UDP length fields are incorrect and it seems a malformed packet.

After fixing the test script locally to have the right values in the IP and UDP header fields, the test case passes.

Sonic mgmt issue : https://github.com/Azure/sonic-mgmt/issues/3815

Summary:
Fixes #3815

### Type of change



- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Modified IPv4 and UDP length fields for dhcp request packet
#### How did you verify/test it?
After fixing the test script locally to have the right values in the IP and UDP header fields, the test case passes.
#### Any platform specific information?
