### PR TITLE
[xfail] remove xfail for TestCOPP::test_add_new_trap

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -31,15 +31,8 @@ cacl/test_cacl_application.py::test_cacl_application:
 #######################################
 #####            copp             #####
 #######################################
-copp/test_copp.py::TestCOPP::test_add_new_trap:
-  xfail:
-    reason: "'Add always_enabled field to coppmgr' is not merged into 202012 yet, a 'strict' param will remind us to remove this mark condition by setting 'xpass' as 'fail'"
-    strict: True
-    conditions:
-      - "release in ['202012']"
-
 copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
-  skip:
+  xfail:
     reason: "'Add always_enabled field to coppmgr' is not merged into 202012 yet"
     conditions:
       - "release in ['202012']"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
TestCOPP::test_add_new_trap is in the xfail list due to mismatch between testcase and image, now the image fix is merged, and the testcase can consistently pass now, remove it from the xfail list.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
