### PR TITLE
[tests/override_config_table] load_minigraph with Golden Config test

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -164,6 +164,7 @@ test_t0() {
       generic_config_updater/test_portchannel_interface.py \
       generic_config_updater/test_syslog.py \
       generic_config_updater/test_vlan_interface.py \
+      override_config_table/test_override_config_table.py \
       process_monitoring/test_critical_process_monitoring.py \
       show_techsupport/test_techsupport_no_secret.py \
       system_health/test_system_status.py"

--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -67,9 +67,11 @@ def setup_env(duthosts, rand_one_dut_hostname, golden_config_exists_on_dut):
 
     # Restore configDB after test.
     restore_config(duthost, CONFIG_DB, CONFIG_DB_BACKUP)
-    # Restore Golden Config after test.
+    # Restore Golden Config after test, else cleanup test file.
     if golden_config_exists_on_dut:
         restore_config(duthost, GOLDEN_CONFIG, GOLDEN_CONFIG_BACKUP)
+    else:
+        duthost.file(path=GOLDEN_CONFIG, state='absent')
 
     # Restore config before test
     config_reload(duthost)

--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -1,0 +1,153 @@
+import json
+import logging
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.config_reload import config_reload
+
+GOLDEN_CONFIG = "/etc/sonic/golden_config_db.json"
+GOLDEN_CONFIG_BACKUP = "/etc/sonic/golden_config_db.json_before_override"
+CONFIG_DB = "/etc/sonic/config_db.json"
+CONFIG_DB_BACKUP = "/etc/sonic/config_db.json_before_override"
+
+logger = logging.getLogger(__name__)
+
+
+def file_exists_on_dut(duthost, filename):
+    return duthost.stat(path=filename).get('stat', {}).get('exists', False)
+
+
+@pytest.fixture(scope="module")
+def golden_config_exists_on_dut(duthost):
+    return file_exists_on_dut(duthost, GOLDEN_CONFIG)
+
+
+def backup_config(duthost, config, config_backup):
+    logger.info("Backup {} to {} on {}".format(
+        config, config_backup, duthost.hostname))
+    duthost.shell("cp {} {}".format(config, config_backup))
+
+
+def restore_config(duthost, config, config_backup):
+    logger.info("Restore {} with {} on {}".format(
+        config, config_backup, duthost.hostname))
+    duthost.shell("mv {} {}".format(config_backup, config))
+
+
+def get_running_config(duthost):
+    return json.loads(duthost.shell("sonic-cfggen -d --print-data")['stdout'])
+
+
+def reload_minigraph_with_golden_config(duthost, json_data):
+    duthost.copy(content=json.dumps(json_data, indent=4), dest=GOLDEN_CONFIG)
+    config_reload(duthost, config_source="minigraph", safe_reload=True)
+
+
+@pytest.fixture(scope="module")
+def setup_env(duthosts, rand_one_dut_hostname, golden_config_exists_on_dut):
+    """
+    Setup/teardown
+    Args:
+        duthosts: list of DUTs.
+        rand_selected_dut: The fixture returns a randomly selected DuT.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    # Backup configDB
+    backup_config(duthost, CONFIG_DB, CONFIG_DB_BACKUP)
+    # Backup Golden Config if exists.
+    if golden_config_exists_on_dut:
+        backup_config(duthost, GOLDEN_CONFIG, GOLDEN_CONFIG_BACKUP)
+
+    # Reload test env with minigraph
+    config_reload(duthost, config_source="minigraph", safe_reload=True)
+    running_config = get_running_config(duthost)
+
+    yield running_config
+
+    # Restore configDB after test.
+    restore_config(duthost, CONFIG_DB, CONFIG_DB_BACKUP)
+    # Restore Golden Config after test.
+    if golden_config_exists_on_dut:
+        restore_config(duthost, GOLDEN_CONFIG, GOLDEN_CONFIG_BACKUP)
+
+    # Restore config before test
+    config_reload(duthost)
+
+
+def load_minigraph_with_golden_empty_input(duthost):
+    """Test Golden Config with empty input
+    """
+    initial_config = get_running_config(duthost)
+
+    empty_input = {}
+    reload_minigraph_with_golden_config(duthost, empty_input)
+
+    current_config = get_running_config(duthost)
+    pytest_assert(initial_config == current_config,
+                  "Running config differs.")
+
+
+def load_minigraph_with_golden_partial_config(duthost):
+    """Test Golden Config with partial config.
+
+    Here we assume all config contain SYSLOG_SERVER table
+    """
+    partial_config = {
+        "SYSLOG_SERVER": {
+            "10.0.0.100": {},
+            "10.0.0.200": {}
+        }
+    }
+    reload_minigraph_with_golden_config(duthost, partial_config)
+
+    current_config = get_running_config(duthost)
+    pytest_assert(
+        current_config['SYSLOG_SERVER'] == partial_config['SYSLOG_SERVER'],
+        "Partial config override fail: {}".format(current_config['SYSLOG_SERVER'])
+    )
+
+
+def load_minigraph_with_golden_new_feature(duthost):
+    """Test Golden Config with new feature
+    """
+    new_feature_config = {
+        "NEW_FEATURE_TABLE": {
+            "entry": {
+                "field": "value",
+                "state": "disabled"
+            }
+        }
+    }
+    reload_minigraph_with_golden_config(duthost, new_feature_config)
+
+    current_config = get_running_config(duthost)
+    pytest_assert(
+        'NEW_FEATURE_TABLE' in current_config and
+        current_config['NEW_FEATURE_TABLE'] == new_feature_config['NEW_FEATURE_TABLE'],
+        "new feature config update fail: {}".format(current_config['NEW_FEATURE_TABLE'])
+    )
+
+
+def load_minigraph_with_golden_full_config(duthost, full_config):
+    """Test Golden Config fully override minigraph config
+    """
+    # Test if the config has been override by full_config
+    reload_minigraph_with_golden_config(duthost, full_config)
+
+    current_config = get_running_config(duthost)
+    for table in full_config:
+        pytest_assert(
+            full_config[table] == current_config[table],
+            "full config override fail! {}".format(table)
+        )
+
+
+def test_load_minigraph_with_golden_config(duthost, setup_env):
+    """Test Golden Config override during load minigraph
+    """
+    load_minigraph_with_golden_empty_input(duthost)
+    load_minigraph_with_golden_partial_config(duthost)
+    load_minigraph_with_golden_new_feature(duthost)
+    full_config = setup_env
+    load_minigraph_with_golden_full_config(duthost, full_config)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: E2E test for load minigraph with Golden Config file
Wait sonic-utilities feature https://github.com/Azure/sonic-utilities/pull/2140 merge in sonic-buildimage
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
This PR is to verify load minigraph with Golden Config and see if Golden Config overrides minigraph.
This test contains below phases:
I. Empty Golden Config
II. Partial Golden Config
III. New Feature in Golden Config
IV. Full Golden Config
#### How did you do it?
Write E2E test to verify
#### How did you verify/test it?
Run E2E test on kvm
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
