### PR TITLE
Fix container_autorestart test case to run on chassis

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -28,13 +28,15 @@ POST_CHECK_INTERVAL_SECS = 1
 POST_CHECK_THRESHOLD_SECS = 360
 
 @pytest.fixture(autouse=True, scope='module')
-def config_reload_after_tests(duthost):
+def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname):
     yield
-    config_reload(duthost)
+    for hostname in selected_rand_one_per_hwsku_hostname:
+        duthost = duthosts[hostname]
+        config_reload(duthost)
 
 @pytest.fixture(autouse=True)
-def ignore_expected_loganalyzer_exception(duthosts, enum_dut_feature_container,
-                                          enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
+def ignore_expected_loganalyzer_exception(duthosts, enum_rand_one_per_hwsku_hostname, enum_rand_one_asic_index,
+                                          enum_dut_feature, loganalyzer):
     """
         Ignore expected failure/error messages during testing the autorestart feature.
 
@@ -98,12 +100,8 @@ def ignore_expected_loganalyzer_exception(duthosts, enum_dut_feature_container,
         'teamd' : swss_syncd_teamd_regex,
     }
 
-    dut_name, container_name = decode_dut_port_name(enum_dut_feature_container)
-    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname and container_name != "unknown",
-                   "Skips testing auto-restart of container '{}' on DuT '{}' since another DuT '{}' was chosen."
-                   .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))
-    duthost = duthosts[dut_name]
-    feature = re.match(CONTAINER_NAME_REGEX, container_name).group(1)
+    feature = enum_dut_feature
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     if loganalyzer:
         loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_dict['common'])
@@ -332,7 +330,7 @@ def postcheck_critical_processes_status(duthost, container_autorestart_states, u
 
     bgp_check = wait_until(
         POST_CHECK_THRESHOLD_SECS, POST_CHECK_INTERVAL_SECS, 0,
-        duthost.check_bgp_session_state, up_bgp_neighbors, "established"
+        duthost.check_bgp_session_state_all, up_bgp_neighbors, "established"
     )
 
     return critical_proceses, bgp_check
@@ -357,8 +355,7 @@ def run_test_on_single_container(duthost, container_name, tbinfo):
     is_running = is_container_running(duthost, container_name)
     pytest_assert(is_running, "Container '{}' is not running. Exiting...".format(container_name))
 
-    bgp_neighbors = duthost.get_bgp_neighbors()
-    up_bgp_neighbors = [ k.lower() for k, v in bgp_neighbors.items() if v["state"] == "established" ]
+    up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
 
     logger.info("Start testing the container '{}'...".format(container_name))
 
@@ -439,18 +436,16 @@ def run_test_on_single_container(duthost, container_name, tbinfo):
 
     logger.info("End of testing the container '{}'".format(container_name))
 
-
-def test_containers_autorestart(duthosts, enum_dut_feature_container,
-                                enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
+def test_containers_autorestart(duthosts, enum_rand_one_per_hwsku_hostname, enum_rand_one_asic_index,
+                                enum_dut_feature, tbinfo):
     """
     @summary: Test the auto-restart feature of each container against two scenarios: killing
               a non-critical process to verify the container is still running; killing each
               critical process to verify the container will be stopped and restarted
     """
-    dut_name, container_name = decode_dut_port_name(enum_dut_feature_container)
-    pytest_require(dut_name == enum_rand_one_per_hwsku_frontend_hostname and container_name != "unknown",
-                   "Skips testing auto-restart of container '{}' on DuT '{}' since another DuT '{}' was chosen."
-                   .format(container_name, dut_name, enum_rand_one_per_hwsku_frontend_hostname))
-    duthost = duthosts[dut_name]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    asic = duthost.asic_instance(enum_rand_one_asic_index)
+    service_name = enum_dut_feature
+    container_name = asic.get_docker_name(service_name)
 
     run_test_on_single_container(duthost, container_name, tbinfo)

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -438,6 +438,26 @@ class MultiAsicSonicHost(object):
 
         return bgp_neigh
 
+    def get_bgp_neighbors_per_asic(self, state="established"):
+        """
+        Get a diction of BGP neighbor states
+
+        Args: 
+        state: BGP session state, return neighbor IP of sessions that match this state
+        Returns: dictionary {namespace: { (neighbor_ip : info_dict)* }}
+
+        """
+        bgp_neigh = {}
+        for asic in self.asics:
+            bgp_neigh[asic.namespace] = {}
+            bgp_info = asic.bgp_facts()["ansible_facts"]["bgp_neighbors"]
+            for k, v in bgp_info.items():
+                if v["state"] != state:
+                    bgp_info.pop(k)                    
+            bgp_neigh[asic.namespace].update(bgp_info)
+
+        return bgp_neigh
+
     def check_bgp_session_state(self, neigh_ips, state="established"):
         """
         @summary: check if current bgp session equals to the target state
@@ -460,6 +480,20 @@ class MultiAsicSonicHost(object):
             return True
 
         return False
+
+    def check_bgp_session_state_all(self, bgp_neighbors, state="established"):
+        """
+        @summary: check if current bgp session equals to the target state in each namespace
+
+        @param bgp_neighbors: dictionary {namespace: { (neighbor_ip : info_dict)* }} 
+        @param state: target state
+        """
+        for asic in self.asics:
+            if asic.namespace in bgp_neighbors:
+                neigh_ips = [ k.lower() for k, v in bgp_neighbors[asic.namespace].items() if v["state"] == state ]
+                if not asic.check_bgp_session_state(neigh_ips, state):
+                    return False
+        return True
 
     def get_bgp_route(self, *args, **kwargs):
         """

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -597,3 +597,24 @@ class SonicAsic(object):
             if def_rt_json:
                 return False
         return True
+
+    def check_bgp_session_state(self, neigh_ips, state="established"):
+        """
+        @summary: check if current bgp session equals to the target state
+
+        @param neigh_ips: bgp neighbor IPs
+        @param state: target state
+        """
+        bgp_facts = self.bgp_facts()['ansible_facts']
+        neigh_ok = []
+        for k, v in bgp_facts['bgp_neighbors'].items():
+            if v['state'] == state:
+                if k.lower() in neigh_ips:
+                    neigh_ok.append(k)
+        logging.info("bgp neighbors that match the state: {} on namespace {}".format(neigh_ok, self.namespace))
+
+        if len(neigh_ips) == len(neigh_ok):
+            return True
+
+        return False
+                     


### PR DESCRIPTION

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Current issues while running container autorestart test case on chassis:
1. Test case uses enum_rand_one_per_hwsku_frontend_hostname, so test case does not run on supervisor and only runs on linecard.
2. Test case uses enum_dut_feature_container, which iterates over a list of container names generated for the testbed. This fixture is a combination of container name and dut name. If the dutname in this fixture does not match with the randomly selected dut, then the test is skipped. This is not efficient and can end up skipping certain containers for multiple sku testbed setup.
3. Test case checks for BGP sessions that are up before and after the test case. This check fails for multi-asic line card, because, in multiasic linecard, BGP neighbor IP can be same for different asics in the same linecard (loopback IP of neighbor asic).

#### How did you do it?
1. Modify to use enum_rand_one_per_hwsku_hostname, so that the test case runs on sup and a randomly selected linecard.
2. With the above change, made sure that the config reload is done on all the selected DUTs after the test is complete.
3. Instead of using the container name and skipping tests if the dut name in the fixture does not match with the selected dut, use enum_dut_feature and enum_rand_one_asic_index so that the test is executed on all features for the selected DUT.
4. Modify check BGP sessions, to get BGP sessions for each asic namespace, and check for each asic namespace separately.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
