### PR TITLE
fix to validate all db device keys are populated after pcied restart

### DIFF
--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -99,7 +99,7 @@ def wait_data(duthost, expected_key_count):
         shared_scope.data_after_restart = collect_data(duthost)
         device_keys_found = len(shared_scope.data_after_restart['devices'])
         if device_keys_found != 0:
-            logger.info("Expected PCIE device keys :{}, Current device key count {}".format(db_key_count,device_keys_found))
+            logger.info("Expected PCIE device keys :{}, Current device key count {}".format(expected_key_count, device_keys_found))
         return device_keys_found == expected_key_count
     pcied_pooling_interval = 60
     wait_until(pcied_pooling_interval, 6, 0, _collect_data)

--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -92,12 +92,16 @@ def collect_data(duthost):
     dev_summary_status = duthost.get_pmon_daemon_db_value(pcie_devices_status_tbl_key, status_field)
     return {'status': dev_summary_status, 'devices': dev_data}
     
-def wait_data(duthost):
+def wait_data(duthost, expected_key_count):
     class shared_scope:
         data_after_restart = {}
     def _collect_data():
         shared_scope.data_after_restart = collect_data(duthost)
-        return bool(shared_scope.data_after_restart['devices'])
+        device_keys_found = len(shared_scope.data_after_restart['devices'])
+        if device_keys_found != 0:
+            logger.info("Expected PCIE device keys :{}, Current device key count {}".format(db_key_count,device_keys_found))
+        if device_keys_found == expected_key_count:
+            return True
     pcied_pooling_interval = 60
     wait_until(pcied_pooling_interval, 6, 0, _collect_data)
     return shared_scope.data_after_restart
@@ -160,7 +164,7 @@ def test_pmon_pcied_stop_and_start_status(check_daemon_status, duthosts, rand_on
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
     
-    data_after_restart = wait_data(duthost)
+    data_after_restart = wait_data(duthost, len(data_before_restart['devices']))
     pytest_assert(data_after_restart == data_before_restart, 'DB data present before and after restart does not match')
 
 
@@ -190,7 +194,7 @@ def test_pmon_pcied_term_and_start_status(check_daemon_status, duthosts, rand_on
                           "{} expected pid is -1 but is {}".format(daemon_name, post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
-    data_after_restart = wait_data(duthost)
+    data_after_restart = wait_data(duthost, len(data_before_restart['devices']))
     pytest_assert(data_after_restart == data_before_restart, 'DB data present before and after restart does not match')
 
 
@@ -217,5 +221,5 @@ def test_pmon_pcied_kill_and_start_status(check_daemon_status, duthosts, rand_on
                           "{} expected pid is -1 but is {}".format(daemon_name, post_daemon_pid))
     pytest_assert(post_daemon_pid > pre_daemon_pid,
                           "Restarted {} pid should be bigger than {} but it is {}".format(daemon_name, pre_daemon_pid, post_daemon_pid))
-    data_after_restart = wait_data(duthost)
+    data_after_restart = wait_data(duthost, len(data_before_restart['devices']))
     pytest_assert(data_after_restart == data_before_restart, 'DB data present before and after restart does not match')

--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -100,8 +100,7 @@ def wait_data(duthost, expected_key_count):
         device_keys_found = len(shared_scope.data_after_restart['devices'])
         if device_keys_found != 0:
             logger.info("Expected PCIE device keys :{}, Current device key count {}".format(db_key_count,device_keys_found))
-        if device_keys_found == expected_key_count:
-            return True
+        return device_keys_found == expected_key_count
     pcied_pooling_interval = 60
     wait_until(pcied_pooling_interval, 6, 0, _collect_data)
     return shared_scope.data_after_restart


### PR DESCRIPTION

### Description of PR
test_pcied.py tests fails intermittently due to early exit of _collect_data function before the db is populated completely

Added code to avoid early exit of _collect_data function

return false until the number of db device keys after restarting pcied process matches the number of db keys before restart

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
 Script change to avoid early exit of _collect_data function before the db is completely populated

#### How did you do it?
1) Pass the number of keys info to wait_data from the initial db snapshot before the pcied process restart
2) Return False until the expected number of keys populated after pcied process restart till the timeout

#### How did you verify/test it?
Tested in Cisco 8000 platform and all tests passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

