### PR TITLE
Update copp_test.py to call count_matched_packets_all_ports instead

### DIFF
--- a/ansible/roles/test/files/ptftests/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/copp_tests.py
@@ -119,7 +119,7 @@ class ControlPlaneBaseTest(BaseTest):
                 testutils.send_packet(self, send_intf, packet)
                 pre_send_count += 1
 
-            rcv_pkt_cnt = testutils.count_matched_packets(self, packet, recv_intf[1], recv_intf[0], timeout=5)
+            rcv_pkt_cnt = testutils.count_matched_packets_all_ports(self, packet, [recv_intf[1]], recv_intf[0], timeout=5)
             self.log("Send %d and receive %d packets in the first second (PolicyTest)" % (pre_send_count, rcv_pkt_cnt))
 
 
@@ -144,7 +144,8 @@ class ControlPlaneBaseTest(BaseTest):
         self.log("Sent out %d packets in %ds" % (send_count, self.DEFAULT_SEND_INTERVAL_SEC))
 
         time.sleep(self.DEFAULT_RECEIVE_WAIT_TIME)  # Wait a little bit for all the packets to make it through
-        recv_count = testutils.count_matched_packets(self, packet, recv_intf[1], recv_intf[0], timeout=10)
+        recv_count = testutils.count_matched_packets_all_ports(self, packet, [recv_intf[1]], recv_intf[0], timeout=10)
+        self.log("Received %d packets after sleep %ds" % (recv_count, self.DEFAULT_RECEIVE_WAIT_TIME))
 
         post_test_ptf_tx_counter = self.dataplane.get_counters(*send_intf)
         post_test_ptf_rx_counter = self.dataplane.get_counters(*recv_intf)


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
`test_copp` failed in `copp_test.py` because the script stuck at `count_matched_packets`.

`count_matched_packets` will recount timeout after receiving any packets from remote ptf_nn_agent(dut).
It keeps receiving packets, then timeout doesn't work. When `TASK_TIMEOUT = 600`  arrives, copp_test will fail.

#### How did you do it?
Replace `count_matched_packets` with `count_matched_packets_all_ports` which will stop receiving and matching packets when the specified timeout reached.

#### How did you verify/test it?
run `copp/test_copp.py`
`copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot[str-dx010-acs-5] PASSED                   [100%]`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
