### PR TITLE
[snmp][chassis]: Modify snmp interfaces test case to support running on supervisor

### DIFF
--- a/ansible/templates/minigraph_dpg_asic.j2
+++ b/ansible/templates/minigraph_dpg_asic.j2
@@ -1,11 +1,6 @@
 {# Note max of 10 Backend Portchannel from one asic #}
 {% macro port_channel_id(asic_idx, neigh_asic_idx) -%}
-{% if card_type is defined and card_type == 'supervisor' %}
-{# Note avoid PortChannel00 #}
-{{ ((1 + 16 * asic_idx + neigh_asic_idx)|string) }}
-{%- else -%}
 {{ ((40 + 10 * asic_idx + neigh_asic_idx)|string) }}
-{%- endif -%}
 {%- endmacro -%}
 {% if num_asics > 1 %}
 {% if (asic_topo_config and slot_num is defined and slot_num in asic_topo_config) or (asic_topo_config and slot_num is not defined) %}

--- a/ansible/templates/minigraph_dpg_asic.j2
+++ b/ansible/templates/minigraph_dpg_asic.j2
@@ -1,6 +1,11 @@
 {# Note max of 10 Backend Portchannel from one asic #}
 {% macro port_channel_id(asic_idx, neigh_asic_idx) -%}
+{% if card_type is defined and card_type == 'supervisor' %}
+{# Note avoid PortChannel00 #}
+{{ ((1 + 16 * asic_idx + neigh_asic_idx)|string) }}
+{%- else -%}
 {{ ((40 + 10 * asic_idx + neigh_asic_idx)|string) }}
+{%- endif -%}
 {%- endmacro -%}
 {% if num_asics > 1 %}
 {% if (asic_topo_config and slot_num is defined and slot_num in asic_topo_config) or (asic_topo_config and slot_num is not defined) %}

--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -143,9 +143,6 @@ def test_snmp_interfaces(localhost, creds_all_duts, duthosts, enum_rand_one_per_
 
     namespace = duthost.get_namespace_from_asic_id(enum_asic_index)
     config_facts  = duthost.config_facts(host=duthost.hostname, source="persistent", namespace=namespace)['ansible_facts']
-    if 'PORT' not in config_facts:
-        pytest.skip("interfaces not present in config_db")
-
     snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
 
     snmp_ifnames = [v['name'] for k, v in snmp_facts['snmp_interfaces'].items()]
@@ -166,9 +163,8 @@ def test_snmp_mgmt_interface(localhost, creds_all_duts, duthosts, enum_rand_one_
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
-    config_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
-
     snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+    config_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
 
     snmp_ifnames = [ v['name'] for k, v in snmp_facts['snmp_interfaces'].items() ]
     logger.info('snmp_ifnames: {}'.format(snmp_ifnames))

--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -167,8 +167,6 @@ def test_snmp_mgmt_interface(localhost, creds_all_duts, duthosts, enum_rand_one_
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
     config_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
-    if 'PORT' not in config_facts:
-        pytest.skip("interfaces not present in config_db")
 
     snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
 

--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -139,12 +139,13 @@ def verify_snmp_speed(facts, snmp_facts, results):
 def test_snmp_interfaces(localhost, creds_all_duts, duthosts, enum_rand_one_per_hwsku_hostname, enum_asic_index):
     """compare the snmp facts between observed states and target state"""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    if duthost.is_supervisor_node():
-        pytest.skip("interfaces not present on supervisor node")
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
     namespace = duthost.get_namespace_from_asic_id(enum_asic_index)
     config_facts  = duthost.config_facts(host=duthost.hostname, source="persistent", namespace=namespace)['ansible_facts']
+    if 'PORT' not in config_facts:
+        pytest.skip("interfaces not present in config_db")
+
     snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
 
     snmp_ifnames = [v['name'] for k, v in snmp_facts['snmp_interfaces'].items()]
@@ -165,8 +166,11 @@ def test_snmp_mgmt_interface(localhost, creds_all_duts, duthosts, enum_rand_one_
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
 
-    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
     config_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
+    if 'PORT' not in config_facts:
+        pytest.skip("interfaces not present in config_db")
+
+    snmp_facts = get_snmp_facts(localhost, host=hostip, version="v2c", community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
 
     snmp_ifnames = [ v['name'] for k, v in snmp_facts['snmp_interfaces'].items() ]
     logger.info('snmp_ifnames: {}'.format(snmp_ifnames))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
- SNMP interfaces test case fails on supervisor for packet chassis.
- All test cases should run on supervisor node for packet chassis as interface data is present in snmp_facts.
#### How did you do it?
- Remove skip for supervisor node, so that all test cases are executed on packet chassis. 
On VoQ chassis, management interface is present in snmp_facts snmp_interfaces, but as there are no interfaces in config_db, the test will be executed but no interface comparison will be done.
#### How did you verify/test it?
Verified on packet chassis and VoQ chassis.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
