### PR TITLE
fix the bug of missing monit results in sanity check

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -595,6 +595,7 @@ def check_monit(duthosts):
                 check_result["failed"] = True
                 check_result["failed_reason"] = "Monit was not running"
                 logger.info("Checking status of each Monit service was done!")
+                results[dut.hostname] = check_result
                 return check_result
 
             check_result = _check_monit_services_status(check_result, monit_services_status)

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -596,7 +596,7 @@ def check_monit(duthosts):
                 check_result["failed_reason"] = "Monit was not running"
                 logger.info("Checking status of each Monit service was done!")
                 results[dut.hostname] = check_result
-                return check_result
+                return
 
             check_result = _check_monit_services_status(check_result, monit_services_status)
         else:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
fix the bug of missing monit results in sanity check
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
`test_service_checker` failed due to monit not running, this failure should be captured in sanity check.
Even monit is not running, sanity check is passed. It missed the monit results in sanity check.

#### How did you do it?
In function `_check_monit_on_dut`, if monit is not running, it doesn't add `check_result` into `results` dict, so in later sanity check, it misses monit result and test cases still run.

#### How did you verify/test it?
stop monit and run `test_service_checker `with enable sanity_check.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
