### PR TITLE
Enhance testbed-cli.sh tool to support configuring L2 mode

### DIFF
--- a/ansible/plugins/filter/filters.py
+++ b/ansible/plugins/filter/filters.py
@@ -1,5 +1,7 @@
+import ipaddress
+import math
+
 from ansible import errors
-from math import log
 
 
 class FilterModule(object):
@@ -10,7 +12,8 @@ class FilterModule(object):
             'filter_vm_targets': filter_vm_targets,
             'extract_hostname': extract_hostname,
             'first_n_elements': first_n_elements,
-            'expand_properties': expand_properties
+            'expand_properties': expand_properties,
+            'first_ip_of_subnet': first_ip_of_subnet
         }
 
 
@@ -151,7 +154,6 @@ def extract_hostname(values, topology, vm_base, inventory_hostname):
     if vm_base not in values:
         raise errors.AnsibleFilterError('Current vm_base: %s is not found in vm_list' % vm_base)
 
-    hash = {}
     base = values.index(vm_base)
     for hostname, attr in topology.items():
         if base + attr['vm_offset'] >= len(values):
@@ -192,3 +194,11 @@ def expand_properties(value, configuration_properties):
             if p in configuration_properties:
                 vm_properties[vm].update(configuration_properties[p])
     return vm_properties
+
+
+def first_ip_of_subnet(value):
+    subnet = ipaddress.ip_network(unicode(value), strict=False)
+    if subnet.num_addresses >= 2:
+        return str(subnet[1])
+    else:
+        return ''

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -490,6 +490,25 @@ function config_y_cable
   echo Done
 }
 
+function set_l2_mode
+{
+  testbed_name=$1
+  passfile=$2
+  shift
+  shift
+
+  read_file ${testbed_name}
+
+  echo "Set DUTs of testbed $testbed_name to l2 mode"
+  echo "Reference: https://github.com/sonic-net/SONiC/wiki/L2-Switch-mode"
+  if [[ $topo != t0* ]]; then
+    echo "Only topology type t0 is supported"
+    exit 1
+  fi
+
+  ansible-playbook -i "$inv_name" testbed_set_l2_mode.yml --vault-password-file="$passfile" -l "$duts" $@
+}
+
 function config_vm
 {
   echo "Configure VM $2"
@@ -625,6 +644,8 @@ case "${subcmd}" in
   test-mg)     test_minigraph $@
                ;;
   config-y-cable) config_y_cable $@
+               ;;
+  set-l2) set_l2_mode $@
                ;;
   cleanup-vmhost) cleanup_vmhost $@
                ;;

--- a/ansible/testbed_set_l2_mode.yml
+++ b/ansible/testbed_set_l2_mode.yml
@@ -1,0 +1,63 @@
+
+- hosts: sonic
+  gather_facts: no
+  tasks:
+
+  - name: Generate initial l2 mode config
+    shell: sonic-cfggen -H -k {{ hwsku }} -p --preset l2 > /tmp/init_l2_config.json
+
+  - name: Read the initial l2 config json content
+    shell: cat /tmp/init_l2_config.json
+    register: output
+
+  - name: Parse the initial l2 config json content to dict
+    set_fact:
+      l2_config: "{{ output.stdout | from_json }}"
+
+  - set_fact:
+      mgmt_addr: "{{ ansible_ssh_host + '/' + mgmt_subnet_mask_length | string }}"
+
+  - name: Prepare extra l2 configs
+    set_fact:
+      metadata: "{{ {'DEVICE_METADATA': {'localhost': {'type': 'ToRRouter', 'hostname': inventory_hostname}}} }}"
+      mgmt_interface: "{{ {'MGMT_INTERFACE': {'eth0|' + mgmt_addr: {'gwaddr': mgmt_addr | first_ip_of_subnet}}} }}"
+      mgmt_port: "{{ {'MGMT_PORT': {'eth0': {'admin_status': 'up', 'alias': 'eth0'}}} }}"
+
+  - name: Update l2 config with more configurations
+    set_fact:
+      l2_config: "{{ l2_config | combine(metadata, mgmt_interface, mgmt_port, recursive=True) }}"
+
+  - name: Backup the normal config_db.json file
+    shell: if [ ! -f /etc/sonic/config_db.json.normal ]; then cp /etc/sonic/config_db.json /etc/sonic/config_db.json.normal; fi
+    become: yes
+
+  - name: Dump the l2_config to /etc/sonic/config_db.json
+    copy:
+      content: "{{ l2_config | to_nice_json(indent=4) }}"
+      dest: /etc/sonic/config_db.json
+    become: yes
+
+  - name: Execute cli "config reload -y" to apply new config_db.json
+    shell: config reload -y
+    become: yes
+
+  - name: Wait for switch to become reachable again
+    local_action: wait_for
+    args:
+      host: "{{ ansible_host }}"
+      port: 22
+      state: started
+      search_regex: "OpenSSH_[\\w\\.]+ Debian"
+      delay: 10
+      timeout: 600
+    changed_when: false
+
+  - name: Wait some time for switch to stabilize
+    pause:
+      seconds: 60
+
+  - name: Check the new vlan config
+    shell: show vlan config
+
+  - name: Check interface status
+    shell: show int status


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To support the BSL testing, the switch needs to be configured to
L2 mode.

Reference document: https://github.com/sonic-net/SONiC/wiki/L2-Switch-mode

#### How did you do it?
This change enhanced the testbed-cli.sh tool to support configuring
switch to L2 mode.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
