### PR TITLE
[telemetry] change the checking field from "status" to "state" for checking enabled feature 

### DIFF
--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -142,16 +142,15 @@ def test_telemetry_enabledbydefault(duthosts, rand_one_dut_hostname):
     """
     duthost = duthosts[rand_one_dut_hostname]
 
-    status = duthost.shell('sonic-db-cli CONFIG_DB HGETALL "FEATURE|telemetry"', module_ignore_errors=False)['stdout_lines']
+    status = duthost.shell('redis-cli -n 4 HGETALL "FEATURE|telemetry"', module_ignore_errors=False)['stdout_lines']
     status_list = get_list_stdout(status)
     # Elements in list alternate between key and value. Separate them and combine into a dict.
     status_key_list = status_list[0::2]
     status_value_list = status_list[1::2]
     status_dict = dict(zip(status_key_list, status_value_list))
-    for k, v in status_dict.items():
-        if str(k) == "status":
-            status_expected = "enabled"
-            pytest_assert(str(v) == status_expected, "Telemetry feature is not enabled")
+    if 'state' in status_dict:
+        status_expected = "enabled";
+        pytest_assert(str(status_dict['state']) == status_expected, "Telemetry feature is not enabled")
 
 def test_telemetry_ouput(duthosts, rand_one_dut_hostname, ptfhost, setup_streaming_telemetry, localhost):
     """Run pyclient from ptfdocker and show gnmi server outputself.


### PR DESCRIPTION

Signed-off-by: mulin_huang <mulin_huang@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
change the checking field from `status` to `state` for checking enabled feature

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Since `state` field is to represented as the state of the feature defined in `src/sonic-yang-models/yang-models/sonic-feature.yang`, the field, used for checking telemetry is enabled or not, should change to `state` instead of `status`.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
