### PR TITLE
[CHASSIS]For Chassis that has dual SUP need to skip the SUP that is not installed.

### DIFF
--- a/tests/platform_tests/cli/test_show_chassis_module.py
+++ b/tests/platform_tests/cli/test_show_chassis_module.py
@@ -66,7 +66,7 @@ def test_show_chassis_module_midplane_status(duthosts, enum_rand_one_per_hwsku_h
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     output = duthost.command(cmd)
     res_mid_status = parse_chassis_module(output['stdout_lines'], expected_headers)
-    mod_key= ['line-cards']
+    mod_key= ['line-cards', 'supervisor']
     skip_mod_list = get_skip_mod_list(duthost, mod_key)
 
     for mod_idx in res_mid_status:


### PR DESCRIPTION
### Description of PR
For chassis there are two types.  One may have additional supervisor card (for HA purpose) while other may only have one supervisor per chassis.  This testcase did not account for the possibility of additional supervisor slot may be present without installing the supervisor and unnecessarily failed the test when testing "show chassis modules midplane-status" For the one that can have more than one supervisor.
The failure seen while testing "show chassis modules status" does nto require a change in this testcase but in the corresponding DUT inventory file which is explained in the Documentation section of this PR.

Summary:
Fixes # (issue)

### Type of change

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run the testcase without my fix and observe the failure.
Run the testcase with my fix in place and it passes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
Please note that in order to utilize this fix one must also make change to the chassis inventory file similar to the following:
```
Example to skip certain modules add to skip modules in inventory for DUT:
DUT1
    skip_modules:
        'line-cards':
          - LINE-CARD0
          - LINE-CARD2
        'fabric-cards':
          - FABRIC-CARD3
        'supervisor':
          - SUPERVISOR1
        'psus':
          - PSU4
          - PSU5
```
Based on inventory file the tests will skip above modules for DUT1. For example, show chassis module will allow empty as status for LINE-CARD0 and LINE-CARD2 as well as "SUPERVISOR1" while all other will be expected to be ONLINE.

