### PR TITLE
fixed unknown mac test - updated a check on MAC presence for a given port

### DIFF
--- a/tests/pfc/test_unknown_mac.py
+++ b/tests/pfc/test_unknown_mac.py
@@ -207,10 +207,17 @@ class PreTestVerify(object):
         """
         Check if the FDB entry is missing for the port
         """
-        result = self.duthost.command("show mac -p {}".format(self.dst_port),
-                                      module_ignore_errors=True)
-        out = result['stdout']
-        pytest_assert("not in list" in out, "{} present in FDB".format(self.arp_entry[self.dst_ip]))
+        
+
+        def is_mac_missing_for_port(port):
+            result = self.duthost.command(
+                "show mac -p {}".format(port),
+                module_ignore_errors=True
+            )
+            out = result['stdout']
+            return "not in list" in out or "Total number of entries 0" in out
+
+        pytest_assert(is_mac_missing_for_port(self.dst_port), "{} present in FDB".format(self.arp_entry[self.dst_ip]))
         logger.info("'{}' not present in fdb as expected".format(self.arp_entry[self.dst_ip]))
 
     def verifyArpFdb(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fixed unknown mac test - updated a check on MAC presence for a given port
Fixes # (issue)

pfc/test_unknown_mac test fails expecting a MAC entry to be missing for the specified port:
> E Failed: 50:6b:4b:b6:35:11 present in FDB

In fact the entry was missing as expected but it seems CLI output has changed and "no entries" is displayed differently. Fixed

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Updated a check on FDB record presence
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t0,any pfc/test_unknown_mac.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
