### PR TITLE
try ssh again with ansible_altpassword when catching AuthencicationException

### DIFF
--- a/tests/ssh/test_ssh_limit.py
+++ b/tests/ssh/test_ssh_limit.py
@@ -55,9 +55,14 @@ def modify_templates(duthost, tacacs_creds, creds):
     hwsku = duthost.facts["hwsku"]
     type = get_device_type(duthost)
     user = tacacs_creds['local_user']
-    
-    # Duthost shell not support run command with J2 template in command text.
-    admin_session = ssh_connect_remote(dut_ip, creds['sonicadmin_user'], creds['sonicadmin_password'])
+
+    try:
+        # Duthost shell not support run command with J2 template in command text.
+        admin_session = ssh_connect_remote(dut_ip, creds['sonicadmin_user'], creds['sonicadmin_password'])
+    except paramiko.AuthenticationException:
+        # try ssh with ansible_altpassword again
+        sonic_admin_alt_password = duthost.host.options['variable_manager']._hostvars[duthost.hostname].get("ansible_altpassword")
+        admin_session = ssh_connect_remote(dut_ip, creds['sonicadmin_user'], sonic_admin_alt_password)
 
     # Backup and change /usr/share/sonic/templates/pam_limits.j2
     additional_content = "session  required  pam_limits.so"


### PR DESCRIPTION


Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
`test_ssh_limit.py` is not skipped on master image. But failed with AuthenticationException because password for master image is different with 202012 image.

#### How did you do it?
Try ssh again with `ansible_altpassword` when catching AuthencicationException.
So many test cases try this method, such as 
`tests/ssh/test_ssh_ciphers.py`
`duthost_console` function in `tests/conftest.py`
`ansible/roles/test/files/ptftests/device_connection.py`

#### How did you verify/test it?
Run `ssh/test_ssh_limit.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
