### PR TITLE
[vsonic]: Enhance vSONiC testbed for recovering bgp support

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1668,6 +1668,22 @@ Totals               6450                 6449
             "docker rm {}".format(service), module_ignore_errors=True
         )
 
+    def start_bgpd(self):
+        return self.command("sudo config feature state bgp enabled")
+
+    def no_shutdown_bgp(self, asn):
+        logging.warning("SONiC don't support `no shutdown bgp`")
+        return None
+
+    def no_shutdown_bgp_neighbors(self, asn, neighbors=[]):
+        if not neighbors:
+            return
+        command = "vtysh -c 'config' -c 'router bgp {}'".format(asn)
+        for nbr in neighbors:
+            command += " -c 'no neighbor {} shutdown'".format(nbr)
+        logging.info('No shut BGP neighbors: {}'.format(json.dumps(neighbors)))
+        return self.command(command)
+
     def is_bgp_state_idle(self):
         """
         Check if all BGP peers are in IDLE state.


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The testbed may trigger BGP recovering  in the sanity checking stage. But vSONiC cannot support bgp recovering before and the following error would be raised:
```
E               Failed: Processes "['neighbor_vm_recover_bgpd--<SonicHost VM0101>', 'neighbor_vm_recover_bgpd--<SonicHost VM0102>', 'neighbor_vm_recover_bgpd--<SonicHost VM0103>', 'neighbor_vm_recover_bgpd--<SonicHost VM0100>']" failed with exit code "1"
E               Exception:
E               '<class 'tests.common.devices.sonic.SonicHost'>' object has no attribute 'start_bgpd'
E               Traceback:
E               Traceback (most recent call last):
E                 File "/data/sonic-mgmt/tests/common/helpers/parallel.py", line 31, in run
E                   Process.run(self)
E                 File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
E                   self._target(*self._args, **self._kwargs)
E                 File "/data/sonic-mgmt/tests/common/helpers/parallel.py", line 226, in wrapper
E                   target(*args, **kwargs)
E                 File "/data/sonic-mgmt/tests/common/plugins/sanity_check/recover.py", line 129, in neighbor_vm_recover_bgpd
E                   result['start_bgpd'] = nbr_host.start_bgpd()
E                 File "/data/sonic-mgmt/tests/common/devices/base.py", line 50, in __getattr__
E                   "'%s' object has no attribute '%s'" % (self.__class__, module_name)
E               AttributeError: '<class 'tests.common.devices.sonic.SonicHost'>' object has no attribute 'start_bgpd'
```
#### How did you do it?
By leveraging the `vtysh` command to support BGP recovering for vSONiC testbed.

#### How did you verify/test it?
In the vSONiC testbed
1. Shutdown interface by `sudo ifconfig Ethernet1 down`
2. The BGP recovering will be triggered due to sanity check
3. The above exception will not be raised again.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
