### PR TITLE
Increase the backup count of mux simulator logs

### DIFF
--- a/ansible/roles/vm_set/files/mux_simulator.py
+++ b/ansible/roles/vm_set/files/mux_simulator.py
@@ -137,7 +137,7 @@ def config_logging(http_port):
     rfh = RotatingFileHandler(
         '/tmp/mux_simulator_{}.log'.format(http_port),
         maxBytes=10*1024*1024,  # 10MB
-        backupCount=3)
+        backupCount=15)
     fmt = logging.Formatter('%(asctime)s %(levelname)s #%(lineno)d: %(message)s')
     rfh.setFormatter(fmt)
     rfh.setLevel(logging.DEBUG)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Currently the backup count of mux simulator logs is set to 3. This is not
enough later troubleshooting of mux simulator issues.

#### How did you do it?
This change increased the backup count from 3 to 15.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
