### PR TITLE
use get_rx_port utility for lag members to select dst_port_id for testQosSaiPGDrop testcase

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -785,14 +785,13 @@ class TestQosSai(QosSaiBase):
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
         pgDropKey = "pg_drop"
-        dst_port_id = qosConfig[pgDropKey]["dst_port_id"]
         testParams.update({
             "dscp": qosConfig[pgDropKey]["dscp"],
             "ecn": qosConfig[pgDropKey]["ecn"],
             "pg": qosConfig[pgDropKey]["pg"],
             "queue": qosConfig[pgDropKey]["queue"],
-            "dst_port_id": dst_port_id,
-            "dst_port_ip": dutConfig["testPortIps"][dst_port_id]['peer_addr'],
+            "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
+            "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
             "src_port_id": dutConfig["testPorts"]["src_port_id"],
             "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
             "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],

--- a/tests/saitests/sai_qos_tests.py
+++ b/tests/saitests/sai_qos_tests.py
@@ -2104,6 +2104,9 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
         margin = int(self.test_params['pkts_num_margin'])
 
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
+        dst_port_id = get_rx_port(
+            self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip
+        )
 
         # Prepare IP packet data
         ttl = 64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Added the change to use get_rx_port utility to select the actual dst_port_id if the passed dst_port_id is part of lag  . 


#### How did you verify/test it?
Verified the change on local cisco-8000 setup .
