### PR TITLE
Replace vtestbed.csv with vtestbed.yaml

### DIFF
--- a/ansible/testbed.yaml
+++ b/ansible/testbed.yaml
@@ -3,7 +3,7 @@
 - conf-name: ptf1-m
   group-name: ptf1
   topo: ptf32
-  ptf_image_name: docker-ptf-sai-mlnx
+  ptf_image_name: docker-ptf
   ptf: ptf-unknown
   ptf_ip: 10.255.0.188/24
   ptf_ipv6:
@@ -11,12 +11,14 @@
   vm_base:
   dut:
     - str-msn2700-01
+  inv_name: lab
+  auto_recover: 'False'
   comment: Test ptf Mellanox
 
 - conf-name: ptf2-b
   group-name: ptf2
   topo: ptf64
-  ptf_image_name: docker-ptf-sai-brcm
+  ptf_image_name: docker-ptf
   ptf: ptf-unknown
   ptf_ip: 10.255.0.189/24
   ptf_ipv6:
@@ -24,12 +26,14 @@
   vm_base:
   dut:
     - lab-s6100-01
+  inv_name: lab
+  auto_recover: 'False'
   comment: Test ptf Broadcom
 
 - conf-name: vms-sn2700-t1
   group-name: vms1-1
   topo: t1
-  ptf_image_name: docker-ptf-sai-mlnx
+  ptf_image_name: docker-ptf
   ptf: ptf-unknown
   ptf_ip: 10.255.0.178/24
   ptf_ipv6:
@@ -37,12 +41,14 @@
   vm_base: VM0100
   dut:
     - str-msn2700-01
+  inv_name: lab
+  auto_recover: 'True'
   comment: Tests Mellanox SN2700 vms
 
 - conf-name: vms-sn2700-t1-lag
   group-name: vms1-1
   topo: t1-lag
-  ptf_image_name: docker-ptf-sai-mlnx
+  ptf_image_name: docker-ptf
   ptf: ptf-unknown
   ptf_ip: 10.255.0.178/24
   ptf_ipv6:
@@ -50,12 +56,14 @@
   vm_base: VM0100
   dut:
     - str-msn2700-01
+  inv_name: lab
+  auto_recover: 'True'
   comment: Tests Mellanox SN2700 vms
 
 - conf-name: vms-sn2700-t0
   group-name: vms1-1
   topo: t0
-  ptf_image_name: docker-ptf-sai-mlnx
+  ptf_image_name: docker-ptf
   ptf: ptf-unknown
   ptf_ip: 10.255.0.178/24
   ptf_ipv6:
@@ -63,12 +71,14 @@
   vm_base: VM0100
   dut:
     - str-msn2700-01
+  inv_name: lab
+  auto_recover: 'True'
   comment: Tests Mellanox SN2700 vms
 
 - conf-name: vms-s6000-t0
   group-name: vms2-1
   topo: t0
-  ptf_image_name: docker-ptf-sai-brcm
+  ptf_image_name: docker-ptf
   ptf: ptf-unknown
   ptf_ip: 10.255.0.179/24
   ptf_ipv6:
@@ -76,12 +86,14 @@
   vm_base: VM0100
   dut:
     - lab-s6000-01
+  inv_name: lab
+  auto_recover: 'True'
   comment: Tests Dell S6000 vms
 
 - conf-name: vms-a7260-t0
   group-name: vms3-1
   topo: t0-116
-  ptf_image_name: docker-ptf-sai-brcm
+  ptf_image_name: docker-ptf
   ptf: ptf-unknown
   ptf_ip: 10.255.0.180/24
   ptf_ipv6:
@@ -89,12 +101,14 @@
   vm_base: VM0100
   dut:
     - lab-a7260-01
+  inv_name: lab
+  auto_recover: 'True'
   comment: Tests Arista A7260 vms
 
 - conf-name: vms-s6100-t0
   group-name: vms4-1
   topo: t0-64
-  ptf_image_name: docker-ptf-sai-brcm
+  ptf_image_name: docker-ptf
   ptf: ptf-unknown
   ptf_ip: 10.255.0.181/24
   ptf_ipv6:
@@ -102,12 +116,14 @@
   vm_base: VM0100
   dut:
     - lab-s6100-01
+  inv_name: lab
+  auto_recover: 'True'
   comment: Tests Dell S6100 vms
 
 - conf-name: vms-s6100-t1
   group-name: vms4-1
   topo: t1-64
-  ptf_image_name: docker-ptf-sai-brcm
+  ptf_image_name: docker-ptf
   ptf: ptf-unknown
   ptf_ip: 10.255.0.182/24
   ptf_ipv6:
@@ -115,12 +131,14 @@
   vm_base: VM0100
   dut:
     - lab-s6100-01
+  inv_name: lab
+  auto_recover: 'True'
   comment: Tests Dell S6100 vms
 
 - conf-name: vms-s6100-t1-lag
   group-name: vms5-1
   topo: t1-64-lag
-  ptf_image_name: docker-ptf-sai-brcm
+  ptf_image_name: docker-ptf
   ptf: ptf-unknown
   ptf_ip: 10.255.0.183/24
   ptf_ipv6:
@@ -128,7 +146,9 @@
   vm_base: VM0100
   dut:
     - lab-s6100-01
-  comment: Tests Dell S6100 vms
+  inv_name: lab
+  auto_recover: 'True'
+  comment: ests Dell S6100 vms
 
 - conf-name: vms-multi-dut
   group-name: vms1-duts
@@ -142,6 +162,8 @@
   dut:
     - dut-host1
     - dut-host2
+  inv_name: lab
+  auto_recover: 'True'
   comment: Example Multi DUTs testbed
 
 - conf-name: vms-example-ixia-1
@@ -155,9 +177,11 @@
   vm_base: VM0600
   dut:
     - example-s6100-dut-1
+  inv_name: lab
+  auto_recover: 'True'
   comment: superman
 
-- conf-name: ixanvl-vs-conf 
+- conf-name: ixanvl-vs-conf
   group-name: anvl
   topo: ptf32
   ptf_image_name: docker-ptf-anvl
@@ -168,6 +192,8 @@
   vm_base:
   dut:
     - vlab-01
+  inv_name: lab
+  auto_recover: 'True'
   comment: Test ptf ANVL SONIC VM
 
 - conf-name: vms-chassis-packet-dut

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ stages:
   - name: inventory
     value: veos_vtb
   - name: testbed_file
-    value: vtestbed.csv
+    value: vtestbed.yaml
 
   jobs:
   - job: t0_part1

--- a/docs/testbed/README.testbed.Example.Config.md
+++ b/docs/testbed/README.testbed.Example.Config.md
@@ -24,11 +24,11 @@ Then we can get the related information from [```ansible/vtestbed.csv```](/ansib
 ### Access the DUT
 
 ```
-grep 'vlab-01' ./vtestbed.csv                          
+grep 'vlab-01' ./vtestbed.yaml
 vms-kvm-t0,vms6-1,t0,docker-ptf,ptf-01,10.250.0.102/24,fec0::ffff:afa:2/64,server_1,VM0100,[vlab-01],veos_vtb,False,Tests virtual switch vm
 ```
 ```
-grep 'vlab-01' -A 4 -B 11 ./vtestbed.yaml 
+grep 'vlab-01' -A 4 -B 11 ./vtestbed.yaml
 
 - conf-name: vms-kvm-t0
   group-name: vms6-1
@@ -45,7 +45,7 @@ grep 'vlab-01' -A 4 -B 11 ./vtestbed.yaml
   auto_recover: 'False'
   comment: Tests virtual switch vm
 ```
-From the two output above, we can see, the content in that two files are same, the files format are different. 
+From the two output above, we can see, the content in that two files are same, the files format are different.
 
 Here we get the information for `vlab-01`.
 
@@ -67,7 +67,7 @@ Then, you can use this IP `10.250.0.101` to access that DUT.
 
 ```
 ssh admin@10.250.0.101
-admin@10.250.0.101's password: 
+admin@10.250.0.101's password:
 Linux vlab-01 4.19.0-12-2-amd64 #1 SMP Debian 4.19.152-1 (2020-10-18) x86_64
 You are on
   ____   ___  _   _ _  ____
@@ -114,7 +114,7 @@ server_1:
 ```
 Here, in `children` section, we get a element `vm_host_1`. Then we can get the host for our PTF instance.
 ```
-grep '^vm_host_1' -A 5 ./veos_vtb 
+grep '^vm_host_1' -A 5 ./veos_vtb
 vm_host_1:
   hosts:
     STR-ACS-VSERV-01:
@@ -129,9 +129,9 @@ Let's check.
 Access from IP
 ```
 ssh root@10.250.0.102
-root@10.250.0.102's password: 
+root@10.250.0.102's password:
 Last login: Tue Jul 20 09:50:31 2021 from 10.250.0.1
-root@8d3f7f4475cd:~# 
+root@8d3f7f4475cd:~#
 ```
 Access from host
 ```
@@ -149,8 +149,7 @@ Then we can see, the docker id is identical `8d3f7f4475cd`.
 ## References
 For this article, some of the reference docs as:
 
-- [```Testbed Topologies```](/docs/testbed/README.testbed.Topology.md): Testbed topologies. 
-- [```Testbed Configuration```](/docs/testbed/README.testbed.Config.md): Introduction about Testbed configuration, mainly about the testbed.csv (Will be replaced by testbed.yaml). 
+- [```Testbed Topologies```](/docs/testbed/README.testbed.Topology.md): Testbed topologies.
+- [```Testbed Configuration```](/docs/testbed/README.testbed.Config.md): Introduction about Testbed configuration, mainly about the testbed.csv (Will be replaced by testbed.yaml).
 - [```New Testbed Configuration```](/docs/testbed/README.new.testbed.Configuration.md): Introduction about Testbed configuration, mainly about the Testbed.yaml.
 - [```KVM Testbed Setup```](/docs/testbed/README.testbed.VsSetup.md)
-  

--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -57,8 +57,8 @@ $ docker images
 REPOSITORY                                             TAG           IMAGE ID       CREATED         SIZE
 ceosimage                                              4.25.5.1M     fa0df4b01467   9 seconds ago   1.62GB
 ```
-**Note**: *For time being, the image might be updated, in that case you can't download the same version of image as in the instruction, 
-please download the corresponding version(following [Arista recommended release](https://www.arista.com/en/support/software-download#datatab300)) of image and import it to your local docker repository. 
+**Note**: *For time being, the image might be updated, in that case you can't download the same version of image as in the instruction,
+please download the corresponding version(following [Arista recommended release](https://www.arista.com/en/support/software-download#datatab300)) of image and import it to your local docker repository.
 The actual image version that is needed in the installation process is defined in the file [ansible/group_vars/all/ceos.yml](../../ansible/group_vars/all/ceos.yml), make sure you modify locally to keep it up with the image version you imported.*
 
 **Note**: *Please also notice the type of the bit for the image, in the example above, it is a standard 32-bit image. Please import the right image as your needs.*
@@ -223,13 +223,13 @@ Now we're finally ready to deploy the topology for our testbed! Run the followin
 ### vEOS
 ```
 cd /data/sonic-mgmt/ansible
-./testbed-cli.sh -t vtestbed.csv -m veos_vtb add-topo vms-kvm-t0 password.txt
+./testbed-cli.sh -t vtestbed.yaml -m veos_vtb add-topo vms-kvm-t0 password.txt
 ```
 
 ### cEOS
 ```
 cd /data/sonic-mgmt/ansible
-./testbed-cli.sh -t vtestbed.csv -m veos_vtb -k ceos add-topo vms-kvm-t0 password.txt
+./testbed-cli.sh -t vtestbed.yaml -m veos_vtb -k ceos add-topo vms-kvm-t0 password.txt
 ```
 
 Verify that the cEOS neighbors were created properly:
@@ -251,7 +251,7 @@ c929c622232a        sonicdev-microsoft.azurecr.io:443/docker-ptf:latest   "/usr/
 ### vSONiC
 ```
 cd /data/sonic-mgmt/ansible
-./testbed-cli.sh -t vtestbed.csv -m veos_vtb -k vsonic add-topo vms-kvm-t0 password.txt
+./testbed-cli.sh -t vtestbed.yaml -m veos_vtb -k vsonic add-topo vms-kvm-t0 password.txt
 ```
 
 ## Deploy minigraph on the DUT
@@ -260,7 +260,7 @@ Once the topology has been created, we need to give the DUT an initial configura
 1. Deploy the `minigraph.xml` to the DUT and save the configuration:
 
 ```
-./testbed-cli.sh -t vtestbed.csv -m veos_vtb deploy-mg vms-kvm-t0 veos_vtb password.txt
+./testbed-cli.sh -t vtestbed.yaml -m veos_vtb deploy-mg vms-kvm-t0 veos_vtb password.txt
 ```
 Verify the DUT is created successfully
 In your host run
@@ -363,13 +363,13 @@ cd sonic-mgmt/tests
 If neighbor devices are EOS
 
 ```
-./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c bgp/test_bgp_fact.py -f vtestbed.csv -i veos_vtb
+./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c bgp/test_bgp_fact.py -f vtestbed.yaml -i ../ansible/veos_vtb
 ```
 
 If neighbor devices are SONiC
 
 ```
-./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c bgp/test_bgp_fact.py -f vtestbed.csv -i veos_vtb -e "--neighbor_type=sonic"
+./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c bgp/test_bgp_fact.py -f vtestbed.yaml -i ../ansible/veos_vtb -e "--neighbor_type=sonic"
 ```
 
 You should see three sets of tests run and pass. You're now set up and ready to use the KVM testbed!
@@ -379,5 +379,5 @@ If you want to clear your testing environment, you can log into your mgmt docker
 
 Then run command:
 ```
-./testbed-cli.sh -t vtestbed.csv -m veos_vtb -k ceos remove-topo vms-kvm-t0 password.txt
+./testbed-cli.sh -t vtestbed.yaml -m veos_vtb -k ceos remove-topo vms-kvm-t0 password.txt
 ```

--- a/docs/tests/pytest.run.md
+++ b/docs/tests/pytest.run.md
@@ -40,7 +40,7 @@ pytest [test script files or directories containing test script files] [options 
 
 For example:
 ```
-pytest test_announce_routes.py --inventory veos_vtb --host-pattern vlab-01 --testbed_file vtestbed.csv --log-cli-level info
+pytest test_announce_routes.py --inventory ../ansible/veos_vtb --host-pattern all --testbed_file vtestbed.yaml --log-cli-level info
 ```
 
 Please ensure that the command line options extended in sonic-mgmt are always added **AFTER** the test script files or directories containing test script files. Otherwise, pytest may complain that the options defined in `conftest.py` of sub-folders are unrecognized.
@@ -50,13 +50,15 @@ The reason is that pytest will do a pre-parse for all of the supplied command li
 For example, if the pytest command line is like this:
 
 ```
-pytest --inventory veos_vtb --host-pattern vlab-01 --testbed vms-kvm-t0 --testbed_file vtestbed.csv --log-cli-level debug --disable_loganalyzer --skip_sanity example/test_example.py --example_option1 my_value1
+pytest example/test_example.py --inventory ../ansible/veos_vtb --host-pattern all --testbed vms-kvm-t0 --testbed_file vtestbed.yaml --log-cli-level debug --disable_loganalyzer --skip_sanity --example_option1 my_value1
 ```
 
 Arguments that are known to pytest during pre-parse phase:
-* `--inventory veos_vtb`
-* `--host-pattern vlab-01`
+* `--inventory ../ansible/veos_vtb`
+* `--host-pattern all`
 * `--log-cli-level debug`
+
+Please be noted that although there is a symbolic link `tests/veos_vtb` pointing to `ansible/veos_vtb`, we still have to specify `../ansible/veos_vtb`. The reason is that under the hood, ansible will try to locate some group and host variables under the same folder of the inventory file. Currently, all the ansible group and host variables are stored under the `ansible` folder. If we run `pytest` under the `tests` folder and specify inventory file using argumetn like `--inventory veos_vtb`, ansible will try to find group and host variables under `tests` folder. Consequently, lost access to group and host variables under the `ansible` folder.
 
 Rest of the arguments are unknown to pytest yet.
 
@@ -67,7 +69,7 @@ After pre-parse is done, pytest will try to locate all the `conftest.py` files r
 If we run the command like below, then there is no problem.
 
 ```
-pytest --inventory veos_vtb --host-pattern vlab-01 example/test_example.py --testbed vms-kvm-t0 --testbed_file vtestbed.csv --log-cli-level debug --disable_loganalyzer --skip_sanity --example_option1 my_value1
+pytest example/test_example.py --inventory ../ansible/veos_vtb --host-pattern vlab-01 --testbed vms-kvm-t0 --testbed_file vtestbed.yaml --log-cli-level debug --disable_loganalyzer --skip_sanity --example_option1 my_value1
 ```
 
 During pre-parse, pytest recognizes that `example/test_example.py ` is a test script. Then pytest will try to load file `sonic-mgmt/tests/try_opt/conftest.py`. After this conftest.py file is loaded, there is no problem of parsing argument `--example_option1`.

--- a/tests/common/plugins/conditional_mark/README.md
+++ b/tests/common/plugins/conditional_mark/README.md
@@ -12,8 +12,8 @@ This plugin works at the collection stage of pytest. It mainly uses two pytest h
 
 In `pytest_collection` hook function, it reads the specified conditions file and collect some basic facts that can be used in condition evaluation. The loaded information is stored in pytest object `session.config.cache`.
 
-In `pytest_collection_modifyitems`, it checks each collected test item (test case). For each item, it searches for the longest matches test case name defined in the conditions content. If a match is found, then it will add the marks specified for this case based on conditions for each of the marks. 
-Different marks in multiple files are allowed. If different marks are found, all of them will be added to the test item(test case). However, when having the duplicate mark, it will choose the first one. 
+In `pytest_collection_modifyitems`, it checks each collected test item (test case). For each item, it searches for the longest matches test case name defined in the conditions content. If a match is found, then it will add the marks specified for this case based on conditions for each of the marks.
+Different marks in multiple files are allowed. If different marks are found, all of them will be added to the test item(test case). However, when having the duplicate mark, it will choose the first one.
 
 ## How to use `--mark-conditions-files`
 `--mark-conditions-files` supports exactly file name such as `tests/common/plugins/conditional_mark/test_mark_conditions.yaml` or the pattern of the file name such as `tests/common/plugins/conditional_mark/test_mark_conditions*.yaml` which will collect all files under the path `tests/common/plugins/conditional_mark` named as `test_mark_conditions*.yaml`.
@@ -21,11 +21,11 @@ It can be supplied multiple times to specify multiple condition files.
 
 For example:
 ```buildoutcfg
-./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c ssh/test_ssh_stress.py -f vtestbed.csv -i veos_vtb -u -l INFO -e "--mark-conditions-files path1/test1.yaml" -e "--mark-conditions-files path2/test2.yaml"
+./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c ssh/test_ssh_stress.py -f vtestbed.yaml -i ../ansible/veos_vtb -u -l INFO -e "--mark-conditions-files path1/test1.yaml" -e "--mark-conditions-files path2/test2.yaml"
 ```
-or 
+or
 ```buildoutcfg
-./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c ssh/test_ssh_stress.py -f vtestbed.csv -i veos_vtb -u -l INFO -e "--mark-conditions-files path1/{pattern}.yaml" 
+./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c ssh/test_ssh_stress.py -f vtestbed.yaml -i ../ansible/veos_vtb -u -l INFO -e "--mark-conditions-files path1/{pattern}.yaml"
 ```
 
 

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -15,7 +15,7 @@ Description:
   -n
        Do not refresh DUT
   -t testbed_file
-       testbed file (default: vtestbed.csv)
+       testbed file (default: vtestbed.yaml)
   -T test_suite
        test suite [t0|t1-lag] (default: t0)
   tbname
@@ -31,7 +31,7 @@ EOF
 }
 
 inventory="../ansible/veos_vtb"
-testbed_file="vtestbed.csv"
+testbed_file="vtestbed.yaml"
 refresh_dut=true
 exit_on_error=""
 SONIC_MGMT_DIR=/data/sonic-mgmt

--- a/tests/pipelines/cont-warmboot.yml
+++ b/tests/pipelines/cont-warmboot.yml
@@ -19,9 +19,9 @@ resources:
     endpoint: build
 
 parameters:
-- name: iterations 
+- name: iterations
   type: object
-  default: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100] 
+  default: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100]
 
 stages:
 - stage: Test
@@ -34,12 +34,12 @@ stages:
   - name: inventory
     value: veos_vtb
   - name: testbed_file
-    value: vtestbed.csv
+    value: vtestbed.yaml
   - name: ptf_name
     value: ptf_vms6-1
   - name: continue
     value: true
-   
+
 
   jobs:
   - job: kvmWarmbootTest
@@ -90,7 +90,7 @@ stages:
                     --continuous_reboot_count=$CONTINUOUS_REBOOT_COUNT \
                     --continuous_reboot_delay=$CONTINUOUS_REBOOT_DELAY \
                     --testbed=$(tbname) --host-pattern=$(dut) --inventory=/data/sonic-mgmt/ansible/veos_vtb \
-                    --testbed_file=/data/sonic-mgmt/ansible/vtestbed.csv --module-path=/data/sonic-mgmt/ansible/library \
+                    --testbed_file=/data/sonic-mgmt/ansible/vtestbed.yaml --module-path=/data/sonic-mgmt/ansible/library \
                     --show-capture=no --log-cli-level=INFO  \
                     --image_location=$IMAGE_LOCATION --image_list=$IMAGE_LIST \
                     --reboot_type=warm --skip_sanity"

--- a/tests/pipelines/multi_asic_201911.yml
+++ b/tests/pipelines/multi_asic_201911.yml
@@ -39,12 +39,12 @@ stages:
   - name: inventory
     value: veos_vtb
   - name: testbed_file
-    value: vtestbed.csv
+    value: vtestbed.yaml
   - name: image_file_path
-    value: https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/buildimage-multiasic-vs-image-201911/lastSuccessfulBuild/artifact/target/sonic-vs.img.gz 
+    value: https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/buildimage-multiasic-vs-image-201911/lastSuccessfulBuild/artifact/target/sonic-vs.img.gz
 
   jobs:
-  - job: four_asic_vs_test 
+  - job: four_asic_vs_test
     displayName: "kvmmultiasictest"
     timeoutInMinutes: 0
     steps:
@@ -107,10 +107,10 @@ stages:
             cp $img $(Build.ArtifactStagingDirectory)/kvmdump/${{ parameters.dut }}.img
             virsh -c qemu:///system undefine ${{ parameters.dut }}
         fi
-    
+
       displayName: "Collect kvmdump"
       condition: failed()
-    
+
     - script: |
         docker ps
         pushd  /data/sonic-mgmt
@@ -119,17 +119,17 @@ stages:
         sudo chown -R $username.$username $(Build.ArtifactStagingDirectory)
       displayName: "Collect test logs"
       condition: succeededOrFailed()
-    
+
     - publish: $(Build.ArtifactStagingDirectory)/kvmdump
       artifact: sonic-buildimage.kvmtest.$(tbtype).memdump@$(System.JobAttempt)
       displayName: "Archive sonic kvm memdump"
       condition: failed()
-    
+
     - publish: $(Build.ArtifactStagingDirectory)/logs
       artifact: sonic-buildimage.kvmtest.$(tbtype).log@$(System.JobAttempt)
       displayName: "Archive sonic kvm logs"
       condition: succeededOrFailed()
-    
+
     - task: PublishTestResults@2
       inputs:
         testResultsFiles: '$(Build.ArtifactStagingDirectory)/logs/**/*.xml'

--- a/tests/vtestbed.yaml
+++ b/tests/vtestbed.yaml
@@ -1,0 +1,1 @@
+../ansible/vtestbed.yaml


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The vtestbed.csv is not as flexible as vtestbed.yaml. File vtestbed.yaml is more preferred.

#### How did you do it?
This change replaced the usage of vtestbed.csv with vtestbed.yaml.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
