### PR TITLE
[test_vrf1_neigh_with_new_router_mac] increase socket size to receive jumbograms

### DIFF
--- a/tests/vrf/test_vrf_attr.py
+++ b/tests/vrf/test_vrf_attr.py
@@ -73,6 +73,7 @@ class TestVrfAttrSrcMac():
                         'fib_info_files': ["/tmp/vrf1_neigh.txt"],
                         'src_ports': g_vars['vrf_intf_member_port_indices']['Vrf1']['Vlan1000'],
                         'ptf_test_port_map': PTF_TEST_PORT_MAP},
+                socket_recv_size=16384,
                 log_file="/tmp/vrf_attr_src_mac_test.FwdTest2.log")
 
     def test_vrf2_neigh_with_default_router_mac(self, partial_ptf_runner):


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
vrf test sends packets of size 9k; need to increase packet socket recv size accordingly, otherwise received packets get truncated to 4096 (default receive size)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified by manually checking if the packet received during test_vrf1_neigh_with_new_router_mac.
With this change it fails with:
```
"Exception: Pkt sent from 30.0.0.1 to 192.168.0.2 on port 2 was rcvd pkt on 1 which is one of the expected ports, but the src mac doesn't match, expected 00:12:34:56:78:9a, got 00:90:fb:5e:d6:be",
```
instead of no packet received.
The reason why the test still fails and ongoing discussion in these issues:
https://github.com/sonic-net/SONiC/pull/409#issuecomment-1130359847
https://github.com/Azure/sonic-swss/issues/1833

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
