### PR TITLE
[macsec] Correct set_macsec_profile for EOS neighbor

### DIFF
--- a/tests/macsec/macsec_config_helper.py
+++ b/tests/macsec/macsec_config_helper.py
@@ -11,13 +11,15 @@ def set_macsec_profile(host, profile_name, priority, cipher_suite, primary_cak, 
             "GCM-AES-XPN-128": "aes128-gcm-xpn",
             "GCM-AES-XPN-256": "aes256-gcm-xpn"
         }
+        lines = [
+            'cipher {}'.format(eos_cipher_suite[cipher_suite]),
+            'key {} 0 {}'.format(primary_ckn, primary_cak),
+            'mka key-server priority {}'.format(priority)
+            ]
+        if send_sci == 'true':
+            lines.append('sci')
         host.eos_config(
-            lines = [
-                'cipher {}'.format(eos_cipher_suite[cipher_suite]),
-                'key {} 0 {}'.format(primary_ckn, primary_cak),
-                'mka key-server priority {}'.format(priority),
-                'sci'
-                ],
+            lines = lines,
             parents=['mac security', 'profile {}'.format(profile_name)])
         return
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Correct EOS macsec configuration with send_sci=false

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
If send_sci is false in macsec profile, macsec config on EOS is not set correctly, which causes test failure.
#### How did you do it?
Correct set_macsec_profile for EOS neighbor
#### How did you verify/test it?
```
./run_tests.sh -u -n vms28-t0-7280-4 -d str2-a7280cr3-4 -c macsec/test_macsec.py -f ../ansible/testbed.yaml -i ../ansible/str2,../ansible/veos -e "--skip_sanity --disable_loganalyzer -x --enable_macsec"

=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
===================================================================================================================== test session starts ======================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.11.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, allure-pytest-2.8.22, ansible-2.2.2
collecting ... /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 96 items                                                                                                                                                                                                                                             

macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[128] PASSED                                                                                                                                                                       [  1%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[128] PASSED                                                                                                                                                                                        [  2%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[128] PASSED                                                                                                                                                                                    [  3%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[128] SKIPPED                                                                                                                                                                               [  4%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[128] PASSED                                                                                                                                                                                   [  5%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[128] SKIPPED                                                                                                                                                                             [  6%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[128]
------------------------------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------------------------------
03:26:17 utilities.wait_until                     L0113 ERROR  | Exception caught while checking check_new_mka_session:Traceback (most recent call last):
  File "/var/src/sonic-mgmt-int/tests/common/utilities.py", line 107, in wait_until
    check_result = condition(*args, **kwargs)
  File "/var/src/sonic-mgmt-int/tests/macsec/test_macsec.py", line 194, in check_new_mka_session
    assert dut_egress_sa_table_new
AssertionError
, error:
PASSED                                                                                                                                                                                                                                                   [  7%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[128] PASSED                                                                                                                                                                 [  8%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[128] PASSED                                                                                                                                                                                [  9%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[128] PASSED                                                                                                                                                                                        [ 10%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[128] PASSED                                                                                                                                                                                         [ 11%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[128] PASSED                                                                                                                                                                                        [ 12%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[128_SCI] PASSED                                                                                                                                                                   [ 13%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[128_SCI] PASSED                                                                                                                                                                                    [ 14%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[128_SCI] PASSED                                                                                                                                                                                [ 15%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[128_SCI] SKIPPED                                                                                                                                                                           [ 16%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[128_SCI] PASSED                                                                                                                                                                               [ 17%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[128_SCI] SKIPPED                                                                                                                                                                         [ 18%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[128_SCI] PASSED                                                                                                                                                                                 [ 19%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[128_SCI] PASSED                                                                                                                                                             [ 20%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[128_SCI] PASSED                                                                                                                                                                            [ 21%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[128_SCI] PASSED                                                                                                                                                                                    [ 22%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[128_SCI] PASSED                                                                                                                                                                                     [ 23%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[128_SCI] PASSED                                                                                                                                                                                    [ 25%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[128_XPN] PASSED                                                                                                                                                                   [ 26%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[128_XPN] PASSED                                                                                                                                                                                    [ 27%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[128_XPN] PASSED                                                                                                                                                                                [ 28%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[128_XPN] SKIPPED                                                                                                                                                                           [ 29%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[128_XPN] PASSED                                                                                                                                                                               [ 30%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[128_XPN] SKIPPED                                                                                                                                                                         [ 31%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[128_XPN] 
------------------------------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------------------------------
03:57:23 utilities.wait_until                     L0113 ERROR  | Exception caught while checking check_new_mka_session:Traceback (most recent call last):
  File "/var/src/sonic-mgmt-int/tests/common/utilities.py", line 107, in wait_until
    check_result = condition(*args, **kwargs)
  File "/var/src/sonic-mgmt-int/tests/macsec/test_macsec.py", line 194, in check_new_mka_session
    assert dut_egress_sa_table_new
AssertionError
, error:
PASSED                                                                                                                                                                                                                                                   [ 32%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[128_XPN] PASSED                                                                                                                                                             [ 33%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[128_XPN] PASSED                                                                                                                                                                            [ 34%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[128_XPN] PASSED                                                                                                                                                                                    [ 35%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[128_XPN] PASSED                                                                                                                                                                                     [ 36%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[128_XPN] PASSED                                                                                                                                                                                    [ 37%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[128_XPN_SCI] PASSED                                                                                                                                                               [ 38%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[128_XPN_SCI] PASSED                                                                                                                                                                                [ 39%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[128_XPN_SCI] PASSED                                                                                                                                                                            [ 40%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[128_XPN_SCI] SKIPPED                                                                                                                                                                       [ 41%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[128_XPN_SCI] PASSED                                                                                                                                                                           [ 42%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[128_XPN_SCI] SKIPPED                                                                                                                                                                     [ 43%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[128_XPN_SCI] PASSED                                                                                                                                                                             [ 44%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[128_XPN_SCI] PASSED                                                                                                                                                         [ 45%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[128_XPN_SCI] PASSED                                                                                                                                                                        [ 46%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[128_XPN_SCI] PASSED                                                                                                                                                                                [ 47%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[128_XPN_SCI] PASSED                                                                                                                                                                                 [ 48%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[128_XPN_SCI] PASSED                                                                                                                                                                                [ 50%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[256] PASSED                                                                                                                                                                       [ 51%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256] PASSED                                                                                                                                                                                        [ 52%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[256] PASSED                                                                                                                                                                                    [ 53%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[256] SKIPPED                                                                                                                                                                               [ 54%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[256] PASSED                                                                                                                                                                                   [ 55%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[256] SKIPPED                                                                                                                                                                             [ 56%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[256] PASSED                                                                                                                                                                                     [ 57%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[256] PASSED                                                                                                                                                                 [ 58%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[256] PASSED                                                                                                                                                                                [ 59%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[256] PASSED                                                                                                                                                                                        [ 60%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[256] PASSED                                                                                                                                                                                         [ 61%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[256] PASSED                                                                                                                                                                                        [ 62%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[256_SCI] PASSED                                                                                                                                                                   [ 63%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256_SCI] PASSED                                                                                                                                                                                    [ 64%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[256_SCI] PASSED                                                                                                                                                                                [ 65%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[256_SCI] SKIPPED                                                                                                                                                                           [ 66%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[256_SCI] PASSED                                                                                                                                                                               [ 67%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[256_SCI] SKIPPED                                                                                                                                                                         [ 68%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[256_SCI] PASSED                                                                                                                                                                                 [ 69%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[256_SCI] PASSED                                                                                                                                                             [ 70%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[256_SCI] PASSED                                                                                                                                                                            [ 71%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[256_SCI] PASSED                                                                                                                                                                                    [ 72%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[256_SCI] PASSED                                                                                                                                                                                     [ 73%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[256_SCI] PASSED                                                                                                                                                                                    [ 75%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[256_XPN] PASSED                                                                                                                                                                   [ 76%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256_XPN] PASSED                                                                                                                                                                                    [ 77%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[256_XPN] PASSED                                                                                                                                                                                [ 78%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[256_XPN] SKIPPED                                                                                                                                                                           [ 79%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[256_XPN] PASSED                                                                                                                                                                               [ 80%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[256_XPN] SKIPPED                                                                                                                                                                         [ 81%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[256_XPN] PASSED                                                                                                                                                                                 [ 82%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[256_XPN] PASSED                                                                                                                                                             [ 83%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[256_XPN] PASSED                                                                                                                                                                            [ 84%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[256_XPN] PASSED                                                                                                                                                                                    [ 85%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[256_XPN] PASSED                                                                                                                                                                                     [ 86%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[256_XPN] PASSED                                                                                                                                                                                    [ 87%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[256_XPN_SCI] PASSED                                                                                                                                                               [ 88%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256_XPN_SCI] PASSED                                                                                                                                                                                [ 89%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[256_XPN_SCI] PASSED                                                                                                                                                                            [ 90%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[256_XPN_SCI] SKIPPED                                                                                                                                                                       [ 91%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[256_XPN_SCI] PASSED                                                                                                                                                                           [ 92%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[256_XPN_SCI] SKIPPED                                                                                                                                                                     [ 93%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[256_XPN_SCI] PASSED                                                                                                                                                                             [ 94%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[256_XPN_SCI] PASSED                                                                                                                                                         [ 95%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[256_XPN_SCI] PASSED                                                                                                                                                                        [ 96%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[256_XPN_SCI] PASSED                                                                                                                                                                                [ 97%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[256_XPN_SCI] PASSED                                                                                                                                                                                 [ 98%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[256_XPN_SCI] PASSED                                                                                                                                                                                [100%]

------------------------------------------------------------------------------------------------ generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------------------------------------
=================================================================================================================== short test summary info ====================================================================================================================
SKIPPED [16] /var/src/sonic-mgmt-int/tests/common/plugins/ptfadapter/__init__.py:180: Neighbor devices aren't SONiC so that the ptf nn service cannot be started
=========================================================================================================== 80 passed, 16 skipped in 7516.97 seconds ===========================================================================================================
INFO:root:Can not get Allure report URL. Please check logs
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
