### PR TITLE
Fix test case: generic_config_updater/test_ipv6.py::test_ipv6_neighbor_admin_change

### DIFF
--- a/tests/generic_config_updater/test_ipv6.py
+++ b/tests/generic_config_updater/test_ipv6.py
@@ -10,6 +10,9 @@ from tests.generic_config_updater.gu_utils import create_checkpoint, delete_chec
 
 logger = logging.getLogger(__name__)
 
+pytestmark = [
+    pytest.mark.topology('t0', 't1'),
+]
 
 @pytest.fixture(autouse=True)
 def ensure_dut_readiness(duthost):
@@ -153,6 +156,11 @@ def test_invalid_ipv6_neighbor(duthost, ensure_dut_readiness, op, dummy_neighbor
 def test_ipv6_neighbor_admin_change(duthost):
     ipv6_neighbor_address, ipv6_neighbor_config = get_ipv6_neighbor(duthost)
     json_patch = [
+        {
+            "op": "add",
+            "path": "/BGP_NEIGHBOR/{}/admin_status".format(ipv6_neighbor_address),
+            "value": "up"
+        },
         {
             "op": "replace",
             "path": "/BGP_NEIGHBOR/{}/admin_status".format(ipv6_neighbor_address),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. This case fails every time on our testbeds because it tries to replace the admin_status value of a bgp neighour, while the admin_status field doesn't exist in the default running configuration generated from minigraph(the admin_status is up without a explicit "admin_status": "up" config in db). 
To fix this,  need to add this config before replace it.
2. And add a topology mark for the test according to the description in https://github.com/Azure/sonic-mgmt/pull/5061 .

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
1. Ensure that the configuration exists in the running config before it is replaced by the patch .
2.  Add a topology mark for the test to ensure it runs with the correct topologies. According to the description in https://github.com/Azure/sonic-mgmt/pull/5061, this test support t0 and t1 testbeds.  
#### How did you do it?
1. Modified the patch to add this config before replace it. If the config already exists before the adding, it won't take any effects because the config is duplicated.
2. Add the topology mark.
#### How did you verify/test it?
Run this test case on testbeds with and without the admin_status field in running configs, all passed.
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
