### PR TITLE
[test_vrf][fib_test] ip options other then False support

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -129,7 +129,14 @@ class FibTest(BaseTest):
 
         self.pkt_action = self.test_params.get('pkt_action', self.ACTION_FWD)
         self.ttl = self.test_params.get('ttl', 64)
-        self.ip_options = self.test_params.get('ip_options', False)
+
+        self.ip_options = False
+        ip_options_list = self.test_params.get('ip_options', False)
+        if isinstance(ip_options_list, list) and ip_options_list:
+            self.ip_options = scapy.IPOption(ip_options_list[0])
+            for opt in ip_options_list[1:]:
+                self.ip_options /= scapy.IPOption(opt)
+
         self.src_vid = self.test_params.get('src_vid', None)
         self.dst_vid = self.test_params.get('dst_vid', None)
 

--- a/tests/vrf/test_vrf_attr.py
+++ b/tests/vrf/test_vrf_attr.py
@@ -154,34 +154,34 @@ class TestVrfAttrIpAction():
         duthost.shell("config load -y /tmp/vrf_restore.json")
 
     def test_vrf1_drop_pkts_with_ip_opt(self, partial_ptf_runner):
-        # verify packets in Vrf1 with ip_option should be drop
+        # verify packets in Vrf1 with ip_options should be drop
         partial_ptf_runner(
             testname='vrf_test.FwdTest',
             pkt_action='drop',
             fib_info_files=['/tmp/vrf1_neigh.txt'],
-            ip_option=True,
+            ip_options=[b'\x94\x04\x00\x00'], # router alert
             ipv4=True,
             ipv6=False,
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
         )
 
     def test_vrf1_fwd_pkts_without_ip_opt(self, partial_ptf_runner):
-        # verify packets in Vrf1 without ip_option should be forward
+        # verify packets in Vrf1 without ip_options should be forward
         partial_ptf_runner(
             testname='vrf_test.FwdTest',
             fib_info_files=['/tmp/vrf1_neigh.txt'],
-            ip_option=False,
+            ip_options=False,
             ipv4=True,
             ipv6=False,
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000']
         )
 
     def test_vrf2_fwd_pkts_with_ip_opt(self, partial_ptf_runner):
-        # verify packets in Vrf2 with ip_option should be forward
+        # verify packets in Vrf2 with ip_options should be forward
         partial_ptf_runner(
             testname='vrf_test.FwdTest',
             fib_info_files=['/tmp/vrf2_neigh.txt'],
-            ip_option=True,
+            ip_options=[b'\x94\x04\x00\x00'], # router alert
             ipv4=True,
             ipv6=False,
             src_ports=g_vars['vrf_intf_member_port_indices']['Vrf2']['Vlan2000']


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
this PR:
1. Adds ability to pass IP option to ptf
2. Fixes vrf test cases - fix typo and add ip option

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To pass test_vrf1_drop_pkts_with_ip_opt
#### How did you do it?

#### How did you verify/test it?
Run test_vrf1_drop_pkts_with_ip_opt

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
