### PR TITLE
Disable log analyzer for test_bgp_slb which performed advanced reboot

### DIFF
--- a/tests/bgp/test_bgp_slb.py
+++ b/tests/bgp/test_bgp_slb.py
@@ -65,6 +65,7 @@ def bgp_slb_neighbor(duthosts, rand_one_dut_hostname, setup_interfaces, ptfhost,
     return bgp_neighbor
 
 
+@pytest.mark.disable_loganalyzer
 def test_bgp_slb_neighbor_persistence_across_advanced_reboot(
     duthosts, rand_one_dut_hostname, bgp_slb_neighbor,
     toggle_all_simulator_ports_to_rand_selected_tor, reboot_type, localhost


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Test script bgp/test_bgp_slb.py performed a warm/fast reboot during tests.
Log analyzer should be disabled for such scenario to avoid false alarm.

#### How did you do it?
Added decorator `@pytest.mark.disable_loganalyzer` to test case.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
