### PR TITLE
[MASIC] Update test_bgp_bbr.py to support check_dut for multi-asic platforms

### DIFF
--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -113,7 +113,6 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts):
     tor_neighbors = natsorted([neighbor for neighbor in nbrhosts.keys() if neighbor.endswith('T0')])
     t2_neighbors = [neighbor for neighbor in nbrhosts.keys() if neighbor.endswith('T2')]
     tor1 = tor_neighbors[0]
-    other_vms = tor_neighbors[1:] + t2_neighbors
 
     neigh_peer_map = defaultdict(dict)
     for bgp_neigh in mg_facts['minigraph_bgp']:
@@ -129,7 +128,15 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts):
         if tor1 == neigh['name']:
             tor1_namespace = neigh['namespace']
             break
-
+            
+    # Modifying other_vms for multi-asic, check bgps on asic of tor1_namespace
+    other_vms = []
+    for dut_port, neigh in mg_facts['minigraph_neighbors'].items():
+        if neigh['name'] == tor1: 
+            continue
+        if neigh['namespace'] == tor1_namespace:
+            other_vms.append(neigh['name'])
+            
     # Announce route to one of the T0 VM
     tor1_offset = tbinfo['topo']['properties']['topology']['VMs'][tor1]['vm_offset']
     tor1_exabgp_port = EXABGP_BASE_PORT + tor1_offset
@@ -246,7 +253,11 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
             if 'advertisedTo' not in dut_route:
                 logging.warn("DUT didn't advertise the route")
                 return False
-            advertised_to = set([bgp_neighbors[_]['name'] for _ in dut_route['advertisedTo']])
+            advertised_to = set()
+            for _ in dut_route['advertisedTo']:
+                # For multi-asic dut, dut_route included duthost which is not a BGP neighbor
+                if _ in bgp_neighbors.keys():
+                    advertised_to.add(bgp_neighbors[_]['name'])
             for vm in other_vms:
                 if vm not in advertised_to:
                     logging.warn("DUT didn't advertise route to neighbor %s" % vm)


### PR DESCRIPTION
To support check_dut() on multi-asic platforms

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In check_dut function created from https://github.com/Azure/sonic-mgmt/pull/4208,
'other_vms' by definition includes all t0 and t2, in multi-asic dut these would be on different asics.
However, 'dut_route' is from tor1_namespace which is a single asic : dut_route = duthost.get_route(route.prefix, setup['tor1_namespace'])
This change is to make other_vms also base on signle asic, tor1_namespace only, to reduce repeat work for multi-asic hosts, and to align with the namespace dut_route looks at.

Summary:
Fixes # (issue)
https://github.com/Azure/sonic-mgmt/issues/5695
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [X] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
