### PR TITLE
Ignore DF bit from outer IPinIP packet in ip_in_ip_tunnel_test.py for Cisco-8000 devices

### DIFF
--- a/ansible/roles/test/files/ptftests/ip_in_ip_tunnel_test.py
+++ b/ansible/roles/test/files/ptftests/ip_in_ip_tunnel_test.py
@@ -116,6 +116,7 @@ class IpinIPTunnelTest(BaseTest):
         exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "id") # since src and dst changed, ID would change too
         exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "ttl") # ttl in outer packet is set to 255
         exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "chksum") # checksum would differ as the IP header is not the same
+        exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "flags") # DF bit may be set
         return exp_tunnel_pkt
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In test_orchagent_standby_tor_downstream.py, DF bit is set from Cisco-8000 silicon one asic since fragmentation on the encapsulated packet is not supported and the expected packet doesn't have it set. This causes the tests to fail despite receiving the complete expected packets.

In reference to [https://datatracker.ietf.org/doc/html/rfc2003](https://datatracker.ietf.org/doc/html/rfc2003), the outer packet can have the DF bit set when the inner packet does not.

 Identification, Flags, Fragment Offset
         These three fields are set as specified in [[10](https://datatracker.ietf.org/doc/html/rfc2003#ref-10)].  However, if the "Don't Fragment" bit is set in the inner IP header, it MUST be set in the outer IP header; if the "Don't Fragment" bit is not set in the inner IP header, it MAY be set in the outer IP header, as described in [Section 5.1](https://datatracker.ietf.org/doc/html/rfc2003#section-5.1).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix






