### PR TITLE
[MASIC] Make test_bgp_bounce.py support for multi-asic platforms

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -41,11 +41,17 @@ def apply_bgp_config(duthost, template_name):
         pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, "bgp"), "BGP not started.") 
 
 def restart_bgp(duthost, asic_index=DEFAULT_ASIC_ID):
+    """
+    Restart bgp services on the DUT
+    Args:
+        duthost: DUT host object
+    """
     duthost.asic_instance(asic_index).reset_service("bgp")
     duthost.asic_instance(asic_index).restart_service("bgp")
     docker_name = duthost.asic_instance(asic_index).get_docker_name("bgp")
     pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, docker_name), "BGP not started.")
-    
+  
+
 def define_config(duthost, template_src_path, template_dst_path):
     """
     Define configuration of bgp on the DUT

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -40,6 +40,12 @@ def apply_bgp_config(duthost, template_name):
     else:
         pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, "bgp"), "BGP not started.") 
 
+def restart_bgp(duthost, asic_index=DEFAULT_ASIC_ID):
+    duthost.asic_instance(asic_index).reset_service("bgp")
+    duthost.asic_instance(asic_index).restart_service("bgp")
+    docker_name = duthost.asic_instance(asic_index).get_docker_name("bgp")
+    pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, docker_name), "BGP not started.")
+    
 def define_config(duthost, template_src_path, template_dst_path):
     """
     Define configuration of bgp on the DUT
@@ -141,7 +147,7 @@ def remove_bgp_neighbors(duthost, asic_index):
     duthost.shell(cmd)
 
     # Restart BGP instance on that asic
-    duthost.restart_bgp(asic_index)
+    restart_bgp(duthost, asic_index)
 
     return bgp_neighbors
 
@@ -158,4 +164,4 @@ def restore_bgp_neighbors(duthost, asic_index, bgp_neighbors):
     duthost.shell("sudo sonic-cfggen {} -a '{}' --write-to-db".format(namespace_prefix, bgp_neigh_json))
 
     # Restart BGP instance on that asic
-    duthost.restart_bgp(asic_index)
+    restart_bgp(duthost, asic_index)

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -32,7 +32,6 @@ def apply_bgp_config(duthost, template_name):
     """
     duthost.docker_copy_to_all_asics('bgp', template_name, DEFAULT_BGP_CONFIG)
     duthost.restart_bgp()
-    
     # Check if all BGPs are up
     if duthost.is_multi_asic:
         for asic_index in range(duthost.facts["num_asic"]):
@@ -79,8 +78,7 @@ def apply_default_bgp_config(duthost, copy=False):
     else:
         duthost.docker_copy_to_all_asics('bgp', bgp_config_backup, DEFAULT_BGP_CONFIG)
         # Skip 'start-limit-hit' threshold
-        duthost.shell('systemctl reset-failed bgp')
-        restart_bgp(duthost)
+        duthost.restart_bgp()
 
 def parse_exabgp_dump(host):
     """
@@ -143,7 +141,7 @@ def remove_bgp_neighbors(duthost, asic_index):
     duthost.shell(cmd)
 
     # Restart BGP instance on that asic
-    restart_bgp(duthost, asic_index)
+    duthost.restart_bgp(asic_index)
 
     return bgp_neighbors
 
@@ -160,4 +158,4 @@ def restore_bgp_neighbors(duthost, asic_index, bgp_neighbors):
     duthost.shell("sudo sonic-cfggen {} -a '{}' --write-to-db".format(namespace_prefix, bgp_neigh_json))
 
     # Restart BGP instance on that asic
-    restart_bgp(duthost, asic_index)
+    duthost.restart_bgp(asic_index)

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -35,7 +35,7 @@ def apply_bgp_config(duthost, template_name):
     if duthost.is_multi_asic:
         for asic_index in range(duthost.facts["num_asic"]):
             docker_name = duthost.asic_instance(asic_index).get_docker_name("bgp")
-            pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, docker_name), "BGP not started.")
+            pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, docker_name), "{} not started.".format(docker_name))
     else:
         pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, "bgp"), "BGP not started.") 
   

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -31,13 +31,6 @@ def apply_bgp_config(duthost, template_name):
     """
     duthost.docker_copy_to_all_asics('bgp', template_name, DEFAULT_BGP_CONFIG)
     duthost.restart_service("bgp")
-    # Check if all BGPs are up
-    if duthost.is_multi_asic:
-        for asic_index in range(duthost.facts["num_asic"]):
-            docker_name = duthost.asic_instance(asic_index).get_docker_name("bgp")
-            pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, docker_name), "{} not started.".format(docker_name))
-    else:
-        pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, "bgp"), "BGP not started.") 
   
 
 def define_config(duthost, template_src_path, template_dst_path):

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -142,7 +142,7 @@ def remove_bgp_neighbors(duthost, asic_index):
     duthost.shell(cmd)
 
     # Restart BGP instance on that asic
-    dusthost.restart_service_on_asic("bgp", asic_index)
+    duthost.restart_service_on_asic("bgp", asic_index)
 
     return bgp_neighbors
 
@@ -159,4 +159,4 @@ def restore_bgp_neighbors(duthost, asic_index, bgp_neighbors):
     duthost.shell("sudo sonic-cfggen {} -a '{}' --write-to-db".format(namespace_prefix, bgp_neigh_json))
 
     # Restart BGP instance on that asic
-    dusthost.restart_service_on_asic("bgp", asic_index)
+    duthost.restart_service_on_asic("bgp", asic_index)

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -31,7 +31,7 @@ def apply_bgp_config(duthost, template_name):
     """
     duthost.docker_copy_to_all_asics('bgp', template_name, DEFAULT_BGP_CONFIG)
     duthost.restart_service("bgp")
-  
+    pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started_per_asic_or_host, "bgp"), "BGP not started.")
 
 def define_config(duthost, template_src_path, template_dst_path):
     """
@@ -44,7 +44,7 @@ def define_config(duthost, template_src_path, template_dst_path):
     """
     duthost.shell("mkdir -p {}".format(DUT_TMP_DIR))
     duthost.copy(src=template_src_path, dest=template_dst_path)
-
+        
 
 def get_no_export_output(vm_host):
     """
@@ -73,6 +73,7 @@ def apply_default_bgp_config(duthost, copy=False):
         # Skip 'start-limit-hit' threshold
         duthost.reset_service("bgp")
         duthost.restart_service("bgp")
+        pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started_per_asic_or_host, "bgp"), "BGP not started.")
 
 def parse_exabgp_dump(host):
     """
@@ -136,6 +137,7 @@ def remove_bgp_neighbors(duthost, asic_index):
 
     # Restart BGP instance on that asic
     duthost.restart_service_on_asic("bgp", asic_index)
+    pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started_per_asic_or_host, "bgp"), "BGP not started.")
 
     return bgp_neighbors
 
@@ -153,3 +155,4 @@ def restore_bgp_neighbors(duthost, asic_index, bgp_neighbors):
 
     # Restart BGP instance on that asic
     duthost.restart_service_on_asic("bgp", asic_index)
+    pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started_per_asic_or_host, "bgp"), "BGP not started.")

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -31,7 +31,7 @@ def apply_bgp_config(duthost, template_name):
         template_name: pathname of the bgp config on the DUT
     """
     duthost.docker_copy_to_all_asics('bgp', template_name, DEFAULT_BGP_CONFIG)
-    duthost.restart_bgp()
+    duthost.restart_service("bgp")
     # Check if all BGPs are up
     if duthost.is_multi_asic:
         for asic_index in range(duthost.facts["num_asic"]):
@@ -39,17 +39,6 @@ def apply_bgp_config(duthost, template_name):
             pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, docker_name), "BGP not started.")
     else:
         pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, "bgp"), "BGP not started.") 
-
-def restart_bgp(duthost, asic_index=DEFAULT_ASIC_ID):
-    """
-    Restart bgp services on the DUT
-    Args:
-        duthost: DUT host object
-    """
-    duthost.asic_instance(asic_index).reset_service("bgp")
-    duthost.asic_instance(asic_index).restart_service("bgp")
-    docker_name = duthost.asic_instance(asic_index).get_docker_name("bgp")
-    pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, docker_name), "BGP not started.")
   
 
 def define_config(duthost, template_src_path, template_dst_path):
@@ -90,7 +79,7 @@ def apply_default_bgp_config(duthost, copy=False):
     else:
         duthost.docker_copy_to_all_asics('bgp', bgp_config_backup, DEFAULT_BGP_CONFIG)
         # Skip 'start-limit-hit' threshold
-        duthost.restart_bgp()
+        duthost.restart_service("bgp")
 
 def parse_exabgp_dump(host):
     """
@@ -153,7 +142,7 @@ def remove_bgp_neighbors(duthost, asic_index):
     duthost.shell(cmd)
 
     # Restart BGP instance on that asic
-    restart_bgp(duthost, asic_index)
+    dusthost.restart_bgp_on_asic(asic_index)
 
     return bgp_neighbors
 
@@ -170,4 +159,4 @@ def restore_bgp_neighbors(duthost, asic_index, bgp_neighbors):
     duthost.shell("sudo sonic-cfggen {} -a '{}' --write-to-db".format(namespace_prefix, bgp_neigh_json))
 
     # Restart BGP instance on that asic
-    restart_bgp(duthost, asic_index)
+    dusthost.restart_bgp_on_asic(asic_index)

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -143,7 +143,7 @@ def remove_bgp_neighbors(duthost, asic_index):
     duthost.shell(cmd)
 
     # Restart BGP instance on that asic
-    dusthost.restart_bgp_on_asic(asic_index)
+    dusthost.restart_service_on_asic("bgp", asic_index)
 
     return bgp_neighbors
 
@@ -160,4 +160,4 @@ def restore_bgp_neighbors(duthost, asic_index, bgp_neighbors):
     duthost.shell("sudo sonic-cfggen {} -a '{}' --write-to-db".format(namespace_prefix, bgp_neigh_json))
 
     # Restart BGP instance on that asic
-    dusthost.restart_bgp_on_asic(asic_index)
+    dusthost.restart_service_on_asic("bgp", asic_index)

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -2,7 +2,6 @@ import os
 import re
 import time
 import json
-from tests.common.helpers.constants import DEFAULT_ASIC_ID
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -79,6 +79,7 @@ def apply_default_bgp_config(duthost, copy=False):
     else:
         duthost.docker_copy_to_all_asics('bgp', bgp_config_backup, DEFAULT_BGP_CONFIG)
         # Skip 'start-limit-hit' threshold
+        duthost.reset_service("bgp")
         duthost.restart_service("bgp")
 
 def parse_exabgp_dump(host):

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -605,6 +605,6 @@ class MultiAsicSonicHost(object):
         
     def restart_service_on_asic(self, service, asic_index=DEFAULT_ASIC_ID):
         """Restart services on one asic of the DUT"""
-        duthost.asic_instance(asic_index).restart_service(service)
-        docker_name = duthost.asic_instance(asic_index).get_docker_name(service)
-        pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, docker_name), "service {} not started.".format(service))
+        self.asic_instance(asic_index).restart_service(service)
+        docker_name = self.asic_instance(asic_index).get_docker_name(service)
+        pytest_assert(wait_until(100, 10, 0, self.is_service_fully_started, docker_name), "service {} not started.".format(service))

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -604,13 +604,5 @@ class MultiAsicSonicHost(object):
         
     def restart_bgp(self, asic_index=DEFAULT_ASIC_ID):
         """Restart bgp services on the DUT"""
-        # If any specific asic_index passed
-        if not asic_index == DEFAULT_ASIC_ID:
-            duthost.asic_instance(asic_index).reset_service("bgp")
-            duthost.asic_instance(asic_index).restart_service("bgp")
-            docker_name = duthost.asic_instance(asic_index).get_docker_name("bgp")
-            pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, docker_name), "BGP not started.")
-        # If no specific asic_index passed, let it consider single-asic and multi-asic scenario and call corresponding function
-        else:
-            self.reset_service("bgp")
-            self.restart_service("bgp")
+        self.reset_service("bgp")
+        self.restart_service("bgp")

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -602,7 +602,7 @@ class MultiAsicSonicHost(object):
             container_name += str(asic_id)
         self.shell("sudo docker cp {}:{} {}".format(container_name, src, dst))
         
-    def restart_bgp(self, asic_index=DEFAULT_ASIC_ID):
+    def restart_bgp(self):
         """Restart bgp services on the DUT"""
         self.reset_service("bgp")
         self.restart_service("bgp")

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -268,7 +268,14 @@ class MultiAsicSonicHost(object):
 
         for asic in self.asics:
             asic.stop_service(service)
+            
+    def reset_service(self, service):
+        if service in self._DEFAULT_SERVICES:
+            return self.sonichost.reset_service(service, service)
 
+        for asic in self.asics:
+            asic.reset_service(service)
+        
     def restart_service(self, service):
         if service in self._DEFAULT_SERVICES:
             return self.sonichost.restart_service(service, service)
@@ -594,3 +601,9 @@ class MultiAsicSonicHost(object):
         if duthost.is_multi_asic:
             container_name += str(asic_id)
         self.shell("sudo docker cp {}:{} {}".format(container_name, src, dst))
+        
+    def restart_bgp(self):
+        """Restart bgp services on the DUT"""
+        duthost = self.sonichost
+        self.reset_service("bgp")
+        self.restart_service("bgp")

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -603,8 +603,8 @@ class MultiAsicSonicHost(object):
             container_name += str(asic_id)
         self.shell("sudo docker cp {}:{} {}".format(container_name, src, dst))
         
-    def restart_bgp_on_asic(self, asic_index=DEFAULT_ASIC_ID):
-        """Restart bgp services on one asic of the DUT"""
-        duthost.asic_instance(asic_index).restart_service("bgp")
-        docker_name = duthost.asic_instance(asic_index).get_docker_name("bgp")
-        pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, docker_name), "BGP not started.")
+    def restart_service_on_asic(self, service, asic_index=DEFAULT_ASIC_ID):
+        """Restart services on one asic of the DUT"""
+        duthost.asic_instance(asic_index).restart_service(service)
+        docker_name = duthost.asic_instance(asic_index).get_docker_name(service)
+        pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, docker_name), "service {} not started.".format(service))

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -602,7 +602,8 @@ class MultiAsicSonicHost(object):
             container_name += str(asic_id)
         self.shell("sudo docker cp {}:{} {}".format(container_name, src, dst))
         
-    def restart_bgp(self):
-        """Restart bgp services on the DUT"""
-        self.reset_service("bgp")
-        self.restart_service("bgp")
+    def restart_bgp_on_asic(self, asic_index=DEFAULT_ASIC_ID):
+        """Restart bgp services on one asic of the DUT"""
+        duthost.asic_instance(asic_index).restart_service("bgp")
+        docker_name = duthost.asic_instance(asic_index).get_docker_name("bgp")
+        pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, docker_name), "BGP not started.")

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -8,6 +8,7 @@ from tests.common.devices.sonic import SonicHost
 from tests.common.devices.sonic_asic import SonicAsic
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.constants import DEFAULT_ASIC_ID, DEFAULT_NAMESPACE
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -607,4 +607,4 @@ class MultiAsicSonicHost(object):
         """Restart services on one asic of the DUT"""
         self.asic_instance(asic_index).restart_service(service)
         docker_name = self.asic_instance(asic_index).get_docker_name(service)
-        pytest_assert(wait_until(100, 10, 0, self.is_service_fully_started, docker_name), "service {} not started.".format(service))
+        pytest_assert(wait_until(100, 10, 0, self.is_service_fully_started, docker_name), "docker {} not started.".format(docker_name))

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -8,7 +8,6 @@ from tests.common.devices.sonic import SonicHost
 from tests.common.devices.sonic_asic import SonicAsic
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.constants import DEFAULT_ASIC_ID, DEFAULT_NAMESPACE
-from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -604,6 +604,7 @@ class MultiAsicSonicHost(object):
         self.shell("sudo docker cp {}:{} {}".format(container_name, src, dst))
         
     def is_service_fully_started_per_asic_or_host(self, service):
+        """This function tell if service is fully started base on multi-asic/single-asic"""
         duthost = self.sonichost
         if duthost.is_multi_asic:
             for asic_index in range(duthost.facts["num_asic"]):
@@ -615,5 +616,6 @@ class MultiAsicSonicHost(object):
             return duthost.is_service_fully_started(service)
 
     def restart_service_on_asic(self, service, asic_index=DEFAULT_ASIC_ID):
+        """Restart service on an asic passed or None(DEFAULT_ASIC_ID)"""
         self.asic_instance(asic_index).restart_service(service)
-        pytest_assert(wait_until(100, 10, 0, self.is_service_fully_started_per_asic_or_host, "bgp"), "BGP not started.")
+        


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
for test introduced from https://github.com/Azure/sonic-mgmt/pull/2866, test_bgp_bounce.py calls 'docker cp' cmd from host to bgp(s), via bgp_helpers.py, which does not consider multi-asic scenario, where we want to copy bgp config files to all BGPs. 
This PR does the following change:
1. For multi-asic, copy to all BGPs, as well as restart all BGPs and make sure all BGPs come back. For single-asic remains the same behavior.
2. Add restart_bgp() in multi_asic.py to do consideration for multi-asic/single-asic all in this file, and leave the wait_until() in bgp_helpers.py to let know if all BGPs are back up.
3. Original restart_bgp(asic_index) moved to restart_service_on_asic in multi_asic.py to work on one asic.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Support test_bgp_bounce.py on multi-asic platform and some refactor.

#### How did you do it?
under sonic-mgmt/tests, do:
./run_tests.sh-n {multi_asic testbed} -i ../ansible/xxx,../ansible/veos  -f ../ansible/testbed.csv -u -e "--skip_sanity --disable_loganalyzer" -c bgp/test_bgp_bounce.py
#### How did you verify/test it?
Before:
2022-05-13T02:18:37.5367742Z E               "stderr": "Error: No such container:path: bgp:/usr/share/sonic/templates/bgpd/bgpd.conf.j2", 
2022-05-13T02:18:37.5370441Z E               "stderr_lines": [
2022-05-13T02:18:37.5373090Z E                   "Error: No such container:path: bgp:/usr/share/sonic/templates/bgpd/bgpd.conf.j2"
2022-05-13T02:18:37.5375680Z E               ], 

After:
bgp/test_bgp_bounce.py::test_bgp_bounce PASSED                                                                                                                                                                                                     [ 10%]
metadata-scripts/test_metadata_upgrade_path.py::test_cancelled_upgrade_path[warm-svcstr-n-acs-1] SKIPPED                                                                                                                                       [ 20%]
metadata-scripts/test_metadata_upgrade_path.py::test_upgrade_path[warm-svcstr-n-acs-1] SKIPPED                                                                                                                                                 [ 30%]
metadata-scripts/test_metadata_upgrade_path.py::test_warm_upgrade_sad_path[warm-sad-svcstr-n-acs-1] SKIPPED                                                                                                                                    [ 40%]
metadata-scripts/test_metadata_upgrade_path.py::test_warm_upgrade_sad_path[warm-multi_sad-svcstr-n-acs-1] SKIPPED                                                                                                                              [ 50%]
metadata-scripts/test_metadata_upgrade_path.py::test_warm_upgrade_sad_path[warm-sad_bgp-svcstr-n-acs-1] SKIPPED                                                                                                                                [ 60%]
metadata-scripts/test_metadata_upgrade_path.py::test_warm_upgrade_sad_path[warm-sad_lag_member-svcstr-n-acs-1] SKIPPED                                                                                                                         [ 70%]
metadata-scripts/test_metadata_upgrade_path.py::test_warm_upgrade_sad_path[warm-sad_lag-svcstr-n-acs-1] SKIPPED                                                                                                                                [ 80%]
metadata-scripts/test_metadata_upgrade_path.py::test_warm_upgrade_sad_path[warm-sad_vlan_port-svcstr-n=-acs-1] SKIPPED                                                                                                                          [ 90%]
metadata-scripts/test_metadata_upgrade_path.py::test_warm_upgrade_sad_path[warm-sad_inboot-svcstr-n-acs-1] SKIPPED                                                                                                                             [100%]

--------------------------------------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml ----------------------------------------------------------------------------------------------
================================================================================================================ short test summary info =================================================================================================================
SKIPPED [9] /var/src/sonic-mgmt-int/tests/metadata-scripts/test_metadata_upgrade_path.py:39: base_image_list or target_image_list is empty
========================================================================================================= 1 passed, 9 skipped in 369.93 seconds ==========================================================================================================
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
