### PR TITLE
[chassis]: Modify minigraph_dpg_asic template to generate unique port channel index

### DIFF
--- a/ansible/templates/minigraph_dpg_asic.j2
+++ b/ansible/templates/minigraph_dpg_asic.j2
@@ -1,6 +1,7 @@
-{# Note max of 10 Backend Portchannel from one asic #}
+{# Note max of 16 Backend Portchannel from one asic #}
 {% macro port_channel_id(asic_idx, neigh_asic_idx) -%}
-{{ ((40 + 10 * asic_idx + neigh_asic_idx)|string) }}
+{# Note avoid PortChannel00 #}
+{{ ((1 + 16 * asic_idx + neigh_asic_idx)|string) }}
 {%- endmacro -%}
 {% if num_asics > 1 %}
 {% if (asic_topo_config and slot_num is defined and slot_num in asic_topo_config) or (asic_topo_config and slot_num is not defined) %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
[chassis]: Modify minigraph_dpg_asic template to generate unique port channel index for supervisor node in chassis with more than 10 asics.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
snmp_interfaces test case fails on supervisor on packet chassis because the internal Portchannel name generated is not unique for the supervisor. The portchannel names generated is unique within a namespace but not across namespaces. SNMP expects the portchannel names to unique as the port channel index used in snmp output has to be unique.
#### How did you do it?
Modify dpg_asic template to generate unique port channel index for supervisor node with maximum of 16 asics.
#### How did you verify/test it?
Tested on multi-asic platform and linecard to ensure unique port channel indices are generated.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
