### PR TITLE
Marking pfc/test_unknown_mac.py as skip for cisco-8000

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -156,6 +156,15 @@ ntp/test_ntp.py::test_ntp_long_jump_disabled:
     reason: "Known NTP bug"
 
 #######################################
+#####           pfc               #####
+#######################################
+pfc/test_unknown_mac.py:
+  skip:
+    reason: In cisco-8000 platform, a packet with unknown MAC will be flooded, not dropped. This case will not pass in cisco-8000.
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
+#######################################
 #####         pfc_asym            #####
 #######################################
 pfc_asym/test_pfc_asym.py:


### PR DESCRIPTION
In Cisco-8000 platforms, a packet with unknown mac will be flooded, instead of being dropped. The testcase in pfc/test_unknown_mac.py will fail in cisco-8000 platforms. So we need to skip it for cisco-8000.