### PR TITLE
Added version check to the num_fans_drawer_fans setup function

### DIFF
--- a/tests/platform_tests/api/test_fan_drawer_fans.py
+++ b/tests/platform_tests/api/test_fan_drawer_fans.py
@@ -53,7 +53,10 @@ class TestFanDrawerFans(PlatformApiTestBase):
             try:
                 self.num_fan_drawers = chassis.get_num_fan_drawers(platform_api_conn)
             except:
-                pytest.fail("num_fans is not an integer")
+                if "201811" in duthost.os_version or "201911" in duthost.os_version:
+                    pytest.skip("Image version {} does not support API: num_fan_drawers, test will be skipped".format(duthost.os_version))
+                else:
+                    pytest.fail("num_fans is not an integer")
             else:
                 if self.num_fan_drawers == 0:
                     pytest.skip("No fan drawers found on device")


### PR DESCRIPTION
### Description of PR

###Summary:

The tests within the test_fan_drawer_fans script were all failing at the test setup step because a function call was throwing an exception. On further inspection it was discovered that the function that was being called was an unsupported API in the 201911 and 201811 SONiC OS versions. Code was added to skip those tests if either of these OSes were encountered.

### Type of change
- [x] Bug fix

### Back port request
- [x] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

To stop test failing at the setup step because a function call was throwing an exception.

#### How did you do it?

Skipped the test if it was being run on an unsupported OS.

#### How did you verify/test it?

Ran test on 201911 and 202012 and verified that additional tests were being skipped on the older OS:

**202012.63**: ==================== 9 passed, 4 skipped in 308.67 seconds =====================
**201911.83**: ========================= 13 skipped in 118.54 seconds =========================