### PR TITLE
[dualtor][icmp_responder] Fix icmp responder

### DIFF
--- a/tests/scripts/icmp_responder.py
+++ b/tests/scripts/icmp_responder.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     ifaces = args.ifaces
     dst_mac = args.dst_mac
 
-    max_workers = 24
+    max_workers = 24 if len(ifaces) > 24 else len(ifaces)
     sniffed_ifaces = [[] for _ in range(max_workers)]
     for i, iface in enumerate(ifaces):
         sniffed_ifaces[i % max_workers].append(iface)

--- a/tests/scripts/icmp_responder.py
+++ b/tests/scripts/icmp_responder.py
@@ -29,7 +29,7 @@ class ICMPSniffer(object):
     """Sniff ICMP packets."""
 
     TYPE_ECHO_REQUEST = 8
-    def __init__(self, iface, request_handler=None, dst_mac=None):
+    def __init__(self, ifaces, request_handler=None, dst_mac=None):
         """
         Init ICMP sniffer.
 
@@ -39,8 +39,9 @@ class ICMPSniffer(object):
         """
         self.sniff_sockets = []
         self.iface_hwaddr = {}
-        self.sniff_sockets.append(conf.L2socket(type=ETH_P_IP, iface=iface, filter="icmp"))
-        self.iface_hwaddr[iface] = get_if_hwaddr(iface)
+        for iface in ifaces:
+            self.sniff_sockets.append(conf.L2socket(type=ETH_P_IP, iface=iface, filter="icmp"))
+            self.iface_hwaddr[iface] = get_if_hwaddr(iface)
         self.request_handler = request_handler
         self.dst_mac = dst_mac
 
@@ -66,7 +67,12 @@ if __name__ == "__main__":
     ifaces = args.ifaces
     dst_mac = args.dst_mac
 
-    with ThreadPoolExecutor(max_workers=24) as executor:
-        for iface in ifaces:
-            icmp_sniffer = ICMPSniffer(iface, request_handler=respond_to_icmp_request, dst_mac=dst_mac)
+    max_workers = 24
+    sniffed_ifaces = [[] for _ in range(max_workers)]
+    for i, iface in enumerate(ifaces):
+        sniffed_ifaces[i % max_workers].append(iface)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        for ifaces in sniffed_ifaces:
+            icmp_sniffer = ICMPSniffer(ifaces, request_handler=respond_to_icmp_request, dst_mac=dst_mac)
             executor.submit(icmp_sniffer)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #5733

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix that `icmp_responder` responds to 24 ports at most.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
For each thread, run event loop polling for multiple ports if ports number > 24.

#### How did you verify/test it?
Run `icmp_responder` and every mux port is in healthy state.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
