### PR TITLE
Update portchannel name for t0-56-po2vlan

### DIFF
--- a/ansible/vars/topo_t0-56-po2vlan.yml
+++ b/ansible/vars/topo_t0-56-po2vlan.yml
@@ -110,7 +110,7 @@ topology:
       vm_offset: 7
   DUT:
     portchannel_config:
-      PortChannel101:
+      PortChannel201:
         intfs: [0, 4]
     vlan_configs:
       default_vlan_config: two_vlan_a
@@ -118,14 +118,14 @@ topology:
         Vlan101:
           id: 101
           intfs: []
-          portchannels: ['PortChannel101']
+          portchannels: ['PortChannel201']
           prefix: 192.168.0.1/22
           prefix_v6: fc02:100::1/64
           tag: 101
         Vlan102:
           id: 102
           intfs: [8, 10, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 44, 46, 48, 50, 52, 54]
-          portchannels: ['PortChannel101']
+          portchannels: ['PortChannel201']
           prefix: 192.168.4.1/22
           prefix_v6: fc02:200::1/64
           tag: 102


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
t0-56-po2lvan nightly test is broken, and root cause is conflicted External portChannel name introduced by #4763 

#### How did you do it?
Update portChannel name for t0-56-po2lvan

#### How did you verify/test it?
Run t0-56-po2lvan nightly test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
