### PR TITLE
Add DHCPv6 T1 CoPP Test

### DIFF
--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -379,11 +379,11 @@ class DHCP6Test(NoPolicyTest):
 
         return packet
     
-  #SONIC configuration has no packets to CPU for DHCPv6-T1 Topo
+ #SONIC configuration has no packets to CPU for DHCPv6-T1 Topo
 class DHCP6TopoT1Test(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
-        # T1 DHCP no packet to packet to CPU so police rate is 0
+        # T1 DHCP6 no packet to packet to CPU so police rate is 0
         self.PPS_LIMIT_MIN = 0
         self.PPS_LIMIT_MAX = 0
 

--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -367,27 +367,44 @@ class DHCP6Test(NoPolicyTest):
     def contruct_packet(self, port_number):
         src_mac = self.my_mac[port_number]
 
-        packet = testutils.simple_udp_packet(
+        packet = testutils.simple_udpv6_packet(
             pktlen=100,
             eth_dst='33:33:00:01:00:02',
             eth_src=src_mac,
-            dl_vlan_enable=False,
-            vlan_vid=0,
-            vlan_pcp=0,
-            dl_vlan_cfi=0,
-            ip_src='::1',
-            ip_dst='ff02::1::2',
-            ip_tos=0,
-            ip_ttl=64,
+            ipv6_src='::1',
+            ipv6_dst='ff02::1:2',
             udp_sport=546,
-            udp_dport=547,
-            ip_ihl=None,
-            ip_options=False,
-            with_udp_chksum=True
+            udp_dport=547
         )
 
         return packet
+    
+  #SONIC configuration has no packets to CPU for DHCPv6-T1 Topo
+class DHCP6TopoT1Test(PolicyTest):
+    def __init__(self):
+        PolicyTest.__init__(self)
+        # T1 DHCP no packet to packet to CPU so police rate is 0
+        self.PPS_LIMIT_MIN = 0
+        self.PPS_LIMIT_MAX = 0
 
+    def runTest(self):
+        self.log("DHCP6TopoT1Test")
+        self.run_suite()
+
+    def contruct_packet(self, port_number):
+        src_mac = self.my_mac[port_number]
+
+        packet = testutils.simple_udpv6_packet(
+            pktlen=100,
+            eth_dst='33:33:00:01:00:02',
+            eth_src=src_mac,
+            ipv6_src='::1',
+            ipv6_dst='ff02::1:2',
+            udp_sport=546,
+            udp_dport=547,
+        )
+
+        return packet
 
 # SONIC configuration has no policer limiting for LLDP
 class LLDPTest(NoPolicyTest):

--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -401,7 +401,7 @@ class DHCP6TopoT1Test(PolicyTest):
             ipv6_src='::1',
             ipv6_dst='ff02::1:2',
             udp_sport=546,
-            udp_dport=547,
+            udp_dport=547
         )
 
         return packet


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://github.com/Azure/sonic-mgmt/issues/5329
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
DHCPv6 is missing T1 topo test

#### How did you do it?
Add a policy DHCPv6 test on T1 topology

#### How did you verify/test it?
Tested on T1 platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
