### PR TITLE
[macsec]: Reduce Azp MACsec testcases

### DIFF
--- a/.azure-pipelines/run-test-template.yml
+++ b/.azure-pipelines/run-test-template.yml
@@ -59,6 +59,8 @@ steps:
     parent_dir=$(basename $PWD)
     docker exec sonic-mgmt-2 bash -c "/var/src/$parent_dir/tests/kvmtest.sh -en -T ${{ parameters.tbtype }} -d /var/src/$parent_dir ${{ parameters.tbname }} ${{ parameters.dut }} ${{ parameters.section }}"
   displayName: "Run tests"
+  ${{ if eq(parameters.tbtype, 't0-sonic') }}:
+      continueOnError: true
 
 - script: |
     # save dut state if test fails

--- a/.azure-pipelines/run-test-template.yml
+++ b/.azure-pipelines/run-test-template.yml
@@ -59,8 +59,6 @@ steps:
     parent_dir=$(basename $PWD)
     docker exec sonic-mgmt-2 bash -c "/var/src/$parent_dir/tests/kvmtest.sh -en -T ${{ parameters.tbtype }} -d /var/src/$parent_dir ${{ parameters.tbname }} ${{ parameters.dut }} ${{ parameters.section }}"
   displayName: "Run tests"
-  ${{ if eq(parameters.tbtype, 't0-sonic') }}:
-      continueOnError: true
 
 - script: |
     # save dut state if test fails

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -15,7 +15,7 @@ Description:
   -n
        Do not refresh DUT
   -t testbed_file
-       testbed file (default: vtestbed.csv)
+       testbed file (default: vtestbed.yaml)
   -T test_suite
        test suite [t0|t1-lag] (default: t0)
   tbname
@@ -31,7 +31,7 @@ EOF
 }
 
 inventory="../ansible/veos_vtb"
-testbed_file="vtestbed.csv"
+testbed_file="vtestbed.yaml"
 refresh_dut=true
 exit_on_error=""
 SONIC_MGMT_DIR=/data/sonic-mgmt

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -200,7 +200,7 @@ test_t0_sonic() {
       macsec/test_macsec.py"
 
     pushd $SONIC_MGMT_DIR/tests
-    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e "--neighbor_type=sonic --enable_macsec --macsec_profile=256_XPN_SCI"
+    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e "--neighbor_type=sonic --enable_macsec --macsec_profile=128,256_XPN_SCI"
     popd
 }
 

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -15,7 +15,7 @@ Description:
   -n
        Do not refresh DUT
   -t testbed_file
-       testbed file (default: vtestbed.yaml)
+       testbed file (default: vtestbed.csv)
   -T test_suite
        test suite [t0|t1-lag] (default: t0)
   tbname
@@ -31,7 +31,7 @@ EOF
 }
 
 inventory="../ansible/veos_vtb"
-testbed_file="vtestbed.yaml"
+testbed_file="vtestbed.csv"
 refresh_dut=true
 exit_on_error=""
 SONIC_MGMT_DIR=/data/sonic-mgmt
@@ -200,7 +200,7 @@ test_t0_sonic() {
       macsec/test_macsec.py"
 
     pushd $SONIC_MGMT_DIR/tests
-    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e "--neighbor_type=sonic --enable_macsec"
+    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e "--neighbor_type=sonic --enable_macsec --macsec_profile=256_XPN_SCI"
     popd
 }
 

--- a/tests/macsec/macsec_helper.py
+++ b/tests/macsec/macsec_helper.py
@@ -128,11 +128,11 @@ def get_mka_session(host):
     130: macsec_eth29: protect on validate strict sc off sa off encrypt on send_sci on end_station off scb off replay off
         cipher suite: GCM-AES-128, using ICV length 16
         TXSC: 52540041303f0001 on SA 0
-            0: PN 1041, state on, key 0ecddfe0f462491c13400dbf7433465d
-            3: PN 2044, state off, key 0ecddfe0f462491c13400dbf7433465d
+            0: PN 1041, state on, SSCI 16777216, key 0ecddfe0f462491c13400dbf7433465d
+            3: PN 2044, state off, SSCI 16777216, key 0ecddfe0f462491c13400dbf7433465d
         RXSC: 525400b5be690001, state on
-            0: PN 1041, state on, key 0ecddfe0f462491c13400dbf7433465d
-            3: PN 0, state on, key 0ecddfe0f462491c13400dbf7433465d
+            0: PN 1041, state on, SSCI 16777216, key 0ecddfe0f462491c13400dbf7433465d
+            3: PN 0, state on, SSCI 16777216, key 0ecddfe0f462491c13400dbf7433465d
     131: macsec_eth30: protect on validate strict sc off sa off encrypt on send_sci on end_station off scb off replay off
         cipher suite: GCM-AES-128, using ICV length 16
         TXSC: 52540041303f0001 on SA 0
@@ -170,7 +170,7 @@ def get_mka_session(host):
             sc_obj = {
                 "sas": {}
             }
-            sa_pattern = r" +([0-3]): PN (\d+), state (on|off), key ([\da-fA-F]+)"
+            sa_pattern = r" +([0-3]): PN (\d+), state (on|off),.* key ([\da-fA-F]+)"
             sas = re.finditer(sa_pattern, sc.group(6))
             for sa in sas:
                 sa_obj = {

--- a/tests/macsec/profile.json
+++ b/tests/macsec/profile.json
@@ -62,6 +62,6 @@
         "primary_ckn": "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435",
         "policy": "security",
         "send_sci": "true",
-        "rekey_period": 120
+        "rekey_period": 240
     }
 }

--- a/tests/macsec/profile.json
+++ b/tests/macsec/profile.json
@@ -5,8 +5,7 @@
         "primary_cak": "0123456789ABCDEF0123456789ABCDEF",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F70",
         "policy": "security",
-        "send_sci": "false",
-        "rekey_period": 240
+        "send_sci": "false"
     },
     "256": {
         "priority": 64,
@@ -62,6 +61,7 @@
         "primary_cak": "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
         "primary_ckn": "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435",
         "policy": "security",
-        "send_sci": "true"
+        "send_sci": "true",
+        "rekey_period": 120
     }
 }

--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -74,22 +74,24 @@ class TestControlPlane():
     def test_rekey_by_period(self, duthost, ctrl_links, upstream_links, rekey_period):
         if rekey_period == 0:
             pytest.skip("If the rekey period is 0 which means rekey by period isn't active.")
-        for port_name, nbr in ctrl_links.items():
-            _, _, _, last_dut_egress_sa_table, last_dut_ingress_sa_table = get_appl_db(
-                duthost, port_name, nbr["host"], nbr["port"])
-            _, _, _, last_nbr_egress_sa_table, last_nbr_ingress_sa_table = get_appl_db(
-                nbr["host"], nbr["port"], duthost, port_name)
-            up_link = upstream_links[port_name]
-            output = duthost.command("ping {} -w {} -q -i 0.1".format(up_link["local_ipv4_addr"], rekey_period * 2))["stdout_lines"]
-            _, _, _, new_dut_egress_sa_table, new_dut_ingress_sa_table = get_appl_db(
-                duthost, port_name, nbr["host"], nbr["port"])
-            _, _, _, new_nbr_egress_sa_table, new_nbr_ingress_sa_table = get_appl_db(
-                nbr["host"], nbr["port"], duthost, port_name)
-            assert last_dut_egress_sa_table != new_dut_egress_sa_table
-            assert last_dut_ingress_sa_table != new_dut_ingress_sa_table
-            assert last_nbr_egress_sa_table != new_nbr_egress_sa_table
-            assert last_nbr_ingress_sa_table != new_nbr_ingress_sa_table
-            assert float(re.search(r"([\d\.]+)% packet loss", output[-2]).group(1)) < 1.0
+        assert len(ctrl_links) > 0
+        # Only pick one link to test
+        port_name, nbr = ctrl_links.items()[0]
+        _, _, _, last_dut_egress_sa_table, last_dut_ingress_sa_table = get_appl_db(
+            duthost, port_name, nbr["host"], nbr["port"])
+        _, _, _, last_nbr_egress_sa_table, last_nbr_ingress_sa_table = get_appl_db(
+            nbr["host"], nbr["port"], duthost, port_name)
+        up_link = upstream_links[port_name]
+        output = duthost.command("ping {} -w {} -q -i 0.1".format(up_link["local_ipv4_addr"], rekey_period * 2))["stdout_lines"]
+        _, _, _, new_dut_egress_sa_table, new_dut_ingress_sa_table = get_appl_db(
+            duthost, port_name, nbr["host"], nbr["port"])
+        _, _, _, new_nbr_egress_sa_table, new_nbr_ingress_sa_table = get_appl_db(
+            nbr["host"], nbr["port"], duthost, port_name)
+        assert last_dut_egress_sa_table != new_dut_egress_sa_table
+        assert last_dut_ingress_sa_table != new_dut_ingress_sa_table
+        assert last_nbr_egress_sa_table != new_nbr_egress_sa_table
+        assert last_nbr_ingress_sa_table != new_nbr_ingress_sa_table
+        assert float(re.search(r"([\d\.]+)% packet loss", output[-2]).group(1)) < 1.0
 
 
 class TestDataPlane():

--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -79,18 +79,12 @@ class TestControlPlane():
         port_name, nbr = ctrl_links.items()[0]
         _, _, _, last_dut_egress_sa_table, last_dut_ingress_sa_table = get_appl_db(
             duthost, port_name, nbr["host"], nbr["port"])
-        _, _, _, last_nbr_egress_sa_table, last_nbr_ingress_sa_table = get_appl_db(
-            nbr["host"], nbr["port"], duthost, port_name)
         up_link = upstream_links[port_name]
         output = duthost.command("ping {} -w {} -q -i 0.1".format(up_link["local_ipv4_addr"], rekey_period * 2))["stdout_lines"]
         _, _, _, new_dut_egress_sa_table, new_dut_ingress_sa_table = get_appl_db(
             duthost, port_name, nbr["host"], nbr["port"])
-        _, _, _, new_nbr_egress_sa_table, new_nbr_ingress_sa_table = get_appl_db(
-            nbr["host"], nbr["port"], duthost, port_name)
         assert last_dut_egress_sa_table != new_dut_egress_sa_table
         assert last_dut_ingress_sa_table != new_dut_ingress_sa_table
-        assert last_nbr_egress_sa_table != new_nbr_egress_sa_table
-        assert last_nbr_ingress_sa_table != new_nbr_ingress_sa_table
         assert float(re.search(r"([\d\.]+)% packet loss", output[-2]).group(1)) < 1.0
 
 


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Reduce the MACsec testcases on Azp for decreasing the checking time.
Needing to wait for a fix PR: https://github.com/Azure/sonic-buildimage/pull/10767

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Reduce the Azp checking time.

#### How did you do it?
1. Choose only one profile `256_XPN_SCI` instead of all profiles
2. To rekey test, only check one link instead of all control links.

#### How did you verify/test it?
Check Azp.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
