### PR TITLE
Loosen criteria of CPU usage check for `sx_sdk`

### DIFF
--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -25,6 +25,10 @@ def setup_thresholds(duthosts, enum_rand_one_per_hwsku_hostname):
         memory_threshold = 80
     if duthost.facts['platform'] in ('x86_64-arista_7260cx3_64'):
         high_cpu_consume_procs['syncd'] = 80
+    # The CPU usage of `sx_sdk` on mellanox is expected to be higher, and the actual CPU usage
+    # is correlated with the number of ports. So we ignore the check of CPU for sx_sdk
+    if duthost.facts["asic_type"] == 'mellanox':
+        high_cpu_consume_procs['sx_sdk'] = 90
     return memory_threshold, cpu_threshold, high_cpu_consume_procs
 
 


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to loosen the criteria of CPU usage of `sx_sdk` on `Mellanox` platform.
The CPU usage of `sx_sdk` is expected to be high, and the actuall usage is correlated with the number of ports.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
This PR is to loosen the criteria of CPU usage of `sx_sdk` on `Mellanox` platform.

#### How did you do it?
Loosen the up limit of CPU usage of `sx_sdk` to `90`.

#### How did you verify/test it?
Verified on SN4600c. Test can pass now.

#### Any platform specific information?
Mellanox specific fix.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
