### PR TITLE
[log_analyser] ignore error log for config reload

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -50,6 +50,7 @@ r, ".* ERR bgp#bgpcfgd: .*BGPVac.*attribute is supported.*"
 
 # https://msazure.visualstudio.com/One/_workitems/edit/14233938
 r, ".* ERR swss#fdbsyncd: :- readData: netlink reports an error=-25 on reading a netlink socket.*"
+r, ".* ERR swss#fdbsyncd: :- readData: netlink reports an error=-33 on reading a netlink socket.*"
 
 # https://dev.azure.com/msazure/One/_workitems/edit/14213168
 r, ".* ERR /hostcfgd: sonic-kdump-config --disable - failed.*"

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -108,6 +108,7 @@ class TestCOPP(object):
                      copp_testbed,
                      dut_type)
 
+    @pytest.mark.disable_loganalyzer
     def test_add_new_trap(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, check_image_version, copp_testbed, dut_type, backup_restore_config_db):
         """
         Validates that one new trap(bgp) can be installed
@@ -137,6 +138,7 @@ class TestCOPP(object):
             wait_until(60, 20, 0, _copp_runner, duthost, ptfhost, self.trap_id.upper(), copp_testbed, dut_type),
             "Installing {} trap fail".format(self.trap_id))
 
+    @pytest.mark.disable_loganalyzer
     @pytest.mark.parametrize("remove_trap_type", ["delete_feature_entry",
                                                   "disable_feature_status"])
     def test_remove_trap(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, check_image_version, copp_testbed, dut_type, backup_restore_config_db, remove_trap_type):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Config reload could trigger error logs as expected, which we should ignore.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Config reload could trigger error logs as expected, which we should ignore.
But some tests which has config reload doesn't trigger errors detected by log analyzer, which depends on when the log analyzer kicked in and out. Need to optimize the mechanism of log analyzer, to recognize the config reload operation and ignore error logs during reload time, file one issue to track this. 
https://github.com/Azure/sonic-mgmt/issues/5691

#### How did you do it?
To skip log analyzer for tests which involve config reload.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
