### PR TITLE
[tests/generic_config_updater]skip test on release 202111

### DIFF
--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -41,7 +41,7 @@ def check_image_version(duthost):
     Returns:
         None.
     """
-    skip_release(duthost, ["201811", "201911", "202012", "202106"])
+    skip_release(duthost, ["201811", "201911", "202012", "202106", "202111"])
 
 @pytest.fixture(scope="module")
 def cfg_facts(duthosts, rand_one_dut_hostname):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip GCU test on non-supported branch
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
GCU feature is not fully supported in 202111
#### How did you do it?
Skip test on branch 202111
#### How did you verify/test it?
Test skip on 202111 release
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
