### PR TITLE
Cisco Platform:skip configurable_drop_counters sip_link_local tests

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -1,3 +1,14 @@
+####################################################
+#####     test_configurable_drop_counters.py   #####
+####################################################
+#Link local address(169.254.xxx.xxx) as a source address as IPv4 header is not invalid in all the cases
+#Hence, it is not dropped by default in Cisco-8000. For dropping link local address, it should be done through security/DATA ACL
+drop_packets/test_configurable_drop_counters.py::test_sip_link_local:
+  skip:
+    reason: "Cisco 8000 platform does not drop SIP link local packets"
+    conditions:
+       - asic_type=="cisco-8000"
+
 #######################################
 #####     test_drop_counters.py   #####
 #######################################


### PR DESCRIPTION

### Description of PR
Link local address(169.254.xxx.xxx) as a source address as IPv4 header is not invalid in all the cases. Hence, it is not dropped by default in Cisco-8000. For dropping link local address, it should be done through security/DATA ACL"


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
skip test_sip_link_local tests in test_configurable_drop_counters
#### How did you do it?
added the skip for the test case specific to cisco platform in tests_mark_conditions_drop_packets.yaml
#### How did you verify/test it?

Verified on cisco-8000 platform and related tests skipped
=========================== short test summary info ============================
SKIPPED [4] /data/tests/drop_packets/test_configurable_drop_counters.py:328: Drop reasons not supported on target DUT
SKIPPED [2] drop_packets/test_configurable_drop_counters.py:198: Cisco 8000 platform does not drop SIP link local packets
========================= 6 skipped in 119.90 seconds ==========================

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?


