### PR TITLE
added DUT/PTF IPv6 addresses to a lab file

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -637,6 +637,7 @@ def makeLabYAML(data, devices, testbed, outfile):
                 if dut in devices:
                     dutDict.update({dut:
                         {'ansible_host': devices[dut].get("ansible").get("ansible_host"),
+                        'ansible_hostv6': devices[dut].get("ansible").get("ansible_hostv6"),
                         'ansible_ssh_user': devices[dut].get("ansible").get("ansible_ssh_user"),
                         'ansible_ssh_pass': devices[dut].get("ansible").get("ansible_ssh_pass"),
                         'hwsku': devices[dut].get("hwsku"),
@@ -687,6 +688,7 @@ def makeLabYAML(data, devices, testbed, outfile):
             if ptfhost in testbed:
                 ptfDict.update({ptfhost:
                     {'ansible_host': testbed[ptfhost].get("ansible").get("ansible_host"),
+                    'ansible_hostv6': testbed[ptfhost].get("ansible").get("ansible_hostv6"),
                     'ansible_ssh_user': testbed[ptfhost].get("ansible").get("ansible_ssh_user"),
                     'ansible_ssh_pass': testbed[ptfhost].get("ansible").get("ansible_ssh_pass")
                     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: added DUT/PTF IPv6 addresses to a lab file
Fixes # (issue)

There are TACACS IPv6 tests which communicate with TACACS server run in PTF via IPv6.
It is expected for addresses to be present in lab file to be eventually configured. Since lab file is generated by TestbedProcessing, we put addresses there and expect them to be generated into lab file but it does not happen. Fixed it

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Enable tests which require DUT-PTF IPv6 connectivity, TACACS IPv6 on instance
#### How did you do it?
Made TestbedProcessing to put IPv6 addresses for DUT and PTF to a lab file
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
