### PR TITLE
fixed startup of QoS SAI tests

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -182,7 +182,7 @@ def ptf_portmap_file(duthosts, rand_one_dut_hostname, ptfhost):
         file.write("# ptf host interface @ switch front port name\n")
         file.writelines(
             map(
-                    lambda index, port: "{0}@{1}\n".format(index, port),
+                    lambda v: "{0}@{1}\n".format(v[0], v[1]),
                     enumerate(portList)
                 )
             )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fixed startup of QoS SAI tests
Fixes # (issue)
QoS SAI tests fail with the error on ptfhost_utils.py:185 :
> `TypeError: <lambda>() takes exactly 2 arguments (1 given)`

Fixed it

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix QoS SAI tests
#### How did you do it?
Fixed syntax issue in `map` func usage
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t1,any qos/test_qos_sai.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
