### PR TITLE
[vrf_test] use strings for booleans in vrf_attr_ip_state.json and vrf_restore.json

### DIFF
--- a/tests/vrf/vrf_attr_ip_state.json
+++ b/tests/vrf/vrf_attr_ip_state.json
@@ -1,10 +1,10 @@
 {
     "VRF": {
         "Vrf1": {
-            "v4": "False"
+            "v4": "false"
         },
         "Vrf2": {
-            "v6": "False"
+            "v6": "false"
         }
     }
 }

--- a/tests/vrf/vrf_restore.json
+++ b/tests/vrf/vrf_restore.json
@@ -1,14 +1,14 @@
 {
     "VRF": {
         "Vrf1": {
-            "v4": true,
-            "v6": true,
+            "v4": "true",
+            "v6": "true",
             "ttl_action": "trap",
             "ip_opt_action": "trap"
         },
         "Vrf2": {
-            "v4": true,
-            "v6": true,
+            "v4": "true",
+            "v6": "true",
             "ttl_action": "trap",
             "ip_opt_action": "trap"
         }


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Use lowercase bool string representation expected by orchagent and https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md

#### How did you do it?

#### How did you verify/test it?
by running vrf/test_vrf_attr.py, the following tests pass after the change:
test_vrf1_drop_pkts_with_ip_opt (fixed vrf_restore.json - clean-up from previous tests)
test_vrf1_drop_v4 (fixed vrf_attr_ip_state.json)
test_vrf2_drop_v6 (fixed vrf_attr_ip_state.json)
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
