### PR TITLE
[python3] Refact `icmp_responder`

### DIFF
--- a/tests/scripts/icmp_responder.py
+++ b/tests/scripts/icmp_responder.py
@@ -1,78 +1,139 @@
 import argparse
+import asyncio
+import ctypes
+import functools
+import signal
+import socket
+import struct
 
-from concurrent.futures.thread import ThreadPoolExecutor
-from scapy.all import conf, Ether, ICMP, IP
-from scapy.arch import get_if_hwaddr
-from scapy.data import ETH_P_IP
-from select import select
-
-
-def respond_to_icmp_request(socket, request, dst_mac=None):
-    """Respond to ICMP request."""
-    reply = request.copy()
-    reply[ICMP].type = 0
-    # Force re-generation of the checksum
-    reply[ICMP].chksum = None
-    reply[IP].src, reply[IP].dst = request[IP].dst, request[IP].src
-    reply[IP].chksum = None
-
-    if dst_mac is None:
-        icmp_reply_dst_mac = request[Ether].src
-    else:
-        icmp_reply_dst_mac = dst_mac
-
-    reply[Ether].src, reply[Ether].dst = request[Ether].dst, icmp_reply_dst_mac
-    socket.send(reply)
+from scapy.all import Ether, ICMP, IP
 
 
-class ICMPSniffer(object):
-    """Sniff ICMP packets."""
+# As defined in asm/socket.h
+SO_ATTACH_FILTER = 26
 
-    TYPE_ECHO_REQUEST = 8
-    def __init__(self, ifaces, request_handler=None, dst_mac=None):
-        """
-        Init ICMP sniffer.
+# BPF filter "icmp[0] == 8"
+icmp_bpf_filter = [
+    [0x28, 0, 0, 0x0000000c],
+    [0x15, 0, 8, 0x00000800],
+    [0x30, 0, 0, 0x00000017],
+    [0x15, 0, 6, 0x00000001],
+    [0x28, 0, 0, 0x00000014],
+    [0x45, 4, 0, 0x00001fff],
+    [0xb1, 0, 0, 0x0000000e],
+    [0x50, 0, 0, 0x0000000e],
+    [0x15, 0, 1, 0x00000008],
+    [0x6, 0, 0, 0x00040000],
+    [0x6, 0, 0, 0x00000000]
+]
 
-        @param ifaces: interfaces to listen for ICMP reqest
-        @param request_handler: handler function that will be called when
-                                receives ICMP request
-        """
-        self.sniff_sockets = []
-        self.iface_hwaddr = {}
-        for iface in ifaces:
-            self.sniff_sockets.append(conf.L2socket(type=ETH_P_IP, iface=iface, filter="icmp"))
-            self.iface_hwaddr[iface] = get_if_hwaddr(iface)
-        self.request_handler = request_handler
+
+def bpf_stmt(code, jt, jf, k):
+    """Format struct `sock_filter`."""
+    return struct.pack("HBBI", code, jt, jf, k)
+
+
+def build_bpfilter(filter):
+    """Build BPF filter buffer."""
+    return ctypes.create_string_buffer(b"".join(bpf_stmt(*_) for _ in filter))
+
+
+class ICMPResponderProtocol(asyncio.Protocol):
+    """ICMP responder protocol class to define read/write callbacks."""
+
+    def __init__(self, on_con_lost, dst_mac=None):
+        self.transport = None
+        self.on_con_lost = on_con_lost
         self.dst_mac = dst_mac
 
-    def __call__(self):
-        try:
-            while True:
-                sel = select(self.sniff_sockets, [], [])
-                for s in sel[0]:
-                    packet = s.recv()
-                    if packet is not None:
-                        if ICMP in packet and packet[ICMP].type == self.TYPE_ECHO_REQUEST and self.request_handler:
-                            self.request_handler(s, packet, self.dst_mac)
-        finally:
-            for s in self.sniff_sockets:
-                s.close()
+    def connection_made(self, transport):
+        self.transport = transport
+
+    def data_received(self, data):
+        reply = self.icmp_reply(data)
+        self.transport.write(reply)
+
+    def eof_received(self):
+        return True
+
+    def connection_lost(self, exc):
+        if not self.on_con_lost.cancelled():
+            self.on_con_lost.set_result(True)
+
+    def icmp_reply(self, icmp_request):
+        reply = Ether(icmp_request)
+        reply[ICMP].type = 0
+        # Force re-generation of the checksum
+        reply[ICMP].chksum = None
+        reply[IP].src, reply[IP].dst = reply[IP].dst, reply[IP].src
+        reply[IP].chksum = None
+        reply[Ether].src, reply[Ether].dst = reply[Ether].dst, reply[Ether].src
+        if self.dst_mac is not None:
+            reply[Ether].dst = self.dst_mac
+        return bytes(reply)
 
 
-if __name__ == "__main__":
+def create_socket(interface):
+    """Create a packet socket binding to a specified interface."""
+
+    sock = socket.socket(family=socket.AF_PACKET, type=socket.SOCK_RAW, proto=0)
+
+    sock.setblocking(False)
+    bpf_filter = build_bpfilter(icmp_bpf_filter)
+    fprog = struct.pack("HL", len(icmp_bpf_filter), ctypes.addressof(bpf_filter))
+    sock.setsockopt(socket.SOL_SOCKET, SO_ATTACH_FILTER, fprog)
+
+    sock.bind((interface, socket.SOCK_RAW))
+
+    return sock
+
+
+async def icmp_responder(interface, dst_mac=None):
+    """Start responding to ICMP requests received from specified interface."""
+    loop = asyncio.get_running_loop()
+    on_con_lost = loop.create_future()
+
+    sock = create_socket(interface)
+    transport, protocol = await loop._create_connection_transport(sock, lambda: ICMPResponderProtocol(on_con_lost, dst_mac), ssl=None, server_hostname=None)
+
+    try:
+        await protocol.on_con_lost
+    finally:
+        transport.close()
+        sock.close()
+
+
+def stop_tasks(loop):
+    """Stop all tasks in current event loop."""
+    for task in asyncio.all_tasks(loop=loop):
+        task.cancel()
+
+
+async def start_icmp_responder(interfaces, dst_mac=None):
+    """Start responding to ICMP requests received from the interfaces."""
+    responders = [icmp_responder(interface, dst_mac=dst_mac) for interface in interfaces]
+
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGINT, functools.partial(stop_tasks, loop))
+    loop.add_signal_handler(signal.SIGTERM, functools.partial(stop_tasks, loop))
+
+    await asyncio.gather(*responders, return_exceptions=True)
+
+
+def main():
     parser = argparse.ArgumentParser(description="ICMP responder")
     parser.add_argument("--intf", "-i", dest="ifaces", required=True, action="append", help="interface to listen for ICMP request")
     parser.add_argument("--dst_mac", "-m", dest="dst_mac", required=False, action="store", help="The destination MAC to use for ICMP echo replies")
     args = parser.parse_args()
-    ifaces = args.ifaces
+    interfaces = args.ifaces
     dst_mac = args.dst_mac
 
-    max_workers = 24 if len(ifaces) > 24 else len(ifaces)
-    sniffed_ifaces = [[] for _ in range(max_workers)]
-    for i, iface in enumerate(ifaces):
-        sniffed_ifaces[i % max_workers].append(iface)
+    try:
+        asyncio.run(start_icmp_responder(interfaces=interfaces, dst_mac=dst_mac))
+    except asyncio.CancelledError:
+        print("Exiting...")
+        return
 
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        for ifaces in sniffed_ifaces:
-            icmp_sniffer = ICMPSniffer(ifaces, request_handler=respond_to_icmp_request, dst_mac=dst_mac)
-            executor.submit(icmp_sniffer)
+
+if __name__ == "__main__":
+    main()

--- a/tests/templates/icmp_responder.conf.j2
+++ b/tests/templates/icmp_responder.conf.j2
@@ -1,5 +1,5 @@
 [program:icmp_responder]
-command=source /root/env-python3/bin/activate && python /opt/icmp_responder.py {{ icmp_responder_args }}
+command=/root/env-python3/bin/python /opt/icmp_responder.py {{ icmp_responder_args }}
 process_name=icmp_responder
 environment=PATH="/root/env-python3/bin"
 stdout_logfile=/tmp/icmp_responder.out.log

--- a/tests/templates/icmp_responder.conf.j2
+++ b/tests/templates/icmp_responder.conf.j2
@@ -1,6 +1,7 @@
 [program:icmp_responder]
-command=/usr/bin/python /opt/icmp_responder.py {{ icmp_responder_args }}
+command=source /root/env-python3/bin/activate && python /opt/icmp_responder.py {{ icmp_responder_args }}
 process_name=icmp_responder
+environment=PATH="/root/env-python3/bin"
 stdout_logfile=/tmp/icmp_responder.out.log
 stderr_logfile=/tmp/icmp_responder.err.log
 redirect_stderr=false


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
1. Migrate `icmp_responder` to `Python3`.
2. Improve `icmp_responder` performance.

#### How did you do it?
Previously, `icmp_responder` was running in a thread pool, for each port, there is a select event loop to poll the packet socket(binding to the port) for any ICMP request and respond to that request.
With the presence of `GIL`, the Python interpreter could only respond to one port read/write operations pair once a time. The threaded `icmp_responder` will not help much here but introduce overhead in the thread context switching. And 
With the introduction of `asyncio`, both read/write operations to the packet socket could be asynchronous.

#### How did you verify/test it?
With running `icmp_responder` in a dualtor testbed, dump 1000 pings from one port:
1. previous threaded version
![threaded](https://user-images.githubusercontent.com/35479537/169852284-344493ab-6a15-4ac2-a764-a32288c8173c.jpeg)
2. proposed asyncio version
![async](https://user-images.githubusercontent.com/35479537/169852683-61ece51d-6c89-4bec-956b-1e527470b082.jpeg)

The average ping request/response interval is decreased from 20ms-30ms to 10ms-20ms
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
