### PR TITLE
Set MTU to 9124 on interfaces of ceos neighbors and allow fragmented packets to neighbors

### DIFF
--- a/ansible/roles/eos/templates/t0-backend-leaf.j2
+++ b/ansible/roles/eos/templates/t0-backend-leaf.j2
@@ -71,6 +71,7 @@ interface {{ name }}
  no shutdown
 {% else %}
 {% set is_loopback = false %}
+ mtu 9214
  no switchport
  no shutdown
 {% endif %}

--- a/ansible/roles/eos/templates/t0-leaf-lag-2.j2
+++ b/ansible/roles/eos/templates/t0-leaf-lag-2.j2
@@ -62,6 +62,7 @@ interface {{ name }}
 {% if name.startswith('Loopback') %}
  description LOOPBACK
 {% else %}
+ mtu 9214
  no switchport
  no shutdown
 {% endif %}

--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -62,6 +62,7 @@ interface {{ name }}
 {% if name.startswith('Loopback') %}
  description LOOPBACK
 {% else %}
+ mtu 9214
  no switchport
  no shutdown
 {% endif %}

--- a/ansible/roles/eos/templates/t0-mclag-leaf.j2
+++ b/ansible/roles/eos/templates/t0-mclag-leaf.j2
@@ -62,6 +62,7 @@ interface {{ name }}
 {% if name.startswith('Loopback') %}
  description LOOPBACK
 {% else %}
+ mtu 9214
  no switchport
  no shutdown
 {% endif %}

--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -63,6 +63,7 @@ interface {{ name }}
 {% if name.startswith('Loopback') %}
  description LOOPBACK
 {% else %}
+ mtu 9214
  no switchport
  no shutdown
 {% endif %}

--- a/ansible/roles/eos/templates/t1-8-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-8-lag-spine.j2
@@ -62,6 +62,7 @@ interface {{ name }}
 {% if name.startswith('Loopback') %}
  description LOOPBACK
 {% else %}
+ mtu 9214
  no switchport
 {% endif %}
 {% if name.startswith('Port-Channel') %}

--- a/ansible/roles/eos/templates/t1-8-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-8-lag-tor.j2
@@ -63,6 +63,7 @@ interface {{ name }}
 {% if name.startswith('Loopback') %}
  description LOOPBACK
 {% else %}
+ mtu 9214
  no switchport
 {% endif %}
 {% if name.startswith('Port-Channel') %}

--- a/ansible/roles/eos/templates/t1-backend-tor.j2
+++ b/ansible/roles/eos/templates/t1-backend-tor.j2
@@ -71,6 +71,7 @@ interface {{ name }}
  no shutdown
 {% else %}
 {% set is_loopback = false %}
+ mtu 9214
  no switchport
  no shutdown
 {% endif %}

--- a/ansible/roles/eos/templates/t1-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-lag-spine.j2
@@ -62,6 +62,7 @@ interface {{ name }}
 {% if name.startswith('Loopback') %}
  description LOOPBACK
 {% else %}
+ mtu 9214
  no switchport
  no shutdown
 {% endif %}

--- a/ansible/roles/eos/templates/t1-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-lag-tor.j2
@@ -62,6 +62,7 @@ interface {{ name }}
 {% if name.startswith('Loopback') %}
  description LOOPBACK
 {% else %}
+ mtu 9214
  no switchport
  no shutdown
 {% endif %}

--- a/ansible/roles/eos/templates/t2-core.j2
+++ b/ansible/roles/eos/templates/t2-core.j2
@@ -62,6 +62,7 @@ interface {{ name }}
 {% if name.startswith('Loopback') %}
  description LOOPBACK
 {% else %}
+ mtu 9214
  no switchport
 {% endif %}
 {% if name.startswith('Port-Channel') %}

--- a/ansible/roles/eos/templates/t2-leaf.j2
+++ b/ansible/roles/eos/templates/t2-leaf.j2
@@ -62,6 +62,7 @@ interface {{ name }}
 {% if name.startswith('Loopback') %}
  description LOOPBACK
 {% else %}
+ mtu 9214
  no switchport
 {% endif %}
 {% if name.startswith('Port-Channel') %}

--- a/ansible/roles/eos/templates/t2-vs-core.j2
+++ b/ansible/roles/eos/templates/t2-vs-core.j2
@@ -62,6 +62,7 @@ interface {{ name }}
 {% if name.startswith('Loopback') %}
  description LOOPBACK
 {% else %}
+ mtu 9214
  no switchport
 {% endif %}
 {% if name.startswith('Port-Channel') %}

--- a/ansible/roles/eos/templates/t2-vs-leaf.j2
+++ b/ansible/roles/eos/templates/t2-vs-leaf.j2
@@ -62,6 +62,7 @@ interface {{ name }}
 {% if name.startswith('Loopback') %}
  description LOOPBACK
 {% else %}
+ mtu 9214
  no switchport
 {% endif %}
 {% if name.startswith('Port-Channel') %}

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -790,7 +790,7 @@ class VMTopology(object):
             VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" % (br_name, dut_iface_id, injected_iface_id))
         else:
             # Add flow from external iface to a VM and a ptf container
-            # Allow BGP, IPinIP, ICMP, SNMP packets and layer2 packets from DUT to neighbors
+            # Allow BGP, IPinIP, fragmented packets, ICMP, SNMP packets and layer2 packets from DUT to neighbors
             # Block other traffic from DUT to EOS for EOS's stability,
             # Allow all traffic from DUT to PTF.
             VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,tcp,in_port=%s,tp_src=179,action=output:%s,%s" % (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
@@ -798,6 +798,8 @@ class VMTopology(object):
             VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,tcp6,in_port=%s,tp_src=179,action=output:%s,%s" % (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
             VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,tcp6,in_port=%s,tp_dst=179,action=output:%s,%s" % (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
             VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,ip,in_port=%s,nw_proto=4,action=output:%s,%s" % (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=8,ip,in_port=%s,nw_frag=yes,action=output:%s,%s" % (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=8,ipv6,in_port=%s,nw_frag=yes,action=output:%s,%s" % (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
             VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=8,icmp,in_port=%s,action=output:%s,%s" % (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
             VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=8,icmp6,in_port=%s,action=output:%s,%s" % (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
             VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=8,udp,in_port=%s,udp_src=161,action=output:%s,%s" % (br_name, dut_iface_id, vm_iface_id, injected_iface_id))


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #5372 
The issue was caused by fragmented packets dropped by current openflow rules configured on ovs bridges between EOS neighbors and DUT.
The fix includes two parts:
1. Allow fragmented packets to EOS neighbors, add one more rule to allow frag tag packets to the interfaces of EOS neighbors.
```
VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=8,ip,in_port=%s,nw_frag=yes,action=output:%s,%s" % (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=8,ipv6,in_port=%s,nw_frag=yes,action=output:%s,%s" % (br_name, dut_iface_id, vm_iface_id, injected_iface_id))     
```
Fragmented ICMPv6 packets can be matched by this rule, ping success.
```
 cookie=0x0, duration=183.746s, table=0, n_packets=1, n_bytes=75, priority=8,ipv6,in_port="p4p1.410",nw_frag=yes actions=output:"VM12009-t0",output:"inje-v12-11-17"
```

2. Our default MTU is 9216 for all cEOS devices, the config is `fp_mtu_size: 9216` in `ansible/roles/vm_set/vars/main.yml`,
During `add-topo` stage, it will call `add_ceos_list.yml` and then call `ceos_network.py`, here all interfaces in ceos will be configured with MTU 9216. Then later it will load startup-config for all cEOS in `ceos_config.yml` , in their config j2 file, if there is any config for interface, after configuration, MTU is set to default 1500. 
That's why MTU of Ethernet1 or Port-channel which have ip address configuration is 1500, in this change, set MTU 9214 on these data interfaces.
Why 9214, because supported max MTU is 9214. So far, large packets whose size is less than 9214 will not be fragmented.

```
ARISTA01T0(config-if-Et1)#mtu 9216
% Max MTU for Ethernet1 is 9214
```

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fixes #5372 

#### How did you do it?
1. add one more rule to allow fragmented packet to EOS neighbors.
2. Set MTU to 9214 for all data interfaces of cEOS neighbors.

#### How did you verify/test it?
Redeploy one t1-lag testbed and ping large ICMP or ICMPv6 packets from one T0 to another T0.
`sudo ping -c1 fc00::46  -W 3 -I fc00::42 -s 1453 -t 225`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
