### PR TITLE
Add a new category 'asic_gen' in dut basic facts.

### DIFF
--- a/tests/common/plugins/conditional_mark/README.md
+++ b/tests/common/plugins/conditional_mark/README.md
@@ -134,6 +134,7 @@ Example variables can be used in condition string:
       "asic_type": "vs",
       "num_asic": 1,
       "is_multi_asic": False,
+      "asic_gen": "td2"
     }
 ```
 

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -85,6 +85,25 @@ def load_conditions(session):
 
     return conditions_list
 
+def read_asic_name(hwsku):
+    asic_name_file = os.path.dirname(__file__) + ASIC_NAME_PATH
+    try:
+        with open(asic_name_file) as f:
+            asic_name = yaml.safe_load(f)
+            logger.info(asic_name)
+
+        for key, value in asic_name.items():
+            if ('td' not in key) and ('th' not in key):
+                asic_name.pop(key)
+
+        for name, hw in asic_name.items():
+            if hwsku in hw:
+                return name.split('_')[1]
+
+        return None
+
+    except IOError as e:
+        return e
 
 def load_dut_basic_facts(session):
     """Run 'ansible -m dut_basic_facts' command to get some basic DUT facts.
@@ -124,6 +143,7 @@ def load_dut_basic_facts(session):
         output_fields = raw_output.split('SUCCESS =>', 1)
         if len(output_fields) >= 2:
             results.update(json.loads(output_fields[1].strip())['ansible_facts']['dut_basic_facts'])
+            results['asic_gen'] = read_asic_name(results['hwsku'])
     except Exception as e:
         logger.error('Failed to load dut basic facts, exception: {}'.format(repr(e)))
 

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -19,6 +19,7 @@ from .issue import check_issues
 logger = logging.getLogger(__name__)
 
 DEFAULT_CONDITIONS_FILE = 'common/plugins/conditional_mark/tests_mark_conditions*.yaml'
+ASIC_NAME_PATH = '/../../../../ansible/group_vars/sonic/variables'
 
 def pytest_addoption(parser):
     """Add options for the conditional mark plugin.
@@ -86,6 +87,16 @@ def load_conditions(session):
     return conditions_list
 
 def read_asic_name(hwsku):
+    '''
+    Get asic generation name from file 'ansible/group_vars/sonic/variables'
+
+    Args:
+        hwsku (str): Dut hwsku name
+
+    Returns:
+        str or None: Return the asic generation name or None if something went wrong or nothing found in the file.
+
+    '''
     asic_name_file = os.path.dirname(__file__) + ASIC_NAME_PATH
     try:
         with open(asic_name_file) as f:
@@ -103,7 +114,7 @@ def read_asic_name(hwsku):
         return None
 
     except IOError as e:
-        return e
+        return None
 
 def load_dut_basic_facts(session):
     """Run 'ansible -m dut_basic_facts' command to get some basic DUT facts.

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -111,7 +111,7 @@ def read_asic_name(hwsku):
             if hwsku in hw:
                 return name.split('_')[1]
 
-        return None
+        return "unknown"
 
     except IOError as e:
         return None

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -313,9 +313,9 @@ ssh/test_ssh_stress.py::test_ssh_stress:
 #######################################
 sub_port_interfaces:
   skip:
-    reason: "sub port interfaces test is not yet supported on multi-ASIC platform"
+    reason: "Unsupported platform or asic"
     conditions:
-      - "is_multi_asic==True"
+      - "is_multi_asic==True or asic_gen not in ['td2']"
 
 sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports:
   skip:

--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -53,19 +53,6 @@ def pytest_addoption(parser):
         help="Max numbers of sub-ports for test_max_numbers_of_sub_ports test case",
     )
 
-
-@pytest.fixture(scope='module', autouse=True)
-def skip_unsupported_asic_type(duthost):
-    SUBPORT_UNSUPPORTED_ASIC_LIST = ["th2"]
-    vendor = duthost.facts["asic_type"]
-    hostvars = get_host_visible_vars(duthost.host.options['inventory'], duthost.hostname)
-    for asic in SUBPORT_UNSUPPORTED_ASIC_LIST:
-        vendorAsic = "{0}_{1}_hwskus".format(vendor, asic)
-        if vendorAsic in hostvars.keys() and duthost.facts['hwsku'] in hostvars[vendorAsic]:
-            pytest.skip(
-                "Skipping test since subport is not supported on {0} {1} platforms".format(vendor, asic))
-
-
 @pytest.fixture(params=['port', 'port_in_lag'])
 def port_type(request):
     """Port type to test, could be either port or port-channel."""

--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -7,7 +7,6 @@ import pytest
 
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert as py_assert
-from tests.common.utilities import get_host_visible_vars
 from tests.common.utilities import wait_until
 from tests.common.ptf_agent_updater import PtfAgentUpdater
 from tests.common import constants


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Test cases under the tests/sub_port_interfaces only support td2 asic generation, we add a new category 'asic_gen' in dut basic facts to skip unsupported asic in advance. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Test cases under the tests/sub_port_interfaces only support td2 asic generation, we add a new category 'asic_gen' in dut basic facts to skip unsupported asic in advance. 

#### How did you do it?
Get the asic generation infomation from  `ansible/group_vars/sonic/variables`,  and add it in dut basic facts. Also,  modify the conditions in `tests_mark_conditions.yaml` to skip cases. 

#### How did you verify/test it?
Running test cases on support/unsupport asic. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
