### PR TITLE
[test_vrf] increase socket_recv_size

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -480,6 +480,7 @@ def partial_ptf_runner(request, ptfhost, tbinfo, dut_facts):
                    platform_dir="ptftests",
                    testname=testname,
                    params=params,
+                   socket_recv_size=16384,
                    log_file="/tmp/{}.{}.log".format(request.cls.__name__, request.function.__name__))
     return _partial_ptf_runner
 


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
vrf test sends jumbo frames of size 9k; need to increase packet socket recv size accordingly, otherwise received packets get truncated to 4096 (default receive size)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Pass vrf/test_vrf_attr.py::TestVrfAttrTTL::test_vrf2_fwd_pkts_with_ttl_1
#### How did you do it?
by specifying --socket-recv-size option for vrf test to ptf runner
#### How did you verify/test it?
run vrf/test_vrf_attr.py::TestVrfAttrTTL::test_vrf2_fwd_pkts_with_ttl_1
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
