### PR TITLE
[loganalyzer] add err msg of bgpcfgd to ignore list

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -38,6 +38,12 @@ r, ".* ERR dhcp_relay.*setsockopt.*No such device.*"
 
 ##### White list below messages found on physical devices for now. Need to address them later.
 
+# https://dev.azure.com/msazure/One/_workitems/edit/14233578
+r, ".* ERR bgp#bgpcfgd: .*default|BGPSLBPassive.*attribute is supported.*"
+
+# https://dev.azure.com/msazure/One/_workitems/edit/14233579
+r, ".* ERR bgp#bgpcfgd: .*default|BGPVac.*attribute is supported.*"
+
 # https://dev.azure.com/msazure/One/_workitems/edit/14213168
 r, ".* ERR /hostcfgd: sonic-kdump-config --disable - failed.*"
 

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -39,10 +39,10 @@ r, ".* ERR dhcp_relay.*setsockopt.*No such device.*"
 ##### White list below messages found on physical devices for now. Need to address them later.
 
 # https://dev.azure.com/msazure/One/_workitems/edit/14233578
-r, ".* ERR bgp#bgpcfgd: .*default|BGPSLBPassive.*attribute is supported.*"
+r, ".* ERR bgp#bgpcfgd: .*BGPSLBPassive.*attribute is supported.*"
 
 # https://dev.azure.com/msazure/One/_workitems/edit/14233579
-r, ".* ERR bgp#bgpcfgd: .*default|BGPVac.*attribute is supported.*"
+r, ".* ERR bgp#bgpcfgd: .*BGPVac.*attribute is supported.*"
 
 # https://dev.azure.com/msazure/One/_workitems/edit/14213168
 r, ".* ERR /hostcfgd: sonic-kdump-config --disable - failed.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
In current bgpcfgd, only support peer update with 'admin_status' field, but for some BGP neighbors, there is no such field. When do the config load config_db.json operation, it will lead to err msg like below. Will lower it to warning, it would take some time to have this in next image, put this to ignore list at this time to avoid false alarm.
ERR bgp#bgpcfgd: Peer '(default|BGPSLBPassive)': Can't update the peer. Only 'admin_status' attribute is supported
This is the issue tracking these error messages: https://github.com/Azure/sonic-mgmt/issues/5410
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
