### PR TITLE
Moved skip reason of qos_config_updates test case

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -149,6 +149,12 @@ generic_config_updater/test_eth_interface.py::test_replace_fec:
     conditions:
       - "platform in ['x86_64-kvm_x86_64-r0']"
 
+generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates:
+  skip:
+    reason: "This test was not run on this hwsku type currently"
+    conditions:
+      - "not any(i in hwsku for i in ['2700', 'Arista-7170-64C', 'montara', 'newport'])"
+
 generic_config_updater:
   skip:
     reason: 'generic_config_updater is not a supported feature for T2'

--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -201,7 +201,6 @@ def ensure_application_of_updated_config(duthost, configdb_field, value):
 @pytest.mark.parametrize("configdb_field", ["ingress_lossless_pool/xoff", "ingress_lossless_pool/size", "egress_lossy_pool/size"])
 @pytest.mark.parametrize("operation", ["add", "replace", "remove"])
 def test_incremental_qos_config_updates(duthost, tbinfo, ensure_dut_readiness, configdb_field, operation):
-    pytest_require('2700' in duthost.facts['hwsku'], "This test only runs on Mellanox 2700 devices")
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {} created for json patch of field: {} and operation: {}".format(tmpfile, configdb_field, operation))
 

--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -3,7 +3,7 @@ import logging
 import json
 import pytest
 
-from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import verify_orchagent_running_or_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_res_success, expect_op_failure


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Updated skipping logic of test_incremental_qos from #5028 for hwsku, which weren't tested currently.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Added support of other platforms to qos_config_updates test case of generic_config_updater test suite.
#### How did you do it?
Moved skip reason for qos_config_updates test case of generic_config_updater test suite from test module to test_mark_conditions YAML file. Also added list of hwsku for barefoot platform to the conditions.
#### How did you verify/test it?
```
PASSED generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[add-ingress_lossless_pool/xoff]
PASSED generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[add-ingress_lossless_pool/size]
PASSED generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[add-egress_lossy_pool/size]
PASSED generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[replace-ingress_lossless_pool/xoff]
PASSED generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[replace-ingress_lossless_pool/size]
PASSED generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[replace-egress_lossy_pool/size]
PASSED generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[remove-ingress_lossless_pool/xoff]
PASSED generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[remove-ingress_lossless_pool/size]
PASSED generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[remove-egress_lossy_pool/size]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
