### PR TITLE
Remove hard code and sniff on each server port for verification of option 82

### DIFF
--- a/ansible/roles/test/files/ptftests/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/dhcp_relay_test.py
@@ -666,14 +666,12 @@ class DHCPTest(DataplaneBaseTest):
             self.assertTrue(False,"DHCP Relay packet not matched or Padded extra on server side")
 
     def runTest(self):
-        t1 = Thread(target=self.Sniffer, args=("eth28",))
-        t1.start()
-        t2 = Thread(target=self.Sniffer, args=("eth29",))
-        t2.start()
-        t3 = Thread(target=self.Sniffer, args=("eth30",))
-        t3.start()
-        t4 = Thread(target=self.Sniffer, args=("eth31",))
-        t4.start()
+        # Start sniffer process for each server port to capture DHCP packet
+        # and then verify option 82
+        for interface_index in self.server_port_indices:
+            t1 = Thread(target=self.Sniffer, args=("eth"+str(interface_index),))
+            t1.start()
+
         self.client_send_discover(self.dest_mac_address, self.client_udp_src_port)
         self.verify_relayed_discover()
         self.server_send_offer()


### PR DESCRIPTION




<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
#5316 introduced verification of option 82, but it has some hard code to sniff packet on `eth28, eth29`.. these t0 topology's server port.
Then test_dhcp_relay failed on other topologies, such as dualtor, t0-64, t1...
Remove hard code and sniff on each server port for verification of option 82. Verified on dualtor and t0-64, test cases are passed.

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
test_dhcp_relay failed on other topologies except t0, such as dualtor, t0-64, t1

#### How did you do it?
Remove hard code and sniff on each server port for verification of option 82.

#### How did you verify/test it?
run dhcp_relay/test_dhcp_relay.py on dualtor, t0-64 these topologies testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
