### PR TITLE
Fix skipping MLNX for 201911 version in `test_decap.py`.

### DIFF
--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -31,7 +31,7 @@ pytestmark = [
 
 @pytest.fixture
 def ttl_dscp_params(duthost, supported_ttl_dscp_params):
-    if "uniform" in supported_ttl_dscp_params.values() and ("201811" in duthost.os_version or "201911" in duthost.os_version):
+    if "uniform" in supported_ttl_dscp_params.values() and "201811" in duthost.os_version:
         pytest.skip('uniform ttl/dscp mode is available from 202012. Current version is %s' % duthost.os_version)
 
     if supported_ttl_dscp_params['dscp'] == 'pipe' and duthost.facts['asic_type'] in ['cisco-8000']:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In previous version, 201911 was skipped in `test_decap.py`. And now, we use the same 202012 sonic-mgmt branch for testing 201911 image, so 201911 should not be skipped in this case. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
In previous version, 201911 was skipped in `test_decap.py`. And now, we use the same 202012 sonic-mgmt branch for testing 201911 image, so 201911 should not be skipped in this case. 

#### How did you do it?
Remove the judge for 201911 in conditional sentence.

#### How did you verify/test it?
Running on testbed which has 201911 version. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
