### PR TITLE
Fix dest_port calculation for T0 Everflow downstream test

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -229,7 +229,7 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
                     "src_port_ptf_id": str(mg_facts["minigraph_ptf_indices"][t1_ports[0]]),
                     # Downstream traffic ingress from the first portchannel,
                     # and mirror packet egress from other portchannels
-                    "dest_port": t1_ports[2:] if len(t1_dest_ports_ptf_id[0].split(',')) == 2 else t1_ports[1:],
+                    "dest_port": t1_dest_ports[1:],
                     "dest_port_ptf_id": t1_dest_ports_ptf_id[1:],
                     "dest_port_lag_name": t1_dest_lag_name[1:],
                     "namespace": server_namespace


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In the everflow EverflowIPv4Tests, there are 3 similar test cases for different port channels.
The code for the first case that can pass:
108 # Add a route to the mirror session destination IP
109 tx_port = setup_info[dest_port_type]["dest_port"][0]
110 peer_ip = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
111 everflow_utils.add_route(duthost, setup_mirror_session["session_prefixes"][0], peer_ip, setup_info[dest_port_type]["names
112 time.sleep(15)
113
114 # Verify that mirrored traffic is sent along the route we installed
115 rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
116 tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]

The code for the second case that failed:
145 tx_port = setup_info[dest_port_type]["dest_port"][1]
146 peer_ip = everflow_utils.get_neighbor_info(duthost, tx_port, tbinfo)
147 everflow_utils.add_route(duthost, setup_mirror_session['session_prefixes'][1], peer_ip, setup_info[dest_port_type]["names
148 time.sleep(15)
149
150 # Verify that mirrored traffic uses the new route
151 tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][1]

“tx_port” is the port to get the peer IP.
“tx_port_ptf_id” is the expected receiving ports.

they are hard coded with setup index 0, 1, …
if we checked the T0 logs that dumped the testbed setup info when crashing, we can see the “tx_port” and “tx_port_ptf_id” do not match.

dest_port_type = 'downstream'
duthost =
duthosts = []
peer_ip = u'10.0.0.5'
ptfadapter = <tests.common.plugins.ptfadapter.ptfadapter.PtfTestAdapter testMethod=runTest>
rand_one_dut_hostname = 'mth-t0-64'
rx_port_ptf_id = '0'
self = <tests.everflow.test_everflow_testbed.TestEverflowV4IngressAclIngressMirror object at 0x7f30f2cc6710>
setup_info = {'downstream': {'dest_port': ['Ethernet4', 'Ethernet5', 'Ethernet16', 'Ethernet17', 'Ethernet21', 'Ethernet20'], 'dest...se, 'ingress': True}, 'port_index_map': {'Ethernet0': 0, 'Ethernet1': 1, 'Ethernet10': 10, 'Ethernet11': 11, ...}, ...}
setup_mirror_session = {'session_dscp': '9', 'session_dst_ip': '2.2.2.2', 'session_gre': 35006, 'session_name': 'test_session_1', ...}
tbinfo = {'auto_recover': 'True', 'comment': 'Tests Mathilda T0-64', 'conf-name': 'mth-t0-64', 'duts': ['mth-t0-64'], ...}
tx_port = 'Ethernet5'
tx_port_ptf_id = '16,17'

The array for “tx_port”:
'dest_port': ['Ethernet4', 'Ethernet5', 'Ethernet16', 'Ethernet17', 'Ethernet21', 'Ethernet20'],

“dest_port_ptf_id” array:
‘dest_port_ptf_id’: ['4,5', '16.17', '20,21'],

The “tx_port” array are all members of port channels,
While the “dest_port_ptf_id” array are port channels
So the first case is okay because the first index (0) can always match (tx_port is Ethernet4 and dest_port_ptf_id is ‘4,5’, but further cases can not match.

### Summary:
in the existing code for getting the setup_info:
"dest_port": t1_ports[2:] if len(t1_dest_ports_ptf_id[0].split(',')) == 2 else t1_ports[1:]
the code works fine if there is no port channel or all port channels after 1st port channel have only one member, otherwise the "dest_port" and "dest_port_ptf_id" will not match.
now change it to
"dest_port": t1_dest_ports[1:],



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
