### PR TITLE
[dualtor] Fix `test_downstream_emcp_nexthops[ipv6]`

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1108,7 +1108,7 @@ def flush_neighbor(duthost, neighbor, restore=True):
     logging.info("remove neighbor entry for %s", neighbor)
     duthost.shell("ip neighbor del %s dev %s" % (neighbor, neighbor_details['dev']))
     try:
-        yield
+        yield neighbor_details
     finally:
         if restore:
             logging.info("restore neighbor entry for %s", neighbor)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix `test_downstream_ecmp_nexthops[ipv6]`

The root cause is that the testcase `test_active_tor_remove_neighbor_downstream_active`, which runs before `test_downstream_emcp_nexthops` during nightlies, will remove a neighbor entry from the neighbor tables, which leave the mocked device in an unhealthy state, so `test_downstream_emcp_nexthops` will fail if it tries to send downstream traffic to the server that has neighbor removed by `test_active_tor_remove_neighbor_downstream_active`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
Let `test_active_tor_remove_neighbor_downstream_active` restore the mocked neighbor table after its finish.

#### How did you verify/test it?
```
dualtor/test_orchagent_active_tor_downstream.py::test_active_tor_remove_neighbor_downstream_active[ipv6] FAILED                                                                                                                                                        [ 50%]
dualtor/test_orchagent_active_tor_downstream.py::test_downstream_ecmp_nexthops[ipv6] PASSED                                                                                                                                                                            [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
