### PR TITLE
Skipping test for absent modules

### DIFF
--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -84,10 +84,19 @@ class TestModuleApi(PlatformApiTestBase):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         self.skip_mod_list = get_skip_mod_list(duthost)
 
+    def skip_absent_module(self, module_num, platform_api_conn):
+        name = module.get_name(platform_api_conn, module_num)
+        if name in self.skip_mod_list:
+            logger.info("Skipping module {} since it is part of skip_mod_list".format(name))
+            return True
+        return False
+
     def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
 
         for i in range(self.num_modules):
             name = module.get_name(platform_api_conn, i)
+            if self.skip_absent_module(i,platform_api_conn):
+                continue
             if self.expect(name is not None, "Unable to retrieve module {} name".format(i)):
                 self.expect(isinstance(name, STRING_TYPE), "Module {} name appears incorrect".format(i))
         self.assert_expectations()
@@ -108,6 +117,8 @@ class TestModuleApi(PlatformApiTestBase):
     def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
 
         for i in range(self.num_modules):
+            if self.skip_absent_module(i,platform_api_conn):
+                continue
             model = module.get_model(platform_api_conn, i)
             if self.expect(model is not None, "Unable to retrieve module {} model".format(i)):
                 self.expect(isinstance(model, STRING_TYPE), "Module {} model appears incorrect".format(i))
@@ -116,6 +127,8 @@ class TestModuleApi(PlatformApiTestBase):
     def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
 
         for i in range(self.num_modules):
+            if self.skip_absent_module(i,platform_api_conn):
+                continue
             serial = module.get_serial(platform_api_conn, i)
             if self.expect(serial is not None, "Module {}: Failed to retrieve serial number".format(i)):
                 self.expect(isinstance(serial, STRING_TYPE), "Module {} serial number appears incorrect".format(i))
@@ -124,6 +137,8 @@ class TestModuleApi(PlatformApiTestBase):
     def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
 
         for i in range(self.num_modules):
+            if self.skip_absent_module(i,platform_api_conn):
+                continue
             status = module.get_status(platform_api_conn, i)
             if self.expect(status is not None, "Unable to retrieve module {} status".format(i)):
                 self.expect(isinstance(status, bool), "Module {} status appears incorrect".format(i))
@@ -131,6 +146,8 @@ class TestModuleApi(PlatformApiTestBase):
 
     def test_get_position_in_parent(self, platform_api_conn):
         for i in range(self.num_modules):
+            if self.skip_absent_module(i,platform_api_conn):
+                continue
             position = module.get_position_in_parent(platform_api_conn, i)
             if self.expect(position is not None, "Failed to perform get_position_in_parent for module {}".format(i)):
                 self.expect(isinstance(position, int), "Position value must be an integer value for module {}".format(i))
@@ -138,6 +155,8 @@ class TestModuleApi(PlatformApiTestBase):
 
     def test_is_replaceable(self, platform_api_conn):
         for i in range(self.num_modules):
+            if self.skip_absent_module(i,platform_api_conn):
+                continue
             replaceable = module.is_replaceable(platform_api_conn, i)
             if self.expect(replaceable is not None, "Failed to perform is_replaceable for module {}".format(i)):
                 self.expect(isinstance(replaceable, bool), "Replaceable value must be a bool value for module {}".format(i))
@@ -153,8 +172,11 @@ class TestModuleApi(PlatformApiTestBase):
         # Ensure the base MAC address of each module is sane
         # TODO: Add expected base MAC address for each module to inventory file and compare against it
         for i in range(self.num_modules):
+            if self.skip_absent_module(i,platform_api_conn):
+                continue
+            name = module.get_name(platform_api_conn, i)
             base_mac = module.get_base_mac(platform_api_conn, i)
-            if not self.expect(base_mac is not None, "Module {}: Failed to retrieve base MAC address".format(i)):
+	    if not self.expect(base_mac is not None, "Module {}: Failed to retrieve base MAC address".format(i)):
                 continue
             self.expect(re.match(REGEX_MAC_ADDRESS, base_mac), "Module {}: Base MAC address appears to be incorrect".format(i))
         self.assert_expectations()
@@ -192,6 +214,9 @@ class TestModuleApi(PlatformApiTestBase):
 
         # TODO: Add expected system EEPROM info for each module to inventory file and compare against it
         for i in range(self.num_modules):
+            if self.skip_absent_module(i,platform_api_conn):
+                continue
+            name = module.get_name(platform_api_conn, i)
             syseeprom_info_dict = module.get_system_eeprom_info(platform_api_conn, i)
             if not self.expect(syseeprom_info_dict is not None, "Module {}: Failed to retrieve system EEPROM data".format(i)):
                 continue
@@ -321,6 +346,8 @@ class TestModuleApi(PlatformApiTestBase):
     def test_get_description(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
 
         for i in range(self.num_modules):
+            if self.skip_absent_module(i,platform_api_conn):
+                continue
             description = module.get_description(platform_api_conn, i)
             if self.expect(description is not None, "Unable to retrieve module {} description".format(i)):
                 self.expect(isinstance(description, STRING_TYPE), "Module {} description appears incorrect".format(i))
@@ -329,6 +356,8 @@ class TestModuleApi(PlatformApiTestBase):
     def test_get_slot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
 
         for i in range(self.num_modules):
+            if self.skip_absent_module(i,platform_api_conn):
+                continue
             slot_id = module.get_slot(platform_api_conn, i)
             if self.expect(slot_id is not None, "Unable to retrieve module {} slot id".format(i)):
                 self.expect(isinstance(slot_id, int), "Module {} slot id is not correct ".format(i))
@@ -337,6 +366,8 @@ class TestModuleApi(PlatformApiTestBase):
     def test_get_type(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
 
         for i in range(self.num_modules):
+            if self.skip_absent_module(i,platform_api_conn):
+                continue
             mod_type = module.get_type(platform_api_conn, i)
             if self.expect(mod_type is not None, "Unable to retrieve module {} slot id".format(i)):
                 self.expect(isinstance(mod_type, STRING_TYPE), "Module {} type format appears not correct ".format(i))
@@ -346,6 +377,9 @@ class TestModuleApi(PlatformApiTestBase):
     def test_get_maximum_consumed_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
 
         for i in range(self.num_modules):
+            name = module.get_name(platform_api_conn, i)
+            if self.skip_absent_module(i,platform_api_conn):
+                continue
             mod_max_con_power = module.get_maximum_consumed_power(platform_api_conn, i)
             if self.expect(mod_max_con_power is not None, "Unable to retrieve module {} slot id".format(i)):
                 self.expect(isinstance(mod_max_con_power, float),
@@ -355,6 +389,8 @@ class TestModuleApi(PlatformApiTestBase):
     def test_get_midplane_ip(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
 
         for i in range(self.num_modules):
+            if self.skip_absent_module(i,platform_api_conn):
+                continue
             module_type = module.get_type(platform_api_conn, i)
             if module_type in MIDPLANE_SUPP_MODULE:
                 midplane_ip = module.get_midplane_ip(platform_api_conn, i)
@@ -365,6 +401,8 @@ class TestModuleApi(PlatformApiTestBase):
     def test_is_midplane_reachable(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
 
         for i in range(self.num_modules):
+            if self.skip_absent_module(i,platform_api_conn):
+                continue
             module_type = module.get_type(platform_api_conn, i)
             if module_type in MIDPLANE_SUPP_MODULE:
                 midplane_status = module.is_midplane_reachable(platform_api_conn, i)
@@ -375,6 +413,8 @@ class TestModuleApi(PlatformApiTestBase):
     def test_get_oper_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
 
         for i in range(self.num_modules):
+            if self.skip_absent_module(i,platform_api_conn):
+                continue
             status = module.get_oper_status(platform_api_conn, i)
             if self.expect(status is not None, "Unable to retrieve module {} status".format(i)):
                 self.expect(isinstance(status, STRING_TYPE), "Module {} status appears incorrect".format(i))

--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -94,9 +94,9 @@ class TestModuleApi(PlatformApiTestBase):
     def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
 
         for i in range(self.num_modules):
-            name = module.get_name(platform_api_conn, i)
             if self.skip_absent_module(i,platform_api_conn):
                 continue
+            name = module.get_name(platform_api_conn, i)	    
             if self.expect(name is not None, "Unable to retrieve module {} name".format(i)):
                 self.expect(isinstance(name, STRING_TYPE), "Module {} name appears incorrect".format(i))
         self.assert_expectations()
@@ -174,7 +174,6 @@ class TestModuleApi(PlatformApiTestBase):
         for i in range(self.num_modules):
             if self.skip_absent_module(i,platform_api_conn):
                 continue
-            name = module.get_name(platform_api_conn, i)
             base_mac = module.get_base_mac(platform_api_conn, i)
 	    if not self.expect(base_mac is not None, "Module {}: Failed to retrieve base MAC address".format(i)):
                 continue
@@ -216,7 +215,6 @@ class TestModuleApi(PlatformApiTestBase):
         for i in range(self.num_modules):
             if self.skip_absent_module(i,platform_api_conn):
                 continue
-            name = module.get_name(platform_api_conn, i)
             syseeprom_info_dict = module.get_system_eeprom_info(platform_api_conn, i)
             if not self.expect(syseeprom_info_dict is not None, "Module {}: Failed to retrieve system EEPROM data".format(i)):
                 continue
@@ -377,7 +375,6 @@ class TestModuleApi(PlatformApiTestBase):
     def test_get_maximum_consumed_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
 
         for i in range(self.num_modules):
-            name = module.get_name(platform_api_conn, i)
             if self.skip_absent_module(i,platform_api_conn):
                 continue
             mod_max_con_power = module.get_maximum_consumed_power(platform_api_conn, i)


### PR DESCRIPTION
### Description of PR
Currently the tests are trying to access modules which are not present and failing for them. Even though there is a skip_mod_list, there is no code present to use it. Added the support for it in all the relevant cases.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Currently the tests are trying to access modules which are not present and failing for them. Even though there is a skip_mod_list, there is no code present to use it. Added the support for it in all the relevant cases.

#### How did you do it?

#### How did you verify/test it?
Verified on cisco-8000 platform for T2 profile

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

