### PR TITLE
[PBH tests] add supporting of other t0 topologies

### DIFF
--- a/ansible/roles/test/files/ptftests/inner_hash_test.py
+++ b/ansible/roles/test/files/ptftests/inner_hash_test.py
@@ -76,6 +76,7 @@ class InnerHashTest(BaseTest):
 
         self.hash_keys = self.test_params.get('hash_keys', ['src-ip', 'dst-ip', 'src-port', 'dst-port'])
         self.src_ports = self.test_params['src_ports']
+        self.exp_port_groups = self.test_params['exp_port_groups']
         self.vxlan_port = self.test_params['vxlan_port']
         self.outer_encap_formats = self.test_params['outer_encap_formats']
         self.symmetric_hashing = self.test_params.get('symmetric_hashing', False)
@@ -96,6 +97,7 @@ class InnerHashTest(BaseTest):
         logging.info("outer_encap_formats:  {}".format(self.outer_encap_formats))
         logging.info("hash_keys:  {}".format(self.hash_keys))
         logging.info("symmetric_hashing:  {}".format(self.symmetric_hashing))
+        logging.info("exp_port_groups:  {}".format(self.exp_port_groups))
 
 
     def check_hash(self, hash_key):
@@ -115,19 +117,20 @@ class InnerHashTest(BaseTest):
                 dport = random.randint(0, 65535) if hash_key == 'dst-port' else 80
                 ip_proto = self._get_ip_proto() if hash_key == 'ip-proto' else 6
 
-                (packet_port_index, _) = self.check_ip_route(hash_key, outer_encap_format, src_port, ip_src, ip_dst, sport, dport, ip_proto)
+                (matched_port, _) = self.check_ip_route(hash_key, outer_encap_format, src_port, ip_src, ip_dst, sport, dport, ip_proto)
                 if self.symmetric_hashing and hash_key != 'ip-proto':
                     # Send the same packet with reversed tuples and validate that it lands on the same port
                     rand_src_port = int(random.choice(self.src_ports))
-                    (rPacket_port_index, _) = self.check_ip_route(hash_key, outer_encap_format, rand_src_port, ip_dst, ip_src, dport, sport, ip_proto)
-                    assert packet_port_index == rPacket_port_index
+                    (rMatched_port, _) = self.check_ip_route(hash_key, outer_encap_format, rand_src_port, ip_dst, ip_src, dport, sport, ip_proto)
+                    self.check_matched_ports(matched_port, rMatched_port)
+                    hit_count_map[rMatched_port] = hit_count_map.get(rMatched_port, 0) + 1
 
-                hit_count_map[packet_port_index] = hit_count_map.get(packet_port_index, 0) + 1
+                hit_count_map[matched_port] = hit_count_map.get(matched_port, 0) + 1
             logging.info("outer_encap_fmts={}, hash_key={}, hit count map: {}".format(outer_encap_format, hash_key, hit_count_map))
             if hash_key == 'outer-tuples':
                 self.check_all_packets_hash_to_same_nh(self.next_hop.get_next_hop(), hit_count_map)
             else:
-                self.check_balancing(self.next_hop.get_next_hop(), hit_count_map)
+                self.check_balancing(self.next_hop.get_next_hop(), hit_count_map, hash_key)
 
 
     def check_ip_route(self, hash_key, outer_encap_format, src_port, ip_src, ip_dst, sport, dport, ip_proto):
@@ -140,6 +143,16 @@ class InnerHashTest(BaseTest):
 
         matched_port = self.exp_port_list[matched_index]
         return (matched_port, received)
+
+
+    def check_matched_ports(self, matched_port, rMatched_port):
+        logging.info("matched_port:  {}, rMatched_port: {}".format(matched_port, rMatched_port))
+        for ports_group in self.exp_port_groups:
+            if matched_port in ports_group:
+                assert (rMatched_port in ports_group, 'The matched_port {} and rMatched_port {} not in same group'.
+                        format(matched_port, rMatched_port, ports_group))
+                break
+        assert (False, "matched port {} not in expected ports {}".format(matched_port, self.exp_port_groups))
 
 
     def _get_ip_proto(self, ipv6=False):
@@ -206,7 +219,7 @@ class InnerHashTest(BaseTest):
 
         assert received
 
-        logging.info("Received packet at " + str(matched_index))
+        logging.info("Received packet at index " + str(matched_index))
         time.sleep(0.02)
 
         return (matched_index, received)
@@ -361,7 +374,7 @@ class InnerHashTest(BaseTest):
 
         assert received
 
-        logging.info("Received packet at " + str(matched_index))
+        logging.info("Received packet at index" + str(matched_index))
         time.sleep(0.02)
 
         return (matched_index, received)
@@ -463,11 +476,12 @@ class InnerHashTest(BaseTest):
         return (percentage, abs(percentage) <= self.balancing_range)
 
 
-    def check_balancing(self, dest_port_list, port_hit_cnt):
+    def check_balancing(self, dest_port_list, port_hit_cnt, hash_key):
         '''
         @summary: Check if the traffic is balanced across the ECMP groups and the LAG members
         @param dest_port_list : a list of ECMP entries and in each ECMP entry a list of ports
         @param port_hit_cnt : a dict that records the number of packets each port received
+        @param hash_key : hash key
         @return bool
         '''
 
@@ -479,17 +493,15 @@ class InnerHashTest(BaseTest):
             total_entry_hit_cnt = 0
             for member in ecmp_entry:
                 total_entry_hit_cnt += port_hit_cnt.get(member, 0)
-            (p, r) = self.check_within_expected_range(total_entry_hit_cnt, float(total_hit_cnt)/len(dest_port_list))
+
+            total_expected = float(total_hit_cnt) / len(dest_port_list)
+            if self.symmetric_hashing and hash_key != 'ip-proto':
+                total_expected = total_expected * 2
+
+            (p, r) = self.check_within_expected_range(total_entry_hit_cnt, total_expected)
             logging.info("%-10s \t %-10s \t %10d \t %10d \t %10s"
-                        % ("ECMP", str(ecmp_entry), total_hit_cnt//len(dest_port_list), total_entry_hit_cnt, str(round(p, 4)*100) + '%'))
+                        % ("ECMP", str(ecmp_entry), (total_hit_cnt//len(dest_port_list)*len(ecmp_entry)), total_entry_hit_cnt, str(round(p, 4)*100) + '%'))
             result &= r
-            if len(ecmp_entry) == 1 or total_entry_hit_cnt == 0:
-                continue
-            for member in ecmp_entry:
-                (p, r) = self.check_within_expected_range(port_hit_cnt.get(member, 0), float(total_entry_hit_cnt)/len(ecmp_entry))
-                logging.info("%-10s \t %-10s \t %10d \t %10d \t %10s"
-                            % ("LAG", str(member), total_entry_hit_cnt//len(ecmp_entry), port_hit_cnt.get(member, 0), str(round(p, 4)*100) + '%'))
-                result &= r
 
         assert result
 
@@ -505,6 +517,8 @@ class InnerHashTest(BaseTest):
         logging.info("%-10s \t %10s" % ("port(s)", "cnt"))
 
         total_hit_cnt = self.balancing_test_times*len(self.exp_port_list)
+        if self.symmetric_hashing:
+            total_hit_cnt = total_hit_cnt*2
         nhs_with_packets_rcvd = 0
         for ecmp_entry in dest_port_list:
             total_entry_hit_cnt = 0

--- a/ansible/roles/test/files/ptftests/inner_hash_test.py
+++ b/ansible/roles/test/files/ptftests/inner_hash_test.py
@@ -147,12 +147,15 @@ class InnerHashTest(BaseTest):
 
     def check_matched_ports(self, matched_port, rMatched_port):
         logging.info("matched_port:  {}, rMatched_port: {}".format(matched_port, rMatched_port))
+        matched_port_in_any_group = False
         for ports_group in self.exp_port_groups:
             if matched_port in ports_group:
-                assert (rMatched_port in ports_group, 'The matched_port {} and rMatched_port {} not in same group {}'.
-                        format(matched_port, rMatched_port, ports_group))
+                assert rMatched_port in ports_group, 'The matched_port {} and rMatched_port {} not in the same group {}'.\
+                    format(matched_port, rMatched_port, ports_group)
+                matched_port_in_any_group = True
                 break
-        assert (False, "matched port {} not in expected ports {}".format(matched_port, self.exp_port_groups))
+        assert matched_port_in_any_group, "The matched port {} not in expected ports list {}".\
+            format(matched_port, self.exp_port_groups)
 
 
     def _get_ip_proto(self, ipv6=False):

--- a/ansible/roles/test/files/ptftests/inner_hash_test.py
+++ b/ansible/roles/test/files/ptftests/inner_hash_test.py
@@ -149,7 +149,7 @@ class InnerHashTest(BaseTest):
         logging.info("matched_port:  {}, rMatched_port: {}".format(matched_port, rMatched_port))
         for ports_group in self.exp_port_groups:
             if matched_port in ports_group:
-                assert (rMatched_port in ports_group, 'The matched_port {} and rMatched_port {} not in same group'.
+                assert (rMatched_port in ports_group, 'The matched_port {} and rMatched_port {} not in same group {}'.
                         format(matched_port, rMatched_port, ports_group))
                 break
         assert (False, "matched port {} not in expected ports {}".format(matched_port, self.exp_port_groups))

--- a/tests/ecmp/inner_hashing/test_inner_hashing.py
+++ b/tests/ecmp/inner_hashing/test_inner_hashing.py
@@ -35,7 +35,8 @@ class TestDynamicInnerHashing():
             request.getfixturevalue("config_hash")
             request.getfixturevalue("config_rules")
 
-    def test_inner_hashing(self, request, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac, vlan_ptf_ports, symmetric_hashing, duthost):
+    def test_inner_hashing(self, request, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
+                           vlan_ptf_ports, symmetric_hashing, duthost, lag_mem_ptf_ports_groups):
         logging.info("Executing dynamic inner hash test for outer {} and inner {} with symmetric_hashing set to {}"
                      .format(outer_ipver, inner_ipver, str(symmetric_hashing)))
         with allure.step('Run ptf test InnerHashTest'):
@@ -46,12 +47,13 @@ class TestDynamicInnerHashing():
             outer_src_ip_range, outer_dst_ip_range = get_src_dst_ip_range(outer_ipver)
             inner_src_ip_range, inner_dst_ip_range = get_src_dst_ip_range(inner_ipver)
 
-            balancing_test_times = 150
+            balancing_test_times = 120
             balancing_range = 0.3
 
             ptf_params = {"fib_info": FIB_INFO_FILE_DST,
                           "router_mac": router_mac,
                           "src_ports": vlan_ptf_ports,
+                          "exp_port_groups": lag_mem_ptf_ports_groups,
                           "hash_keys": hash_keys,
                           "vxlan_port": VXLAN_PORT,
                           "inner_src_ip_range": ",".join(inner_src_ip_range),
@@ -75,7 +77,8 @@ class TestDynamicInnerHashing():
                        socket_recv_size=16384)
 
             retry_call(check_pbh_counters,
-                       fargs=[duthost, outer_ipver, inner_ipver, balancing_test_times, symmetric_hashing, hash_keys],
+                       fargs=[duthost, outer_ipver, inner_ipver, balancing_test_times,
+                              symmetric_hashing, hash_keys, lag_mem_ptf_ports_groups],
                        tries=5,
                        delay=5)
 
@@ -112,7 +115,8 @@ class TestDynamicInnerHashing():
 @pytest.mark.static_config
 class TestStaticInnerHashing():
 
-    def test_inner_hashing(self, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac, vlan_ptf_ports, symmetric_hashing):
+    def test_inner_hashing(self, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
+                           vlan_ptf_ports, symmetric_hashing, lag_mem_ptf_ports_groups):
         logging.info("Executing static inner hash test for outer {} and inner {} with symmetric_hashing set to {}"
                      .format(outer_ipver, inner_ipver, str(symmetric_hashing)))
         timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
@@ -129,6 +133,7 @@ class TestStaticInnerHashing():
                    params={"fib_info": FIB_INFO_FILE_DST,
                            "router_mac": router_mac,
                            "src_ports": vlan_ptf_ports,
+                           "exp_port_groups": lag_mem_ptf_ports_groups,
                            "hash_keys": hash_keys,
                            "vxlan_port": VXLAN_PORT,
                            "inner_src_ip_range": ",".join(inner_src_ip_range),

--- a/tests/ecmp/inner_hashing/test_inner_hashing.py
+++ b/tests/ecmp/inner_hashing/test_inner_hashing.py
@@ -106,8 +106,8 @@ class TestDynamicInnerHashing():
                            socket_recv_size=16384)
 
             retry_call(check_pbh_counters,
-                       fargs=[duthost, swapped_outer_ipver, swapped_inner_ipver,
-                              balancing_test_times, symmetric_hashing, hash_keys],
+                       fargs=[duthost, swapped_outer_ipver, swapped_inner_ipver, balancing_test_times,
+                              symmetric_hashing, hash_keys, lag_mem_ptf_ports_groups],
                        tries=5,
                        delay=5)
 

--- a/tests/ecmp/inner_hashing/test_wr_inner_hashing.py
+++ b/tests/ecmp/inner_hashing/test_wr_inner_hashing.py
@@ -29,7 +29,7 @@ class TestWRDynamicInnerHashing():
             request.getfixturevalue("config_rules")
 
     def test_inner_hashing(self, duthost, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
-                           vlan_ptf_ports, symmetric_hashing, localhost):
+                           vlan_ptf_ports, symmetric_hashing, localhost, lag_mem_ptf_ports_groups):
         logging.info("Executing warm boot dynamic inner hash test for outer {} and inner {} with symmetric_hashing"
                      " set to {}".format(outer_ipver, inner_ipver, str(symmetric_hashing)))
         with allure.step('Run ptf test InnerHashTest and warm-reboot in parallel'):
@@ -57,6 +57,7 @@ class TestWRDynamicInnerHashing():
                        params={"fib_info": FIB_INFO_FILE_DST,
                                "router_mac": router_mac,
                                "src_ports": vlan_ptf_ports,
+                               "exp_port_groups": lag_mem_ptf_ports_groups,
                                "hash_keys": hash_keys,
                                "vxlan_port": VXLAN_PORT,
                                "inner_src_ip_range": ",".join(inner_src_ip_range),
@@ -78,7 +79,7 @@ class TestWRDynamicInnerHashing():
 class TestWRStaticInnerHashing():
 
     def test_inner_hashing(self, duthost, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
-                           vlan_ptf_ports, symmetric_hashing, localhost):
+                           vlan_ptf_ports, symmetric_hashing, localhost, lag_mem_ptf_ports_groups):
         logging.info("Executing static inner hash test for outer {} and inner {} with symmetric_hashing set to {}"
                      .format(outer_ipver, inner_ipver, str(symmetric_hashing)))
         timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
@@ -98,6 +99,7 @@ class TestWRStaticInnerHashing():
                    params={"fib_info": FIB_INFO_FILE_DST,
                            "router_mac": router_mac,
                            "src_ports": vlan_ptf_ports,
+                           "exp_port_groups": lag_mem_ptf_ports_groups,
                            "hash_keys": hash_keys,
                            "vxlan_port": VXLAN_PORT,
                            "inner_src_ip_range": ",".join(inner_src_ip_range),

--- a/tests/ecmp/inner_hashing/test_wr_inner_hashing_lag.py
+++ b/tests/ecmp/inner_hashing/test_wr_inner_hashing_lag.py
@@ -32,7 +32,7 @@ class TestWRDynamicInnerHashingLag():
             request.getfixturevalue("config_rules")
 
     def test_inner_hashing(self, duthost, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
-                           vlan_ptf_ports, symmetric_hashing, localhost):
+                           vlan_ptf_ports, symmetric_hashing, localhost, lag_mem_ptf_ports_groups):
         logging.info("Executing warm boot dynamic inner hash test for outer {} and inner {} with symmetric_hashing"
                      " set to {}".format(outer_ipver, inner_ipver, str(symmetric_hashing)))
         timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
@@ -59,6 +59,7 @@ class TestWRDynamicInnerHashingLag():
                    params={"fib_info": FIB_INFO_FILE_DST,
                            "router_mac": router_mac,
                            "src_ports": vlan_ptf_ports,
+                           "exp_port_groups": lag_mem_ptf_ports_groups,
                            "hash_keys": hash_keys,
                            "vxlan_port": VXLAN_PORT,
                            "inner_src_ip_range": ",".join(inner_src_ip_range),


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enhancement of PBH tests.
Added support of other topologies with few members in PortChannel. The change was executed by passing to ptf test the list of members lists from PortChannels.
Example of the list from t0-64 topo: [[21, 20], [1, 0], [16, 17], [4, 5]]
Now the tests support any t0 topology

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
PBH tests enhancement 

#### How did you do it?

#### How did you verify/test it?
executed all PBH tests on MSN4600C, MSN4700 with t0,t0-64 topo

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
