### PR TITLE
[python3] migrate `ip_in_ip_tunnel_test.py` to python3 

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
+++ b/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
@@ -24,8 +24,8 @@ PACKET_NUM = 10000
 PACKET_NUM_FOR_NEGATIVE_CHECK = 100
 
 DIFF = 0.25 # The valid range for balance check
-SRC_IP_RANGE = [str('8.0.0.0'), str('8.255.255.255')]
-SRC_IPV6_RANGE = [str('20D0:A800:0:00::'), str('20D0:FFFF:0:00::FFFF')]
+SRC_IP_RANGE = ['8.0.0.0', '8.255.255.255']
+SRC_IPV6_RANGE = ['20D0:A800:0:00::', '20D0:FFFF:0:00::FFFF']
 TIMEOUT = 1
 
 class IpinIPTunnelTest(BaseTest):

--- a/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
+++ b/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
@@ -51,7 +51,7 @@ class IpinIPTunnelTest(BaseTest):
         self.standby_tor_ip = self.test_params['standby_tor_ip']
         self.ptf_portchannel_indices = self.test_params['ptf_portchannel_indices']
         self.indice_to_portchannel = {}
-        for port_channel, indices in list(self.ptf_portchannel_indices.items()):
+        for port_channel, indices in self.ptf_portchannel_indices.items():
             for indice in indices:
                 self.indice_to_portchannel[indice] = port_channel
 
@@ -185,19 +185,19 @@ class IpinIPTunnelTest(BaseTest):
         self.logger.info("hash key = {}".format(hash_key))
         self.logger.info("%-10s \t %10s \t %10s \t" % ("port(s)", "exp_cnt", "act_cnt"))
         balance = True
-        for portchannel, count in list(pkt_distribution.items()):
+        for portchannel, count in pkt_distribution.items():
             self.logger.info("%-10s \t %10s \t %10s \t" % (portchannel, str(expect_packet_num), str(count)))
             if count < pkt_num_lo or count > pkt_num_hi:
                 balance = False
         if not balance:
-            print(("Check balance failed for {}".format(hash_key)))
+            print("Check balance failed for {}".format(hash_key))
         assert(balance)
 
     def send_and_verify_packets(self):
         """
         Send packet from ptf (T1) to standby ToR, and verify
         """
-        dst_ports = list(self.indice_to_portchannel.keys())
+        dst_ports = self.indice_to_portchannel.keys()
         # Select the first ptf indice as src port
         src_port = dst_ports[0]
         # Step 1. verify no packet is received from standby_tor to server

--- a/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
+++ b/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py
@@ -24,8 +24,8 @@ PACKET_NUM = 10000
 PACKET_NUM_FOR_NEGATIVE_CHECK = 100
 
 DIFF = 0.25 # The valid range for balance check
-SRC_IP_RANGE = [unicode('8.0.0.0'), unicode('8.255.255.255')]
-SRC_IPV6_RANGE = [unicode('20D0:A800:0:00::'), unicode('20D0:FFFF:0:00::FFFF')]
+SRC_IP_RANGE = [str('8.0.0.0'), str('8.255.255.255')]
+SRC_IPV6_RANGE = [str('20D0:A800:0:00::'), str('20D0:FFFF:0:00::FFFF')]
 TIMEOUT = 1
 
 class IpinIPTunnelTest(BaseTest):
@@ -51,7 +51,7 @@ class IpinIPTunnelTest(BaseTest):
         self.standby_tor_ip = self.test_params['standby_tor_ip']
         self.ptf_portchannel_indices = self.test_params['ptf_portchannel_indices']
         self.indice_to_portchannel = {}
-        for port_channel, indices in self.ptf_portchannel_indices.items():
+        for port_channel, indices in list(self.ptf_portchannel_indices.items()):
             for indice in indices:
                 self.indice_to_portchannel[indice] = port_channel
 
@@ -185,19 +185,19 @@ class IpinIPTunnelTest(BaseTest):
         self.logger.info("hash key = {}".format(hash_key))
         self.logger.info("%-10s \t %10s \t %10s \t" % ("port(s)", "exp_cnt", "act_cnt"))
         balance = True
-        for portchannel, count in pkt_distribution.items():
+        for portchannel, count in list(pkt_distribution.items()):
             self.logger.info("%-10s \t %10s \t %10s \t" % (portchannel, str(expect_packet_num), str(count)))
             if count < pkt_num_lo or count > pkt_num_hi:
                 balance = False
         if not balance:
-            print("Check balance failed for {}".format(hash_key))
+            print(("Check balance failed for {}".format(hash_key)))
         assert(balance)
 
     def send_and_verify_packets(self):
         """
         Send packet from ptf (T1) to standby ToR, and verify
         """
-        dst_ports = self.indice_to_portchannel.keys()
+        dst_ports = list(self.indice_to_portchannel.keys())
         # Select the first ptf indice as src port
         src_port = dst_ports[0]
         # Step 1. verify no packet is received from standby_tor to server

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -748,7 +748,8 @@ def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip, stan
                params=params,
                log_file=log_file,
                qlen=2000,
-               socket_recv_size=16384)
+               socket_recv_size=16384,
+               is_python3=True)
 
 
 def generate_hashed_packet_to_server(ptfadapter, duthost, hash_key, target_server_ip, count=1):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Following instructions to migrate ptf test script `ip_in_ip_tunnel_test.py` to python3.

Sign-off: Jing Zhang zhangjing@microsoft.com 


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?
1. use `2to3` to update `ip_in_ip_tunnel_test.py`  script. 
2. add `is_python3==True` argument to ptf_runner called in dual_tor_utils.py.

#### How did you verify/test it?
1. dualtor/test_orchagent_standby_tor_downstream.py tests 
```
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_loopback_route_readded[ipv4]   PASSED
dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_loopback_route_readded[ipv6]   PASSED 
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
