### PR TITLE
Fix the issue of finding test server IP address from inventory file

### DIFF
--- a/ansible/library/vmhost_server_info.py
+++ b/ansible/library/vmhost_server_info.py
@@ -22,9 +22,6 @@ EXAMPLES = '''
       vmhost_server_info: vmhost_server_name='server_1' vm_file='veos'
 '''
 
-# Here we assume that the group name of host server starts with 'vm_host_'.
-VMHOST_PREFIX = "vm_host_"
-
 VM_INV_FILE = 'veos'
 
 def main():
@@ -36,15 +33,22 @@ def main():
         supports_check_mode=True
     )
     m_args = module.params
-    vmhost_group_name = VMHOST_PREFIX + m_args['vmhost_server_name'].split('_')[-1]
-    inv_mgr = InventoryManager(loader=DataLoader(), sources=m_args['vm_file'])
-    all_hosts = inv_mgr.get_hosts(pattern=vmhost_group_name)
-    if len(all_hosts) != 1:
-        module.fail_json(msg="{} host servers are found in {}, which should be 1".format(len(all_hosts), vmhost_group_name))
+    vmhost_server_name = m_args["vmhost_server_name"]
+    vm_file = m_args["vm_file"]
+
+    inv_mgr = InventoryManager(loader=DataLoader(), sources=vm_file)
+
+    all_hosts = inv_mgr.get_hosts(pattern=vmhost_server_name)
+    if len(all_hosts) == 0:
+        module.fail_json(msg="No host matches {} in inventory file {}".format(vmhost_server_name, vm_file))
     else:
-        module.exit_json(ansible_facts={'vmhost_server_address':all_hosts[0].get_vars()['ansible_host']})
+        for host in all_hosts:
+            if host.name.startswith('VM'):
+                continue
+            module.exit_json(ansible_facts={"vmhost_server_address": host.get_vars()["ansible_host"]})
+        else:
+            module.fail_json(msg="Unable to find IP address of host server {} in inventory file {}".format(vmhost_server_name, vm_file))
 
 from ansible.module_utils.basic import *
 if __name__ == "__main__":
     main()
-

--- a/ansible/library/vmhost_server_info.py
+++ b/ansible/library/vmhost_server_info.py
@@ -46,8 +46,8 @@ def main():
             if host.name.startswith('VM'):
                 continue
             module.exit_json(ansible_facts={"vmhost_server_address": host.get_vars()["ansible_host"]})
-        else:
-            module.fail_json(msg="Unable to find IP address of host server {} in inventory file {}".format(vmhost_server_name, vm_file))
+
+        module.fail_json(msg="Unable to find IP address of host server {} in inventory file {}".format(vmhost_server_name, vm_file))
 
 from ansible.module_utils.basic import *
 if __name__ == "__main__":


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Customized ansible module `vmhost_server_info` is for finding out IP
address of the test server based on server name.

This module is used by the playbook for configuring y_cable of dualtor topo.

This module assumes that all the test server hostname is defined as
`vm_host_xx`. This is not robust enough and may get wrong result under
some scenarios.

#### How did you do it?
This change improved robustness of this module. It firstly finds out all
the hosts belong to group specified by argument vmhost_server_name.
Then the first host which does not start with "VM" should be the test
server. This method is more robust.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
