### PR TITLE
Update get_acl_couner with command instead of getting value from redis

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -284,13 +284,16 @@ def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_
     Returns:
         Acl counter value for packets
     """
-    cmd = "redis-cli -n 2 hget 'COUNTERS:{}:{}' Packets"
     # Wait for orchagent to update the ACL counters
     time.sleep(timeout)
-    result = duthost.shell(cmd.format(table_name, rule_name))['stdout']
-    if result == "":
-        pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
-    return int(result)
+    result = duthost.show_and_parse('aclshow')
+
+    if len(result) == 0:
+        return 0
+    for rule in result:
+        if rule_name == rule['rule name']:
+            return int(rule['packets count'])
+    return 0
 
 
 def craft_packet(src_mac, dst_mac, dst_ip, ip_version, stage, tagged_mode, vlan_id=10, outer_vlan_id=0, pkt_type=None):

--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -286,14 +286,14 @@ def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_
     """
     # Wait for orchagent to update the ACL counters
     time.sleep(timeout)
-    result = duthost.show_and_parse('aclshow')
+    result = duthost.show_and_parse('aclshow -a')
 
     if len(result) == 0:
-        return 0
+        pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
     for rule in result:
-        if rule_name == rule['rule name']:
+        if table_name == rule['table name'] and rule_name == rule['rule name']:
             return int(rule['packets count'])
-    return 0
+    pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
 
 
 def craft_packet(src_mac, dst_mac, dst_ip, ip_version, stage, tagged_mode, vlan_id=10, outer_vlan_id=0, pkt_type=None):


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
We can't get acl counters from redis COUNTERS_DB due to this RP https://github.com/Azure/sonic-swss/pull/1943.
Parse the output of `aclshow` to get counters.

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
We can't get acl counters from redis `COUNTERS_DB` due to this RP https://github.com/Azure/sonic-swss/pull/1943.
`test_acl_outer_vlan.py` keeps failing  because of the error `Failed: Failed to retrieve acl counter for DATAACL_ingress_ipv6|rule_1`.

#### How did you do it?
Parse the output of `aclshow` to get counters.

#### How did you verify/test it?
run `acl/test_acl_outer_vlan.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
