### PR TITLE
Fix pfc counters test for Onyx fanout

### DIFF
--- a/tests/common/devices/onyx.py
+++ b/tests/common/devices/onyx.py
@@ -57,6 +57,10 @@ class OnyxHost(AnsibleHostBase):
         out = self.host.onyx_command(commands=[cmd])
         return out
 
+    def config(self, cmd):
+        out = self.host.onyx_config(commands=[cmd])
+        return out
+
     def set_interface_lacp_rate_mode(self, interface_name, mode):
         out = self.host.onyx_config(
             lines=['lacp rate %s' % mode],

--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -27,13 +27,17 @@ def ansible_stdout_to_str(ansible_stdout):
         result += x.encode('UTF8')
     return result
 
-def eos_to_linux_intf(eos_intf_name):
+def eos_to_linux_intf(eos_intf_name, hwsku=None):
     """
     @Summary: Map EOS's interface name to Linux's interface name
     @param eos_intf_name: Interface name in EOS
     @return: Return the interface name in Linux
     """
-    return eos_intf_name.replace('Ethernet', 'et').replace('/', '_')
+    if hwsku == "MLNX-OS":
+        linux_intf_name = eos_intf_name.replace("ernet 1/", "sl1p").replace("/", "sp")
+    else:
+        linux_intf_name = eos_intf_name.replace('Ethernet', 'et').replace('/', '_')
+    return linux_intf_name
 
 def get_phy_intfs(host_ans):
     """


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test fails on testbeds with Onyx fanout switch for two reasons:
1. The port name format is not correct for Onyx
2. The script used to generate PFC frames(pfc_gen.py) is contained in a "storm" docker on Onyx fanouts. The test was running pfc_gen.py directly from the fanout switch, not from the docker.
Fix the test to support testbeds with Onyx fanout.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012

### Approach
#### What is the motivation for this PR?
Fix the test to support testbeds with Onyx fanout.
#### How did you do it?
1. Modify eos_to_linux_intf() in tests/qos/qos_helpers.py to return a Onyx format interface name.
2. Fix the commands run on Onyx fanouts to send PFC frames from the storm docker. 
3. No changes for other fanout types.
#### How did you verify/test it?
Verified on several testbeds with Onyx fanouts, all cases passed.
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
