### PR TITLE
[test gap] Add idle timeout test. 

### DIFF
--- a/tests/dut_console/test_idle_timeout.py
+++ b/tests/dut_console/test_idle_timeout.py
@@ -13,7 +13,7 @@ SET_TMOUT = "10"
 def test_timeout(duthost_console, duthost):
     logger.info("Get default session idle timeout")
     default_tmout = duthost_console.send_command('echo $TMOUT')
-    pytest_assert(default_tmout == DEFAULT_TMOUT, "default timeout on dut is not 900 seconds")
+    pytest_assert(default_tmout == DEFAULT_TMOUT, "default timeout on dut is not {} seconds".format(DEFAULT_TMOUT))
 
     logger.info("Set session idle timeout")
     duthost_console.send_command('export TMOUT={}'.format(SET_TMOUT))
@@ -21,4 +21,4 @@ def test_timeout(duthost_console, duthost):
     pytest_assert(set_tmout == SET_TMOUT, "set timeout fail")
 
     time.sleep(15)
-    duthost_console.send_command("\n", expect_string=r"str-s6000-on-6 login:")
+    duthost_console.send_command("\n", expect_string=r"{} login:".format(duthost.hostname))

--- a/tests/dut_console/test_idle_timeout.py
+++ b/tests/dut_console/test_idle_timeout.py
@@ -10,8 +10,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_TMOUT = "900"
 SET_TMOUT = "10"
 
-
-@pytest.fixture(scope="module")
 def test_timeout(duthost_console, duthost):
     logger.info("Get default session idle timeout")
     default_tmout = duthost_console.send_command('echo $TMOUT')

--- a/tests/dut_console/test_idle_timeout.py
+++ b/tests/dut_console/test_idle_timeout.py
@@ -1,0 +1,26 @@
+import pytest
+import pexpect
+import logging
+import time
+
+from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TMOUT = "900"
+SET_TMOUT = "10"
+
+
+@pytest.fixture(scope="module")
+def test_timeout(duthost_console, duthost):
+    logger.info("Get default session idle timeout")
+    default_tmout = duthost_console.send_command('echo $TMOUT')
+    pytest_assert(default_tmout == DEFAULT_TMOUT, "default timeout on dut is not 900 seconds")
+
+    logger.info("Set session idle timeout")
+    duthost_console.send_command('export TMOUT={}'.format(SET_TMOUT))
+    set_tmout = duthost_console.send_command('echo $TMOUT')
+    pytest_assert(set_tmout == SET_TMOUT, "set timeout fail")
+
+    time.sleep(15)
+    duthost_console.send_command("\n", expect_string=r"str-s6000-on-6 login:")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Linux-Unix shell variable `TMOUT` provides the “Auto Logout Functionality” for the login shell in case of no activity for a specified time. In this case, we will test if it can logout after the specified time in case of no activity.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Linux-Unix shell variable `TMOUT` provides the “Auto Logout Functionality” for the login shell in case of no activity for a specified time. In this case, we will test if it can logout after the specified time in case of no activity.

#### How did you do it?
The default `TMOUT` value of sonic is 900s, it's too long for us to test. So, firstly, modify the `TMOUT` value to 10s. Then, wait for more than 10s and observe whether the console session is logout.  

#### How did you verify/test it?
Modify the `TMOUT` value to 10s and wait for more than 10s to observe whether the console session is logout.  

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
