### PR TITLE
[COPP] Fixed COPP test - reload logic

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -365,7 +365,7 @@ def _setup_testbed(dut, creds, ptf, test_params, tbinfo):
         # NOTE: Even if the rpc syncd image is already installed, we need to restart
         # SWSS for the COPP changes to take effect.
         logging.info("Reloading config and restarting swss...")
-        config_reload(dut, safe_reload=True)
+        config_reload(dut)
 
     logging.info("Configure syncd RPC for testing")
     copp_utils.configure_syncd(dut, test_params.nn_target_port, test_params.nn_target_interface,
@@ -387,7 +387,7 @@ def _teardown_testbed(dut, creds, ptf, test_params, tbinfo):
     else:
         copp_utils.restore_syncd(dut, test_params.nn_target_namespace)
         logging.info("Reloading config and restarting swss...")
-        config_reload(dut, safe_reload=True)
+        config_reload(dut)
 
 def _setup_multi_asic_proxy(dut, creds, test_params, tbinfo):
     """


### PR DESCRIPTION


Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR

Fixed COPP test - reload logic
Old logic caused time to time failures in first test in class due to traffic loss(looks like DUT not ready after reload). Issue introduced in PR: https://github.com/Azure/sonic-mgmt/pull/5564

Summary: Fixed COPP test - reload logic
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix test failure

#### How did you do it?
See code

#### How did you verify/test it?
Executed tests from file sonic-mgmt/tests/copp/test_copp.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
