### PR TITLE
[nbr_health] Add to check eos' BGP connection state

### DIFF
--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -60,10 +60,16 @@ def check_sonic_facts(hostname, mgmt_addr, host):
 
 def check_eos_bgp_facts(hostname, host):
     logger.info("Check neighbor {} bgp facts".format(hostname))
-    res = host.eos_command(commands=['show ip bgp sum'])
-    logger.info("bgp: {}".format(res))
-    if not res.has_key('stdout_lines') or u'BGP summary' not in res['stdout_lines'][0][0]:
-        return "neighbor {} bgp not configured correctly".format(hostname)
+    for ip_type in ['ip', 'ipv6']:
+        res = host.eos_command(commands=['show {} bgp sum'.format(ip_type)])
+        logger.info("{} bgp: {}".format(ip_type, res))
+        if not res.has_key('stdout_lines') or u'BGP summary' not in res['stdout_lines'][0][0]:
+            return "{} neighbor {} bgp not configured correctly".format(ip_type, hostname)
+
+        for peer_status in res['stdout_lines'][0][4::]:
+            logger.info("{} bgp peer: {}".format(ip_type, peer_status))
+            if 'Estab' not in peer_status:
+                return "{} neighbor {} bgp state is not establish".format(ip_type, hostname)
 
 def check_sonic_bgp_facts(hostname, host):
     logger.info("Check neighbor {} bgp facts".format(hostname))


### PR DESCRIPTION
### Description of PR
In current design, nbr_health only check the bgp configurations
be normal in the VMs but not check the bgp connections states
which include DUT to VM and VM to PTF. If one of them is not in
establish state, that means the deployment is not successful.

This patch adds to check the BGP state be Establish in the eos VMs

Signed-off-by: gord_chen <gord_chen@edge-core.com>

Summary:
Improvement

### Type of change


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Run test_nbr_health.py

#### How did you verify/test it?
deploy t0 
supervisorctl stop exabgp-ARISTA04T1 then the test would be failed
supervisorctl start exabgp-ARISTA04T1 then the test would be passed
supervisorctl stop exabgp-ARISTA04T1-v6 then the test would be failed
supervisorctl start exabgp-ARISTA04T1-v6 then the test would be passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
