### PR TITLE
raise exception with detailed info for user if virtual env for python3 doesn't exist

### DIFF
--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -25,10 +25,10 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
         if path_exists["stat"]["exists"]:
             cmd = "/root/env-python3/bin/ptf --test-dir {} {}".format(testdir+'/py3', testname)
         else:
-            error_msg = "Virtual environment for Python3 /root/env-python3/bin/ptf doesn't exist.\nPlease check the docker-ptf image, make sure to use the correct one."
+            error_msg = "Virtual environment for Python3 /root/env-python3/bin/ptf doesn't exist.\nPlease check and update docker-ptf image, make sure to use the correct one."
             logger.error("Exception caught while executing case: {}. Error message: {}"\
             .format(testname, error_msg))
-            raise Exception
+            raise Exception(error_msg)
     else:
         cmd = "ptf --test-dir {} {}".format(testdir, testname)
 

--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -21,7 +21,14 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
     # ptf will load all scripts under ptftests, it will throw error for py2 scripts.
     # So move migrated scripts to seperated py3 folder avoid impacting py2 scripts.
     if is_python3:
-        cmd = "/root/env-python3/bin/ptf --test-dir {} {}".format(testdir+'/py3', testname)
+        path_exists = host.stat(path="/root/env-python3/bin/ptf")
+        if path_exists["stat"]["exists"]:
+            cmd = "/root/env-python3/bin/ptf --test-dir {} {}".format(testdir+'/py3', testname)
+        else:
+            error_msg = "Virtual environment for Python3 /root/env-python3/bin/ptf doesn't exist.\nPlease check the docker-ptf image, make sure to use the correct one."
+            logger.error("Exception caught while executing case: {}. Error message: {}"\
+            .format(testname, error_msg))
+            raise Exception
     else:
         cmd = "ptf --test-dir {} {}".format(testdir, testname)
 


### PR DESCRIPTION

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The latest docker-ptf image has virtual environment for python3, but if user runs test case in an old docker-ptf image without virtual environment, it will call ptf command which doesn't exist in docker-ptf container and test case will fail.

#### How did you do it?
Check if `/root/env-python3/bin/ptf` exists, throw exception if it doesn't exist.
It also prints out the detailed information for user.

#### How did you verify/test it?
run `dhcp_relay/test_dhcp_relay.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
