### PR TITLE
[autorestart] Ignore known swss/syncd/teamd log

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -75,6 +75,8 @@ def ignore_expected_loganalyzer_exception(duthosts, enum_dut_feature_container,
             ".*ERR syncd[0-9]*#syncd.*sendApiResponse: api SAI_COMMON_API_SET failed in syncd mode.*",
             ".*ERR syncd[0-9]*#syncd.*processQuadEvent.*",
             ".*WARNING syncd[0-9]*#syncd.*skipping since it causes crash.*",
+            # Known issue, captured here: https://github.com/Azure/sonic-buildimage/issues/10000 , ignore it for now
+            ".*ERR swss[0-9]*#fdbsyncd.*readData.*netlink reports an error=-25 on reading a netlink socket.*",
             ".*ERR swss[0-9]*#portsyncd.*readData.*netlink reports an error=-33 on reading a netlink socket.*",
             ".*ERR teamd[0-9]*#teamsyncd.*readData.*netlink reports an error=-33 on reading a netlink socket.*",
             ".*ERR swss[0-9]*#orchagent.*set status: SAI_STATUS_ATTR_NOT_IMPLEMENTED_0.*",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #5573 
ignore known log: ERR swss#fdbsyncd: :- readData: netlink reports an error=-25 on reading a netlink socket
captured in: https://github.com/Azure/sonic-buildimage/issues/10000
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Fixes #5573 
ignore known log: ERR swss#fdbsyncd: :- readData: netlink reports an error=-25 on reading a netlink socket
captured in: https://github.com/Azure/sonic-buildimage/issues/10000
#### How did you do it?
Ignore the log
#### How did you verify/test it?
Run on physical testbeds, all of them passed
=== Running tests in groups ===
============================= test session starts ==============================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: celery-4.4.7, forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, ansible-2.2.2
collected 20 items

autorestart/test_container_autorestart.py::test_containers_autorestart[*-*|lldp] PASSED [  5%]
autorestart/test_container_autorestart.py::test_containers_autorestart[*-*|pmon] PASSED [ 10%]
autorestart/test_container_autorestart.py::test_containers_autorestart[*-*|database] SKIPPED [ 15%]
autorestart/test_container_autorestart.py::test_containers_autorestart[*-*|telemetry] PASSED [ 20%]
autorestart/test_container_autorestart.py::test_containers_autorestart[*-*|snmp] PASSED [ 25%]
autorestart/test_container_autorestart.py::test_containers_autorestart[*-*|bgp] PASSED [ 30%]
autorestart/test_container_autorestart.py::test_containers_autorestart[*-*|radv] SKIPPED [ 35%]
autorestart/test_container_autorestart.py::test_containers_autorestart[*-*|teamd] PASSED [ 40%]
autorestart/test_container_autorestart.py::test_containers_autorestart[*-*|dhcp_relay] PASSED [ 45%]
autorestart/test_container_autorestart.py::test_containers_autorestart[*-*|swss] PASSED [ 50%]
autorestart/test_container_autorestart.py::test_containers_autorestart[*-*|syncd] PASSED [ 55%]
metadata-scripts/test_metadata_upgrade_path.py::test_cancelled_upgrade_path[warm-*] SKIPPED [ 60%]
metadata-scripts/test_metadata_upgrade_path.py::test_upgrade_path[warm-*] SKIPPED [ 65%]
metadata-scripts/test_metadata_upgrade_path.py::test_warm_upgrade_sad_path[warm-sad-*] SKIPPED [ 70%]
metadata-scripts/test_metadata_upgrade_path.py::test_warm_upgrade_sad_path[warm-multi_sad-*] SKIPPED [ 75%]
metadata-scripts/test_metadata_upgrade_path.py::test_warm_upgrade_sad_path[warm-sad_bgp-*] SKIPPED [ 80%]
metadata-scripts/test_metadata_upgrade_path.py::test_warm_upgrade_sad_path[warm-sad_lag_member-*] SKIPPED [ 85%]
metadata-scripts/test_metadata_upgrade_path.py::test_warm_upgrade_sad_path[warm-sad_lag-*] SKIPPED [ 90%]
metadata-scripts/test_metadata_upgrade_path.py::test_warm_upgrade_sad_path[warm-sad_vlan_port-*] SKIPPED [ 95%]
metadata-scripts/test_metadata_upgrade_path.py::test_warm_upgrade_sad_path[warm-sad_inboot-*] SKIPPED [100%]

-------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml ---------
=========================== short test summary info ============================
SKIPPED [9] /var/src/sonic-mgmt-int/tests/metadata-scripts/test_metadata_upgrade_path.py:39: base_image_list or target_image_list is empty
SKIPPED [1] /var/src/sonic-mgmt-int/tests/common/helpers/assertions.py:13: Skipping test for container radv
SKIPPED [1] /var/src/sonic-mgmt-int/tests/common/helpers/assertions.py:13: Skipping test for container database
=================== 9 passed, 11 skipped in 1731.91 seconds ====================

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
