### PR TITLE
[reboot] Remove restriction on test_reboot.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -603,6 +603,12 @@ platform_tests/test_platform_info.py::test_thermal_control_load_invalid_value_js
 #######################################
 #####        test_reboot.py       #####
 #######################################
+platform_tests/test_reboot.py:
+  skip:
+    reason: "Skip reboot test for Celestica"
+    conditions:
+      - "hwsku in ['Celestica-E1031-T48S4']"
+
 platform_tests/test_reboot.py::test_warm_reboot:
   xfail:
     reason: "Image issue on Boradcom dualtor testbeds"

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -100,8 +100,6 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type =
         logging.info("Wait {} seconds for all the transceivers to be detected".format(MAX_WAIT_TIME_FOR_INTERFACES))
         result = wait_until(MAX_WAIT_TIME_FOR_INTERFACES, 20, 0, check_all_interface_information, dut, interfaces,
                             xcvr_skip_list)
-        if not dut.has_sku:
-            pytest.xfail("hwsku.json is needed for interface checking to pass, and it is not provided.")
         assert result, "Not all transceivers are detected or interfaces are up in {} seconds".format(
             MAX_WAIT_TIME_FOR_INTERFACES)
 


### PR DESCRIPTION
Missing hwsku.json might cause test_reboot.py to fail on some platforms
but not others. In previous commits, hwsku.json will be checked and if
missing, xfail the test. In this commit, the check is removed and some
machine where it is known will have the test skipped. In future commits,
this check will be implemented again but further limited to a few hwsku.

Signed-off-by: Xichen Lin <xichenlin@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Missing hwsku.json might cause test_reboot.py to fail on some platforms
but not others. In previous commits, hwsku.json will be checked and if
missing, xfail the test. In this commit, the check is removed and some
machine where it is known will have the test skipped. In future commits,
this check will be implemented again but further limited to a few hwsku.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Missing hwsku.json might cause test_reboot to fail, but some has passed the test without having hwsku.json.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
