### PR TITLE
[copp] Reduce timeout in count_matched_packets to 2 sec

### DIFF
--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -119,7 +119,7 @@ class ControlPlaneBaseTest(BaseTest):
                 testutils.send_packet(self, send_intf, packet)
                 pre_send_count += 1
 
-            rcv_pkt_cnt = testutils.count_matched_packets(self, packet, recv_intf[1], recv_intf[0], timeout=5)
+            rcv_pkt_cnt = testutils.count_matched_packets(self, packet, recv_intf[1], recv_intf[0], timeout=2)
             self.log("Send %d and receive %d packets in the first second (PolicyTest)" % (pre_send_count, rcv_pkt_cnt))
 
 
@@ -144,7 +144,7 @@ class ControlPlaneBaseTest(BaseTest):
         self.log("Sent out %d packets in %ds" % (send_count, self.DEFAULT_SEND_INTERVAL_SEC))
 
         time.sleep(self.DEFAULT_RECEIVE_WAIT_TIME)  # Wait a little bit for all the packets to make it through
-        recv_count = testutils.count_matched_packets(self, packet, recv_intf[1], recv_intf[0], timeout=10)
+        recv_count = testutils.count_matched_packets(self, packet, recv_intf[1], recv_intf[0], timeout=2)
 
         post_test_ptf_tx_counter = self.dataplane.get_counters(*send_intf)
         post_test_ptf_rx_counter = self.dataplane.get_counters(*recv_intf)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes copp tests being stuck on count_matched_packets. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
[Enhance the copp test case](https://github.com/Azure/sonic-mgmt/pull/5402) added 5 and 10 seconds timeout to `testutils.count_matched_packets`. This timeout is passed on to [`dp_poll` function to inside a while True loop](https://github.com/p4lang/ptf/blob/405513bcad2eae3092b0ac4ceb31e8dec5e32311/src/ptf/testutils.py#L3639). Since expected packet is not passed to `dp_poll`, it simply checks if there is any packet within provided timeout period. This loop is only broken once `dp_poll` is no longer successful.
[Minigraph template](https://github.com/Azure/sonic-mgmt/blob/master/ansible/templates/minigraph_cpg.j2) sets keepalive timeout for BGP sessions to 3 seconds. 
This results in keepalive packets arriving every ~3 seconds, causing the loop never to break until [600 sec timeout](https://github.com/Azure/sonic-mgmt/blob/e2f1fbc84b3aaa0b7b66a29983779e3339408f5e/ansible/roles/test/files/ptftests/copp_tests.py#L39) is reached and test fails. 

#### How did you do it?
Set count_matched_packets timeout to 2 seconds.
#### How did you verify/test it?
Run any copp test:
`copp/test_copp.py::TestCOPP::test_no_policer[cab18-5-dut-BGP] PASSED `
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
