### PR TITLE
[platform] Spend more time waiting for DUT reboot after OOM

### DIFF
--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -10,6 +10,9 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
+SSH_SHUTDOWN_TIMEOUT = 360
+SSH_STARTUP_TIMEOUT = 360
+
 
 def test_memory_exhaustion(duthosts, enum_frontend_dut_hostname, localhost):
     """validate kernel will panic and reboot the DUT when runs out of memory and hits oom event"""
@@ -33,7 +36,7 @@ def test_memory_exhaustion(duthosts, enum_frontend_dut_hostname, localhost):
                              state='absent',
                              search_regex=SONIC_SSH_REGEX,
                              delay=10,
-                             timeout=120,
+                             timeout=SSH_SHUTDOWN_TIMEOUT,
                              module_ignore_errors=True)
     pytest_assert(not res.is_failed and 'Timeout' not in res.get('msg', ''),
                   'DUT {} did not shutdown'.format(hostname))
@@ -44,7 +47,7 @@ def test_memory_exhaustion(duthosts, enum_frontend_dut_hostname, localhost):
                              state='started',
                              search_regex=SONIC_SSH_REGEX,
                              delay=10,
-                             timeout=120,
+                             timeout=SSH_STARTUP_TIMEOUT,
                              module_ignore_errors=True)
     pytest_assert(not res.is_failed and 'Timeout' not in res.get('msg', ''),
                   'DUT {} did not startup'.format(hostname))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Spend more time waiting for DUT reboot after OOM.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

Spend more time waiting for DUT reboot after OOM.
Test cases in `test_reboot.py` wait 3 to 5 minutes for both SSH shutdown and startup. For OOM reboot, we should be more tolerant. So I decided to wait at most 6 minutes in `test_memory_exhaustion`.

#### How did you do it?

For OOM reboot, wait at most 6 minutes for both SSH shutdown and startup.

#### How did you verify/test it?

Verified on physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
