### PR TITLE
[MASIC] [Everflow] Update test_everflow_per_interface.py to support masic

### DIFF
--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -77,9 +77,15 @@ def apply_mirror_session(rand_selected_dut):
     logger.info("Applying mirror session to DUT")
     BaseEverflowTest.apply_mirror_config(rand_selected_dut, mirror_session_info)
     time.sleep(10)
-    cmd = 'sonic-db-cli STATE_DB hget \"MIRROR_SESSION_TABLE|{}\" \"monitor_port\"'.format(EVERFLOW_SESSION_NAME)
-    monitor_port = rand_selected_dut.shell(cmd=cmd)['stdout']
-    pytest_assert(monitor_port != "", "Failed to retrieve monitor_port")
+    single_asic_cmd = 'sonic-db-cli STATE_DB hget \"MIRROR_SESSION_TABLE|{}\" \"monitor_port\"'.format(EVERFLOW_SESSION_NAME)
+    if rand_selected_dut.is_multi_asic:
+        for front_ns in rand_selected_dut.get_frontend_asic_namespace_list():
+            cmd = "{} -n {}".format(single_asic_cmd, front_ns)
+            monitor_port = rand_selected_dut.shell(cmd=cmd)['stdout']
+            pytest_assert(monitor_port != "", "Failed to retrieve monitor_port")
+    else:
+        monitor_port = rand_selected_dut.shell(cmd=single_asic_cmd)['stdout']
+        pytest_assert(monitor_port != "", "Failed to retrieve monitor_port")
 
     yield mirror_session_info, monitor_port
 

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -82,7 +82,7 @@ def apply_mirror_session(rand_selected_dut):
         for front_ns in rand_selected_dut.get_frontend_asic_namespace_list():
             cmd = "{} -n {}".format(single_asic_cmd, front_ns)
             monitor_port = rand_selected_dut.shell(cmd=cmd)['stdout']
-            pytest_assert(monitor_port != "", "Failed to retrieve monitor_port")
+            pytest_assert(monitor_port != "", "Failed to retrieve monitor_port on multi-asic dut's frontend namespace: {}".format(front_ns))
     else:
         monitor_port = rand_selected_dut.shell(cmd=single_asic_cmd)['stdout']
         pytest_assert(monitor_port != "", "Failed to retrieve monitor_port")


### PR DESCRIPTION
change 'sonic-db-cli' cmd in apply_mirror_session to support for masic.
Reason is, the apply_mirror_session actually calls 'config mirror_session add' cmd in sonic-utilities/config/main.py, which set entry for each frontend asics, if host is multi-asic. 
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Before:
2022-05-13T07:30:48.1262642Z     @pytest.fixture(scope='module')
2022-05-13T07:30:48.1265161Z     def apply_mirror_session(rand_selected_dut):
2022-05-13T07:30:48.1268261Z         mirror_session_info = BaseEverflowTest.mirror_session_info(EVERFLOW_SESSION_NAME, rand_selected_dut.facts["asic_type"])
2022-05-13T07:30:48.1271235Z         logger.info("Applying mirror session to DUT")
2022-05-13T07:30:48.1274192Z         BaseEverflowTest.apply_mirror_config(rand_selected_dut, mirror_session_info)
2022-05-13T07:30:48.1276804Z         time.sleep(10)
2022-05-13T07:30:48.1279872Z         cmd = 'sonic-db-cli STATE_DB hget \"MIRROR_SESSION_TABLE|{}\" \"monitor_port\"'.format(EVERFLOW_SESSION_NAME)
2022-05-13T07:30:48.1282785Z         monitor_port = rand_selected_dut.shell(cmd=cmd)['stdout']
2022-05-13T07:30:48.1285468Z >       pytest_assert(monitor_port != "", "Failed to retrieve monitor_port")
2022-05-13T07:30:48.1288011Z E       Failed: Failed to retrieve monitor_port
2022-05-13T07:30:48.1288931Z 
2022-05-13T07:30:48.1291716Z cmd        = 'sonic-db-cli STATE_DB hget "MIRROR_SESSION_TABLE|everflow_session_per_interface" "monitor_port"'
2022-05-13T07:30:48.1295284Z mirror_session_info = {'session_dscp': '8', 'session_dst_ip': '2.2.2.2', 'session_gre': 35006, 'session_name': 'everflow_session_per_interface', ...}
2022-05-13T07:30:48.1298419Z monitor_port = u''
2022-05-13T07:30:48.1301320Z rand_selected_dut = <MultiAsicSonicHost >
2022-05-13T07:30:48.1302493Z 
2022-05-13T07:30:48.1304972Z everflow/test_everflow_per_interface.py:82: Failed

After:

everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4] PASSED                                                                                                                                                                  [  9%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6] PASSED                                                                                                                                                                  [ 18%]
=================================================================================================== 2 passed, 9 skipped, 2 warnings in 125.04 seconds ===================================================================================================
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
