### PR TITLE
[log analyzer] skip log analyzer for test_static_route_ecmp which involve config reload

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -238,7 +238,7 @@ def test_static_route(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggle_all
     run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, "1.1.1.0/24",
                           nexthop_addrs, prefix_len, nexthop_devs, nexthop_interfaces)
 
-
+@pytest.mark.disable_loganalyzer
 def test_static_route_ecmp(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggle_all_simulator_ports_to_rand_selected_tor_m):
     duthost = rand_selected_dut
     skip_201911_and_older(duthost)
@@ -254,7 +254,7 @@ def test_static_route_ipv6(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggl
     run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, "2000:1::/64",
                           nexthop_addrs, prefix_len, nexthop_devs, nexthop_interfaces, ipv6=True)
 
-
+@pytest.mark.disable_loganalyzer
 def test_static_route_ecmp_ipv6(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggle_all_simulator_ports_to_rand_selected_tor_m):
     duthost = rand_selected_dut
     skip_201911_and_older(duthost)

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -238,6 +238,7 @@ def test_static_route(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggle_all
     run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, "1.1.1.0/24",
                           nexthop_addrs, prefix_len, nexthop_devs, nexthop_interfaces)
 
+
 @pytest.mark.disable_loganalyzer
 def test_static_route_ecmp(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggle_all_simulator_ports_to_rand_selected_tor_m):
     duthost = rand_selected_dut
@@ -253,6 +254,7 @@ def test_static_route_ipv6(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggl
     prefix_len, nexthop_addrs, nexthop_devs, nexthop_interfaces = get_nexthops(duthost, tbinfo, ipv6=True)
     run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, "2000:1::/64",
                           nexthop_addrs, prefix_len, nexthop_devs, nexthop_interfaces, ipv6=True)
+
 
 @pytest.mark.disable_loganalyzer
 def test_static_route_ecmp_ipv6(rand_selected_dut, ptfadapter, ptfhost, tbinfo, toggle_all_simulator_ports_to_rand_selected_tor_m):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
skip log analyzer for test_static_route_ecmp which involve config reload
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
To skip log analyzer for test.
#### How did you do it?
Add skip mark for tests which involve config reload which could trigger some errors during container restart.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
