### PR TITLE
Fix timeout logic for wr_arp ptf test

### DIFF
--- a/ansible/roles/test/files/ptftests/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/wr_arp.py
@@ -103,11 +103,20 @@ class ArpTest(BaseTest):
 
     def test_port_thr(self):
         self.log("test_port_thr started")
-        while time.time() < self.stop_at:
+        while True:
             for test in self.tests:
+                self.log("Looping through tests: {}".format(test))
                 for port in test['acc_ports']:
+                    if time.time() > self.stop_at:
+                        break
                     nr_rcvd = self.testPort(port)
                     self.records[port][time.time()] = nr_rcvd
+                else:
+                    continue
+                break
+            else:
+                continue
+            break
         self.log("Quiting from test_port_thr")
         return
 

--- a/ansible/roles/test/files/ptftests/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/wr_arp.py
@@ -307,9 +307,9 @@ class ArpTest(BaseTest):
 
         test_port_thr.join(timeout=self.how_long)
         if test_port_thr.isAlive():
-            self.log("Timed out waiting for warm reboot")
+            self.log("Timed out waiting for traffic-sender (test_port_thr thread)")
             self.req_dut('quit')
-            self.assertTrue(False, "Timed out waiting for warm reboot")
+            self.assertTrue(False, "Timed out waiting for traffic-sender (test_port_thr thread)")
 
         uptime_after = self.req_dut('uptime')
         if uptime_after.startswith('error'):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix timeout check logic in wr_arp test.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911
- [x] 202012

### Approach

#### What is the motivation for this PR?
In the HW SKUs with large number of ports, `test_wr_arp` is flaky. The reason is that timeout logic in the ptftest is incorrect.
The present logic sends all the packets through all the ports, and then checks timeout.
The problem is that the inner-most loop can take ~20-25s in SKU with large number of ports. This means that for these platforms, the timeout will be checked only at every 25s. This causes the corner cases where the time has elapsed,but the logic still waits for 20s before checking timeout.
This delayed check triggers error when main thread checks for liveness of child thread.

#### How did you do it?
Move the timeout check from outer loop to inner loop.
Additionally, fix the logs to indicate that the traffic thread has timed out. The present log say timedout on warmboot, which is not true.

#### How did you verify/test it?
Tested multiple times on SKU with large number of ports, the issue was seen without fix, and not seen with this fix.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
