### PR TITLE
[Mellanox] Fixed "AttributeError" in mellanox_thermal_control_test_helper.py

### DIFF
--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -1104,7 +1104,7 @@ class MinTableMocker(object):
     FAN_AMB_PATH = 'fan_amb'
     PORT_AMB_PATH = 'port_amb'
     TRUST_PATH = 'module1_temp_fault'
-    LIST_THERMAL_ZONE_TEMPERATURE_FILE= 'ls /run/hw-management/thermal/mlxsw*/thermal_zone_temp'
+    LIST_THERMAL_ZONE_TEMPERATURE_FILE = 'ls /run/hw-management/thermal/mlxsw*/thermal_zone_temp'
     NORMAL_TEMPERATURE = 40000
 
     def __init__(self, dut):
@@ -1133,11 +1133,11 @@ class MinTableMocker(object):
         self.mock_helper.mock_thermal_value(self.TRUST_PATH, str(trust_value))
 
     def mock_normal_temperature(self):
-        output = self.mock_helper.dut.shell(self.THERMAL_ZONE_TEMPERATURE_PATTERN)
+        output = self.mock_helper.dut.shell(self.LIST_THERMAL_ZONE_TEMPERATURE_FILE)
         for thermal_file in output['stdout_lines']:
             if self.mock_helper.read_value(thermal_file) != '0':
                 self.mock_helper.mock_value(thermal_file, self.NORMAL_TEMPERATURE)
-        
+
     def deinit(self):
         """
         Destructor of MinTableMocker.


### PR DESCRIPTION
### Description of PR
Fixed _platform_tests.mellanox.test_thermal_control#test_dynamic_minimum_table_
`AttributeError: 'MinTableMocker' object has no attribute 'THERMAL_ZONE_TEMPERATURE_PATTERN'` in mellanox_thermal_control_test_helper.py

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Approach
#### What is the motivation for this PR?
Fix the error in the test

#### How did you verify/test it?
By running test_thermal_control.py

#### Any platform specific information?
Mellanox
