### PR TITLE
Update test_po_cleanup.py

### DIFF
--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -47,24 +47,24 @@ def check_topo_and_restore(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
 
     if len(mg_facts['minigraph_portchannels'].keys()) == 0 and not duthost.is_multi_asic:
         pytest.skip("Skip test due to there is no portchannel exists in current topology.")
-
-def test_po_cleanup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_asic_index, tbinfo):
+    
+def test_po_cleanup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
     """
     test port channel are cleaned up correctly and teammgrd and teamsyncd process
     handle  SIGTERM gracefully
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    logging.info("Disable swss/teamd Feature")
-    duthost.asic_instance(enum_asic_index).stop_service("swss")
+    logging.info("Disable swss/teamd Feature in all asics")
+    # Following will call "sudo systemctl stop swss@0", same for swss@1 ..
+    duthost.stop_service("swss")
     # Check if Linux Kernel Portchannel Interface teamdev are clean up
-    if not wait_until(10, 1, 0, check_kernel_po_interface_cleaned, duthost, enum_asic_index):
-        fail_msg = "PortChannel interface still exists in kernel"
-        pytest.fail(fail_msg)
-    # Restore swss service.
-    duthost.asic_instance(enum_asic_index).start_service("swss")
-    assert wait_until(800, 20, 0, duthost.critical_services_fully_started),\
-        "Not all critical services are fully started"
-
+    for asic_id in duthost.get_asic_ids():
+        if not wait_until(10, 1, 0, check_kernel_po_interface_cleaned, duthost, asic_id):        
+            fail_msg = "PortChannel interface still exists in kernel"
+            pytest.fail(fail_msg)
+    # Restore config services
+    config_reload(duthost)
+    
 def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
     """
     test port channel are cleaned up correctly after config reload, with system under stress.

--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -62,7 +62,7 @@ def test_po_cleanup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_as
         pytest.fail(fail_msg)
     # Restore swss service.
     duthost.asic_instance(enum_asic_index).start_service("swss")
-    assert wait_until(300, 20, 0, duthost.critical_services_fully_started),\
+    assert wait_until(800, 20, 0, duthost.critical_services_fully_started),\
         "Not all critical services are fully started"
 
 def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):


### PR DESCRIPTION
[test_po_cleanup] Change timeout length to 800 instead of 300 to allow more time for multi-asic asics to come back.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
For a multi-asic device, restart of swss and teamd is done per asic, noticed that for a 6-asic device, asic3 and asic4 are experiencing more time during restart. Also, interfaces and bgp neighbors need more minutes to come back. Execute a config_reload at the end of test_po_cleanup helps to bring back processes in a safe manner.
duthost.asic_instance(enum_asic_index).start_service("swss")
assert wait_until(300, 20, 0, duthost.critical_services_fully_started),\
>           "Not all critical services are fully started"
E       AssertionError: Not all critical services are fully started
duthost    = <MultiAsicSonicHost >
duthosts   = [<MultiAsicSonicHost >]
enum_asic_index = 3
enum_rand_one_per_hwsku_frontend_hostname = 'xxx'
tbinfo     = {'auto_recover': 'True', 'comment': 'Arvind', 'conf-name': 'xxx', 'duts': ['xxx'], ...}
[pc/test_po_cleanup.py:66: AssertionError]


<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
1. Execute an "config_reload" at the end of test_po_cleanup, to start up not only all critical services, but also wait for all port, interfaces, bgp neighbors to come up.
2. Call duthost.stop_service("swss") directly from duthost, instead of passing each asics inside the test_po_cleanup. to avoid execution sequence of test_po_cleanup[asic0], test_po_cleanup_after_reload[duthost], test_po_cleanup[asic1].

Summary:
Fixes # (issue)
https://github.com/Azure/sonic-mgmt/issues/5294
https://github.com/Azure/sonic-mgmt/issues/4887
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ X] Test case(new/improvement)


### Back port request
- [X ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
