### PR TITLE
[python3]migrate dhcp relay ptftests scripts from python2 to python3

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -1,6 +1,7 @@
 import ast
 import struct
 import ipaddress
+import binascii
 
 # Packet Test Framework imports
 import ptf
@@ -17,7 +18,7 @@ from threading import Thread
 # ip_addr should be passed as a dot-decimal string
 # Return value is also a dot-decimal string
 def incrementIpAddress(ip_addr, by=1):
-    new_addr = ipaddress.ip_address(unicode(ip_addr))
+    new_addr = ipaddress.ip_address(str(ip_addr))
     new_addr = new_addr + by
     return str(new_addr)
 
@@ -102,7 +103,7 @@ class DHCPTest(DataplaneBaseTest):
         self.hostname = self.test_params['hostname']
         self.verified_option82 = False
         
-        if self.test_params.has_key('other_client_port'):
+        if 'other_client_port' in self.test_params:
             self.other_client_port = ast.literal_eval(self.test_params['other_client_port'])
 
         # These are the interfaces we are injected into that link to out leaf switches
@@ -142,7 +143,7 @@ class DHCPTest(DataplaneBaseTest):
         # Our circuit_id string is of the form "hostname:portname"
         circuit_id_string = self.hostname + ":" + self.client_iface_alias
         self.option82 = struct.pack('BB', 1, len(circuit_id_string))
-        self.option82 += circuit_id_string
+        self.option82 += circuit_id_string.encode('utf-8')
 
         # remote_id is stored as suboption 2 of option 82.
         # It consists of the following:
@@ -152,7 +153,7 @@ class DHCPTest(DataplaneBaseTest):
         # Our remote_id string simply consists of the MAC address of the port that received the request
         remote_id_string = self.relay_iface_mac
         self.option82 += struct.pack('BB', 2, len(remote_id_string))
-        self.option82 += remote_id_string
+        self.option82 += remote_id_string.encode('utf-8')
 
         # In 'dual' testing mode, vlan ip is stored as suboption 5 of option 82.
         # It consists of the following:
@@ -160,7 +161,7 @@ class DHCPTest(DataplaneBaseTest):
         #  Byte 1: Length of suboption data in bytes, always set to 4 (ipv4 addr has 4 bytes)
         #  Bytes 2+: vlan ip addr
         if self.dual_tor:
-            link_selection = ''.join([chr(int(byte)) for byte in self.relay_iface_ip.split('.')])
+            link_selection = bytes(list(map(int, self.relay_iface_ip.split('.'))))
             self.option82 += struct.pack('BB', 5, 4)
             self.option82 += link_selection
 
@@ -194,7 +195,8 @@ class DHCPTest(DataplaneBaseTest):
         return discover_packet
 
     def create_dhcp_discover_relayed_packet(self):
-        my_chaddr = ''.join([chr(int(octet, 16)) for octet in self.client_mac.split(':')])
+        my_chaddr = binascii.unhexlify(self.client_mac.replace(':', ''))
+        my_chaddr += b'\x00\x00\x00\x00\x00\x00'
 
         # Relay modifies the DHCPDISCOVER message in the following ways:
         #  1.) Increments the hops count in the DHCP header
@@ -227,7 +229,7 @@ class DHCPTest(DataplaneBaseTest):
                     giaddr=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
                     chaddr=my_chaddr)
         bootp /= scapy.DHCP(options=[('message-type', 'discover'),
-                    ('relay_agent_Information', self.option82),
+                    (82, self.option82),
                     ('end')])
 
         # If our bootp layer is too small, pad it
@@ -253,7 +255,8 @@ class DHCPTest(DataplaneBaseTest):
                     set_broadcast_bit=True)
 
     def create_dhcp_offer_relayed_packet(self):
-        my_chaddr = ''.join([chr(int(octet, 16)) for octet in self.client_mac.split(':')])
+        my_chaddr = binascii.unhexlify(self.client_mac.replace(':', ''))
+        my_chaddr += b'\x00\x00\x00\x00\x00\x00'
 
         # Relay modifies the DHCPOFFER message in the following ways:
         #  1.) Replaces the source MAC with the MAC of the interface it received it on
@@ -310,7 +313,8 @@ class DHCPTest(DataplaneBaseTest):
         return request_packet
 
     def create_dhcp_request_relayed_packet(self):
-        my_chaddr = ''.join([chr(int(octet, 16)) for octet in self.client_mac.split(':')])
+        my_chaddr = binascii.unhexlify(self.client_mac.replace(':', ''))
+        my_chaddr += b'\x00\x00\x00\x00\x00\x00'
 
         # Here, the actual destination MAC should be the MAC of the leaf the relay
         # forwards through and the destination IP should be the IP of the DHCP server
@@ -338,7 +342,7 @@ class DHCPTest(DataplaneBaseTest):
         bootp /= scapy.DHCP(options=[('message-type', 'request'),
                     ('requested_addr', self.client_ip),
                     ('server_id', self.server_ip),
-                    ('relay_agent_Information', self.option82),
+                    (82, self.option82),
                     ('end')])
 
         # If our bootp layer is too small, pad it
@@ -364,7 +368,8 @@ class DHCPTest(DataplaneBaseTest):
                     set_broadcast_bit=True)
 
     def create_dhcp_ack_relayed_packet(self):
-        my_chaddr = ''.join([chr(int(octet, 16)) for octet in self.client_mac.split(':')])
+        my_chaddr = binascii.unhexlify(self.client_mac.replace(':', ''))
+        my_chaddr += b'\x00\x00\x00\x00\x00\x00'
 
         # Relay modifies the DHCPACK message in the following ways:
         #  1.) Replaces the source MAC with the MAC of the interface it received it on
@@ -426,7 +431,7 @@ class DHCPTest(DataplaneBaseTest):
                 self.verified_option82 = False
                 pkt_options = ''
                 for option in pkt.getlayer(scapy2.DHCP).options:
-                    if option[0] == 'relay_agent_Information':
+                    if option[0] == 'relay_agent_information':
                         pkt_options = option[1]
                         break
                 if self.option82 in pkt_options:
@@ -683,7 +688,6 @@ class DHCPTest(DataplaneBaseTest):
         self.assertTrue(self.verified_option82,"Failed: Verifying option 82")
 
         ## Below verification will be done only when client port is set in ptf_runner
-        if self.test_params.has_key('other_client_port'):
+        if 'other_client_port' in self.test_params:
             self.verify_dhcp_relay_pkt_on_other_client_port_with_no_padding(self.dest_mac_address, self.client_udp_src_port)
             self.verify_dhcp_relay_pkt_on_server_port_with_no_padding(self.dest_mac_address, self.client_udp_src_port)
-        

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -509,10 +509,6 @@ class DHCPTest(DataplaneBaseTest):
         masked_offer.set_do_not_care_scapy(scapy.BOOTP, "sname")
         masked_offer.set_do_not_care_scapy(scapy.BOOTP, "file")
 
-        masked_offer.set_do_not_care_scapy(scapy.DHCP, "lease_time")
-
-        #masked_offer.set_do_not_care_scapy(scapy.PADDING, "load")
-
         # NOTE: verify_packet() will fail for us via an assert, so no need to check a return value here
         testutils.verify_packet(self, masked_offer, self.client_port_index)
 
@@ -586,8 +582,6 @@ class DHCPTest(DataplaneBaseTest):
 
         masked_ack.set_do_not_care_scapy(scapy.BOOTP, "sname")
         masked_ack.set_do_not_care_scapy(scapy.BOOTP, "file")
-
-        masked_ack.set_do_not_care_scapy(scapy.DHCP, "lease_time")
 
         # NOTE: verify_packet() will fail for us via an assert, so no need to check a return value here
         testutils.verify_packet(self, masked_ack, self.client_port_index)

--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
@@ -1,6 +1,6 @@
 import ast
 import subprocess
-
+import scapy
 # Packet Test Framework imports
 import ptf
 import ptf.testutils as testutils
@@ -8,6 +8,17 @@ from ptf import config
 from ptf.base_tests import BaseTest
 
 IPv6 = scapy.layers.inet6.IPv6
+DHCP6_Solicit = scapy.layers.dhcp6.DHCP6_Solicit
+DHCP6_Request = scapy.layers.dhcp6.DHCP6_Request
+DHCP6_Confirm = scapy.layers.dhcp6.DHCP6_Confirm
+DHCP6_Renew = scapy.layers.dhcp6.DHCP6_Renew
+DHCP6_Rebind = scapy.layers.dhcp6.DHCP6_Rebind
+DHCP6_Release = scapy.layers.dhcp6.DHCP6_Release
+DHCP6_Decline = scapy.layers.dhcp6.DHCP6_Decline
+DHCP6_Advertise = scapy.layers.dhcp6.DHCP6_Advertise
+DHCP6_Reply = scapy.layers.dhcp6.DHCP6_Reply
+DHCP6_RelayReply = scapy.layers.dhcp6.DHCP6_RelayReply
+DHCP6OptRelayMsg = scapy.layers.dhcp6.DHCP6OptRelayMsg
 
 class DataplaneBaseTest(BaseTest):
     def __init__(self):
@@ -97,8 +108,7 @@ class DHCPCounterTest(DataplaneBaseTest):
         packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
         packet /= UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         packet /= DHCP6_RelayReply(msgtype=13, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
-        packet /= DHCP6OptRelayMsg()
-        packet /= message(trid=12345)
+        packet /= DHCP6OptRelayMsg(message=[message(trid=12345)])
 
         return packet
 

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -285,7 +285,7 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                            "uplink_mac": str(dhcp_relay['uplink_mac']),
                            "testbed_mode": testbed_mode,
                            "testing_mode": testing_mode},
-                   log_file="/tmp/dhcp_relay_test.DHCPTest.log")
+                   log_file="/tmp/dhcp_relay_test.DHCPTest.log", is_python3=True)
 
 
 def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
@@ -337,7 +337,7 @@ def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_r
                            "uplink_mac": str(dhcp_relay['uplink_mac']),
                            "testbed_mode": testbed_mode,
                            "testing_mode": testing_mode},
-                   log_file="/tmp/dhcp_relay_test.DHCPTest.log")
+                   log_file="/tmp/dhcp_relay_test.DHCPTest.log", is_python3=True)
 
 
 def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
@@ -400,7 +400,7 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
                            "uplink_mac": str(dhcp_relay['uplink_mac']),
                            "testbed_mode": testbed_mode,
                            "testing_mode": testing_mode},
-                   log_file="/tmp/dhcp_relay_test.DHCPTest.log")
+                   log_file="/tmp/dhcp_relay_test.DHCPTest.log", is_python3=True)
 
 
 def test_dhcp_relay_unicast_mac(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config, toggle_all_simulator_ports_to_rand_selected_tor_m):
@@ -436,7 +436,7 @@ def test_dhcp_relay_unicast_mac(ptfhost, dut_dhcp_relay_data, validate_dut_route
                            "uplink_mac": str(dhcp_relay['uplink_mac']),
                            "testbed_mode": testbed_mode,
                            "testing_mode": testing_mode},
-                   log_file="/tmp/dhcp_relay_test.DHCPTest.log")
+                   log_file="/tmp/dhcp_relay_test.DHCPTest.log", is_python3=True)
 
 
 def test_dhcp_relay_random_sport(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config, toggle_all_simulator_ports_to_rand_selected_tor_m):
@@ -471,4 +471,4 @@ def test_dhcp_relay_random_sport(ptfhost, dut_dhcp_relay_data, validate_dut_rout
                            "uplink_mac": str(dhcp_relay['uplink_mac']),
                            "testbed_mode": testbed_mode,
                            "testing_mode": testing_mode},
-                   log_file="/tmp/dhcp_relay_test.DHCPTest.log")
+                   log_file="/tmp/dhcp_relay_test.DHCPTest.log", is_python3=True)

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -155,7 +155,7 @@ def test_dhcpv6_relay_counter(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
                            "relay_link_local": str(dhcp_relay['uplink_interface_link_local']),
                            "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr'])},
-                   log_file="/tmp/dhcpv6_relay_test.DHCPCounterTest.log")
+                   log_file="/tmp/dhcpv6_relay_test.DHCPCounterTest.log", is_python3=True)
 
         for message in messages:
             get_message = 'sonic-db-cli STATE_DB hget "DHCPv6_COUNTER_TABLE|{}" {}'.format(dhcp_relay['downlink_vlan_iface']['name'], message)
@@ -184,7 +184,7 @@ def test_dhcp_relay_default(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp_r
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
                            "relay_link_local": str(dhcp_relay['uplink_interface_link_local']),
                            "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr'])},
-                   log_file="/tmp/dhcpv6_relay_test.DHCPTest.log")
+                   log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
 
 
 def test_dhcp_relay_after_link_flap(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp_relay_data, validate_dut_routes_exist):
@@ -224,7 +224,7 @@ def test_dhcp_relay_after_link_flap(ptfhost, duthosts, rand_one_dut_hostname, du
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
                            "relay_link_local": str(dhcp_relay['uplink_interface_link_local']),
                            "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr'])},
-                   log_file="/tmp/dhcpv6_relay_test.DHCPTest.log")
+                   log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
 
 
 def test_dhcp_relay_start_with_uplinks_down(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp_relay_data, validate_dut_routes_exist):
@@ -275,4 +275,4 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, duthosts, rand_one_dut_host
                            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
                            "relay_link_local": str(dhcp_relay['uplink_interface_link_local']),
                            "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr'])},
-                   log_file="/tmp/dhcpv6_relay_test.DHCPTest.log")
+                   log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)

--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -16,9 +16,14 @@ def ptf_collect(host, log_file):
 def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                platform="remote", qlen=0, relax=True, debug_level="info",
                socket_recv_size=None, log_file=None, device_sockets=[], timeout=0,
-               module_ignore_errors=False):
-
-    cmd = "ptf --test-dir {} {}".format(testdir, testname)
+               module_ignore_errors=False, is_python3=False):
+    # Call virtual env ptf for migrated py3 scripts.
+    # ptf will load all scripts under ptftests, it will throw error for py2 scripts.
+    # So move migrated scripts to seperated py3 folder avoid impacting py2 scripts.
+    if is_python3:
+        cmd = "/root/env-python3/bin/ptf --test-dir {} {}".format(testdir+'/py3', testname)
+    else:
+        cmd = "ptf --test-dir {} {}".format(testdir, testname)
 
     if platform_dir:
         cmd += " --platform-dir {}".format(platform_dir)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Migrate dhcp relay ptftests scripts from python2 to python3.

PR cannot be merged until merging of https://github.com/Azure/sonic-buildimage/pull/10599 which includes necessary changes for the setup of the Python3 virtual environment in the docker-ptf docker container.

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Do an incremental migration, migrate ptftests scripts from python2 to python3 one by one.

#### How did you do it?
Avoid impact py2 script, add virtual env in` docker-ptf` container, then call virtual env ptf for migrated py3 scripts.
But ptf command will load all scripts under ptftests, it will throw error for py2 scripts when using new ptf.
So move migrated scripts to separated py3 folder avoid impacting py2 scripts.

#### How did you verify/test it?
run `dhcp_relay/test_dhcp_relay.py `and  d`hcp_relay/test_dhcpv6_relay.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
