### PR TITLE
Add missing ':' in watchdog.yml

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -51,7 +51,7 @@ x86_64-mlnx_msn2700-r0:
     greater_timeout: 100
     too_big_timeout: 66000
 
-x86_64-nvidia_sn2201-r0
+x86_64-nvidia_sn2201-r0:
   default:
     greater_timeout: 100
     too_big_timeout: 66000


### PR DESCRIPTION
Add missing ':' after x86_64-nvidia_sn2201-r0 in watchdog.yml

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
