### PR TITLE
Comment out test cases which don't support KVM dualtor testbed。

### DIFF
--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -62,7 +62,7 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def common_setup_teardown(rand_selected_dut, request, tbinfo, vmhost):
     # Skip dualtor test cases on unsupported platform
     supported_platforms = ['broadcom_td3_hwskus', 'broadcom_th2_hwskus', 'cisco_hwskus']

--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -62,7 +62,7 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module")
 def common_setup_teardown(rand_selected_dut, request, tbinfo, vmhost):
     # Skip dualtor test cases on unsupported platform
     supported_platforms = ['broadcom_td3_hwskus', 'broadcom_th2_hwskus', 'cisco_hwskus']

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -270,19 +270,18 @@ test_multi_asic_t1_lag() {
 
 test_dualtor(){
     tgname=dualtor
-    tests="\
-    arp/test_arp_dualtor.py \
-    dualtor/test_ipinip.py \
-    dualtor/test_orch_stress.py \
-    dualtor/test_orchagent_active_tor_downstream.py \
-    dualtor/test_orchagent_mac_move.py \
-    dualtor/test_orchagent_slb.py \
-    dualtor/test_orchagent_standby_tor_downstream.py \
-    dualtor/test_server_failure.py \
-    dualtor/test_standby_tor_upstream_mux_toggle.py \
-    dualtor/test_toggle_mux.py \
-    dualtor/test_tor_ecn.py \
-    dualtor/test_tunnel_memory_leak.py "
+    tests="arp/test_arp_dualtor.py"
+#    dualtor/test_ipinip.py \
+#    dualtor/test_orch_stress.py \
+#    dualtor/test_orchagent_active_tor_downstream.py \
+#    dualtor/test_orchagent_mac_move.py \
+#    dualtor/test_orchagent_slb.py \
+#    dualtor/test_orchagent_standby_tor_downstream.py \
+#    dualtor/test_server_failure.py \
+#    dualtor/test_standby_tor_upstream_mux_toggle.py \
+#    dualtor/test_toggle_mux.py \
+#    dualtor/test_tor_ecn.py \
+#    dualtor/test_tunnel_memory_leak.py "
 #    dualtor_io/test_heartbeat_failure.py \
 #    dualtor_io/test_link_drop.py \
 #    dualtor_io/test_link_failure.py \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In pr # 5388, there are lots of skipped testcases on kvm dualtor testbed, which case a long running time. These cases are under the folder tests/dualtor and tests/dualtor_io. Kvm testbed is the unsupported platform in these cases, so, comment out these cases to shorten the running time. When the kvm testbed is supported, we can delete the comments and running these cases.

Summary:
Fixes # 5388

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
In pr # 5388, there are lots of skipped testcases on kvm dualtor testbed, which case a long running time. These cases are under the folder tests/dualtor and tests/dualtor_io. Kvm testbed is the unsupported platform in these cases, so, comment out these cases to shorten the running time. When the kvm testbed is supported, we can delete the comments and running these cases.

#### How did you do it?
Comment out test cases which don't support the kvm dualtor testbed.

#### How did you verify/test it?
Running pipeline. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
