### PR TITLE
[multi-asic]Fix minigraph_png template to generate all DeviceInterfaceLink

### DIFF
--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -76,7 +76,6 @@
 {% endfor %}
 {% endfor %}
 {% endif %}
-{% if switch_type is not defined or (switch_type != 'voq' and switch_type != 'chassis-packet') %}
 {% for asic_intf in front_panel_asic_ifnames %}
       <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
@@ -94,7 +93,6 @@
         <Validate>true</Validate>
       </DeviceLinkBase>
 {% endfor %}
-{% endif %}
 {% endif %}
     </DeviceInterfaceLinks>
     <Devices>

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -76,8 +76,8 @@
 {% endfor %}
 {% endfor %}
 {% endif %}
+{% if switch_type is not defined or (switch_type != 'voq' and switch_type != 'chassis-packet') %}
 {% for asic_intf in front_panel_asic_ifnames %}
-{% if inventory_hostname not in device_conn or port_alias[loop.index - 1] in device_conn[inventory_hostname] %}
       <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
 {% if port_alias[loop.index - 1] in port_speed %}
@@ -93,8 +93,8 @@
         <StartPort>{{ port_alias[loop.index - 1] }}</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
-{% endif %}
 {% endfor %}
+{% endif %}
 {% endif %}
     </DeviceInterfaceLinks>
     <Devices>


### PR DESCRIPTION
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #5368

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
DeviceInterfaceLink for front panel interface to ASIC interface is not getting generated for multi-asic platform.
https://github.com/Azure/sonic-mgmt/pull/4420 introduced a change in minigraph_png.j2 template which caused this change.

#### How did you do it?
Fix png template so that DeviceInterfaceLink with front panel interface to asic interface is generated for all platforms.

#### How did you verify/test it?
Verified  on multi-asic platform,  DeviceInterfaceLink with front panel interface to asic interface mapping is generated correctly.
In multi-asic linecard minigraph will nclude all DeviceInterfaceLinks.
In multi-asic linecard, DEVICE_NEIGHBOR table in default config_db gets populated.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
