### PR TITLE
[platform_tests/api] Skipping test for absent psu's

### DIFF
--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -81,6 +81,13 @@ class TestPsuApi(PlatformApiTestBase):
 
         return def_value
 
+    def skip_absent_psu(self, psu_num, platform_api_conn):
+        name = psu.get_name(platform_api_conn, psu_num)
+        if name in self.psu_skip_list:
+            logger.info("Skipping PSU {} since it is part of psu_skip_list".format(name))
+            return True
+        return False
+
     #
     # Functions to test methods inherited from DeviceBase class
     #
@@ -88,6 +95,8 @@ class TestPsuApi(PlatformApiTestBase):
     def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for i in range(self.num_psus):
+            if self.skip_absent_psu(i,platform_api_conn):
+                continue
             name = psu.get_name(platform_api_conn, i)
             if self.expect(name is not None, "Unable to retrieve PSU {} name".format(i)):
                 self.expect(isinstance(name, STRING_TYPE), "PSU {} name appears incorrect".format(i))
@@ -109,6 +118,8 @@ class TestPsuApi(PlatformApiTestBase):
 
     def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         for i in range(self.num_psus):
+            if self.skip_absent_psu(i,platform_api_conn):
+                continue
             model = psu.get_model(platform_api_conn, i)
             if self.expect(model is not None, "Unable to retrieve PSU {} model".format(i)):
                 self.expect(isinstance(model, STRING_TYPE), "PSU {} model appears incorrect".format(i))
@@ -116,6 +127,8 @@ class TestPsuApi(PlatformApiTestBase):
 
     def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         for i in range(self.num_psus):
+            if self.skip_absent_psu(i,platform_api_conn):
+                continue
             serial = psu.get_serial(platform_api_conn, i)
             if self.expect(serial is not None, "Unable to retrieve PSU {} serial number".format(i)):
                 self.expect(isinstance(serial, STRING_TYPE), "PSU {} serial number appears incorrect".format(i))
@@ -125,6 +138,8 @@ class TestPsuApi(PlatformApiTestBase):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release(duthost, ["201811", "201911", "202012"])
         for i in range(self.num_psus):
+            if self.skip_absent_psu(i,platform_api_conn):
+                continue
             revision = psu.get_revision(platform_api_conn, i)
             if self.expect(revision is not None, "Unable to retrieve PSU {} serial number".format(i)):
                 self.expect(isinstance(revision, STRING_TYPE), "PSU {} serial number appears incorrect".format(i))
@@ -132,6 +147,8 @@ class TestPsuApi(PlatformApiTestBase):
 
     def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         for i in range(self.num_psus):
+            if self.skip_absent_psu(i,platform_api_conn):
+                continue
             status = psu.get_status(platform_api_conn, i)
             if self.expect(status is not None, "Unable to retrieve PSU {} status".format(i)):
                 self.expect(isinstance(status, bool), "PSU {} status appears incorrect".format(i))
@@ -139,6 +156,8 @@ class TestPsuApi(PlatformApiTestBase):
 
     def test_get_position_in_parent(self, platform_api_conn):
         for psu_id in range(self.num_psus):
+            if self.skip_absent_psu(psu_id,platform_api_conn):
+                continue
             position = psu.get_position_in_parent(platform_api_conn, psu_id)
             if self.expect(position is not None, "Failed to perform get_position_in_parent for psu id {}".format(psu_id)):
                 self.expect(isinstance(position, int), "Position value must be an integer value for psu id {}".format(psu_id))
@@ -146,6 +165,8 @@ class TestPsuApi(PlatformApiTestBase):
 
     def test_is_replaceable(self, platform_api_conn):
         for psu_id in range(self.num_psus):
+            if self.skip_absent_psu(psu_id,platform_api_conn):
+                continue
             replaceable = psu.is_replaceable(platform_api_conn, psu_id)
             if self.expect(replaceable is not None, "Failed to perform is_replaceable for psu id {}".format(psu_id)):
                 self.expect(isinstance(replaceable, bool), "Replaceable value must be a bool value for psu id {}".format(psu_id))
@@ -300,6 +321,8 @@ class TestPsuApi(PlatformApiTestBase):
 
         psus_skipped = 0
         for psu_id in range(self.num_psus):
+            if self.skip_absent_psu(psu_id,platform_api_conn):
+                continue
             name = psu.get_name(platform_api_conn, psu_id)
             led_support = duthost.facts.get("chassis").get("psus")[psu_id].get("led")
             if led_support == "N/A":
@@ -354,6 +377,8 @@ class TestPsuApi(PlatformApiTestBase):
 
     def test_thermals(self, platform_api_conn):
         for psu_id in range(self.num_psus):
+            if self.skip_absent_psu(psu_id,platform_api_conn):
+                continue
             try:
                 num_thermals = int(psu.get_num_thermals(platform_api_conn, psu_id))
             except Exception:


### PR DESCRIPTION
### Description of PR
Currently the tests are trying to access PSU which are not present and failing for them. Even though there is a skip_psu_list, there is no code present to use it. Added the support for it in all the relevant cases.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Currently the tests are trying to access PSU which are not present and failing for them. Even though there is a skip_psu_list, there is no code present to use it. Added the support for it in all the relevant cases.

#### How did you do it?

#### How did you verify/test it?
Verified against cisco-8000 platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

