### PR TITLE
[Vrf] Update check of REDIRECT_ACTION and acl_redirect rule

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -714,10 +714,9 @@ class TestVrfAclRedirect():
         Check if switch supports acl redirect_action, if not then skip test cases
         """
         duthost = duthosts[rand_one_dut_hostname]
-        switch_cap = duthost.switch_capabilities_facts()['ansible_facts']['switch_capabilities']['switch']
-        res = [capabilities for capabilities in switch_cap.values() if "REDIRECT_ACTION" in capabilities]
-        if not res:
-            pytest.skip("Switch does not support ACL REDIRECT_ACTION")
+        acl_stage_cap  = duthost.shell('redis-cli -n 6 hget "ACL_STAGE_CAPABILITY_TABLE|INGRESS" action_list')['stdout']
+        if "REDIRECT_ACTION" not in acl_stage_cap:
+            pytest.skip("Switch does not support ACL REDIRECT_ACTION, supported actions {}".format(acl_stage_cap))
 
     @pytest.fixture(scope="class", autouse=True)
     def setup_acl_redirect(self, duthosts, rand_one_dut_hostname, cfg_facts, tbinfo):

--- a/tests/vrf/vrf_acl_redirect.j2
+++ b/tests/vrf/vrf_acl_redirect.j2
@@ -15,12 +15,12 @@
     "ACL_RULE": {
         "VRF_ACL_REDIRECT_V4|rule1": {
             "priority": "55",
-            "SRC_IP": "10.0.0.1",
+            "SRC_IP": "30.0.0.1",
             "packet_action": "redirect:{% for intf, ip in redirect_dst_ips %}{{ ip ~ "@" ~ intf }}{{ "," if not loop.last else "" }}{% endfor %}"
         },
         "VRF_ACL_REDIRECT_V6|rule1": {
             "priority": "55",
-            "SRC_IPV6": "2000::1",
+            "SRC_IPV6": "2000:0030::1",
             "packet_action": "redirect:{% for intf, ip in redirect_dst_ipv6s %}{{ ip ~ "@" ~ intf }}{{ "," if not loop.last else "" }}{% endfor %}"
         }
     }


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  
Test cases in **TestVrfAclRedirect** fail with below error: 
```
FAILED vrf/test_vrf.py::TestVrfAclRedirect::test_origin_ports_recv_no_pkts_v4 - Exception
"AssertionError: Received packet that we expected not to receive on device 0, port 28."

FAILED vrf/test_vrf.py::TestVrfAclRedirect::test_origin_ports_recv_no_pkts_v6 - Exception
"AssertionError: Received packet that we expected not to receive on device 0, port 28."

FAILED vrf/test_vrf.py::TestVrfAclRedirect::test_redirect_to_new_ports_v4 - Exception
"AssertionError: Received expected packet on port 28 for device 0, but it should have arrived on one of these ports: [29, 31]."

FAILED vrf/test_vrf.py::TestVrfAclRedirect::test_redirect_to_new_ports_v6 - Exception
"AssertionError: Received expected packet on port 28 for device 0, but it should have arrived on one of these ports: [29, 31]."
```

Made below changes that fix test cases:
1) Run TC if **REDIRECT_ACTION** is present in **'ACL_STAGE_CAPABILITY_TABLE|INGRESS'**, otherwise skip TC as for redirect is not supported.

2) Updated **vrf_acl_redirect.j2** rule for **vrf/test_vrf.py::TestVrfAclRedirect**, due to changes made in **ptftests/fib_test.py** where src_ip was changed.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Updated the way check of REDIRECT_ACTION is happening, and fix acl_redirect rule as for now it is invalid after changes in fib_test.py
#### How did you do it?

#### How did you verify/test it?
Run test case:
```
PASSED vrf/test_vrf.py::TestVrfAclRedirect::test_origin_ports_recv_no_pkts_v4
PASSED vrf/test_vrf.py::TestVrfAclRedirect::test_origin_ports_recv_no_pkts_v6
PASSED vrf/test_vrf.py::TestVrfAclRedirect::test_redirect_to_new_ports_v4
PASSED vrf/test_vrf.py::TestVrfAclRedirect::test_redirect_to_new_ports_v6 
```

#### Any platform specific information?
```
SONiC Software Version: SONiC.master.94647-dirty-20220429.133828
Distribution: Debian 11.3
Kernel: 5.10.0-8-2-amd64
Build commit: d258db8aa
Build date: Fri Apr 29 19:07:06 UTC 2022
Built by: AzDevOps@sonic-build-workers-001GZ0
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
ASIC: barefoot
```
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
