### PR TITLE
[pc/test_lag_2.py]: Updating print command.

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -116,7 +116,7 @@ class LagTest:
             # Verify PortChannel interfaces are up correctly
             for po_intf in po_interfaces.keys():
                 if po_intf != intf:
-                    command = 'bash -c "teamdctl %s %s state dump" | python -c "import sys, json; print json.load(sys.stdin)[\'ports\'][\'%s\'][\'runner\'][\'selected\']"' \
+                    command = 'bash -c "teamdctl %s %s state dump" | python -c "import sys, json; print(json.load(sys.stdin)[\'ports\'][\'%s\'][\'runner\'][\'selected\'])"' \
                     % (namespace_prefix, lag_name, po_intf)
                     wait_until(wait_timeout, delay, 0, self.__check_shell_output, self.duthost, command)
 
@@ -140,7 +140,7 @@ class LagTest:
             # Verify PortChannel interfaces are up correctly
             for po_intf in po_interfaces.keys():
                 if po_intf != intf:
-                    command = 'bash -c "teamdctl %s %s state dump" | python -c "import sys, json; print json.load(sys.stdin)[\'ports\'][\'%s\'][\'link\'][\'up\']"'\
+                    command = 'bash -c "teamdctl %s %s state dump" | python -c "import sys, json; print(json.load(sys.stdin)[\'ports\'][\'%s\'][\'link\'][\'up\'])"'\
                               % (namespace_prefix, lag_name, po_intf)
                     wait_until(wait_timeout, delay, 0, self.__check_shell_output, self.duthost, command)
 


### PR DESCRIPTION
### Description of PR
The print statement in Python3.x has been replaced with a print() function, with keyword arguments to replace most of the special syntax of the old print statement. This is causing the script to fail in the latest master code.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The print statement in Python3.x has been replaced with a print() function, with keyword arguments to replace most of the special syntax of the old print statement. This is causing the script to fail in the latest master code.

#### How did you do it?

#### How did you verify/test it?
Fixed the print statement and verified on T2 profile with Cisco-8000 platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?


