### PR TITLE
changes to testQosSaiPfcXoffLimit on cisco-8000

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -122,6 +122,9 @@ class TestQosSai(QosSaiBase):
         if "pkts_num_margin" in qosConfig[xoffProfile].keys():
             testParams["pkts_num_margin"] = qosConfig[xoffProfile]["pkts_num_margin"]
 
+        if "packet_size" in qosConfig[xoffProfile].keys():
+            testParams["packet_size"] = qosConfig[xoffProfile]["packet_size"]
+
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.PFCtest", testParams=testParams
         )

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -685,8 +685,11 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
 
         # Prepare IP packet data
         ttl = 64
-        default_packet_length = 64
-        pkt = construct_ip_pkt(default_packet_length,
+        if 'packet_size' in self.test_params.keys():
+            packet_length = int(self.test_params['packet_size'])
+        else:
+            packet_length = 64
+        pkt = construct_ip_pkt(packet_length,
                                pkt_dst_mac,
                                src_port_mac,
                                src_port_ip,
@@ -735,6 +738,10 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             if hwsku == 'DellEMC-Z9332f-M-O16C64' or hwsku == 'DellEMC-Z9332f-O32':
                 # send packets short of triggering pfc
                 send_packet(self, src_port_id, pkt, pkts_num_egr_mem + pkts_num_leak_out + pkts_num_trig_pfc - 1 - margin)
+            elif 'cisco-8000' in asic_type:
+                assert(fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, int(self.test_params['pg']), asic_type))
+                # Send 1 less packet due to leakout filling
+                send_packet(self, src_port_id, pkt, pkts_num_leak_out + pkts_num_trig_pfc - 2 - margin)
             else:
                 # send packets short of triggering pfc
                 send_packet(self, src_port_id, pkt, pkts_num_leak_out + pkts_num_trig_pfc - 1 - margin)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Changes for testQosSaiPfcXoffLimit on Cisco-8000.

Test case modifications for Cisco-8000:
-Account for leakout using utility.

The above changes are backwards compatible with other vendors.


#### What is the motivation for this PR?
Provide Cisco-8000 support for testQosSaiPfcXoffLimit.

#### How did you verify/test it?
Verified the Changes on Cisco platform and Testcase Passes

