### PR TITLE
Increase timeout for sniffing option 82 packets

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -438,7 +438,7 @@ class DHCPTest(DataplaneBaseTest):
                     self.verified_option82 = True
 
     def Sniffer(self,iface):
-        scapy2.sniff(iface=iface, filter="udp and (port 67 or 68)",prn=self.pkt_callback, store=0, timeout=3)
+        scapy2.sniff(iface=iface, filter="udp and (port 67 or 68)",prn=self.pkt_callback, store=0, timeout=5)
 
 
     # Verify that the DHCP relay actually received and relayed the DHCPDISCOVER message to all of


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
test_dhcp_relay.py fails at "Failed: Verifying option 82" sometimes. It means it doesn't sniff any DHCP Relay packet with option 82. 

#### How did you do it?
After debugging, timeout=3 may be too short for waiting relayed discover packets from DUT.
Add timestamp, I found relayed discover packets may arrive at PTF 3s later after starting sniff.
Increase it to 5s to make sure it can capture expected packets.

#### How did you verify/test it?
run `test_dhcp_relay.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
