### PR TITLE
Add check_intf status for all admin up ports as part of config_reload

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -397,7 +397,7 @@ def teardown(duthosts, rand_one_dut_hostname):
     """
     yield
     duthost = duthosts[rand_one_dut_hostname]
-    config_reload(duthost, safe_reload=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
 class AclVlanOuterTest_Base(object):
     """

--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -163,7 +163,7 @@ def common_setup_teardown(duthosts, ptfhost, enum_rand_one_per_hwsku_frontend_ho
         yield duthost, ptfhost, router_mac
     finally:
         #Recover DUT interface IP address
-        config_reload(duthost, config_source='config_db', safe_reload=True)
+        config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
 
 @pytest.fixture
 def garp_enabled(rand_selected_dut, config_facts):

--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -77,7 +77,7 @@ class TestNeighborMacNoPtf:
         yield
 
         logger.info("Reload Config DB")
-        config_reload(duthost, config_source='config_db', safe_reload=True)
+        config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
 
     @pytest.fixture(params=[4, 6])
     def ipVersion(self, request):

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -496,7 +496,7 @@ def backup_bgp_config(duthost):
     try:
         apply_default_bgp_config(duthost)
     except Exception:
-        config_reload(duthost, safe_reload=True)
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
         apply_default_bgp_config(duthost)
 
 @pytest.fixture(scope="module")

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -106,7 +106,7 @@ def clean_scale_rules(duthosts, rand_one_dut_hostname, collect_ignored_rules):
     # delete the tmp file
     duthost.file(path=SCALE_ACL_FILE, state='absent')
     logger.info("Reload config to recover configuration.")
-    config_reload(duthost, safe_reload=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
 def is_acl_rule_empty(duthost):
     """

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -93,9 +93,9 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
         if config_source == 'minigraph':
             pytest_assert(wait_until(300, 20, 0, chk_for_pfc_wd, duthost),
                     "PFC_WD is missing in CONFIG-DB")
+
+        if check_intf_up_ports:
+            pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
+                          "Not all ports that are admin up on are operationally up")
     else:
         time.sleep(wait)
-
-    if check_intf_up_ports:
-        pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
-                      "Not all ports that are admin up on are operationally up")

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -4,6 +4,7 @@ import logging
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.configlet.util.common import chk_for_pfc_wd
+from tests.common.platform.interface_utils import check_interface_status_of_up_ports
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +41,8 @@ def config_force_option_supported(duthost):
         return True
     return False
 
-def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True, safe_reload=False):
+def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True, safe_reload=False,
+                  check_intf_up_ports=False):
     """
     reload SONiC configuration
     :param duthost: DUT host object
@@ -93,3 +95,7 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
                     "PFC_WD is missing in CONFIG-DB")
     else:
         time.sleep(wait)
+
+    if check_intf_up_ports:
+        pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
+                      "Not all ports that are admin up on are operationally up")

--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -148,7 +148,7 @@ def swap_syncd(duthost, creds):
         )
 
     logger.info("Reloading config and restarting swss...")
-    config_reload(duthost, safe_reload=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
     _perform_syncd_liveness_check(duthost)
 

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -365,7 +365,7 @@ def _setup_testbed(dut, creds, ptf, test_params, tbinfo):
         # NOTE: Even if the rpc syncd image is already installed, we need to restart
         # SWSS for the COPP changes to take effect.
         logging.info("Reloading config and restarting swss...")
-        config_reload(dut, safe_reload=True)
+        config_reload(dut, safe_reload=True, check_intf_up_ports=True)
 
     logging.info("Configure syncd RPC for testing")
     copp_utils.configure_syncd(dut, test_params.nn_target_port, test_params.nn_target_interface,
@@ -387,7 +387,7 @@ def _teardown_testbed(dut, creds, ptf, test_params, tbinfo):
     else:
         copp_utils.restore_syncd(dut, test_params.nn_target_namespace)
         logging.info("Reloading config and restarting swss...")
-        config_reload(dut, safe_reload=True)
+        config_reload(dut, safe_reload=True, check_intf_up_ports=True)
 
 def _setup_multi_asic_proxy(dut, creds, test_params, tbinfo):
     """

--- a/tests/ecmp/test_fgnhg.py
+++ b/tests/ecmp/test_fgnhg.py
@@ -579,7 +579,7 @@ def fg_ecmp_to_regular_ecmp_transitions(ptfhost, duthost, router_mac, net_ports,
 def cleanup(duthost, ptfhost):
     logger.info("Start cleanup")
     ptfhost.command('rm -f /tmp/fg_ecmp_persist_map.json')
-    config_reload(duthost, safe_reload=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
 
 @pytest.fixture(scope="module")

--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -26,7 +26,7 @@ def restore_config_db(duthost):
     duthost.shell("mv /etc/sonic/config_db.json.bak /etc/sonic/config_db.json")
 
     # Reload to restore configuration
-    config_reload(duthost, safe_reload=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
 @pytest.fixture(scope="module")
 def check_ntp_sync(duthosts, rand_one_dut_hostname):

--- a/tests/nat/conftest.py
+++ b/tests/nat/conftest.py
@@ -188,7 +188,7 @@ def apply_global_nat_config(duthost, config_nat_feature_enabled):
     nat_global_config(duthost)
     yield
     # reload config on teardown
-    config_reload(duthost, config_source='minigraph', safe_reload=True)
+    config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True)
 
 
 @pytest.fixture()
@@ -204,7 +204,7 @@ def reload_dut_config(request, duthost, setup_test_env):
     dut_iface = setup_data[interface_type]["vrf_conf"]["red"]["dut_iface"]
     gw_ip = setup_data[interface_type]["vrf_conf"]["red"]["gw"]
     mask = setup_data[interface_type]["vrf_conf"]["red"]["mask"]
-    config_reload(duthost, config_source='minigraph', safe_reload=True)
+    config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True)
     pch_ip = setup_info["pch_ips"][dut_iface]
     duthost.shell("sudo config interface ip remove {} {}/31".format(dut_iface, pch_ip))
     duthost.shell("sudo config interface ip add {} {}/{}".format(dut_iface, gw_ip, mask))

--- a/tests/voq/test_voq_disrupts.py
+++ b/tests/voq/test_voq_disrupts.py
@@ -265,7 +265,7 @@ def test_config_reload_lc(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
     logger.info("Config reload on node: %s", duthosts.frontend_nodes[0].hostname)
     logger.info("-" * 80)
 
-    config_reload(duthosts.frontend_nodes[0], config_source='config_db', safe_reload=True)
+    config_reload(duthosts.frontend_nodes[0], config_source='config_db', safe_reload=True, check_intf_up_ports=True)
     poll_bgp_restored(duthosts)
 
     logger.info("=" * 80)

--- a/tests/voq/test_voq_intfs.py
+++ b/tests/voq/test_voq_intfs.py
@@ -66,7 +66,7 @@ def test_cycle_voq_intf(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
         logger.info("Save and reload config")
 
         duthost.shell_cmds(cmds=["config save -y"])
-        config_reload(duthost, config_source='config_db', safe_reload=True)
+        config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
         pytest_assert(wait_until(300, 10, 0, check_bgp_neighbors, duthosts, bgp_nbrs_to_portchannel),
                       "All BGP's are not established after ports removed from LAG and IP added to one of them")
         logger.info("Check interfaces after add.")
@@ -95,7 +95,7 @@ def test_cycle_voq_intf(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
         logger.info("Save and reload config")
 
         duthost.shell_cmds(cmds=["config save -y"])
-        config_reload(duthost, config_source='config_db', safe_reload=True)
+        config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
         pytest_assert(wait_until(300, 10, 0, check_bgp_neighbors, duthosts, bgp_nbrs_to_portchannel),
                       "All BGP's are not established after added IP removed from a LAG member")
         logger.info("check interface is gone after config reload")
@@ -111,7 +111,7 @@ def test_cycle_voq_intf(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
     finally:
         # restore interface from minigraph
         logger.info("Restore config from minigraph.")
-        config_reload(duthost, config_source='minigraph', safe_reload=True)
+        config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True)
         pytest_assert(wait_until(300, 10, 0, check_bgp_neighbors, duthosts),
                       "All BGP's are not established after config reload from original minigraph")
         duthost.shell_cmds(cmds=["config save -y"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
After a reload config, we need to ensure the operational state is up for all the interfaces with admin state up.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To ensure the operational state is up for all the interfaces with admin state up.

#### How did you do it?
Added check_interface_status_of_up_ports definition to interface_utils.py.
Added check_intf_up_ports=False option to reload_config definition.
Added code to reload_config definition to call check_interface_status_of_up_ports if check_intf_up_ports is set to True.  
This will check the operational state for all the interfaces with admin state up.
Added check_intf_up_ports=True to all test cases which calls reload_config and has safe_reload arg set to "True"

#### How did you verify/test it?
Ran all test cases which calls reload_config

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
