### PR TITLE
[T2-profile]: Skipping database'x' and syncd'x' for distributed chassis (Cisco-8000)

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -120,7 +120,7 @@ def test_service_checker_with_process_exit(duthosts, enum_rand_one_per_hwsku_hos
     wait_system_health_boot_up(duthost)
     with ConfigFileContext(duthost, os.path.join(FILES_DIR, IGNORE_DEVICE_CHECK_CONFIG_FILE)):
         processes_status = duthost.all_critical_process_status()
-        containers = [x for x in list(processes_status.keys()) if x != "syncd" and x !="database"]
+        containers = [x for x in list(processes_status.keys()) if "syncd" not in x and "database" not in x]
         logging.info('Test containers: {}'.format(containers))
         random.shuffle(containers)
         for container in containers:


### PR DESCRIPTION
### Description of PR
In case of distributed chassis, there is multiple syncd'x' and database'x' containers, the test was only skipping syncd and database containers. Made a change to skip all database and syncd containers

Summary:
Fixes # (issue)

### Type of change


- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
In case of distributed chassis, there is multiple syncd'x' and database'x' containers, the test was only skipping syncd and database containers. Made a change to skip all database and syncd containers

#### How did you do it?

#### How did you verify/test it?
Verified on T2 profile on Cisco-8000 platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
