### PR TITLE
Add GCU empty input test to verify functional usage and valid configDB

### DIFF
--- a/tests/generic_config_updater/test_empty_input.py
+++ b/tests/generic_config_updater/test_empty_input.py
@@ -1,0 +1,41 @@
+import logging
+import pytest
+
+from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success
+from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile
+from tests.generic_config_updater.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
+
+logger = logging.getLogger(__name__)
+
+@pytest.fixture(autouse=True)
+def setup_env(duthosts, rand_one_dut_hostname):
+    """
+    Setup/teardown fixture for empty input=
+
+    Args:
+        duthosts: list of DUTs.
+        rand_selected_dut: The fixture returns a randomly selected DuT.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    create_checkpoint(duthost)
+
+    yield
+
+    try:
+        logger.info("Rolled back to original checkpoint")
+        rollback_or_reload(duthost)
+
+    finally:
+        delete_checkpoint(duthost)
+
+def test_tc1_empty_input(duthost):
+    json_patch = []
+
+    tmpfile = generate_tmpfile(duthost)
+    logger.info("tmpfile {}".format(tmpfile))
+
+    try:
+        output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+        expect_op_success(duthost, output)
+    finally:
+        delete_tmpfile(duthost, tmpfile)

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -152,6 +152,7 @@ test_t0() {
       container_checker/test_container_checker.py \
       process_monitoring/test_critical_process_monitoring.py \
       system_health/test_system_status.py \
+      generic_config_updater/test_empty_input.py \
       generic_config_updater/test_aaa.py \
       generic_config_updater/test_bgpl.py \
       generic_config_updater/test_bgp_prefix.py \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add empty input test before GCU tests to check GCU feature and if current configDB is valid
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
During PR test, there will have change on config DB. It will fail on generic_config_updater/test_aaa.py. This empty input test is to verify if it is GCU aaa test failure or invalid config DB cause the failure.
#### How did you do it?
Add empty input test case.
#### How did you verify/test it?
Run test of sonic-mgmt/tests/generic_config_updater/test_empty_input.py on KVM
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
