### PR TITLE
Update macsec tests to support t2 topology and multi-asic

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -113,6 +113,26 @@ class MultiAsicSonicHost(object):
             else:
                 raise ValueError("Argument 'asic_index' must be an int or string 'all'.")
 
+    def get_dut_iface_mac(self, iface_name):
+        """
+        Gets the MAC address of specified interface.
+
+        Returns:
+            str: The MAC address of the specified interface, or None if it is not found.
+        """
+        try:
+            if self.sonichost.facts['num_asic'] == 1:
+                cmd_prefix = " "
+            else:
+                asic = self.get_port_asic_instance(iface_name)
+                cmd_prefix = "sudo ip netns exec {} ".format(asic.namespace)
+ 
+            mac = self.command('{} cat /sys/class/net/{}/address'.format(cmd_prefix, iface_name))['stdout']
+            return mac
+        except Exception as e:
+            logger.error('Failed to get MAC address for interface "{}", exception: {}'.format(iface_name, repr(e)))
+            return None
+
     def get_frontend_asic_ids(self):
         if self.sonichost.facts['num_asic'] == 1:
             return [DEFAULT_ASIC_ID]

--- a/tests/macsec/__init__.py
+++ b/tests/macsec/__init__.py
@@ -159,6 +159,8 @@ class MacsecPlugin(object):
             if neighbor["name"] not in nbrhosts.keys():
                 return
             port = mg_facts["minigraph_neighbors"][interface]["port"]
+
+            # Currently in t2 topology macsec is validated on regular interfaces. To remove this once it is validated with PC.
             if tbinfo["topo"]["type"] == "t2" and is_interface_portchannel_member(mg_facts['minigraph_portchannels'], interface):
                 return
             links[interface] = {

--- a/tests/macsec/__init__.py
+++ b/tests/macsec/__init__.py
@@ -146,6 +146,12 @@ class MacsecPlugin(object):
         for interface, neighbor in mg_facts["minigraph_neighbors"].items():
             filter(interface, neighbor, mg_facts, tbinfo)
 
+    def is_interface_portchannel_member(self, pc, interface):
+        for pc_name, elements in pc.items():
+            if interface in elements['members']:
+                return True
+        return False
+
     def find_links_from_nbr(self, duthost, tbinfo, nbrhosts):
         links = collections.defaultdict(dict)
 
@@ -153,6 +159,8 @@ class MacsecPlugin(object):
             if neighbor["name"] not in nbrhosts.keys():
                 return
             port = mg_facts["minigraph_neighbors"][interface]["port"]
+            if tbinfo["topo"]["type"] == "t2" and is_interface_portchannel_member(mg_facts['minigraph_portchannels'], interface):
+                return
             links[interface] = {
                 "name": neighbor["name"],
                 "host": nbrhosts[neighbor["name"]]["host"],

--- a/tests/macsec/macsec_config_helper.py
+++ b/tests/macsec/macsec_config_helper.py
@@ -99,12 +99,16 @@ def enable_macsec_feature(duthost, macsec_nbrhosts):
     global_cmd(duthost, nbrhosts, "sudo config feature state macsec enabled")
 
     def check_macsec_enabled():
-        for nbr in [n["host"] for n in nbrhosts.values()] + [duthost]:
+        if len(duthost.shell("docker ps | grep macsec | grep -v grep")["stdout_lines"]) < num_asics:
+            return False
+        if len(duthost.shell("ps -ef | grep macsecmgrd | grep -v grep")["stdout_lines"]) < num_asics:
+            return False
+        for nbr in [n["host"] for n in nbrhosts.values()]:
             if isinstance(nbr, EosHost):
                 continue
-            if len(nbr.shell("docker ps | grep macsec | grep -v grep")["stdout_lines"]) != num_asics:
+            if len(nbr.shell("docker ps | grep macsec | grep -v grep")["stdout_lines"]) < 1:
                 return False
-            if len(nbr.shell("ps -ef | grep macsecmgrd | grep -v grep")["stdout_lines"]) != num_asics:
+            if len(nbr.shell("ps -ef | grep macsecmgrd | grep -v grep")["stdout_lines"]) < 1:
                 return False
         return True
     assert wait_until(180, 5, 10, check_macsec_enabled)

--- a/tests/macsec/macsec_config_helper.py
+++ b/tests/macsec/macsec_config_helper.py
@@ -95,15 +95,16 @@ def disable_macsec_port(host, port):
 
 def enable_macsec_feature(duthost, macsec_nbrhosts):
     nbrhosts = macsec_nbrhosts
+    num_asics = duthost.num_asics()
     global_cmd(duthost, nbrhosts, "sudo config feature state macsec enabled")
 
     def check_macsec_enabled():
         for nbr in [n["host"] for n in nbrhosts.values()] + [duthost]:
             if isinstance(nbr, EosHost):
                 continue
-            if len(nbr.shell("docker ps | grep macsec | grep -v grep")["stdout_lines"]) < 1:
+            if len(nbr.shell("docker ps | grep macsec | grep -v grep")["stdout_lines"]) != num_asics:
                 return False
-            if len(nbr.shell("ps -ef | grep macsecmgrd | grep -v grep")["stdout_lines"]) < 1:
+            if len(nbr.shell("ps -ef | grep macsecmgrd | grep -v grep")["stdout_lines"]) != num_asics:
                 return False
         return True
     assert wait_until(180, 5, 10, check_macsec_enabled)

--- a/tests/macsec/macsec_config_helper.py
+++ b/tests/macsec/macsec_config_helper.py
@@ -2,7 +2,7 @@ import time
 from tests.common.utilities import wait_until
 from tests.common.devices.eos import EosHost
 from macsec_platform_helper import global_cmd
-from macsec_helper import get_mka_session
+from macsec_helper import get_mka_session, getns_prefix
 
 
 __all__ = [
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 
-def set_macsec_profile(host, profile_name, priority, cipher_suite, primary_cak, primary_ckn, policy, send_sci, rekey_period = 0):
+def set_macsec_profile(host, port, profile_name, priority, cipher_suite, primary_cak, primary_ckn, policy, send_sci, rekey_period = 0):
     if isinstance(host, EosHost):
         eos_cipher_suite = {
             "GCM-AES-128": "aes128-gcm",
@@ -46,8 +46,8 @@ def set_macsec_profile(host, profile_name, priority, cipher_suite, primary_cak, 
         "send_sci": send_sci,
         "rekey_period": rekey_period,
     }
-    cmd = "sonic-db-cli CONFIG_DB HMSET 'MACSEC_PROFILE|{}' ".format(
-        profile_name)
+    cmd = "sonic-db-cli {} CONFIG_DB HMSET 'MACSEC_PROFILE|{}' ".format(
+        getns_prefix(host, port), profile_name)
     for k, v in macsec_profile.items():
         cmd += " '{}' '{}' ".format(k, v)
     host.command(cmd)
@@ -59,14 +59,14 @@ def set_macsec_profile(host, profile_name, priority, cipher_suite, primary_cak, 
         host.command("lldpcli configure system bond-slave-src-mac-type real")
 
 
-def delete_macsec_profile(host, profile_name):
+def delete_macsec_profile(host, port, profile_name):
     if isinstance(host, EosHost):
         host.eos_config(
             lines=['no profile {}'.format(profile_name)],
             parents=['mac security'])
         return
 
-    cmd = "sonic-db-cli CONFIG_DB DEL 'MACSEC_PROFILE|{}'".format(profile_name)
+    cmd = "sonic-db-cli {} CONFIG_DB DEL 'MACSEC_PROFILE|{}'".format(getns_prefix(host, port), profile_name)
     host.command(cmd)
 
 
@@ -77,8 +77,8 @@ def enable_macsec_port(host, port, profile_name):
             parents=['interface {}'.format(port)])
         return
 
-    cmd = "sonic-db-cli CONFIG_DB HSET 'PORT|{}' 'macsec' '{}'".format(
-        port, profile_name)
+    cmd = "sonic-db-cli {} CONFIG_DB HSET 'PORT|{}' 'macsec' '{}'".format(
+        getns_prefix(host, port), port, profile_name)
     host.command(cmd)
 
 
@@ -89,7 +89,7 @@ def disable_macsec_port(host, port):
             parents=['interface {}'.format(port)])
         return
 
-    cmd = "sonic-db-cli CONFIG_DB HDEL 'PORT|{}' 'macsec'".format(port)
+    cmd = "sonic-db-cli {} CONFIG_DB HDEL 'PORT|{}' 'macsec'".format(getns_prefix(host, port), port)
     host.command(cmd)
 
 
@@ -101,9 +101,9 @@ def enable_macsec_feature(duthost, macsec_nbrhosts):
         for nbr in [n["host"] for n in nbrhosts.values()] + [duthost]:
             if isinstance(nbr, EosHost):
                 continue
-            if len(nbr.shell("docker ps | grep macsec | grep -v grep")["stdout_lines"]) != 1:
+            if len(nbr.shell("docker ps | grep macsec | grep -v grep")["stdout_lines"]) < 1:
                 return False
-            if len(nbr.shell("ps -ef | grep macsecmgrd | grep -v grep")["stdout_lines"]) != 1:
+            if len(nbr.shell("ps -ef | grep macsecmgrd | grep -v grep")["stdout_lines"]) < 1:
                 return False
         return True
     assert wait_until(180, 5, 10, check_macsec_enabled)
@@ -115,13 +115,14 @@ def disable_macsec_feature(duthost, macsec_nbrhosts):
 
 def cleanup_macsec_configuration(duthost, ctrl_links, profile_name):
     devices = set()
-    devices.add(duthost)
+    if duthost.facts["asic_type"] == "vs":
+        devices.add(duthost)
     for dut_port, nbr in ctrl_links.items():
         disable_macsec_port(duthost, dut_port)
         disable_macsec_port(nbr["host"], nbr["port"])
-        delete_macsec_profile(nbr["host"], profile_name)
+        delete_macsec_profile(nbr["host"], nbr["port"], profile_name)
         devices.add(nbr["host"])
-    delete_macsec_profile(duthost, profile_name)
+        delete_macsec_profile(duthost, dut_port, profile_name)
     # Waiting for all mka session were cleared in all devices
     for d in devices:
         if isinstance(d, EosHost):
@@ -131,16 +132,16 @@ def cleanup_macsec_configuration(duthost, ctrl_links, profile_name):
 
 def setup_macsec_configuration(duthost, ctrl_links, profile_name, default_priority,
                                cipher_suite, primary_cak, primary_ckn, policy, send_sci, rekey_period):
-    set_macsec_profile(duthost, profile_name, default_priority,
-                       cipher_suite, primary_cak, primary_ckn, policy, send_sci, rekey_period)
     i = 0
     for dut_port, nbr in ctrl_links.items():
+        set_macsec_profile(duthost, dut_port, profile_name, default_priority,
+                       cipher_suite, primary_cak, primary_ckn, policy, send_sci, rekey_period)
         enable_macsec_port(duthost, dut_port, profile_name)
         if i % 2 == 0:
             priority = default_priority - 1
         else:
             priority = default_priority + 1
-        set_macsec_profile(nbr["host"], profile_name, priority,
+        set_macsec_profile(nbr["host"], nbr["port"], profile_name, priority,
                            cipher_suite, primary_cak, primary_ckn, policy, send_sci, rekey_period)
         enable_macsec_port(nbr["host"], nbr["port"], profile_name)
         wait_until(20, 3, 0,

--- a/tests/macsec/profile.json
+++ b/tests/macsec/profile.json
@@ -5,7 +5,7 @@
         "primary_cak": "0123456789ABCDEF0123456789ABCDEF",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F70",
         "policy": "security",
-        "send_sci": "false"
+        "send_sci": "true"
     },
     "256": {
         "priority": 64,
@@ -13,7 +13,7 @@
         "primary_cak": "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435",
         "policy": "security",
-        "send_sci": "false"
+        "send_sci": "true"
     },
     "128_XPN": {
         "priority": 64,
@@ -21,7 +21,7 @@
         "primary_cak": "0123456789ABCDEF0123456789ABCDEF",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F70",
         "policy": "security",
-        "send_sci": "false"
+        "send_sci": "true"
     },
     "256_XPN": {
         "priority": 64,
@@ -29,7 +29,7 @@
         "primary_cak": "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435",
         "policy": "security",
-        "send_sci": "false"
+        "send_sci": "true"
     },
     "128_SCI": {
         "priority": 64,

--- a/tests/macsec/profile.json
+++ b/tests/macsec/profile.json
@@ -5,7 +5,7 @@
         "primary_cak": "0123456789ABCDEF0123456789ABCDEF",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F70",
         "policy": "security",
-        "send_sci": "true"
+        "send_sci": "false"
     },
     "256": {
         "priority": 64,
@@ -13,7 +13,7 @@
         "primary_cak": "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435",
         "policy": "security",
-        "send_sci": "true"
+        "send_sci": "false"
     },
     "128_XPN": {
         "priority": 64,
@@ -21,7 +21,7 @@
         "primary_cak": "0123456789ABCDEF0123456789ABCDEF",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F70",
         "policy": "security",
-        "send_sci": "true"
+        "send_sci": "false"
     },
     "256_XPN": {
         "priority": 64,
@@ -29,7 +29,7 @@
         "primary_cak": "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435",
         "policy": "security",
-        "send_sci": "true"
+        "send_sci": "false"
     },
     "128_SCI": {
         "priority": 64,

--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -152,7 +152,7 @@ class TestDataPlane():
                 "ping -c {} {}".format(4, up_link['local_ipv4_addr']))
             assert not ret['failed']
 
-    def test_neighbor_to_neighbor(self, duthost, ctrl_links, upstream_links, nbr_device_numbers, nbr_ptfadapter, tbinfo):
+    def test_neighbor_to_neighbor(self, duthost, ctrl_links, upstream_links, nbr_device_numbers, nbr_ptfadapter):
         portchannels = get_portchannel(duthost).values()
         for i in range(len(portchannels)):
             assert portchannels[i]["members"]
@@ -180,7 +180,7 @@ class TestFaultHandling():
     MKA_TIMEOUT = 6
     LACP_TIMEOUT = 90
 
-    def test_link_flap(self, duthost, ctrl_links, tbinfo):
+    def test_link_flap(self, duthost, ctrl_links):
         # Only pick one link for link flap test
         assert ctrl_links
         port_name, nbr = ctrl_links.items()[0]
@@ -285,7 +285,7 @@ class TestInteropProtocol():
     Macsec interop with other protocols
     '''
 
-    def test_port_channel(self, duthost, ctrl_links, tbinfo):
+    def test_port_channel(self, duthost, ctrl_links):
         '''Verify lacp
         '''
         ctrl_port, _ = ctrl_links.items()[0]
@@ -332,7 +332,7 @@ class TestInteropProtocol():
             assert wait_until(1, 1, LLDP_TIMEOUT,
                             lambda: nbr["name"] in get_lldp_list(duthost))
 
-    def test_bgp(self, duthost, ctrl_links, upstream_links, profile_name, tbinfo):
+    def test_bgp(self, duthost, ctrl_links, upstream_links, profile_name):
         '''Verify BGP neighbourship
         '''
         bgp_config = duthost.get_running_config_facts()[
@@ -377,7 +377,7 @@ class TestInteropProtocol():
             assert wait_until(BGP_HOLDTIME * 2, BGP_KEEPALIVE, BGP_HOLDTIME,
                               check_bgp_established, upstream_links[ctrl_port])
 
-    def test_snmp(self, duthost, ctrl_links, upstream_links, creds, tbinfo):
+    def test_snmp(self, duthost, ctrl_links, upstream_links, creds):
         '''
         Verify SNMP request/response works across interface with macsec configuration
         '''

--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -91,7 +91,7 @@ class TestControlPlane():
 class TestDataPlane():
     BATCH_COUNT = 10
 
-    def test_server_to_neighbor(self, duthost, ctrl_links, downstream_links, upstream_links, nbr_device_numbers, nbr_ptfadapter, tbinfo):
+    def test_server_to_neighbor(self, duthost, ctrl_links, downstream_links, upstream_links, nbr_device_numbers, nbr_ptfadapter):
         nbr_ptfadapter.dataplane.set_qlen(TestDataPlane.BATCH_COUNT * 10)
 
         down_link = downstream_links.values()[0]


### PR DESCRIPTION
### Description of PR
Update macsec tests to support t2 topology and multi-asic. 

There are a few testcases which uses portchannel and it still needs to be validated with t2 topology. So currently the following tests are skipped by setting the platform skip option in plugins/conditional_mark/tests_mark_conditions.yaml
```
test_bgp
test_port_channel
test_link_flap
test_neighbor_to_neighbor
test_server_to_neighbor
```

### Approach
The following are the changes in this PR 
> support for namespaces for multi-asic devices 
> In case of T2 we are skipping interfaces which is a portchanel.

#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

```
admin@014cbe230674:~/CHASSIS/CHASSIS/sonic-mgmt-int/sonic-mgmt-int/tests$ ./run_tests.sh -u -n vms29-t2--1 -d str2--lc2-1  -c macsec/test_macsec.py -f ../ansible/testbed.yaml -i ../ansible/str2,../ansible/veos -e "--skip_sanity --disable_loganalyzer -x --enable_macsec"                                                            
        [ 21%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[128_SCI] PASSED                                                                                                                                                     d will be remov        [ 22%]
  from cryptography.exceptions import InvalidSignature
========================================================================================================== test session starts ==========================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.11.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /home/admin/CHASSIS/CHASSIS/sonic-mgmt-int/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, allure-pytest-2.8.22, ansible-2.2.2
collecting ... /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 96 items                                                                                                                                                                                                                      

macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[128] PASSED                                                                                                                                                [  1%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[128] PASSED                                                                                                                                                                 [  2%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[128] PASSED                                                                                                                                                             [  3%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[128] SKIPPED                                                                                                                                                        [  4%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[128] PASSED                                                                                                                                                            [  5%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[128] SKIPPED                                                                                                                                                      [  6%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[128] SKIPPED                                                                                                                                                             [  7%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[128] PASSED                                                                                                                                          [  8%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[128] SKIPPED                                                                                                                                                        [  9%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[128] PASSED                                                                                                                                                                 [ 10%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[128] SKIPPED                                                                                                                                                                 [ 11%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[128] SKIPPED                                                                                                                                                                [ 12%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[128_SCI] PASSED                                                                                                                                            [ 13%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[128_SCI] PASSED                                                                                                                                                             [ 14%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[128_SCI] PASSED                                                                                                                                                         [ 15%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[128_SCI] SKIPPED                                                                                                                                                    [ 16%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[128_SCI] PASSED                                                                                                                                                        [ 17%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[128_SCI] SKIPPED                                                                                                                                                  [ 18%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[128_SCI] SKIPPED                                                                                                                                                         [ 19%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[128_SCI] PASSED                                                                                                                                      [ 20%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[128_SCI] SKIPPED                                                                                                                                                    [ 21%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[128_SCI] PASSED                                                                                                                                                             [ 22%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[128_SCI] SKIPPED                                                                                                                                                             [ 23%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[128_SCI] SKIPPED                                                                                                                                                            [ 25%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[128_XPN] PASSED                                                                                                                                            [ 26%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[128_XPN] PASSED                                                                                                                                                             [ 27%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[128_XPN] PASSED                                                                                                                                                         [ 28%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[128_XPN] SKIPPED                                                                                                                                                    [ 29%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[128_XPN] PASSED                                                                                                                                                        [ 30%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[128_XPN] SKIPPED                                                                                                                                                  [ 31%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[128_XPN] SKIPPED                                                                                                                                                         [ 32%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[128_XPN] PASSED                                                                                                                                      [ 33%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[128_XPN] SKIPPED                                                                                                                                                    [ 34%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[128_XPN] PASSED                                                                                                                                                             [ 35%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[128_XPN] SKIPPED                                                                                                                                                             [ 36%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[128_XPN] SKIPPED                                                                                                                                                            [ 37%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[128_XPN_SCI] PASSED                                                                                                                                        [ 38%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[128_XPN_SCI] PASSED                                                                                                                                                         [ 39%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[128_XPN_SCI] PASSED                                                                                                                                                     [ 40%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[128_XPN_SCI] SKIPPED                                                                                                                                                [ 41%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[128_XPN_SCI] PASSED                                                                                                                                                    [ 42%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[128_XPN_SCI] SKIPPED                                                                                                                                              [ 43%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[128_XPN_SCI] SKIPPED                                                                                                                                                     [ 44%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[128_XPN_SCI] PASSED                                                                                                                                  [ 45%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[128_XPN_SCI] SKIPPED                                                                                                                                                [ 46%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[128_XPN_SCI] PASSED                                                                                                                                                         [ 47%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[128_XPN_SCI] SKIPPED                                                                                                                                                         [ 48%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[128_XPN_SCI] SKIPPED                                                                                                                                                        [ 50%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[256] PASSED                                                                                                                                                [ 51%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256] PASSED                                                                                                                                                                 [ 52%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[256] PASSED                                                                                                                                                             [ 53%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[256] SKIPPED                                                                                                                                                        [ 54%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[256] PASSED                                                                                                                                                            [ 55%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[256] SKIPPED                                                                                                                                                      [ 56%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[256] SKIPPED                                                                                                                                                             [ 57%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[256] PASSED                                                                                                                                          [ 58%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[256] SKIPPED                                                                                                                                                        [ 59%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[256] PASSED                                                                                                                                                                 [ 60%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[256] SKIPPED                                                                                                                                                                 [ 61%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[256] SKIPPED                                                                                                                                                                [ 62%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[256_SCI] PASSED                                                                                                                                            [ 63%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256_SCI] PASSED                                                                                                                                                             [ 64%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[256_SCI] PASSED                                                                                                                                                         [ 65%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[256_SCI] SKIPPED                                                                                                                                                    [ 66%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[256_SCI] PASSED                                                                                                                                                        [ 67%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[256_SCI] SKIPPED                                                                                                                                                  [ 68%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[256_SCI] SKIPPED                                                                                                                                                         [ 69%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[256_SCI] PASSED                                                                                                                                      [ 70%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[256_SCI] SKIPPED                                                                                                                                                    [ 71%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[256_SCI] PASSED                                                                                                                                                             [ 72%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[256_SCI] SKIPPED                                                                                                                                                             [ 73%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[256_SCI] SKIPPED                                                                                                                                                            [ 75%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[256_XPN] PASSED                                                                                                                                            [ 76%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256_XPN] PASSED                                                                                                                                                             [ 77%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[256_XPN] PASSED                                                                                                                                                         [ 78%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[256_XPN] SKIPPED                                                                                                                                                    [ 79%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[256_XPN] PASSED                                                                                                                                                        [ 80%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[256_XPN] SKIPPED                                                                                                                                                  [ 81%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[256_XPN] SKIPPED                                                                                                                                                         [ 82%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[256_XPN] PASSED                                                                                                                                      [ 83%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[256_XPN] SKIPPED                                                                                                                                                    [ 84%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[256_XPN] PASSED                                                                                                                                                             [ 85%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[256_XPN] SKIPPED                                                                                                                                                             [ 86%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[256_XPN] SKIPPED                                                                                                                                                            [ 87%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[256_XPN_SCI] PASSED                                                                                                                                        [ 88%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256_XPN_SCI] PASSED                                                                                                                                                         [ 89%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[256_XPN_SCI] PASSED                                                                                                                                                     [ 90%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[256_XPN_SCI] SKIPPED                                                                                                                                                [ 91%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[256_XPN_SCI] PASSED                                                                                                                                                    [ 92%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[256_XPN_SCI] SKIPPED                                                                                                                                              [ 93%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[256_XPN_SCI] SKIPPED                                                                                                                                                     [ 94%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[256_XPN_SCI] PASSED                                                                                                                                  [ 95%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[256_XPN_SCI] SKIPPED                                                                                                                                                [ 96%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[256_XPN_SCI] PASSED                                                                                                                                                         [ 97%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[256_XPN_SCI] SKIPPED                                                                                                                                                         [ 98%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[256_XPN_SCI] SKIPPED                                                                                                                                                        [100%]

------------------------------------------------------------------ generated xml file: /home/admin/CHASSIS/CHASSIS/sonic-mgmt-int/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------
======================================================================================================== short test summary info ========================================================================================================
SKIPPED [8] /home/admin/CHASSIS/CHASSIS/sonic-mgmt-int/sonic-mgmt-int/tests/macsec/test_macsec.py:360: Portchanel not supported
SKIPPED [8] /home/admin/CHASSIS/CHASSIS/sonic-mgmt-int/sonic-mgmt-int/tests/macsec/test_macsec.py:169: Portchanel not supported
SKIPPED [8] /home/admin/CHASSIS/CHASSIS/sonic-mgmt-int/sonic-mgmt-int/tests/macsec/test_macsec.py:313: Portchanel not supported
SKIPPED [8] /home/admin/CHASSIS/CHASSIS/sonic-mgmt-int/sonic-mgmt-int/tests/macsec/test_macsec.py:265: Portchanel not supported
SKIPPED [16] /home/admin/CHASSIS/CHASSIS/sonic-mgmt-int/sonic-mgmt-int/tests/common/plugins/ptfadapter/__init__.py:180: Neighbor devices aren't SONiC so that the ptf nn service cannot be started
=============================================================================================== 48 passed, 48 skipped in 2009.02 seconds ================================================================================================

jujoseph@014cbe230674:~/CHASSIS/CHASSIS/sonic-mgmt-int/sonic-mgmt-int/tests$ vi macsec/macsec_helper.py
jujoseph@014cbe230674:~/CHASSIS/CHASSIS/sonic-mgmt-int/sonic-mgmt-int/tests$ ./run_tests.sh -u -n vms29-t2--1 -d str2--lc1-1 -c macsec/test_macsec.py::TestControlPlane::test_appl_db -f ../ansible/testbed.yaml -i ../ansible/str2,../ansible/veos -e "--skip_sanity --disable_loganalyzer -x --enable_macsec --neighbor_type=sonic "     
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
===================================================================================================================== test session starts ======================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.11.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, allure-pytest-2.8.22, ansible-2.2.2
collecting ... /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 8 items                                                                                                                                                                                                                                              

macsec/test_macsec.py::TestControlPlane::test_appl_db[128] PASSED                                                                                                                                                                                        [ 12%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[128_SCI] PASSED                                                                                                                                                                                    [ 25%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[128_XPN] PASSED                                                                                                                                                                                    [ 37%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[128_XPN_SCI] PASSED                                                                                                                                                                                [ 50%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256] PASSED                                                                                                                                                                                        [ 62%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256_SCI] PASSED                                                                                                                                                                                    [ 75%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256_XPN] PASSED                                                                                                                                                                                    [ 87%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256_XPN_SCI] PASSED    

-- Verified it works ok on a single ASIC device 


./run_tests.sh -u -n vms28-t0-7280-4   -c macsec/test_macsec.py -f ../ansible/testbed.yaml -i ../ansible/str2,../ansible/veos -e "--skip_sanity --disable_loganalyzer -x --enable_macsec"

macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[128] PASSED [  0%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[128] PASSED        [  1%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[128] PASSED    [  2%]
macsec/test_macsec.py::TestControlPlane::test_rekey_by_period[128] SKIPPED [  3%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[128] SKIPPED [  4%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[128] PASSED   [  5%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[128] SKIPPED [  6%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[128] PASSED     [  7%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[128] SKIPPED [  8%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[128] PASSED [  9%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[128] PASSED        [ 10%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[128] PASSED         [ 11%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[128] PASSED        [ 12%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[128_SCI] PASSED [ 13%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[128_SCI] PASSED    [ 14%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[128_SCI] PASSED [ 15%]
macsec/test_macsec.py::TestControlPlane::test_rekey_by_period[128_SCI] SKIPPED [ 16%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[128_SCI] SKIPPED [ 17%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[128_SCI] PASSED [ 18%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[128_SCI] SKIPPED [ 19%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[128_SCI] PASSED [ 20%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[128_SCI] SKIPPED [ 21%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[128_SCI] PASSED [ 22%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[128_SCI] PASSED    [ 23%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[128_SCI] PASSED     [ 24%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[128_SCI] PASSED    [ 25%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[128_XPN] PASSED [ 25%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[128_XPN] PASSED    [ 26%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[128_XPN] PASSED [ 27%]
macsec/test_macsec.py::TestControlPlane::test_rekey_by_period[128_XPN] SKIPPED [ 28%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[128_XPN] SKIPPED [ 29%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[128_XPN] PASSED [ 30%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[128_XPN] SKIPPED [ 31%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[128_XPN_SCI] PASSED [ 38%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[128_XPN_SCI] PASSED [ 39%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[128_XPN_SCI] PASSED [ 40%]
macsec/test_macsec.py::TestControlPlane::test_rekey_by_period[128_XPN_SCI] SKIPPED [ 41%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[128_XPN_SCI] SKIPPED [ 42%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[128_XPN_SCI] PASSED [ 43%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[128_XPN_SCI] SKIPPED [ 44%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[128_XPN_SCI] PASSED [ 45%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[128_XPN_SCI] SKIPPED [ 46%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[128_XPN_SCI] PASSED [ 47%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[128_XPN_SCI] PASSED [ 48%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[128_XPN_SCI] PASSED [ 49%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[128_XPN_SCI] PASSED [ 50%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[256] PASSED [ 50%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256] PASSED        [ 51%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[256] PASSED    [ 52%]
macsec/test_macsec.py::TestControlPlane::test_rekey_by_period[256] SKIPPED [ 53%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[256] SKIPPED [ 54%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[256] PASSED   [ 55%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[256] SKIPPED [ 56%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[256] PASSED     [ 57%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[256] SKIPPED [ 58%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[256] PASSED [ 59%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[256] PASSED        [ 60%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[256] PASSED         [ 61%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[256] PASSED        [ 62%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[256_SCI] PASSED [ 63%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256_SCI] PASSED    [ 64%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[256_SCI] PASSED [ 65%]
macsec/test_macsec.py::TestControlPlane::test_rekey_by_period[256_SCI] SKIPPED [ 66%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[256_SCI] SKIPPED [ 67%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[256_SCI] PASSED [ 68%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[256_SCI] SKIPPED [ 69%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[256_SCI] PASSED [ 70%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[256_SCI] SKIPPED [ 71%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[256_SCI] PASSED [ 72%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[256_SCI] PASSED    [ 73%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[256_SCI] PASSED     [ 74%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[256_SCI] PASSED    [ 75%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[256_XPN] PASSED [ 75%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256_XPN] PASSED    [ 76%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[256_XPN] PASSED [ 77%]
macsec/test_macsec.py::TestControlPlane::test_rekey_by_period[256_XPN] SKIPPED [ 78%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[256_XPN] SKIPPED [ 79%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[256_XPN] PASSED [ 80%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[256_XPN] SKIPPED [ 81%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[256_XPN] PASSED [ 82%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[256_XPN] SKIPPED [ 83%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[256_XPN] PASSED [ 84%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[256_XPN] PASSED    [ 85%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[256_XPN] PASSED     [ 86%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[256_XPN] PASSED    [ 87%]
macsec/test_macsec.py::TestControlPlane::test_wpa_supplicant_processes[256_XPN_SCI] PASSED [ 88%]
macsec/test_macsec.py::TestControlPlane::test_appl_db[256_XPN_SCI] PASSED [ 89%]
macsec/test_macsec.py::TestControlPlane::test_mka_session[256_XPN_SCI] PASSED [ 90%]
macsec/test_macsec.py::TestControlPlane::test_rekey_by_period[256_XPN_SCI] SKIPPED [ 91%]
macsec/test_macsec.py::TestDataPlane::test_server_to_neighbor[256_XPN_SCI] SKIPPED [ 92%]
macsec/test_macsec.py::TestDataPlane::test_dut_to_neighbor[256_XPN_SCI] PASSED [ 93%]
macsec/test_macsec.py::TestDataPlane::test_neighbor_to_neighbor[256_XPN_SCI] SKIPPED [ 94%]
macsec/test_macsec.py::TestFaultHandling::test_link_flap[256_XPN_SCI] PASSED [ 95%]
macsec/test_macsec.py::TestFaultHandling::test_mismatch_macsec_configuration[256_XPN_SCI] SKIPPED [ 96%]
macsec/test_macsec.py::TestInteropProtocol::test_port_channel[256_XPN_SCI] PASSED [ 97%]
macsec/test_macsec.py::TestInteropProtocol::test_lldp[256_XPN_SCI] PASSED [ 98%]
macsec/test_macsec.py::TestInteropProtocol::test_bgp[256_XPN_SCI] PASSED [ 99%]
macsec/test_macsec.py::TestInteropProtocol::test_snmp[256_XPN_SCI] PASSED [100%]

- generated xml file: /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/sonic-mgmt-int/tests/logs/tr.xml -
================== 72 passed, 32 skipped in 10353.20 seconds ===================
   
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
