### PR TITLE
Update DHCPv6 counter test and solicit packet options

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
@@ -137,7 +137,7 @@ class DHCPCounterTest(DataplaneBaseTest):
     """
 
     def client_send(self):
-        client_messages = [DHCP6_Solicit, DHCP6_Request, DHCP6_Confirm, DHCP6_Renew, DHCP6_Rebind, DHCP6_Release, DHCP6_Decline, DHCP6_InfoRequest]
+        client_messages = [DHCP6_Solicit, DHCP6_Request, DHCP6_Confirm, DHCP6_Renew, DHCP6_Rebind, DHCP6_Release, DHCP6_Decline, DHCP6_Reconf, DHCP6_InfoRequest]
         for message in client_messages:
             packet = self.create_packet(message)
             testutils.send_packet(self, self.client_port_index, packet)

--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
@@ -21,7 +21,7 @@ DHCP6_Advertise = scapy.layers.dhcp6.DHCP6_Advertise
 DHCP6_Reply = scapy.layers.dhcp6.DHCP6_Reply
 DHCP6_RelayReply = scapy.layers.dhcp6.DHCP6_RelayReply
 DHCP6OptRelayMsg = scapy.layers.dhcp6.DHCP6OptRelayMsg
-DHCP6OptBootFileUrl = scapy.layers.dhcp6.DHCP6OptBootFileUrl # dhcp6opt out of client scope to test malformed counters
+DHCP6OptAuth = scapy.layers.dhcp6.DHCP6OptAuth
 
 class DataplaneBaseTest(BaseTest):
     def __init__(self):
@@ -110,7 +110,7 @@ class DHCPCounterTest(DataplaneBaseTest):
         packet = Ether(src=self.client_mac, dst=self.BROADCAST_MAC)
         packet /= IPv6(src=self.client_link_local, dst=self.BROADCAST_IP)
         packet /= UDP(sport=self.DHCP_CLIENT_PORT, dport=self.DHCP_SERVER_PORT)
-        packet /= message(trid=12345)/DHCP6OptBootFileUrl()
+        packet /= message(trid=12345)/DHCP6OptAuth(optcode=100) # changes optcode to be out of client scope to test malformed counters
 
         return packet
 

--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
@@ -15,10 +15,13 @@ DHCP6_Renew = scapy.layers.dhcp6.DHCP6_Renew
 DHCP6_Rebind = scapy.layers.dhcp6.DHCP6_Rebind
 DHCP6_Release = scapy.layers.dhcp6.DHCP6_Release
 DHCP6_Decline = scapy.layers.dhcp6.DHCP6_Decline
+DHCP6_Reconf= scapy.layers.dhcp6.DHCP6_Reconf
+DHCP6_InfoRequest = scapy.layers.dhcp6.DHCP6_InfoRequest
 DHCP6_Advertise = scapy.layers.dhcp6.DHCP6_Advertise
 DHCP6_Reply = scapy.layers.dhcp6.DHCP6_Reply
 DHCP6_RelayReply = scapy.layers.dhcp6.DHCP6_RelayReply
 DHCP6OptRelayMsg = scapy.layers.dhcp6.DHCP6OptRelayMsg
+DHCP6OptBootFileUrl = scapy.layers.dhcp6.DHCP6OptBootFileUrl # dhcp6opt out of client scope to test malformed counters
 
 class DataplaneBaseTest(BaseTest):
     def __init__(self):
@@ -103,6 +106,14 @@ class DHCPCounterTest(DataplaneBaseTest):
 
         return packet
 
+    def create_malformed_client_packet(self, message):
+        packet = Ether(src=self.client_mac, dst=self.BROADCAST_MAC)
+        packet /= IPv6(src=self.client_link_local, dst=self.BROADCAST_IP)
+        packet /= UDP(sport=self.DHCP_CLIENT_PORT, dport=self.DHCP_SERVER_PORT)
+        packet /= message(trid=12345)/DHCP6OptBootFileUrl()
+
+        return packet
+
     def create_server_packet(self, message):
         packet = Ether(dst=self.relay_iface_mac)
         packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
@@ -112,25 +123,38 @@ class DHCPCounterTest(DataplaneBaseTest):
 
         return packet
 
+    def create_unknown_server_packet(self):
+        packet = Ether(dst=self.relay_iface_mac)
+        packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
+        packet /= UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
+        packet /= DHCP6_RelayReply(msgtype=13, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
+
+        return packet
+
     """
      Send functions
 
     """
 
     def client_send(self):
-        client_messages = [DHCP6_Solicit, DHCP6_Request, DHCP6_Confirm, DHCP6_Renew, DHCP6_Rebind, DHCP6_Release, DHCP6_Decline]
+        client_messages = [DHCP6_Solicit, DHCP6_Request, DHCP6_Confirm, DHCP6_Renew, DHCP6_Rebind, DHCP6_Release, DHCP6_Decline, DHCP6_InfoRequest]
         for message in client_messages:
             packet = self.create_packet(message)
             testutils.send_packet(self, self.client_port_index, packet)
 
+        malformed_packet = self.create_malformed_client_packet(DHCP6_Solicit)
+        testutils.send_packet(self, self.client_port_index, malformed_packet)
+
     def server_send(self):
-        server_messages = [DHCP6_Advertise, DHCP6_Reply]
+        server_messages = [DHCP6_Advertise, DHCP6_Reply, DHCP6_Reconf]
         for message in server_messages:
             packet = self.create_server_packet(message)
             packet.src = self.dataplane.get_mac(0, self.server_port_indices[0])
             testutils.send_packet(self, self.server_port_indices[0], packet)
 
+        unknown_packet = self.create_unknown_server_packet()
+        testutils.send_packet(self, self.server_port_indices[0], unknown_packet)
+
     def runTest(self):
         self.client_send()
         self.server_send()
-

--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
@@ -21,6 +21,12 @@ DHCP6_Reply = scapy.layers.dhcp6.DHCP6_Reply
 DHCP6_RelayReply = scapy.layers.dhcp6.DHCP6_RelayReply
 DHCP6OptRelayMsg = scapy.layers.dhcp6.DHCP6OptRelayMsg
 DHCP6OptUnknown = scapy.layers.dhcp6.DHCP6OptUnknown
+
+DHCP6OptClientId = scapy.layers.dhcp6.DHCP6OptClientId
+DHCP6OptOptReq = scapy.layers.dhcp6.DHCP6OptOptReq
+DHCP6OptElapsedTime = scapy.layers.dhcp6.DHCP6OptElapsedTime
+DHCP6OptIA_NA = scapy.layers.dhcp6.DHCP6OptIA_NA
+DUID_LLT = scapy.layers.dhcp6.DUID_LLT
  
 class DataplaneBaseTest(BaseTest):
     def __init__(self):
@@ -142,6 +148,10 @@ class DHCPTest(DataplaneBaseTest):
         solicit_packet /= IPv6(src=self.client_link_local, dst=self.BROADCAST_IP)
         solicit_packet /= UDP(sport=self.DHCP_CLIENT_PORT, dport=self.DHCP_SERVER_PORT)
         solicit_packet /= DHCP6_Solicit(trid=12345)
+        solicit_packet /= DHCP6OptClientId(duid=DUID_LLT(lladdr=self.client_mac))
+        solicit_packet /= DHCP6OptOptReq(reqopts=[23,24,29])
+        solicit_packet /= DHCP6OptElapsedTime(elapsedtime=0)
+        solicit_packet /= DHCP6OptIA_NA()
 
         return solicit_packet
 
@@ -151,7 +161,7 @@ class DHCPTest(DataplaneBaseTest):
         solicit_relay_forward_packet /= UDP(sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         solicit_relay_forward_packet /= DHCP6_RelayForward(msgtype=12, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
         solicit_relay_forward_packet /= DHCP6OptClientLinkLayerAddr()
-        solicit_relay_forward_packet /= DHCP6OptRelayMsg(message=[DHCP6_Solicit(trid=12345)])
+        solicit_relay_forward_packet /= DHCP6OptRelayMsg(message=[DHCP6_Solicit(trid=12345)/DHCP6OptClientId(duid=DUID_LLT(lladdr=self.client_mac))/DHCP6OptOptReq(reqopts=[23,24,29])/DHCP6OptElapsedTime(elapsedtime=0)/DHCP6OptIA_NA()])
 
         return solicit_relay_forward_packet
 

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -133,7 +133,7 @@ def test_dhcpv6_relay_counter(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp
     duthost = duthosts[rand_one_dut_hostname]
     skip_release(duthost, ["201911", "202106"])
     
-    messages = ["Solicit", "Advertise", "Request", "Confirm", "Renew", "Rebind", "Reply", "Release", "Decline", "Relay-Forward", "Relay-Reply"]
+    messages = ["Unknown", "Solicit", "Advertise", "Request", "Confirm", "Renew", "Rebind", "Reply", "Release", "Decline", "Reconfigure", "Information-Request", "Relay-Forward", "Relay-Reply", "Malformed"]
 
     for dhcp_relay in dut_dhcp_relay_data:
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Update DHCPv6 counter test with most updated counter messages, and add dhcpv6 options to solicit packet to test for DHCPv6 option check

#### How did you do it?
Add all counter messages, including Unknown and Malformed messages
Add common client solicit options that would typically be sent by dhclient to solicit packet

#### How did you verify/test it?
Run test with most updated dhcp6relay

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
