### PR TITLE
Skip slb for mgmt tor

### DIFF
--- a/tests/bgp/test_bgp_slb.py
+++ b/tests/bgp/test_bgp_slb.py
@@ -16,13 +16,6 @@ PEER_COUNT = 1
 NEIGHBOR_EXABGP_PORT = 11000
 
 
-@pytest.fixture(scope="module", autouse=True)
-def skip_on_backend(tbinfo):
-    """Skip over storage backend topologies."""
-    if "backend" in tbinfo["topo"]["name"]:
-        pytest.skip("Skipping test_bgp_slb, unsupported topology %s." % tbinfo["topo"]["name"])
-
-
 @pytest.fixture(params=["warm", "fast"])
 def reboot_type(request):
     return request.param

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -8,7 +8,16 @@ acl/test_acl_outer_vlan.py:
     reason: "Cisco platform does not support ACL Outer VLAN ID tests"
     conditions:
       - asic_type=="cisco-8000"
-       
+
+#######################################
+#####            bgp              #####
+#######################################
+bgp/test_bgp_slb.py:
+  skip:
+    reason: "Skip over topologies which doesn't support slb"
+    conditions:
+     - "'backend' not in topo_name or 'mgmttor' not in topo_name"
+
 #######################################
 #####            cacl             #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -16,7 +16,7 @@ bgp/test_bgp_slb.py:
   skip:
     reason: "Skip over topologies which doesn't support slb"
     conditions:
-     - "'backend' not in topo_name or 'mgmttor' not in topo_name"
+     - "'backend' in topo_name or 'mgmttor' in topo_name"
 
 #######################################
 #####            cacl             #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
mgmt tor doesn't support slb scenario, skip test_bgp_slb for it.
and move the skip to the mark condition file, which would skip the test from beginning, save time comparing with skip in the testcase by fixture.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
mgmt tor doesn't support slb scenario, skip test_bgp_slb for it.
#### How did you do it?
and move the skip to the mark condition file, which would skip the test from beginning, save time comparing with skip in the testcase by fixture.

#### How did you verify/test it?
run test on mgmttor and other tors, on mgmt tor, the test_bgp_slb would be skipped, and other testbeds, it won't skip.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
