### PR TITLE
fix to validate the psu absence based on the psu voltage/current/power info

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -650,6 +650,10 @@ def _check_psu_status_after_power_off(duthost, localhost, creds_all_duts):
             for field, sensor_tuple in PSU_SENSOR_INFO.items():
                 sensor_oid = expect_oid + DEVICE_TYPE_POWER_MONITOR + sensor_tuple[2]
                 # entity_sensor_mib_info is only supported in image newer than 202012
+                if sensor_oid in entity_mib_info:
+                    if psu_info['current'] == '0.0' and psu_info['voltage'] == '0.0' and psu_info['power'] == '0.0':
+                        power_off_psu_found = True
+                        break
                 if is_sensor_test_supported(duthost):
                     if sensor_oid not in entity_mib_info and sensor_oid not in entity_sensor_mib_info:
                         power_off_psu_found = True


### PR DESCRIPTION
Description of PR:
Cisco platforms maintain accessibility to a PSU's sensors information even when input power is removed

Test case expects the sensor information to be absent ofter PSU power off

What is the motivation for this PR?
Return the psu found info based on the power/current/voltage info instead of sensor information from mib

How did you do it?

validate the psu info such as voltage, current and power is set to zero once the psu is turned off and set power_off_psu_found to true

How did you verify/test it?
generated xml file: /data/tests/dt20.10_reruns/snmp/test_snmp_phy_entity.py::test_turn_off_psu_and_check_psu_info_2022-04-20-08-00-47.xml -
INFO:root:Can not get Allure report URL. Please check logs
-------------------------------------------- live log sessionfinish --------------------------------------------
08:02:29 init.pytest_terminal_summary L0064 INFO | Can not get Allure report URL. Please check logs
=================================== 1 passed, 99 warnings in 100.87 seconds =====================