### PR TITLE
Remove DATAACL table before `test_acl`

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 from tests.common import reboot, port_toggle
 from tests.common.helpers.assertions import pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
-from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts
+from tests.common.config_reload import config_reload
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py, run_garp_service, change_mac_addresses
 from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr
@@ -29,7 +29,6 @@ pytestmark = [
     pytest.mark.acl,
     pytest.mark.disable_loganalyzer,  # Disable automatic loganalyzer, since we use it for the test
     pytest.mark.topology("any"),
-    pytest.mark.usefixtures('backup_and_restore_config_db_on_duts')
 ]
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -96,6 +95,34 @@ LOG_EXPECT_ACL_RULE_REMOVE_RE = ".*Successfully deleted ACL rule.*"
 PACKETS_COUNT = "packets_count"
 BYTES_COUNT = "bytes_count"
 
+@pytest.fixture(scope="module", autouse=True)
+def remove_dataacl_table(duthosts):
+    """
+    Remove DATAACL to free TCAM resources.
+    The change is written to configdb as we don't want DATAACL recovered after reboot  
+    """
+    TABLE_NAME = "DATAACL"
+    for duthost in duthosts:
+        lines = duthost.shell(cmd="show acl table {}".format(TABLE_NAME))['stdout_lines']
+        data_acl_existing = False
+        for line in lines:
+            if TABLE_NAME in line:
+                data_acl_existing = True
+                break
+        if not data_acl_existing:
+            yield
+            return
+        # Remove DATAACL
+        logger.info("Removing ACL table {}".format(TABLE_NAME))
+        cmds = [
+            "config acl remove table {}".format(TABLE_NAME),
+            "config save -y"
+        ]
+        duthost.shell_cmds(cmds=cmds)
+    yield
+    # Recover DATAACL by reloading minigraph
+    for duthost in duthosts:
+        config_reload(duthost, config_source="minigraph")
 
 @pytest.fixture(scope="module")
 def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter):


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to remove `DATAACL` table at the beginning of `test_acl`.

As `test_acl` creates extra ACL table for testing, to free TCAM resources, the `DATAACL` table is to be removed, and recovered back at the end of testing by `load minigraph`

Signed-off-by: bingwang <bingwang@microsoft.com>
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
This PR is to remove `DATAACL` table at the beginning of `test_acl`.

#### How did you do it?
Add a module level, autoused fixture to remove `DATAACL` before test running, and do a `load minigraph` after test running.

#### How did you verify/test it?
Verified on both dual-tor and single-tor platform.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
