### PR TITLE
Skip test_memory_exhaustion for Force10-S6000

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -563,7 +563,7 @@ platform_tests/test_memory_exhaustion.py:
   skip:
     reason: "Skip this test case until vendors fix the issue"
     conditions:
-      - ("hwsku in ['Celestica-DX010-C32', 'Celestica-E1031-T48S4']" and https://github.com/Azure/sonic-buildimage/issues/10339) or ("hwsku in ['Force10-S6000']" and https://github.com/Azure/sonic-buildimage/issues/10921)
+      - "(hwsku in ['Celestica-DX010-C32', 'Celestica-E1031-T48S4'] and https://github.com/Azure/sonic-buildimage/issues/10339) or (hwsku in ['Force10-S6000'] and https://github.com/Azure/sonic-buildimage/issues/10921)"
 
 #######################################
 #####    test_platform_info.py    #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -563,8 +563,7 @@ platform_tests/test_memory_exhaustion.py:
   skip:
     reason: "Skip this test case until vendors fix the issue"
     conditions:
-      - "hwsku in ['Celestica-DX010-C32', 'Celestica-E1031-T48S4']"
-      - https://github.com/Azure/sonic-buildimage/issues/10339
+      - ("hwsku in ['Celestica-DX010-C32', 'Celestica-E1031-T48S4']" and https://github.com/Azure/sonic-buildimage/issues/10339) or ("hwsku in ['Force10-S6000']" and https://github.com/Azure/sonic-buildimage/issues/10921)
 
 #######################################
 #####    test_platform_info.py    #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
As described in Azure/sonic-buildimage#10921, device `Force10-S6000` cannot pass test case `platform_tests.test_memory_exhaustion`, we should temporarily skip this test case before the issue is fixed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

As described in Azure/sonic-buildimage#10921, device `Force10-S6000` cannot pass test case `platform_tests.test_memory_exhaustion`, we should temporarily skip this test case before the issue is fixed.

#### How did you do it?

Add configurations in `tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml`.

#### How did you verify/test it?

Verified on physical DUTs.

#### Any platform specific information?

This PR only affects `Force10-S6000`.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
