### PR TITLE
Ignore error logs in `test_acl`

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -382,6 +382,8 @@ def acl_table(duthosts, rand_one_dut_hostname, setup, stage, ip_version):
 
         try:
             loganalyzer.expect_regex = [LOG_EXPECT_ACL_TABLE_CREATE_RE]
+            # Ignore any other errors to reduce noise
+            loganalyzer.ignore_regex = [r".*"]
             with loganalyzer:
                 create_or_remove_acl_table(duthost, acl_table_config, setup, "add")
         except LogAnalyzerError as err:
@@ -471,6 +473,8 @@ class BaseAclTest(object):
 
             try:
                 loganalyzer.expect_regex = [LOG_EXPECT_ACL_RULE_CREATE_RE]
+                # Ignore any other errors to reduce noise
+                loganalyzer.ignore_regex = [r".*"]
                 with loganalyzer:
                     self.setup_rules(duthost, acl_table, ip_version)
 


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to update `test_acl` to ignore errors.
We saw many test errors in `test_acl` caused by irrelevant error logs. Actually, the ACL feature works fine.
This PR ignores the errors by adding `r".*"` into `ignore_regex` of the local `LogAnalyzer` in `test_acl`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
This PR is to update `test_acl` to ignore errors.

#### How did you do it?
This PR ignores the errors by adding `r".*"` into `ignore_regex` of the local `LogAnalyzer` in `test_acl`.

#### How did you verify/test it?
Verified on arista-7260 testbed, running master image.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
