### PR TITLE
[dualtor] Add support to setup netns topo

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -153,6 +153,7 @@
   - name: set default dualtor facts
     set_fact:
       dual_tor_facts: {}
+      mux_cable_facts: {}
     when: "'dualtor' not in topo"
 
   - name: gather dual ToR information
@@ -165,6 +166,12 @@
       vlan_intfs: "{{ vlan_intfs }}"
     delegate_to: localhost
     when: "'dualtor' in topo or 'cable' in topo"
+
+  - name: gather mux cable information
+    mux_cable_facts:
+      topo_name: "{{ topo }}"
+    delegate_to: localhost
+    when: "'dualtor' in topo"
 
   - name: generate y_cable simulator driver
     include_tasks: dualtor/config_simulated_y_cable.yml

--- a/ansible/library/mux_cable_facts.py
+++ b/ansible/library/mux_cable_facts.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+import os.path
+import sys
+import traceback
+import yaml
+
+from ansible.module_utils.basic import *
+
+try:
+    from ansible.module_utils.dualtor_utils import generate_mux_cable_facts
+except ImportError:
+    # Add parent dir for using outside Ansible
+    sys.path.append('..')
+    from ansible.module_utils.dualtor_utils import generate_mux_cable_facts
+
+
+DOCUMENTATION = """
+module: mux_cable_facts.py
+version_added:  2.0.0.2
+short_description: get mux cable information
+options:
+    - topo_name:
+      Description: the topology name
+      required: False
+    - topology:
+      Description: the topology dict defined in topo .yml file
+      require: False
+"""
+
+
+def load_topo_file(topo_name):
+    """Load topo definition yaml file."""
+    topo_file = "vars/topo_%s.yml" % topo_name
+    if not os.path.exists(topo_file):
+        raise ValueError("Topo file %s not exists" % topo_file)
+    with open(topo_file) as fd:
+        return yaml.safe_load(fd)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            topo_name=dict(required=False, type="str"),
+            topology=dict(required=False, type="dict"),
+        ),
+        mutually_exclusive=[["topo_name", "topology"]],
+        required_one_of=[["topo_name", "topology"]]
+    )
+    args = module.params
+    if args["topo_name"]:
+        topo_name = args["topo_name"]
+        topology = load_topo_file(topo_name)["topology"]
+    else:
+        topology = args["topology"]
+
+    try:
+        mux_cable_facts = generate_mux_cable_facts(topology=topology)
+        module.exit_json(ansible_facts={"mux_cable_facts": mux_cable_facts})
+    except Exception:
+        module.fail_json(msg=traceback.format_exc())
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/module_utils/dualtor_utils.py
+++ b/ansible/module_utils/dualtor_utils.py
@@ -1,0 +1,39 @@
+"""Common dualtor related utilities."""
+import ipaddress
+import re
+
+
+def get_intf_index(intf):
+    """Get interface index."""
+    if isinstance(intf, str):
+        intf = intf.split(",")[0]
+        return tuple(map(int, re.split(r'\.|@', intf.strip())))[1]
+    else:
+        return intf
+
+
+def generate_mux_cable_facts(topology):
+    """Generate mux cable table facts for dualtor topology."""
+    mux_cable_facts = {}
+    host_interfaces = set(get_intf_index(_) for _ in topology.get("host_interfaces", []))
+    disabled_host_interfaces = set(get_intf_index(_) for _ in topology.get("disabled_host_interfaces", []))
+    host_interfaces_active_active = set(get_intf_index(_) for _ in topology.get("host_interfaces_active_active", []))
+    enabled_interfaces = sorted(list(host_interfaces - disabled_host_interfaces))
+
+    vlan_config = list(topology["DUT"]["vlan_configs"][topology["DUT"]["vlan_configs"]["default_vlan_config"]].values())[0]
+    vlan_prefix_v4 = vlan_config["prefix"]
+    vlan_prefix_v6 = vlan_config["prefix_v6"]
+    vlan_address_v4, netmask_v4 = vlan_prefix_v4.split("/")
+    vlan_address_v6, netmask_v6 = vlan_prefix_v6.split("/")
+    vlan_address_v4 = ipaddress.ip_address(vlan_address_v4.decode())
+    vlan_address_v6 = ipaddress.ip_address(vlan_address_v6.decode())
+    for index, intf in enumerate(enabled_interfaces):
+        is_active_active = intf in host_interfaces_active_active
+        mux_cable_facts[intf] = dict(
+            server_ipv4=str(vlan_address_v4 + index * 2 + 1) + "/" + netmask_v4,
+            server_ipv6=str(vlan_address_v6 + index * 2 + 1) + "/" + netmask_v6,
+            cable_type="active-active" if is_active_active else "active-standby"
+        )
+        if is_active_active:
+            mux_cable_facts[intf]["soc_ipv4"] = str(vlan_address_v4 + (index + 1) * 2) + "/" + netmask_v4
+    return mux_cable_facts

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -137,7 +137,7 @@ NETNS_NAME_TEMPLATE = 'ns-%s'
 NETNS_IFACE_TEMPLATE = 'eth%d'
 PTF_NAME_TEMPLATE = 'ptf_%s'
 PTF_MGMT_IF_TEMPLATE = 'ptf-%s-m'
-NETNS_MGMT_IF_TEMPLATE = 'netns-%s-m'
+NETNS_MGMT_IF_TEMPLATE = 'ns-%s-m'
 PTF_BP_IF_TEMPLATE = 'ptf-%s-b'
 ROOT_BACK_BR_TEMPLATE = 'br-b-%s'
 PTF_FP_IFACE_TEMPLATE = 'eth%d'
@@ -476,6 +476,7 @@ class VMTopology(object):
         VMTopology.iface_up(int_if, pid=self.pid)
 
     def add_br_if_to_netns(self, bridge, ext_if, int_if):
+        """Create a veth pair to connect the netns to the bridge."""
         # add unique suffix to int_if to support multiple tasks run concurrently
         tmp_int_if = int_if + VMTopology._generate_fingerprint(ext_if, MAX_INTF_LEN-len(int_if))
         logging.info('=== For veth pair, add %s to bridge %s, set %s to netns, tmp intf %s' % (ext_if, bridge, int_if, tmp_int_if))

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -2,16 +2,27 @@
 
 import hashlib
 import json
+import os.path
 import re
 import subprocess
 import shlex
+import sys
 import time
 import traceback
 import logging
 import docker
+import ipaddress
 
 from ansible.module_utils.debug_utils import config_module_logging
 from ansible.module_utils.basic import *
+
+try:
+    from ansible.module_utils.dualtor_utils import generate_mux_cable_facts
+except ImportError:
+    # Add parent dir for using outside Ansible
+    sys.path.append('..')
+    from ansible.module_utils.dualtor_utils import generate_mux_cable_facts
+
 
 DOCUMENTATION = '''
 ---
@@ -126,6 +137,7 @@ NETNS_NAME_TEMPLATE = 'ns-%s'
 NETNS_IFACE_TEMPLATE = 'eth%d'
 PTF_NAME_TEMPLATE = 'ptf_%s'
 PTF_MGMT_IF_TEMPLATE = 'ptf-%s-m'
+NETNS_MGMT_IF_TEMPLATE = 'netns-%s-m'
 PTF_BP_IF_TEMPLATE = 'ptf-%s-b'
 ROOT_BACK_BR_TEMPLATE = 'br-b-%s'
 PTF_FP_IFACE_TEMPLATE = 'eth%d'
@@ -234,8 +246,10 @@ class VMTopology(object):
         self.host_interfaces_active_active = self.topo.get('host_interfaces_active_active', [])
         if self.host_interfaces_active_active:
             self.netns = NETNS_NAME_TEMPLATE % self.vm_set_name
+            self.mux_cable_facts = generate_mux_cable_facts(self.topo)
         else:
             self.netns = None
+            self.mux_cable_facts = {}
 
         self.devices_interconnect_interfaces = self.topo.get('devices_interconnect_interfaces', {})
 
@@ -338,6 +352,21 @@ class VMTopology(object):
             vlans[vm] = attr['vlans'][:]
 
         return vlans
+
+    def add_network_namespace(self):
+        """Create a network namespace."""
+        self.delete_network_namespace()
+        VMTopology.cmd("ip netns add %s" % self.netns)
+
+    def delete_network_namespace(self):
+        """Delete a network namespace."""
+        if os.path.exists("/var/run/netns/%s" % self.netns):
+            VMTopology.cmd("ip netns delete %s" % self.netns)
+
+    def add_mgmt_port_to_netns(self, mgmt_bridge, mgmt_ip, mgmt_gw, mgmt_ipv6_addr=None, mgmt_gw_v6=None):
+        if VMTopology.intf_not_exists(MGMT_PORT_NAME, netns=self.netns):
+            self.add_br_if_to_netns(mgmt_bridge, NETNS_MGMT_IF_TEMPLATE % self.vm_set_name, MGMT_PORT_NAME)
+        self.add_ip_to_netns_if(MGMT_PORT_NAME, mgmt_ip, ipv6_addr=mgmt_ipv6_addr, default_gw=mgmt_gw, default_gw_v6=mgmt_gw_v6)
 
     def create_bridges(self):
         for vm in self.vm_names:
@@ -446,6 +475,25 @@ class VMTopology(object):
 
         VMTopology.iface_up(int_if, pid=self.pid)
 
+    def add_br_if_to_netns(self, bridge, ext_if, int_if):
+        # add unique suffix to int_if to support multiple tasks run concurrently
+        tmp_int_if = int_if + VMTopology._generate_fingerprint(ext_if, MAX_INTF_LEN-len(int_if))
+        logging.info('=== For veth pair, add %s to bridge %s, set %s to PTF docker, tmp intf %s' % (ext_if, bridge, int_if, tmp_int_if))
+        if VMTopology.intf_not_exists(ext_if):
+            VMTopology.cmd("ip link add %s type veth peer name %s" % (ext_if, tmp_int_if))
+
+        _, if_to_br = VMTopology.brctl_show(bridge)
+        if ext_if not in if_to_br:
+            VMTopology.cmd("brctl addif %s %s" % (bridge, ext_if))
+
+        VMTopology.iface_up(ext_if)
+
+        if VMTopology.intf_exists(tmp_int_if) and VMTopology.intf_not_exists(tmp_int_if, netns=self.netns):
+            VMTopology.cmd("ip link set netns %s dev %s" % (self.netns, tmp_int_if))
+            VMTopology.cmd("ip netns exec %s ip link set dev %s name %s" % (self.netns, tmp_int_if, int_if))
+
+        VMTopology.iface_up(int_if, netns=self.netns)
+
     def add_ip_to_docker_if(self, int_if, mgmt_ip_addr, mgmt_ipv6_addr=None, mgmt_gw=None, mgmt_gw_v6=None, api_server_pid=None):
         if api_server_pid:
             self.pid = api_server_pid
@@ -463,6 +511,21 @@ class VMTopology(object):
             if mgmt_ipv6_addr and mgmt_gw_v6:
                 VMTopology.cmd("nsenter -t %s -n ip -6 route flush default" % (self.pid))
                 VMTopology.cmd("nsenter -t %s -n ip -6 route add default via %s dev %s" % (self.pid, mgmt_gw_v6, int_if))
+
+    def add_ip_to_netns_if(self, int_if, ip_addr, ipv6_addr=None, default_gw=None, default_gw_v6=None):
+        """Add ip address to netns interface."""
+        if VMTopology.intf_exists(int_if, netns=self.netns):
+            VMTopology.cmd("ip netns exec %s ip addr flush dev %s" % (self.netns, int_if))
+            VMTopology.cmd("ip netns exec %s ip addr add %s dev %s" % (self.netns, ip_addr, int_if))
+            if default_gw:
+                VMTopology.cmd("ip netns exec %s ip route flush default" % (self.netns))
+                VMTopology.cmd("ip netns exec %s ip route add default via %s dev %s" % (self.netns, default_gw, int_if))
+            if ipv6_addr:
+                VMTopology.cmd("ip netns exec %s ip -6 addr flush dev %s" % (self.netns, int_if))
+                VMTopology.cmd("ip netns exec %s ip -6 addr add %s dev %s" % (self.netns, ipv6_addr, int_if))
+                if default_gw_v6:
+                    VMTopology.cmd("ip netns exec %s ip -6 route flush default" % (self.netns))
+                    VMTopology.cmd("ip netns exec %s ip -6 route add default via %s dev %s" % (self.netns, default_gw_v6, int_if))
 
     def add_dut_if_to_docker(self, iface_name, dut_iface):
         logging.info("=== Add DUT interface %s to PTF docker as %s ===" % (dut_iface, iface_name))
@@ -831,14 +894,19 @@ class VMTopology(object):
         """
         create dualtor cable
 
-                          +--------------+
-                          |              +----- upper_if
-          PTF (host_if) --+  OVS bridge  |
-                          |              +----- lower_if
-                          +--------------+
-
         For the active/standby dualtor scenario, the OVS bridge is to simulate mux of y-cable.
+                            +--------------+
+                            |              +----- upper_if
+            PTF (host_if) --+  OVS bridge  |
+                            |              +----- lower_if
+                            +--------------+
+
         For the active/active dualtor scenario, the OVS bridge is to simulator server smart NIC with two ports.
+                            +--------------+
+            PTF (host_if) --+              +----- upper_if
+                            |  OVS bridge  |
+            netns (ns_if) --+              +----- lower_if
+                            +--------------+
         """
 
         br_name_template = MUXY_BRIDGE_TEMPLATE if nic_if is None else ACTIVE_ACTIVE_BRIDGE_TEMPLATE
@@ -919,6 +987,7 @@ class VMTopology(object):
                         nic_if = adaptive_name(SERVER_NIC_INTERFACE_TEMPLATE, self.vm_set_name, host_ifindex)
                         ns_if = NETNS_IFACE_TEMPLATE % host_ifindex
                         self.add_veth_if_to_netns(nic_if, ns_if)
+                        self.add_ip_to_netns_if(ns_if, self.mux_cable_facts[host_ifindex]["soc_ipv4"])
                     else:
                         nic_if = None
 
@@ -960,6 +1029,28 @@ class VMTopology(object):
                     vlan_separator = self.topo.get("DUT", {}).get("sub_interface_separator", SUB_INTERFACE_SEPARATOR)
                     vlan_id = self.vlan_ids[str(intf)]
                     self.add_dut_vlan_subif_to_docker(ptf_if, vlan_separator, vlan_id)
+
+    def setup_netns_source_routing(self):
+        """Setup policy-based routing to forward packet to its igress ports."""
+        slot_start_index = 100
+        for i, intf in enumerate(self.host_interfaces):
+            is_active_active = intf in self.host_interfaces_active_active
+            if self._is_multi_duts and not self._is_cable and isinstance(intf, list) and is_active_active:
+                host_ifindex = intf[0][2] if len(intf[0]) == 3 else i
+                ns_if = NETNS_IFACE_TEMPLATE % host_ifindex
+                if not VMTopology.intf_exists(ns_if, netns=self.netns):
+                    raise RuntimeError("Interface %s not exists in netns %s" % (ns_if, self.netns))
+                rt_slot = slot_start_index + int(host_ifindex)
+                rt_name = ns_if
+                ns_if_addr = ipaddress.ip_interface(self.mux_cable_facts[host_ifindex]["soc_ipv4"].decode())
+                gateway_addr = str(ns_if_addr.network.network_address + 1)
+                # add route table mapping, use interface name as route table name
+                VMTopology.cmd("ip netns exec %s echo \"%s\t%s\n\" >> /etc/iproute2/rt_tables" % (self.netns, rt_slot, rt_name), shell=True, split_cmd=False)
+                VMTopology.cmd("ip netns exec %s ip rule add iif %s table %s" % (self.netns, ns_if, rt_name))
+                VMTopology.cmd("ip netns exec %s ip rule add from %s table %s" % (self.netns, ns_if_addr.ip, rt_name))
+                VMTopology.cmd("ip netns exec %s ip route flush table %s" % (self.netns, rt_name))
+                VMTopology.cmd("ip netns exec %s ip route add %s dev %s table %s" % (self.netns, ns_if_addr.network, ns_if, rt_name))
+                VMTopology.cmd("ip netns exec %s ip route add default via %s dev %s table %s" % (self.netns, gateway_addr, ns_if, rt_name))
 
     def remove_host_ports(self):
         """
@@ -1087,7 +1178,7 @@ class VMTopology(object):
             return VMTopology.cmd('nsenter -t %s -n ethtool -K %s tx off' % (pid, iface_name))
 
     @staticmethod
-    def cmd(cmdline, grep_cmd=None, retry=1, negative=False):
+    def cmd(cmdline, grep_cmd=None, retry=1, negative=False, shell=False, split_cmd=True):
         """Execute a command and return the output
 
         Args:
@@ -1105,17 +1196,23 @@ class VMTopology(object):
 
         for attempt in range(retry):
             logging.debug('*** CMD: %s, grep: %s, attempt: %d' % (cmdline, grep_cmd, attempt+1))
+            if split_cmd:
+                cmdline = shlex.split(cmdline)
             process = subprocess.Popen(
-                shlex.split(cmdline),
+                cmdline,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+                stderr=subprocess.PIPE,
+                shell=shell)
             if grep_cmd:
+                if split_cmd:
+                    grep_cmd = shlex.split(grep_cmd)
                 process_grep = subprocess.Popen(
-                    shlex.split(grep_cmd),
+                    grep_cmd,
                     stdin=process.stdout,
                     stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE)
+                    stderr=subprocess.PIPE,
+                    shell=shell)
                 out, err = process_grep.communicate()
                 ret_code = process_grep.returncode
             else:
@@ -1381,6 +1478,7 @@ def main():
             duts_name=dict(required=False, type='list'),
             fp_mtu=dict(required=False, type='int', default=DEFAULT_MTU),
             max_fp_num=dict(required=False, type='int', default=NUM_FP_VLANS_PER_FP),
+            netns_mgmt_ip_addr=dict(required=False, type='str', default=None)
         ),
         supports_check_mode=False)
 
@@ -1442,6 +1540,7 @@ def main():
             ptf_mgmt_ip_gw = module.params['ptf_mgmt_ip_gw']
             ptf_mgmt_ipv6_gw = module.params['ptf_mgmt_ipv6_gw']
             mgmt_bridge = module.params['mgmt_bridge']
+            netns_mgmt_ip_addr = module.params['netns_mgmt_ip_addr'] 
 
             # Add management port to PTF docker and configure IP
             net.add_mgmt_port_to_docker(mgmt_bridge, ptf_mgmt_ip_addr, ptf_mgmt_ip_gw, ptf_mgmt_ipv6_addr, ptf_mgmt_ipv6_gw)
@@ -1462,8 +1561,15 @@ def main():
                     net.bind_vm_backplane()
                     net.add_bp_port_to_docker(ptf_bp_ip_addr, ptf_bp_ipv6_addr)
 
+            if net.netns:
+                net.add_network_namespace()
+                net.add_mgmt_port_to_netns(mgmt_bridge, netns_mgmt_ip_addr, ptf_mgmt_ip_gw)
+
             if hostif_exists:
                 net.add_host_ports()
+
+            if net.netns:
+                net.setup_netns_source_routing()
 
             if devices_interconnect_exists:
                 net.bind_devices_interconnect()
@@ -1522,6 +1628,10 @@ def main():
 
             if hostif_exists:
                 net.remove_host_ports()
+
+            if net.netns:
+                net.unbind_mgmt_port(NETNS_MGMT_IF_TEMPLATE % net.vm_set_name)
+                net.delete_network_namespace()
 
             if devices_interconnect_exists:
                 net.unbind_devices_interconnect()

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -478,7 +478,7 @@ class VMTopology(object):
     def add_br_if_to_netns(self, bridge, ext_if, int_if):
         # add unique suffix to int_if to support multiple tasks run concurrently
         tmp_int_if = int_if + VMTopology._generate_fingerprint(ext_if, MAX_INTF_LEN-len(int_if))
-        logging.info('=== For veth pair, add %s to bridge %s, set %s to PTF docker, tmp intf %s' % (ext_if, bridge, int_if, tmp_int_if))
+        logging.info('=== For veth pair, add %s to bridge %s, set %s to netns, tmp intf %s' % (ext_if, bridge, int_if, tmp_int_if))
         if VMTopology.intf_not_exists(ext_if):
             VMTopology.cmd("ip link add %s type veth peer name %s" % (ext_if, tmp_int_if))
 

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -195,11 +195,6 @@
   - include_tasks: add_ceos_list.yml
     when: vm_type is defined and vm_type == "ceos"
 
-  - name: Add network namespace for active-active dualtor
-    command: ip netns add ns-{{ vm_set_name }}
-    become: yes
-    when: "'host_interfaces_active_active' in topology"
-
   - name: Bind topology {{ topo }} to VMs. base vm = {{ VM_base }}
     vm_topology:
       cmd: "bind"
@@ -221,7 +216,11 @@
       duts_name: "{{ duts_name.split(',') }}"
       fp_mtu: "{{ fp_mtu_size }}"
       max_fp_num: "{{ max_fp_num }}"
+      netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
     become: yes
+    debugger: always
+
+  - pause:
 
   - name: Change MAC address for PTF interfaces
     include_tasks: ptf_change_mac.yml

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -218,9 +218,6 @@
       max_fp_num: "{{ max_fp_num }}"
       netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
     become: yes
-    debugger: always
-
-  - pause:
 
   - name: Change MAC address for PTF interfaces
     include_tasks: ptf_change_mac.yml

--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -45,11 +45,6 @@
       max_fp_num: "{{ max_fp_num }}"
     become: yes
 
-  - name: Remove network namespace for active-active dualtor
-    command: ip netns delete ns-{{ vm_set_name }}
-    become: yes
-    when: "'host_interfaces_active_active' in topology"
-
   - include_tasks: remove_ceos_list.yml
     when: vm_type is defined and vm_type == "ceos"
 

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -130,7 +130,7 @@ function read_yaml
 
   tb_line=${tb_lines[0]}
   line_arr=($1)
-  for attr in group-name topo ptf_image_name ptf ptf_ip ptf_ipv6 server vm_base dut inv_name auto_recover comment;
+  for attr in group-name topo ptf_image_name ptf ptf_ip ptf_ipv6 netns_mgmt_ip server vm_base dut inv_name auto_recover comment;
   do
     value=$(python -c "from __future__ import print_function; tb=eval(\"$tb_line\"); print(tb.get('$attr', None))")
     [ "$value" == "None" ] && value=
@@ -143,11 +143,12 @@ function read_yaml
   ptf=${line_arr[4]}
   ptf_ip=${line_arr[5]}
   ptf_ipv6=${line_arr[6]}
-  server=${line_arr[7]}
-  vm_base=${line_arr[8]}
-  dut=${line_arr[9]}
+  netns_mgmt_ip=${line_arr[7]}
+  server=${line_arr[8]}
+  vm_base=${line_arr[9]}
+  dut=${line_arr[10]}
   duts=$(python -c "from __future__ import print_function; print(','.join(eval(\"$dut\")))")
-  inv_name=${line_arr[10]}
+  inv_name=${line_arr[11]}
 }
 
 function read_file
@@ -249,7 +250,7 @@ function add_topo
   ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_add_vm_topology.yml --vault-password-file="${passwd}" -l "$server" \
         -e testbed_name="$testbed_name" -e duts_name="$duts" -e VM_base="$vm_base" \
         -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" \
-        -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" \
+        -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6"  -e netns_mgmt_ip="$netns_mgmt_ip" \
         $ansible_options $@
 
   if [[ "$ptf_imagename" != "docker-keysight-api-server" ]]; then
@@ -288,7 +289,7 @@ function remove_topo
   ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_remove_vm_topology.yml --vault-password-file="${passwd}" -l "$server" \
       -e testbed_name="$testbed_name" -e duts_name="$duts" -e VM_base="$vm_base" \
       -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" \
-      -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" \
+      -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" -e netns_mgmt_ip="$netns_mgmt_ip" \
       -e remove_keysight_api_server="$remove_keysight_api_server" \
       $ansible_options $@
 
@@ -350,7 +351,7 @@ function restart_ptf
 
   ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile testbed_renumber_vm_topology.yml --vault-password-file="${passwd}" \
       -l "$server" -e testbed_name="$testbed_name" -e duts_name="$duts" -e VM_base="$vm_base" -e ptf_ip="$ptf_ip" \
-      -e topo="$topo" -e vm_set_name="$vm_set_name" -e ptf_imagename="$ptf_imagename" -e ptf_ipv6="$ptf_ipv6" $@
+      -e topo="$topo" -e vm_set_name="$vm_set_name" -e ptf_imagename="$ptf_imagename" -e ptf_ipv6="$ptf_ipv6" -e netns_mgmt_ip="$netns_mgmt_ip" $@
 
   echo Done
 }

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -28,6 +28,7 @@
 # -e topo=t0                 - the name of removed topo
 # -e ptf_imagename=docker-ptf - name of a docker-image which will be used for the ptf docker container
 # -e vm_type=veos|ceos|vsonic
+# -e netns_mgmt_ip=10.255.0.254/23 - the ip address and prefix of netns mgmt interface, only for dualtor topo with ports in active-active cable type
 
 - hosts: servers:&vm_host
   gather_facts: no

--- a/ansible/vtestbed.yaml
+++ b/ansible/vtestbed.yaml
@@ -175,6 +175,7 @@
   ptf: ptf-08
   ptf_ip: 10.250.0.109/24
   ptf_ipv6: fec0::ffff:afa:9/64
+  netns_mgmt_ip: 10.250.0.126/24
   server: server_1
   vm_base: VM0140
   dut:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To support `active-active` dualtor network namespace setup.

#### How did you do it?
1. Add new Ansible module `mux_cable_facts` to gather cable type, server ip and soc ip from topology defined.
2. Use `mux_cable_facts` for minigraph gen/deloy.
3. Support network namespace interface ip assignment and route setup.

#### How did you verify/test it?
Run `add-topo` and `remove-topo` for dualtor-mixed topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
