### PR TITLE
[Azp]: allowPartiallySucceededBuilds at DownloadPipelineArtifact

### DIFF
--- a/.azure-pipelines/run-test-template.yml
+++ b/.azure-pipelines/run-test-template.yml
@@ -31,6 +31,7 @@ steps:
     artifact: sonic-buildimage.vs
     runVersion: 'latestFromBranch'
     runBranch: 'refs/heads/master'
+    allowPartiallySucceededBuilds: true
   displayName: "Download sonic kvm image"
 
 - script: |


### PR DESCRIPTION
allowPartiallySucceededBuilds at DownloadPipelineArtifact

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
If the sonic-buildimage is partially failed, sonic-mgmt cannot fetch the latest image for testing.

#### How did you do it?
Update the configuration of Azp for allowing partially succeeded build.

#### How did you verify/test it?
Check Azp and download id.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
