### PR TITLE
Use dut_mg_facts instead of asic mg_facts to set in_ptf_index.

### DIFF
--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -192,7 +192,7 @@ def test_po_update_io_no_loss(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     # use first port of in_pc as input port
     # all ports in out_pc will be output/forward ports
     pc, pc_members = out_pc[2], out_pc[3]
-    in_ptf_index = mg_facts["minigraph_ptf_indices"][in_pc[3][0]]
+    in_ptf_index = dut_mg_facts["minigraph_ptf_indices"][in_pc[3][0]]
     out_ptf_indices = map(lambda port: mg_facts["minigraph_ptf_indices"][port], out_pc[3])
     logging.info(
         "selected_pcs is: %s, in_ptf_index is %s, out_ptf_indices is %s" % (


### PR DESCRIPTION




<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
test test_po_update_io_no_loss requires 2 portchannels. 

However, In a min T2 topology, we have one portchannel per asic.  The test was enhanced to use the ingress portchannel from another asic. But, the ptf index for this ingress portchannel was being derived from the asic mg_facts of the egress portchannel on enum_frontend_asic_index which would not have info about the ports in the other asic.

#### How did you do it?
Fix was to use dut_mg_facts to get the ptf index for ingress portchannel on the other asic.

#### How did you verify/test it?
Verified the test against T2 min topology with multi-asic linecards.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
