### PR TITLE
Support for multi-asic to 'show interface transciever presence' in ch…

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -60,7 +60,10 @@ def check_interface_status(dut, asic_index, interfaces, xcvr_skip_list):
         mg_ports = interface_list
     output = dut.command("show interface description")
     intf_status = parse_intf_status(output["stdout_lines"][2:])
-    check_intf_presence_command = 'show interface transceiver presence {}'
+    if dut.is_multi_asic:
+        check_intf_presence_command = 'show interface transceiver presence -n {} {}'.format(namespace, {})
+    else:
+        check_intf_presence_command = 'show interface transceiver presence {}'
     for intf in interfaces:
         expected_oper = "up" if intf in mg_ports else "down"
         expected_admin = "up" if intf in mg_ports else "down"


### PR DESCRIPTION
…eck_interface_status

pass asic namespace to 'show interface transciever presence' in check_interface_status

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
On a multi-asic board executing "show interface transceiver presence Ethernet4" returns "Not present" for Ethernet4
although "show interface transceiver presence" without specifying any specific interface returns "Present" for the same interface
A multi-asic board requires the namespace to be included when specifying an interface (show interface transceiver presence -n asic0 Ethernet4)

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To provide support for a multi-asics card for the command  "show interface transceiver presence" for a specific interface

1. This command returns "Present"  - without specifying any interfaces: 
admin@board~$ show interface transceiver presence
Port        Presence
.....................................
Ethernet3   Not present
Ethernet4   Present

3. This command returns "Not present"  - when specifying an interface:
admin@board:~$ show interface transceiver presence Ethernet4
Port       Presence
....................................
Ethernet4  Not present

4. A multi-asic board requires the namespace to be included when specifying an interface 
admin@board:~$ show interface transceiver presence -n asic0 Ethernet4
Port       Presence
...................................
Ethernet4  Present

#### How did you do it?
Added the namespace to  the "show interface transceiver presence" command for multi-asics cards.

#### How did you verify/test it?
Executed the command with and without specifying a namespace.  
It returned "Present" when specifying the namespace.
It returned "Not present" without specifying the namespace.   

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
