### PR TITLE
[tacacs]: Update test to use SONiC reboot

### DIFF
--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -5,6 +5,7 @@ from tests.common.devices.base import RunAnsibleModuleFail
 from tests.common.utilities import wait_until
 from tests.common.utilities import skip_release
 from tests.common.utilities import wait
+from tests.common.reboot import reboot
 from .test_ro_user import ssh_remote_run
 from .utils import setup_tacacs_client
 
@@ -45,7 +46,7 @@ def chk_ssh_remote_run(localhost, remote_ip, username, password, cmd):
     return rc == 0
 
 
-def do_reboot(duthost, localhost, dutip="", rw_user="", rw_pass=""):
+def do_reboot(duthost, localhost, duthosts, rw_user="", rw_pass=""):
     # occasionally reboot command fails with some kernel error messages
     # Hence retry if needed.
     #
@@ -54,15 +55,13 @@ def do_reboot(duthost, localhost, dutip="", rw_user="", rw_pass=""):
     rebooted = False
 
     for i in range(retries):
-        # Regular reboot command would not work, as it would try to
-        # collect show tech, which will fail in RO state.
         #
         try:
-            if dutip:
-                chk_ssh_remote_run(localhost, dutip, rw_user, rw_pass, "sudo /sbin/reboot")
-            else:
-                duthost.shell("/sbin/reboot")
-
+            # Reboot DUT using reboot function instead of using ssh_remote_run.
+            # ssh_remote_run gets blocked due to console messages from reboot on DUT
+            # Do not wait for ssh as next step checks if ssh is stopped to ensure DUT is
+            # is rebooting.
+            reboot(duthost, localhost, wait_for_ssh=False)
             localhost.wait_for(host=duthost.mgmt_ip, port=22, state="stopped", delay=5, timeout=60)
             rebooted = True
             break
@@ -75,7 +74,14 @@ def do_reboot(duthost, localhost, dutip="", rw_user="", rw_pass=""):
     wait(wait_time, msg="Wait {} seconds for system to be stable.".format(wait_time))
     assert wait_until(300, 20, 0, duthost.critical_services_fully_started), \
             "All critical services should fully started!"
-
+    # If supervisor node is rebooted in chassis, linecards also will reboot.
+    # Check if all linecards are back up.
+    if duthost.is_supervisor_node():
+        for host in duthosts:
+            if host != duthost:
+                logger.info("checking if {} critical services are up".format(host.hostname))
+                assert wait_until(300, 20, 0, host.critical_services_fully_started), \
+                        "All critical services of {} should fully started!".format(host.hostname)
 
 def do_setup_tacacs(ptfhost, duthost, tacacs_creds):
     logger.info('Upon reboot: setup tacacs_creds')
@@ -128,7 +134,7 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
         #
         logger.info("PRETEST: reboot {} to restore system state".
                 format(enum_rand_one_per_hwsku_hostname))
-        do_reboot(duthost, localhost)
+        do_reboot(duthost, localhost, duthosts)
         assert do_check_clean_state(duthost), "state not good even after reboot"
         do_setup_tacacs(ptfhost, duthost, tacacs_creds)
 
@@ -168,6 +174,10 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
         # Remove file, so the reboot at the end of test will revert this logs redirect.
         duthost.shell("rm /etc/rsyslog.d/000-ro_disk.conf") 
 
+        # Enable AAA failthrough authentication so that duthost.shell can be used
+        # to reboot DUT 
+        duthost.shell("config aaa authentication failthrough enable")
+
         # Set disk in RO state
         simulate_ro(duthost)
 
@@ -203,7 +213,6 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
     finally:
         logger.debug("START: reboot {} to restore disk RW state".
                 format(enum_rand_one_per_hwsku_hostname))
-        do_reboot(duthost, localhost, dutip, rw_user, rw_pass)
-        assert wait_until(600, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        do_reboot(duthost, localhost, duthosts, rw_user, rw_pass)
         logger.debug("  END: reboot {} to restore disk RW state".
                 format(enum_rand_one_per_hwsku_hostname))

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -174,7 +174,7 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
         # Remove file, so the reboot at the end of test will revert this logs redirect.
         duthost.shell("rm /etc/rsyslog.d/000-ro_disk.conf") 
 
-        # Enable AAA failthrough authentication so that duthost.shell can be used
+        # Enable AAA failthrough authentication so that reboot function can be used
         # to reboot DUT 
         duthost.shell("config aaa authentication failthrough enable")
 


### PR DESCRIPTION
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
test_ro_disk uses /sbin/reboot to reboot DUT after converting disk to read-only state.
/sbin/reboot can put chassis in bad sate as in chassis there is an order in which the components should be rebooted.
SONiC reboot will handle the order based on the DUT platform.
#### How did you do it?
- Modify to use SONiC reboot
- Remove redundant critical_services_fully_started as do_reboot already does this check
- If supervisor is rebooted, linecards will also reboot, hence check critical services on linecards as well.
#### How did you verify/test it?
Verified on single asic DUT:
```
18:59:51 utilities.check_skip_release             L0036 INFO   | DUT has version 20201231.65 and test does not support 201811, 201911, 202012, 202106
19:00:01 utils.check_all_services_status          L0024 INFO   | [u' [ - ]  cgmanager', u' [ - ]  cgproxy', u' [ - ]  cron', u' [ - ]  dbus', u' [ - ]  exim4', u' [ - ]  ntp', u' [ - ]  procps', u' [ - ]  rsync', u' [ - ]  rsyslog', u' [ + ]  ssh', u' [ - ]  tacacs_plus']
19:00:09 utils.check_all_services_status          L0024 INFO   | [u' [ - ]  cgmanager', u' [ - ]  cgproxy', u' [ - ]  cron', u' [ - ]  dbus', u' [ - ]  exim4', u' [ - ]  ntp', u' [ - ]  procps', u' [ - ]  rsync', u' [ - ]  rsyslog', u' [ + ]  ssh', u' [ + ]  tacacs_plus']
19:00:09 __init__.loganalyzer                     L0048 INFO   | Log analyzer is disabled
--------------------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------------------
19:00:22 test_ro_disk.test_ro_disk                L0147 INFO   | del user test_rouser done
19:00:34 test_ro_disk.simulate_ro                 L0035 INFO   | Disk turned to RO state; pause for 30s before attempting to ssh
19:00:35 test_ro_disk.check_disk_ro               L0029 INFO   | touch file failed as expected
...
...
19:01:55 reboot.execute_reboot_command            L0141 INFO   | rebooting DUT with command "reboot"
19:03:39 utilities.wait                           L0078 INFO   | Pause 20 seconds, reason: Wait 20 seconds for system to be stable.
PASSED                                                                                                                                                                                            [100%]
------------------------------------------------------------------------------------------- live log teardown -------------------------------------------------------------------------------------------
19:06:48 utils.check_all_services_status          L0024 INFO   | [u' [ - ]  cgmanager', u' [ - ]  cgproxy', u' [ - ]  cron', u' [ - ]  dbus', u' [ - ]  exim4', u' [ - ]  ntp', u' [ - ]  procps', u' [ - ]  rsync', u' [ - ]  rsyslog', u' [ + ]  ssh', u' [ - ]  tacacs_plus']
19:07:15 utilities.check_skip_release             L0036 INFO   | DUT has version 20201231.65 and test does not support 201811, 201911, 202012, 202106


------------------------------------------------------------------------ generated xml file: /data/sonic-mgmt/tests/logs/tr.xml -------------------------------------------------------------------------
---------------------------------------------------------------------------------------- live log sessionfinish -----------------------------------------------------------------------------------------
19:07:21 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
====================================================================================== 1 passed in 493.05 seconds =======================================================================================
```
Verified on Chassis.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
