### PR TITLE
[qos] Disable FDB aging before start of test

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -916,10 +916,82 @@ class QosSaiBase(QosBase):
             testParams=dutTestParams["basicParams"]
         )
 
+    def __loadSwssConfig(self, duthost):
+        """
+            Load SWSS configuration on DUT
+
+            Args:
+                duthost (AnsibleHost): Device Under Test (DUT)
+
+            Raises:
+                asserts if the load SWSS config failed
+
+            Returns:
+                None
+        """
+        duthost.shell(argv=[
+            "docker",
+            "exec",
+            "swss",
+            "bash",
+            "-c",
+            "swssconfig /etc/swss/config.d/switch.json"
+        ])
+
+    def __deleteTmpSwitchConfig(self, duthost):
+        """
+            Delete temporary switch.json cofiguration files
+
+            Args:
+                duthost (AnsibleHost): Device Under Test (DUT)
+
+            Returns:
+                None
+        """
+        result = duthost.find(path=["/tmp"], patterns=["switch.json*"])
+        for file in result["files"]:
+            duthost.file(path=file["path"], state="absent")
+
+    @pytest.fixture(scope='class', autouse=True)
+    def handleFdbAging(self, duthosts, rand_one_dut_hostname):
+        """
+            Disable FDB aging and reenable at the end of tests
+
+            Set fdb_aging_time to 0, update the swss configuration, and restore SWSS configuration afer
+            test completes
+
+            Args:
+                duthost (AnsibleHost): Device Under Test (DUT)
+
+            Returns:
+                None
+        """
+        duthost = duthosts[rand_one_dut_hostname]
+        fdbAgingTime = 0
+
+        self.__deleteTmpSwitchConfig(duthost)
+        duthost.shell(argv=["docker", "cp", "swss:/etc/swss/config.d/switch.json", "/tmp"])
+        duthost.replace(
+            dest='/tmp/switch.json',
+            regexp='"fdb_aging_time": ".*"',
+            replace='"fdb_aging_time": "{0}"'.format(fdbAgingTime),
+            backup=True
+        )
+        duthost.shell(argv=["docker", "cp", "/tmp/switch.json", "swss:/etc/swss/config.d/switch.json"])
+        self.__loadSwssConfig(duthost)
+
+        yield
+
+        result = duthost.find(path=["/tmp"], patterns=["switch.json.*"])
+        if result["matched"] > 0:
+            duthost.shell(argv=["docker", "cp", result["files"][0]["path"], "swss:/etc/swss/config.d/switch.json"])
+            self.__loadSwssConfig(duthost)
+        self.__deleteTmpSwitchConfig(duthost)
+
     @pytest.fixture(scope='class', autouse=True)
     def populateArpEntries(
         self, duthosts, enum_frontend_asic_index, rand_one_dut_hostname,
-        ptfhost, dutTestParams, dutConfig, releaseAllPorts,
+        ptfhost, dutTestParams, dutConfig, releaseAllPorts, handleFdbAging,
     ):
         """
             Update ARP entries of QoS SAI test ports


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Few qos testcases were consistently failing on backend T0 topology. This test populates the fdb prior to the start of the test run.  The failures were  due to mac entries aging in the middle of the tests and hence the tests not seeing the expected number of packets in the respective pg/queue of the desired port.  

This PR contains the following changes
* Disable fdb aging before populating fdb entries and then restore the default aging value at the end of all the tests
* add more logging to the PGShared and QShared watermark tests to get the number of packets received. This will help rule out slow PTF possibility

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012




#### How did you verify/test it?
Reproduced the problem on backend T0. Reran the testcases with the changes in this PR and could no longer see the issue. 