### PR TITLE
Xfail dhcpv6_relay test cases on cisco platform dualtor

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -60,14 +60,14 @@ decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform]:
       - "(topo_name in ['t1-backend', 't0-backend']) or (asic_type in ['broadcom'] and release in ['201811', '201911'])"
 
 #######################################
-#####         dhcp_relay          #####
+#####         dhcpv6_relay        #####
 #######################################
 dhcp_relay/test_dhcpv6_relay.py:
   xfail:
-    reason: "Generic internal image feature missing"
+    reason: "Not supported on dualtor"
     strict: True
     conditions:
-      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'mgmttor']"
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
 
 #######################################
 #####           dualtor           #####
@@ -167,6 +167,12 @@ pfc_asym/test_pfc_asym.py:
 #######################################
 #####         pfcwd               #####
 #######################################
+pfcwd/test_pfc_config.py::TestPfcConfig::test_forward_action_cfg:
+   skip:
+     reason: "Forward action not supported in cisco-8000"
+     conditions:
+        - "asic_type in ['cisco-8000']"
+
 pfcwd/test_pfcwd_timer_accuracy.py::TestPfcwdAllTimer::test_pfcwd_timer_accuracy:
   xfail:
     reason: "Test flaky"
@@ -174,12 +180,6 @@ pfcwd/test_pfcwd_timer_accuracy.py::TestPfcwdAllTimer::test_pfcwd_timer_accuracy
 pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb:
   xfail:
     reason: "Test flaky"
-
-pfcwd/test_pfc_config.py::TestPfcConfig::test_forward_action_cfg:
-   skip:
-     reason: "Forward action not supported in cisco-8000"
-     conditions:
-        - "asic_type in ['cisco-8000']"
 
 #######################################
 #####         platform_tests      #####
@@ -237,17 +237,18 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark[None]:
     conditions:
       - "platform in ['x86_64-arista_7050cx3_32s']"
 
+qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
+  skip:
+    reason: "Priority Group Headroom Watermark is not supported on cisco asic. PG drop counter stat is covered as a part of testQosSaiPfcXoffLimit"
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
 qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[None-wm_pg_shared_lossy]:
   xfail:
     reason: "Image issue on Arista platforms"
     conditions:
       - "platform in ['x86_64-arista_7050cx3_32s']"
 
-qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
-  skip:
-    reason: "Priority Group Headroom Watermark is not supported on cisco asic. PG drop counter stat is covered as a part of testQosSaiPfcXoffLimit"
-    conditions:
-      - "asic_type in ['cisco-8000']"
 #######################################
 #####         restapi             #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -67,8 +67,7 @@ dhcp_relay/test_dhcpv6_relay.py:
     reason: "Generic internal image feature missing"
     strict: True
     conditions:
-      - "asic_type in ['broadcom']"
-      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'mgmttor']"
 
 #######################################
 #####           dualtor           #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
`test_dhcpv6_relay` failed on cisco platform dualtor, it doesn't expect to run on this topology.
Define more accurate condition to skip them in `tests_mark_conditions.yaml`.
Also sorted items in alphabetic order in  `tests_mark_conditions.yaml`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Avoid the failures of `test_dhcpv6_relay` on cisco platform dualtor

#### How did you do it?
Define more accurate conditions to xfail them in `tests_mark_conditions.yaml`.

#### How did you verify/test it?
run  `test_dhcpv6_relay` on cisco platform dualtor

#### Any platform specific information?
cisco platform dualtor

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
