### PR TITLE
Use safe config reload for some tests

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -397,7 +397,7 @@ def teardown(duthosts, rand_one_dut_hostname):
     """
     yield
     duthost = duthosts[rand_one_dut_hostname]
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True)
 
 class AclVlanOuterTest_Base(object):
     """

--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -150,7 +150,7 @@ def common_setup_teardown(duthosts, ptfhost, enum_rand_one_per_hwsku_frontend_ho
         yield duthost, ptfhost, router_mac
     finally:
         #Recover DUT interface IP address
-        config_reload(duthost, config_source='config_db', wait=120)
+        config_reload(duthost, config_source='config_db', safe_reload=True)
 
 @pytest.fixture
 def garp_enabled(rand_selected_dut, config_facts):

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -496,7 +496,7 @@ def backup_bgp_config(duthost):
     try:
         apply_default_bgp_config(duthost)
     except Exception:
-        config_reload(duthost)
+        config_reload(duthost, safe_reload=True)
         apply_default_bgp_config(duthost)
 
 @pytest.fixture(scope="module")

--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -148,7 +148,7 @@ def swap_syncd(duthost, creds):
         )
 
     logger.info("Reloading config and restarting swss...")
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True)
 
     _perform_syncd_liveness_check(duthost)
 

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -365,7 +365,7 @@ def _setup_testbed(dut, creds, ptf, test_params, tbinfo):
         # NOTE: Even if the rpc syncd image is already installed, we need to restart
         # SWSS for the COPP changes to take effect.
         logging.info("Reloading config and restarting swss...")
-        config_reload(dut)
+        config_reload(dut, safe_reload=True)
 
     logging.info("Configure syncd RPC for testing")
     copp_utils.configure_syncd(dut, test_params.nn_target_port, test_params.nn_target_interface,
@@ -387,7 +387,7 @@ def _teardown_testbed(dut, creds, ptf, test_params, tbinfo):
     else:
         copp_utils.restore_syncd(dut, test_params.nn_target_namespace)
         logging.info("Reloading config and restarting swss...")
-        config_reload(dut)
+        config_reload(dut, safe_reload=True)
 
 def _setup_multi_asic_proxy(dut, creds, test_params, tbinfo):
     """

--- a/tests/ecmp/test_fgnhg.py
+++ b/tests/ecmp/test_fgnhg.py
@@ -579,7 +579,7 @@ def fg_ecmp_to_regular_ecmp_transitions(ptfhost, duthost, router_mac, net_ports,
 def cleanup(duthost, ptfhost):
     logger.info("Start cleanup")
     ptfhost.command('rm -f /tmp/fg_ecmp_persist_map.json')
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True)
 
 
 @pytest.fixture(scope="module")

--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -26,7 +26,7 @@ def restore_config_db(duthost):
     duthost.shell("mv /etc/sonic/config_db.json.bak /etc/sonic/config_db.json")
 
     # Reload to restore configuration
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True)
 
 @pytest.fixture(scope="module")
 def check_ntp_sync(duthosts, rand_one_dut_hostname):

--- a/tests/nat/conftest.py
+++ b/tests/nat/conftest.py
@@ -188,7 +188,7 @@ def apply_global_nat_config(duthost, config_nat_feature_enabled):
     nat_global_config(duthost)
     yield
     # reload config on teardown
-    config_reload(duthost, config_source='minigraph')
+    config_reload(duthost, config_source='minigraph', safe_reload=True)
 
 
 @pytest.fixture()
@@ -204,7 +204,7 @@ def reload_dut_config(request, duthost, setup_test_env):
     dut_iface = setup_data[interface_type]["vrf_conf"]["red"]["dut_iface"]
     gw_ip = setup_data[interface_type]["vrf_conf"]["red"]["gw"]
     mask = setup_data[interface_type]["vrf_conf"]["red"]["mask"]
-    config_reload(duthost, config_source='minigraph')
+    config_reload(duthost, config_source='minigraph', safe_reload=True)
     pch_ip = setup_info["pch_ips"][dut_iface]
     duthost.shell("sudo config interface ip remove {} {}/31".format(dut_iface, pch_ip))
     duthost.shell("sudo config interface ip add {} {}/{}".format(dut_iface, gw_ip, mask))


### PR DESCRIPTION
Change some tests to use safe config reload (which is to wait until all
docker containers are running before continuing). This is just a portion
of the tests that should be doing a safe config reload.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

Some test cases should be doing a safe config reload (`config reload` followed by waiting for docker containers to come back up). Make sure that before the test case proceeds/finishes, the containers are all up.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
