### PR TITLE
Remove default acl tables before testing subinterfaces based on portchannels

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -104,6 +104,13 @@ def define_sub_ports_configuration(request, duthost, ptfhost, ptfadapter, port_t
     vlan_ranges_dut = range(20, 60, 10)
     vlan_ranges_ptf = range(20, 60, 10)
 
+    # Remove acl tables when test port channel, the port with acl bindings can not be added to a port channel
+    # The removed tables will be added back in reload_dut_config
+    if 'port_in_lag' in port_type:
+        table_names = ["DATAACL", "EVERFLOW", "EVERFLOWV6"]
+        for table in table_names:
+            duthost.shell(cmd="config acl remove table {}".format(table))
+
     if 'invalid' in request.node.name:
         vlan_ranges_ptf = range(21, 41, 10)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In sub interfaces test, the portchannel cases add ethernet ports to portchannels.
But on some testbeds, the selected ports are already in some default acl tables. In SONiC,  ports in acl tables can not be used as portchannel members. So the case will fail.
To fix this, need to remove default acl tables before running the portchannel cases.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix the portchannel cases to run on testbeds with default acl tables.
#### How did you do it?
The ethernet ports are selected and added to portchannels in fixture define_sub_ports_configuration, so add logic to remove the default acl tables in this fixture, before the ports are added.
The removal action won't affect testbeds without default acl tables. 
The acl tables will be added back automatically by config reload in single test case and test suite teardowns.

#### How did you verify/test it?
Verified on t0 and t1 testbeds, all cases passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
