### PR TITLE
Cisco platform : platform fan speed set/tolerance test skips

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -213,7 +213,7 @@ platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_set_fan_drawers_le
 #######################################
 ##### api/test_fan_drawer_fans.py #####
 #######################################
-platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_fans_speed_tolerance:
+platform_tests/api/test_chassis_fans.py::TestFanDrawerFans::test_get_fans_speed_tolerance:
   #get_speed_tolerance API was disabled so platform code can perform fan tolerance checks 
   #using RPM rather than thermalctld checking tolerance on percentages
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -213,7 +213,7 @@ platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_set_fan_drawers_le
 #######################################
 ##### api/test_fan_drawer_fans.py #####
 #######################################
-platform_tests/api/test_chassis_fans.py::TestFanDrawerFans::test_get_fans_speed_tolerance:
+platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_fans_speed_tolerance:
   #get_speed_tolerance API was disabled so platform code can perform fan tolerance checks 
   #using RPM rather than thermalctld checking tolerance on percentages
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -56,6 +56,14 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_status_led:
 #######################################
 #####   api/test_chassis_fans.py  #####
 #######################################
+platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_fans_speed_tolerance:
+  #get_speed_tolerance API was disabled so platform code can perform fan tolerance checks 
+  #using RPM rather than thermalctld checking tolerance on percentages
+  skip:
+    reason: "Unsupported platform API"
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_model:
   skip:
     reason: "Unsupported platform API"
@@ -77,10 +85,13 @@ platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_led:
       - "asic_type in ['mellanox']"
 
 platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_speed:
+  #test_set_fans_speed requires get_speed_tolerance to be implemented 
+  #get_speed_tolerance API was disabled so platform code can perform fan tolerance checks 
+  #using RPM rather than thermalctld checking tolerance on percentages
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox']"
+      - "asic_type in ['mellanox', 'cisco-8000']"
 
 #######################################
 #####    api/test_component.py    #####
@@ -202,6 +213,14 @@ platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_set_fan_drawers_le
 #######################################
 ##### api/test_fan_drawer_fans.py #####
 #######################################
+platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_fans_speed_tolerance:
+  #get_speed_tolerance API was disabled so platform code can perform fan tolerance checks 
+  #using RPM rather than thermalctld checking tolerance on percentages
+  skip:
+    reason: "Unsupported platform API"
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_model:
   skip:
     reason: "Unsupported platform API"
@@ -223,10 +242,13 @@ platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_led
        - "asic_type in ['mellanox', 'cisco-8000']"
 
 platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_speed:
+  #test_set_fans_speed requires get_speed_tolerance to be implemented 
+  #get_speed_tolerance API was disabled so platform code can perform fan tolerance checks 
+  #using RPM rather than thermalctld checking tolerance on percentages
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox']"
+      - "asic_type in ['mellanox', 'cisco-8000']"
 
 #######################################
 #####        api/test_psu.py      #####


### PR DESCRIPTION

### Description of PR
get_speed_tolerance API was disabled so platform code can perform fan tolerance checks using RPM rather than thermalctld checking tolerance on percentages

test_set_fans_speed requires get_speed_tolerance to be implemented and return an integer 

Hence, test_get_fans_speed_tolerance and test_set_fans_speed need to be skipped for all platforms, for both test_chassis _fans and test_fan_drawer_fans until an upstream solution for fan tolerance is proposed and accepted.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

To skip test_get_fans_speed_tolerance and test_set_fans_speed 

#### How did you do it?

added the skip for the tests in the conditional mark file

#### How did you verify/test it?

Tested in Cisco 8000 platform and tests skipped

-------------------------------------------- live log sessionfinish --------------------------------------------
08:36:05 init.pytest_terminal_summary L0064 INFO | Can not get Allure report URL. Please check logs
=========================================== short test summary info ============================================
SKIPPED [1] /data/tests/platform_tests/api/test_chassis_fans.py:304: skipped as all chassis fans' LED is not available/controllable
SKIPPED [2] platform_tests/api/test_chassis_fans.py: Unsupported platform API
SKIPPED [1] platform_tests/api/test_chassis_fans.py: Retrieving fan tray serial number is not supported in Cisco 8000 and mellanox platform
==================================== 9 passed, 4 skipped in 295.45 seconds =============

-------------------------------------------- live log sessionfinish --------------------------------------------
08:42:32 init.pytest_terminal_summary L0064 INFO | Can not get Allure report URL. Please check logs
=========================================== short test summary info ============================================
SKIPPED [1] platform_tests/api/test_fan_drawer_fans.py: On Cisco 8000 and mellanox platform, fans do not have their own leds.
SKIPPED [2] platform_tests/api/test_fan_drawer_fans.py: Unsupported platform API
SKIPPED [1] platform_tests/api/test_fan_drawer_fans.py: Retrieving fan tray serial number is not supported in Cisco 8000 and mellanox platform
==================================== 9 passed, 4 skipped in 271.17 seconds ===================



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
