### PR TITLE
Cisco platform hwsku change

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -23,8 +23,8 @@ barefoot_hwskus: [ "montara", "mavericks", "Arista-7170-64C", "newport", "Arista
 
 marvell_hwskus: [ "et6448m" ]
 
-cisco_hwskus: ["64x100Gb"]
-cisco-8000_gb_hwskus: ["64x100Gb"]
+cisco_hwskus: ["Cisco-8102-C64"]
+cisco-8000_gb_hwskus: ["Cisco-8102-C64"]
 
 ## Note:
 ## Docker volumes should be list instead of dict. However, if we want to keep code DRY, we

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -199,7 +199,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku == "36x100Gb":
             for i in range(0, 36):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
-        elif hwsku == "64x100Gb":
+        elif hwsku == "Cisco-8102-C64":
             for i in range(0, 64):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
         elif hwsku in ["8800-LC-48H-O", "88-LC0-36FH-MO"]:


### PR DESCRIPTION

### Description of PR
In the latest sonic image, Cisco platform hwsku value changed from 64x100Gb to Cisco-8102-C64.

Hence making the changes in the inventory files for the topology bring up and pytest

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
change hwsku value from 64x100Gb to Cisco-8102-C64

#### How did you do it?

#### How did you verify/test it?
Made the change, deploy the configs and ran tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
