### PR TITLE
Support both str and int type for slot_id received in pmon API

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -530,13 +530,13 @@ class TestChassisApi(PlatformApiTestBase):
     def test_get_supervisor_slot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         if chassis.is_modular_chassis(platform_api_conn):
             sup_slot = chassis.get_supervisor_slot(platform_api_conn)
-            pytest_assert(isinstance(sup_slot, int), "supervisor slot is not type integer")
+            pytest_assert(isinstance(sup_slot, int) or isinstance(sup_slot, STRING_TYPE), "supervisor slot is not type integer")
         else:
             pytest.skip("skipped as this test is applicable to modular chassis only")
 
     def test_get_my_slot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         if chassis.is_modular_chassis(platform_api_conn):
             my_slot = chassis.get_my_slot(platform_api_conn)
-            pytest_assert(isinstance(my_slot, int), "supervisor slot is not type integer")
+            pytest_assert(isinstance(my_slot, int) or isinstance(my_slot, STRING_TYPE), "supervisor slot is not type integer")
         else:
             pytest.skip("skipped as this test is applicable to modular chassis only")

--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -331,7 +331,7 @@ class TestModuleApi(PlatformApiTestBase):
         for i in range(self.num_modules):
             slot_id = module.get_slot(platform_api_conn, i)
             if self.expect(slot_id is not None, "Unable to retrieve module {} slot id".format(i)):
-                self.expect(isinstance(slot_id, int), "Module {} slot id is not correct ".format(i))
+                self.expect(isinstance(slot_id, int) or isinstance(slot_id, STRING_TYPE), "Module {} slot id is not correct ".format(i))
         self.assert_expectations()
 
     def test_get_type(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):


### PR DESCRIPTION





<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Based on PR https://github.com/Azure/SONiC/pull/945/, we should return the sticker/label name on the chassis for the physical slot id in the get_supervisor_slot PMON API and 'show chassis module status' command.

For Nokia supervisor card, the sticker label is 'A'.

#### How did you do it?
Allow for string as possible return value as well of get_supervisor_slot chassis PMON API.

#### How did you verify/test it?
Ran test with changes above against Nokia supervisor card

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
