### PR TITLE
Everflow packets TTL check for cisco platform

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -744,28 +744,19 @@ class BaseEverflowTest(object):
         if duthost.facts["asic_type"] in ["barefoot", "cisco-8000"]:
             payload = binascii.unhexlify("0" * 24) + str(payload)
 
-        #Add vendor specific ttl check ,reused pkts in mirror session has 1 decrement in TTL 
-        if duthost.facts["asic_type"] in ["cisco-8000"] and (int(mirror_session["session_ttl"]) >= 1):
-            expected_packet = testutils.simple_gre_packet(
-               eth_src=setup["router_mac"],
-               ip_src=mirror_session["session_src_ip"],
-               ip_dst=mirror_session["session_dst_ip"],
-               ip_dscp=int(mirror_session["session_dscp"]),
-               ip_id=0,
-               ip_ttl=(int(mirror_session["session_ttl"]) -1),
-               inner_frame=payload
-            )
-        else:
-            expected_packet = testutils.simple_gre_packet(
-               eth_src=setup["router_mac"],
-               ip_src=mirror_session["session_src_ip"],
-               ip_dst=mirror_session["session_dst_ip"],
-               ip_dscp=int(mirror_session["session_dscp"]),
-               ip_id=0,
-               ip_ttl=int(mirror_session["session_ttl"]),
-               inner_frame=payload
-            )
+        expected_packet = testutils.simple_gre_packet(
+            eth_src=setup["router_mac"],
+            ip_src=mirror_session["session_src_ip"],
+            ip_dst=mirror_session["session_dst_ip"],
+            ip_dscp=int(mirror_session["session_dscp"]),
+            ip_id=0,
+            ip_ttl=int(mirror_session["session_ttl"]),
+            inner_frame=payload
+        )
 
+        #Add vendor specific ttl check ,reused pkts in mirror session has 1 decrement in TTL
+        if duthost.facts["asic_type"] in ["cisco-8000"] and (int(mirror_session["session_ttl"]) >= 1):
+            expected_packet.ttl = (int(mirror_session["session_ttl"]) -1)
 
         expected_packet["GRE"].proto = mirror_session["session_gre"]
 

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -764,6 +764,7 @@ class BaseEverflowTest(object):
         expected_packet.set_do_not_care_scapy(packet.IP, "chksum")
         if duthost.facts["asic_type"] in ["cisco-8000"]:
             expected_packet.set_do_not_care_scapy(packet.GRE, "seqnum_present")
+            expected_packet.set_do_not_care_scapy(packet.IP, "ttl")
         if not check_ttl:
             expected_packet.set_do_not_care_scapy(packet.IP, "ttl")
 


### PR DESCRIPTION
**Description of PR**
"Cisco-8000 platform mirror packets are generated by doing recycling the original packet. During recycling the generated packet TTL will be decreased by 1. This is done recently in silicon-one SDK as a part of supporting two mirror sessions in the same port."
**Type of change**
•	  Bug fix
•	  Testbed and Framework(new/improvement)
•	  Test case(new/improvement)
**Back port request**
•	  201911
•	  202012
**Approach
What is the motivation for this PR?**
"Cisco-8000 platform mirror packets are generated by doing recycling the original packet. During recycling the generated packet TTL will be decreased by 1. This is done recently in silicon-one SDK as a part of supporting two mirror sessions in the same port." 
**How did you do it?**
Added cisco-8000 asic-type check
**How did you verify/test it?**
Verified on cisco-8000 platform and all tests passed
**Any platform specific information?**
Supported testbed topology if it's a new test case?
**Documentation**
