### PR TITLE
Update test_cpu_memory_usage for a sonic image with sanitizer

### DIFF
--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -15,13 +15,25 @@ pytestmark = [
 ]
 
 
+def is_asan_image(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    asan_val_from_sonic_ver_cmd = "sonic-cfggen -y /etc/sonic/sonic_version.yml -v asan"
+    asan_val = duthost.command(asan_val_from_sonic_ver_cmd)['stdout']
+    is_asan = False
+    if asan_val == "yes":
+        logging.info("The current sonic image is a ASAN image")
+        is_asan = True
+    return is_asan
+
+
 @pytest.fixture(scope='module')
 def setup_thresholds(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     cpu_threshold = 50
     memory_threshold = 60
     high_cpu_consume_procs = {}
-    if duthost.facts['platform'] in ('x86_64-arista_7050_qx32', 'x86_64-kvm_x86_64-r0'):
+    is_asan = is_asan_image(duthosts, enum_rand_one_per_hwsku_hostname)
+    if duthost.facts['platform'] in ('x86_64-arista_7050_qx32', 'x86_64-kvm_x86_64-r0') or is_asan:
         memory_threshold = 80
     if duthost.facts['platform'] in ('x86_64-arista_7260cx3_64'):
         high_cpu_consume_procs['syncd'] = 80


### PR DESCRIPTION
### Description of PR

The test test_cpu_memory_usage has been modified to take into consideration memory consumption on a sonic image with address sanitizer(ASAN image), which has a higher memory consumption so it requires to have a higher threshold(80 instead of 60)
the fix is to check if the image is a sanitizer image by checking the value of key 'asan' in sonic_version.yaml,
and if it is, increase the memory_threshold to 80.

### Type of change
- [x] Test case(new/improvement)


### Back port request
- [x] 202111
- [x] 202012

### Approach
#### What is the motivation for this PR?

sonic image with address sanitizer(ASAN image) has a higher memory consumption so it require to have a higher memory threshold (80 instead of 60)

#### How did you do it?
I added the fix mentioned above and tested it on a setup with sonic ASAN image/regular sonic image.

#### How did you verify/test it?
tested it on a setup with sonic ASAN image/regular sonic image.

#### Any platform specific information?
no. it's relevant to all the platforms.



### Documentation
https://github.com/google/sanitizers/wiki/AddressSanitizer
