### PR TITLE
[dualtor][minigraph] Add SoC addr minigraph support

### DIFF
--- a/ansible/library/dual_tor_facts.py
+++ b/ansible/library/dual_tor_facts.py
@@ -87,9 +87,12 @@ class DualTorParser:
         self.dual_tor_facts['cables'] = cables
 
     def generate_mux_cable_facts(self):
-        topology = load_topo_file(self.testbed_facts["topo"])["topology"]
-        mux_cable_facts = generate_mux_cable_facts(topology=topology)
-        self.dual_tor_facts["mux_cable_facts"] = mux_cable_facts
+        topo_name = self.testbed_facts["topo"]
+        # use mux_cable_facts only for dualtor mixed topologies
+        if "mixed" in topo_name:
+            topology = load_topo_file(topo_name)["topology"]
+            mux_cable_facts = generate_mux_cable_facts(topology=topology)
+            self.dual_tor_facts["mux_cable_facts"] = mux_cable_facts
 
     def get_dual_tor_facts(self):
         '''

--- a/ansible/library/dual_tor_facts.py
+++ b/ansible/library/dual_tor_facts.py
@@ -1,4 +1,26 @@
+import os
+import yaml
+
 from collections import defaultdict
+
+try:
+    from ansible.module_utils.dualtor_utils import generate_mux_cable_facts
+except ImportError:
+    # Add parent dir for using outside Ansible
+    import sys
+    sys.path.append('..')
+    from ansible.module_utils.dualtor_utils import generate_mux_cable_facts
+
+
+def load_topo_file(topo_name):
+    """Load topo definition yaml file."""
+    topo_file = "vars/topo_%s.yml" % topo_name
+    if not os.path.exists(topo_file):
+        raise ValueError("Topo file %s not exists" % topo_file)
+    with open(topo_file) as fd:
+        return yaml.safe_load(fd)
+
+
 class DualTorParser:
 
     def __init__(self, hostname, testbed_facts, host_vars, vm_config, port_alias, vlan_intfs):
@@ -64,6 +86,11 @@ class DualTorParser:
 
         self.dual_tor_facts['cables'] = cables
 
+    def generate_mux_cable_facts(self):
+        topology = load_topo_file(self.testbed_facts["topo"])["topology"]
+        mux_cable_facts = generate_mux_cable_facts(topology=topology)
+        self.dual_tor_facts["mux_cable_facts"] = mux_cable_facts
+
     def get_dual_tor_facts(self):
         '''
         Gathers facts related to a dual ToR configuration
@@ -73,6 +100,7 @@ class DualTorParser:
             self.parse_tor_position()
             self.generate_cable_names()
             self.parse_loopback_ips()
+            self.generate_mux_cable_facts()
 
         return self.dual_tor_facts
 

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -139,12 +139,21 @@
 {% set server_base_address_v6 = (vlan_configs.values() | list)[0]['prefix_v6'] %}
 {% set server_base_address_v6 = server_base_address_v6 | ipaddr('network') %}
 {% set server_base_address_v6 = ':'.join(server_base_address_v6.split(':')[:-1]) + ':{:x}' %}
+{% set mux_cable_facts = dual_tor_facts['mux_cable_facts'] if 'mux_cable_facts' in dual_tor_facts %}
 {% for cable in dual_tor_facts['cables'] %}
+{% set intf_index = port_alias.index(cable['dut_intf'])|string %}
       <Device i:type="SmartCable">
         <ElementType>SmartCable</ElementType>
+{% if mux_cable_facts is defined %}
+        <SubType>{{ mux_cable_facts[intf_index]['cable_type'] }}</SubType>
+        <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>{{ mux_cable_facts[intf_index]['soc_ipv4'] if 'soc_ipv4' in mux_cable_facts[intf_index] else '0.0.0.0/0' }}</d5p1:IPPrefix>
+        </Address>
+{% else %}
         <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>
         </Address>
+{% endif %}
         <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>::/0</d5p1:IPPrefix>
         </AddressV6>
@@ -159,12 +168,21 @@
       </Device>
       <Device i:type="Server">
         <ElementType>Server</ElementType>
+{% if mux_cable_facts is defined %}
+        <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>{{ mux_cable_facts[intf_index]['server_ipv4'] }}</d5p1:IPPrefix>
+        </Address>
+        <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>{{ mux_cable_facts[intf_index]['server_ipv6'] }}</d5p1:IPPrefix>
+        </AddressV6>
+{% else %}
         <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>{{ server_base_address_v4.format(loop.index + 1) }}/26</d5p1:IPPrefix>
-        </Address> 
+        </Address>
         <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>{{ server_base_address_v6.format(loop.index + 1) }}/96</d5p1:IPPrefix>
         </AddressV6>
+{% endif %}
         <ManagementAddress xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>
         </ManagementAddress>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Add minigraph generation support to include mux cable type and soc address details.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
1. Include `mux_cable_facts` into `dual_tor_facts`
2. modify minigraph templates to include mux cable type and soc address details with the following schema proposal:
```
      <Device i:type="SmartCable">
        <ElementType>SmartCable</ElementType>
        <SubType>active-active</SubType>
        <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
          <d5p1:IPPrefix>192.168.0.3/21</d5p1:IPPrefix>
        </Address>
        <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
          <d5p1:IPPrefix>::/0</d5p1:IPPrefix>
        </AddressV6>
        <ManagementAddress xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
          <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>
        </ManagementAddress>
        <ManagementAddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
          <d5p1:IPPrefix>::/0</d5p1:IPPrefix>
        </ManagementAddressV6>
        <SerialNumber i:nil="true" />
        <Hostname>svcstr-7050-acs-1-Servers0-SC</Hostname>
      </Device>
      <Device i:type="Server">
        <ElementType>Server</ElementType>
        <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
          <d5p1:IPPrefix>192.168.0.2/21</d5p1:IPPrefix>
        </Address> 
        <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
          <d5p1:IPPrefix>fc02:1000::2/64</d5p1:IPPrefix>
        </AddressV6>
        <ManagementAddress xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
          <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>
        </ManagementAddress>
        <Hostname>Servers0</Hostname>
      </Device>
```

#### How did you verify/test it?
This PR depends on: https://github.com/Azure/sonic-buildimage/pull/10776
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
