### PR TITLE
Added code to check swss on all asics if dut is_multi_asic

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -16,13 +16,24 @@ def config_system_checks_passed(duthost):
         return False
 
     logging.info("Checking if Orchagent up for at least 2 min")
-    out = duthost.shell("systemctl show swss.service --property ActiveState --value")
-    if out["stdout"] != "active":
-        return False
+    if duthost.is_multi_asic:
+        for asic in duthost.asics:
+            out = duthost.shell("systemctl show swss@{}.service --property ActiveState --value".format(asic.asic_index))
+            if out["stdout"] != "active":
+                return False
 
-    out = duthost.shell("ps -o etimes -p $(systemctl show swss.service --property ExecMainPID --value) | sed '1d'")
-    if int(out['stdout'].strip()) < 120:
-        return False
+            out = duthost.shell(
+                "ps -o etimes -p $(systemctl show swss@{}.service --property ExecMainPID --value) | sed '1d'".format(asic.asic_index))
+            if int(out['stdout'].strip()) < 120:
+                return False
+    else:
+        out = duthost.shell("systemctl show swss.service --property ActiveState --value")
+        if out["stdout"] != "active":
+            return False
+
+        out = duthost.shell("ps -o etimes -p $(systemctl show swss.service --property ExecMainPID --value) | sed '1d'")
+        if int(out['stdout'].strip()) < 120:
+            return False
 
     logging.info("Checking if delayed services are up")
     out = duthost.shell("systemctl list-dependencies sonic-delayed.target --plain |sed '1d'")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
swss docker should be check on all ASICs if  dut is multi ASICs.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
To ensure swss docker is checked on all ASICs if the dut is multi ASICs 

#### How did you do it?
dded code to config_system_checks_passed definition to check all ASICs if dut is multi ASICs.  Otherwise will check one ASIC.
  - If dut is multi_asic
    - duthost.shell("systemctl show swss@{}.service --property ActiveState --value".format(asic.asic_index))
    - duthost.shell("ps -o etimes -p $(systemctl show swss@{}.service --property ExecMainPID --value) | sed '1d'".format(asic.asic_index))

  - If dut is not multi_asic
    - duthost.shell("systemctl show swss.service --property ActiveState --value")
    - duthost.shell("ps -o etimes -p $(systemctl show swss.service --property ExecMainPID --value) | sed '1d'")
    - 
#### How did you verify/test it?
Ran test_reload_configuration and test_reload_configuration_checks testcases which call config_system_checks_passed on a multi ASICss chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
