### PR TITLE
[python3]migrate dir_bcast_test and fdb scripts to python3

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dir_bcast_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dir_bcast_test.py
@@ -55,17 +55,17 @@ class BcastTest(BaseTest):
         self.router_mac = self.test_params['router_mac']
         self.setUpVlan(self.test_params['vlan_info'])
         if self.test_params['testbed_type'] == 't0':
-            self.src_ports = range(1, 25) + range(28, 32)
+            self.src_ports = list(range(1, 25)) + list(range(28, 32))
         if self.test_params['testbed_type'] == 't0-52':
-            self.src_ports = range(0, 52)
+            self.src_ports = list(range(0, 52))
         if self.test_params['testbed_type'] == 't0-56':
-            self.src_ports = range(0, 2) + range(4, 6) + range(8, 10) + range(12, 18) + range(20, 22) + \
-                             range(24, 26) + range(28, 30) + range(32, 34) + range(36, 38) + range(40, 46) + \
-                             range(48, 50) + range(52, 54)
+            self.src_ports = list(range(0, 2)) + list(range(4, 6)) + list(range(8, 10)) + list(range(12, 18)) + list(range(20, 22)) + \
+                             list(range(24, 26)) + list(range(28, 30)) + list(range(32, 34)) + list(range(36, 38)) + list(range(40, 46)) + \
+                             list(range(48, 50)) + list(range(52, 54))
         if self.test_params['testbed_type'] == 't0-64':
-            self.src_ports = range(0, 2) + range(4, 18) + range(20, 33) + range(36, 43) + range(48, 49) + range(52, 59)
+            self.src_ports = list(range(0, 2)) + list(range(4, 18)) + list(range(20, 33)) + list(range(36, 43)) + list(range(48, 49)) + list(range(52, 59))
         if self.test_params['testbed_type'] == 't0-116':
-            self.src_ports = range(24, 32)
+            self.src_ports = list(range(24, 32))
         if self.test_params['testbed_type'] == 't0-120':
             self.src_ports = [48, 49, 54, 55, 60, 61, 66, 67]
 
@@ -79,7 +79,7 @@ class BcastTest(BaseTest):
         with open(file_path, 'r') as f:
             for line in f.readlines():
                 entry = line.split(' ', 1)
-                prefix = ip_network(unicode(entry[0]))
+                prefix = ip_network(str(entry[0]))
                 if prefix.version != 4:
                     continue
                 self._vlan_dict[prefix] = [int(i) for i in entry[1].split()]

--- a/ansible/roles/test/files/ptftests/py3/fdb.py
+++ b/ansible/roles/test/files/ptftests/py3/fdb.py
@@ -14,7 +14,7 @@ class Fdb():
             for line in f.readlines():
                 if pattern.match(line): continue
                 entry = line.split(' ', 1)
-                prefix = ip_network(unicode(entry[0]))
+                prefix = ip_network(str(entry[0]))
                 self._vlan_dict[prefix] = [int(i) for i in entry[1].split()]
 
     def insert(self, mac, member):

--- a/ansible/roles/test/files/ptftests/py3/fdb_mac_expire_test.py
+++ b/ansible/roles/test/files/ptftests/py3/fdb_mac_expire_test.py
@@ -57,5 +57,4 @@ class FdbMacExpireTest(BaseTest):
         self.populateFdb()
         if self.refresh_type == REFRESH_DEST_MAC:
             self.refreshFdbWithInvalidPackets()
-	return
     #--------------------------------------------------------------------------

--- a/ansible/roles/test/files/ptftests/py3/fdb_test.py
+++ b/ansible/roles/test/files/ptftests/py3/fdb_test.py
@@ -31,7 +31,7 @@ class FdbTest(BaseTest):
     def setUp(self):
         self.dataplane = ptf.dataplane_instance
         self.fdb = fdb.Fdb(self.test_params['fdb_info'])
-        self.vlan_ip = ip_address(unicode(self.test_params['vlan_ip']))
+        self.vlan_ip = ip_address(str(self.test_params['vlan_ip']))
         self.dummy_mac_prefix = self.test_params["dummy_mac_prefix"]
         self.dummy_mac_number = int(self.test_params["dummy_mac_number"])
         self.dummy_mac_table = {}

--- a/tests/fdb/test_fdb_mac_expire.py
+++ b/tests/fdb/test_fdb_mac_expire.py
@@ -91,9 +91,9 @@ class TestFdbMacExpire:
         """
         logger.info("Running PTF test case '{0}' on '{1}'".format(testCase, ptfhost.hostname))
         ptfhost.shell(argv=[
-            "ptf",
+            "/root/env-python3/bin/ptf",
             "--test-dir",
-            "ptftests",
+            "ptftests/py3",
             testCase,
             "--platform-dir",
             "ptftests",

--- a/tests/ipfwd/test_dir_bcast.py
+++ b/tests/ipfwd/test_dir_bcast.py
@@ -39,4 +39,5 @@ def test_dir_bcast(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
         'dir_bcast_test.BcastTest',
         '/root/ptftests',
         params=params,
-        log_file=log_file)
+        log_file=log_file,
+        is_python3=True)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
migrate the following scripts to python3, this PR can't be merged until #5534 is merged which has dependency of `ptf_runner.py`
```
ansible/roles/test/files/ptftests/dir_bcast_test.py
ansible/roles/test/files/ptftests/fdb.py
ansible/roles/test/files/ptftests/fdb_mac_expire_test.py
ansible/roles/test/files/ptftests/fdb_test.py
```
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
migrate dir_bcast_test and fdb scripts to python3

#### How did you do it?
Update test cases accordingly.
```
tests/fdb/test_fdb_mac_expire.py
tests/ipfwd/test_dir_bcast.py
```
#### How did you verify/test it?
run` tests/fdb/test_fdb_mac_expire.py` and` tests/ipfwd/test_dir_bcast.py`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
