### PR TITLE
Voq test case optimizations and some bug fixes

### DIFF
--- a/tests/common/helpers/sonic_db.py
+++ b/tests/common/helpers/sonic_db.py
@@ -35,6 +35,7 @@ class SonicDbCli(object):
             Empty dictionary on error.
 
         """
+        logger.debug("SONIC-DB-CLI: %s", cmd)
         result = self.host.run_sonic_db_cli_cmd(cmd)
 
         if len(result["stdout_lines"]) == 0:
@@ -235,7 +236,8 @@ class AsicDbCli(SonicDbCli):
             return self.lagid_key_list
 
         cmd = self._cli_prefix() + "KEYS %s:*" % AsicDbCli.ASIC_LAG_TABLE
-        return self._run_and_raise(cmd)["stdout_lines"]
+        self.lagid_key_list =self._run_and_raise(cmd)["stdout_lines"]
+        return self.lagid_key_list
 
     def get_asic_db_lag_member_list(self):
         """Returns a list of keys in the lag member table"""

--- a/tests/voq/test_voq_disrupts.py
+++ b/tests/voq/test_voq_disrupts.py
@@ -13,10 +13,11 @@ from voq_helpers import dump_and_verify_neighbors_on_asic
 
 from tests.common import reboot
 from tests.common import config_reload
-from tests.common.utilities import wait_until
 
 from tests.common.helpers.parallel import parallel_run
 from tests.common.helpers.parallel import reset_ansible_local_tmp
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ pytestmark = [
 ]
 
 
-def check_bgp_neighbors(duthosts):
+def check_bgp_neighbors(duthosts, excluded_ips=[]):
     """
     Validates neighbors are established
 
@@ -42,7 +43,7 @@ def check_bgp_neighbors(duthosts):
             bgp_facts = asic.bgp_facts()['ansible_facts']
 
             for address in bgp_facts['bgp_neighbors']:
-                if bgp_facts['bgp_neighbors'][address]['state'] != "established":
+                if address.lower() not in excluded_ips and bgp_facts['bgp_neighbors'][address]['state'] != "established":
                     logger.info("BGP neighbor: %s is down: %s." % (
                         address, bgp_facts['bgp_neighbors'][address]['state']))
                     down_nbrs += 1
@@ -68,15 +69,8 @@ def poll_bgp_restored(duthosts, timeout=900, delay=20):
 
     """
     logger.info("Poll for BGP to recover.")
-    restored = False
-    endtime = time.time() + timeout
-    while not restored and time.time() < endtime:
-        restored = check_bgp_neighbors(duthosts)
-        if restored:
-            break
-        time.sleep(delay)
-    else:
-        raise AssertionError("BGP was never restored.")
+    pytest_assert(wait_until(timeout, 10, 0, check_bgp_neighbors, duthosts),
+                  "All BGP's are not established after config reload from original minigraph")
 
 
 def check_intfs_and_nbrs(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
@@ -186,6 +180,8 @@ def test_reboot_supervisor(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_mac
 
     reboot(duthosts.supervisor_nodes[0], localhost, wait=600)
     assert wait_until(300, 20, duthosts.supervisor_nodes[0].critical_services_fully_started), "Not all critical services are fully started"
+    reboot(duthosts.supervisor_nodes[0], localhost, wait=240)
+    assert wait_until(300, 20, 2, duthosts.supervisor_nodes[0].critical_services_fully_started), "Not all critical services are fully started"
 
     poll_bgp_restored(duthosts)
 
@@ -212,7 +208,7 @@ def test_reboot_system(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_macs):
     @reset_ansible_local_tmp
     def reboot_node(lh, node=None, results=None):
         node_results = []
-        node_results.append(reboot(node, lh, wait=600))
+        node_results.append(reboot(node, lh, wait=120))
         results[node.hostname] = node_results
 
     logger.info("=" * 80)
@@ -229,10 +225,8 @@ def test_reboot_system(duthosts, localhost, all_cfg_facts, nbrhosts, nbr_macs):
     t0 = time.time()
 
     parallel_run(reboot_node, [localhost], {}, duthosts.nodes, timeout=1000)
-
     for node in duthosts.nodes:
-        assert wait_until(300, 20, node.critical_services_fully_started), "Not all critical services are fully started"
-
+        assert wait_until(300, 20, 2, node.critical_services_fully_started), "Not all critical services are fully started"
     poll_bgp_restored(duthosts)
 
     t1 = time.time()
@@ -271,7 +265,7 @@ def test_config_reload_lc(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
     logger.info("Config reload on node: %s", duthosts.frontend_nodes[0].hostname)
     logger.info("-" * 80)
 
-    config_reload(duthosts.frontend_nodes[0], config_source='config_db', wait=600)
+    config_reload(duthosts.frontend_nodes[0], config_source='config_db', safe_reload=True)
     poll_bgp_restored(duthosts)
 
     logger.info("=" * 80)

--- a/tests/voq/test_voq_init.py
+++ b/tests/voq/test_voq_init.py
@@ -179,6 +179,15 @@ def check_voq_interfaces(duthosts, per_host, asic, cfg_facts):
     asicdb = AsicDbCli(asic)
     asicdb_rif_table = asicdb.dump(asicdb.ASIC_ROUTERINTF_TABLE)
     sys_port_table = asicdb.dump(asicdb.ASIC_SYSPORT_TABLE)
+    asicdb_lag_table = asicdb.dump(asicdb.ASIC_LAG_TABLE + ":")
+
+    if per_host.is_multi_asic and len(duthosts.supervisor_nodes) == 0:
+        voqdb = VoqDbCli(per_host)
+    else:
+        voqdb = VoqDbCli(duthosts.supervisor_nodes[0])
+
+    systemlagtable = voqdb.dump("SYSTEM_LAG_ID_TABLE")
+    systemintftable = voqdb.dump("SYSTEM_INTERFACE")
 
     # asicdb_intf_key_list = asicdb.get_router_if_list()
     # Check each rif in the asicdb, if it is local port, check VOQ DB for correct RIF.
@@ -197,7 +206,7 @@ def check_voq_interfaces(duthosts, per_host, asic, cfg_facts):
         if porttype == 'hostif':
             # find the hostif entry to get the physical port the router interface is on.
             hostifkey = asicdb.find_hostif_by_portid(portid)
-            hostif = asicdb.hget_key_value(hostifkey, 'SAI_HOSTIF_ATTR_NAME')
+            hostif = asicdb.get_hostif_table(refresh=False)[hostifkey]['value']['SAI_HOSTIF_ATTR_NAME'].decode('unicode-escape')
             logger.info("RIF: %s is on local port: %s", rif, hostif)
             rif_ports_in_asicdb.append(hostif)
             if hostif not in dev_intfs and hostif not in voq_intfs:
@@ -213,11 +222,7 @@ def check_voq_interfaces(duthosts, per_host, asic, cfg_facts):
             sysport_info = {'slot': cfg_facts['DEVICE_METADATA']['localhost']['hostname'],
                             'asic': cfg_facts['DEVICE_METADATA']['localhost']['asic_name']}
 
-            if per_host.is_multi_asic and len(duthosts.supervisor_nodes) == 0:
-                check_rif_on_sup(per_host, sysport_info['slot'], sysport_info['asic'], hostif)
-            else:
-                for sup in duthosts.supervisor_nodes:
-                    check_rif_on_sup(sup, sysport_info['slot'], sysport_info['asic'], hostif)
+            check_rif_on_sup(systemintftable, sysport_info['slot'], sysport_info['asic'], hostif)
 
         elif porttype == 'sysport':
             try:
@@ -235,11 +240,7 @@ def check_voq_interfaces(duthosts, per_host, asic, cfg_facts):
                 raise AssertionError("Did not find OID %s in local or system tables" % portid)
 
             sys_slot, sys_asic, sys_port = cfg_port.split("|")
-            if per_host.is_multi_asic and len(duthosts.supervisor_nodes) == 0:
-                check_rif_on_sup(per_host, sys_slot, sys_asic, sys_port)
-            else:
-                for sup in duthosts.supervisor_nodes:
-                    check_rif_on_sup(sup, sys_slot, sys_asic, sys_port)
+            check_rif_on_sup(systemintftable, sys_slot, sys_asic, sys_port)
 
         elif porttype == 'port':
             # this is the RIF on the inband port.
@@ -256,23 +257,15 @@ def check_voq_interfaces(duthosts, per_host, asic, cfg_facts):
             sysport_info = {'slot': cfg_facts['DEVICE_METADATA']['localhost']['hostname'],
                             'asic': cfg_facts['DEVICE_METADATA']['localhost']['asic_name']}
 
-            if per_host.is_multi_asic and len(duthosts.supervisor_nodes) == 0:
-                check_rif_on_sup(per_host, sysport_info['slot'], sysport_info['asic'], inband['port'])
-            else:
-                for sup in duthosts.supervisor_nodes:
-                    check_rif_on_sup(sup, sysport_info['slot'], sysport_info['asic'], inband['port'])
+            check_rif_on_sup(systemintftable, sysport_info['slot'], sysport_info['asic'], inband['port'])
 
         # TODO: Could be on a LAG
         elif porttype == 'lag':
-            lagid = asicdb.hget_key_value("%s:%s" % (AsicDbCli.ASIC_LAG_TABLE, portid), 'SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID')
+            #lagid = asicdb.hget_key_value("%s:%s" % (AsicDbCli.ASIC_LAG_TABLE, portid), 'SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID')
+            lagid = asicdb_lag_table["%s:%s" % (AsicDbCli.ASIC_LAG_TABLE, portid)]['value']['SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID']
             logger.info("RIF: %s is on system LAG: %s", rif, lagid)
 
-            if per_host.is_multi_asic and len(duthosts.supervisor_nodes) == 0:
-                voqdb = VoqDbCli(per_host)
-            else:
-                voqdb = VoqDbCli(duthosts.supervisor_nodes[0])
 
-            systemlagtable = voqdb.dump("SYSTEM_LAG_ID_TABLE")
             for lag, sysid in systemlagtable['SYSTEM_LAG_ID_TABLE']['value'].iteritems():
                 if sysid == lagid:
                     logger.info("System LAG ID %s is portchannel: %s", lagid, lag)
@@ -285,11 +278,7 @@ def check_voq_interfaces(duthosts, per_host, asic, cfg_facts):
                 (s, a, lagname) = lag.split("|")
                 pytest_assert(lagname in cfg_facts['PORTCHANNEL_INTERFACE'], "RIF Interface %s is in configdb.json but not in asicdb" % rif)
 
-                if per_host.is_multi_asic and len(duthosts.supervisor_nodes) == 0:
-                    check_rif_on_sup(per_host, myslot, myasic, lagname)
-                else:
-                    for sup in duthosts.supervisor_nodes:
-                        check_rif_on_sup(sup, myslot, myasic, lagname)
+                check_rif_on_sup(systemintftable, myslot, myasic, lagname)
 
             else:
                 logger.info("Lag: %s is a remote portchannel with a router interface.", lag)

--- a/tests/voq/test_voq_intfs.py
+++ b/tests/voq/test_voq_intfs.py
@@ -8,7 +8,9 @@ from tests.common import config_reload
 from test_voq_init import check_voq_interfaces
 
 from tests.common.helpers.sonic_db import VoqDbCli, SonicDbKeyNotFound
-
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+from test_voq_disrupts import check_bgp_neighbors
 logger = logging.getLogger(__name__)
 
 pytestmark = [
@@ -41,6 +43,11 @@ def test_cycle_voq_intf(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
                                              asic_index=intf_asic.asic_index)['ansible_facts']
     portchannel = intf_config_facts['PORTCHANNEL'].keys()[0]
     portchannel_members = intf_config_facts['PORTCHANNEL'][portchannel].get('members')
+    portchannel_ips = [x.split("/")[0].lower() for x in intf_config_facts['PORTCHANNEL_INTERFACE'][portchannel].keys()]
+    bgp_nbrs_to_portchannel = []
+    for a_bgp_neighbor in intf_config_facts['BGP_NEIGHBOR']:
+        if intf_config_facts['BGP_NEIGHBOR'][a_bgp_neighbor]['local_addr'] in portchannel_ips:
+            bgp_nbrs_to_portchannel.append(a_bgp_neighbor.lower())
 
     try:
         logger.info("remove ethernet from a portchannel to use for interface create")
@@ -59,8 +66,9 @@ def test_cycle_voq_intf(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
         logger.info("Save and reload config")
 
         duthost.shell_cmds(cmds=["config save -y"])
-        config_reload(duthost, config_source='config_db', wait=600)
-
+        config_reload(duthost, config_source='config_db', safe_reload=True)
+        pytest_assert(wait_until(300, 10, 0, check_bgp_neighbors, duthosts, bgp_nbrs_to_portchannel),
+                      "All BGP's are not established after ports removed from LAG and IP added to one of them")
         logger.info("Check interfaces after add.")
         for asic in duthost.asics:
             new_cfgfacts = duthost.config_facts(source='persistent', asic_index='all')[asic.asic_index]['ansible_facts']
@@ -87,8 +95,9 @@ def test_cycle_voq_intf(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
         logger.info("Save and reload config")
 
         duthost.shell_cmds(cmds=["config save -y"])
-        config_reload(duthost, config_source='config_db', wait=600)
-
+        config_reload(duthost, config_source='config_db', safe_reload=True)
+        pytest_assert(wait_until(300, 10, 0, check_bgp_neighbors, duthosts, bgp_nbrs_to_portchannel),
+                      "All BGP's are not established after added IP removed from a LAG member")
         logger.info("check interface is gone after config reload")
 
         for asic in duthost.asics:
@@ -102,7 +111,9 @@ def test_cycle_voq_intf(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
     finally:
         # restore interface from minigraph
         logger.info("Restore config from minigraph.")
-        config_reload(duthost, config_source='minigraph', wait=600)
+        config_reload(duthost, config_source='minigraph', safe_reload=True)
+        pytest_assert(wait_until(300, 10, 0, check_bgp_neighbors, duthosts),
+                      "All BGP's are not established after config reload from original minigraph")
         duthost.shell_cmds(cmds=["config save -y"])
 
         for asic in duthost.asics:


### PR DESCRIPTION




<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Running voq test cases against a T2 chassis with 2 multi-asic linecards and all front panel ports connected to fanout takes ~10 hours to run.  Need to see if the tests could be optimized.

Also, there were some bug fixes that were required in the voq tests

#### How did you do it?
In this commit, we optimized the execution of Voq tests against a T2 chassis by:
- using sonic-db-dump to get the whole database table instead of sonic-db-dump for each individual record.
- changing config_reload to use safe_reload option that polls for all critical services to be started instead of hard-coded 600 seconds wait time.
   - Added check to make sure all eBGP and iBGP are established after the config_reload as well.
- changing the boot wait time from hard-coded 600 seconds to 120, with added check for critical services and all eBGP/iBGP connections established.
 
The above changes resulted in ~2.5hrs of reduced execution time of all voq tests against a T2 chassis.

There were also the following bug fixes that were required:
- sonic_db.py:
    - get_asic_db_lag_list had a refresh arguement and if passed as True and our stored lagid_key_list is not None, then we would return it. But, when we do refresh the lagid_key_list by sending the cmd to the DUT, we were not storing it. So, we were always sending the cmd, regardless of the value of refresh.
- Ignore expected failures logs during test execution of Grat Arp and neighbor mac change test cases.
- voq_nbr.py:
    - shutdown eBGP to the appropriate neighbors in test_neighbor_clear_all/test_neighbor_clear_one to avoid arp table refersh
      based on packets received because of BGP
- voq_helpers:
    - check_bgp_kernel_route had argument to pass in previously parsed output. However, if the parsed output has all routes, then the check for route not present would fail as it would not be empty.
      Changed to use 'not in' instead of '== {}' check
    - verify_no_routes_from_nexthop was intermittently failing with 30 seconds max wait in runs.
      Changed max timeout to 45 secs instead of 30 to let the nbr routes clear

#### How did you verify/test it?
Ran voq tests against T2 chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
