### PR TITLE
[subport][loganalyzer] Fix subport loganalyzer errors

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -575,3 +575,17 @@ def teardown_test_class(duthost):
     """
     yield
     config_reload(duthost)
+
+
+def pytest_generate_tests(metafunc):
+    # try to put fixture loganalyzer after fixture reload_dut_config, during
+    # teardown, loganalyzer will be executed before reload_dut_config, so any
+    # log error introduced by config load will be skipped.
+    try:
+        metafunc.fixturenames.index("loganalyzer")
+        reload_dut_config_index = metafunc.fixturenames.index("reload_dut_config")
+    except ValueError:
+        return
+    else:
+        metafunc.fixturenames.remove("loganalyzer")
+        metafunc.fixturenames.insert(reload_dut_config_index + 1, "loganalyzer")


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix the test failures introduced by loganalyzer for subport related testcases:
```
'May  4 22:59:06.547748 str2-7050qx-32s-acs-03 ERR swss#intfmgrd: :- setIntfIp: Command \'/sbin/ip address "add" "10.0.0.36/31" dev "Ethernet12.10"\' failed with rc 2\n', 
```
#### How did you do it?
For those failures, they are caused by the `config load` command inside the fixture `reload_dut_config`, which try to restore the config db after each testcase finished. So moving the `loganalyzer` fixture after `reload_dut_config` fixture in the fixtures list to let `loganalyzer` teardown executes before `reload_dut_config` fixture teardown, so syslog errors after `config load` will not be able to fail the testcases.

#### How did you verify/test it?
```
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_packet_routed_with_valid_vlan[port] PASSED                                                                                                                                                         [100%]


========================================================================================================================= 1 passed in 442.70 seconds =========================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
