### PR TITLE
[sanity_check]: Fix sanity check with macsec

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -2,6 +2,7 @@
 import logging
 import copy
 import json
+import time
 
 import pytest
 
@@ -111,6 +112,7 @@ def sanity_check(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
     recover_method = "adaptive"
     pre_check_items = copy.deepcopy(SUPPORTED_CHECKS)  # Default check items
     post_check = False
+    enable_macsec = False
 
     customized_sanity_check = None
     for m in request.node.iter_markers():
@@ -152,6 +154,11 @@ def sanity_check(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
 
     if request.config.option.post_check:
         post_check = True
+
+    if request.config.option.enable_macsec:
+        enable_macsec = True
+        startup_macsec = request.getfixturevalue("startup_macsec")
+        start_macsec_service = request.getfixturevalue("start_macsec_service")
 
     cli_check_items = request.config.getoption("--check_items")
     cli_post_check_items = request.config.getoption("--post_check_items")
@@ -226,6 +233,11 @@ def sanity_check(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
                     neighbor_vm_restore(duthosts[dut_name], nbrhosts, tbinfo)
                 for action in infra_recovery_actions:
                     action()
+
+                if enable_macsec:
+                    start_macsec_service()
+                    startup_macsec()
+                    time.sleep(720)
 
                 logger.info("Run sanity check again after recovery")
                 new_check_results = do_checks(request, pre_check_items, stage=STAGE_PRE_TEST, after_recovery=True)

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -2,7 +2,6 @@
 import logging
 import copy
 import json
-import time
 
 import pytest
 
@@ -237,7 +236,6 @@ def sanity_check(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
                 if enable_macsec:
                     start_macsec_service()
                     startup_macsec()
-                    time.sleep(720)
 
                 logger.info("Run sanity check again after recovery")
                 new_check_results = do_checks(request, pre_check_items, stage=STAGE_PRE_TEST, after_recovery=True)


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
In sanity check stage, the config_reload will be executed for recover DUT, but MACsec configuration wasn't written into config_db.json so that the MACsec configuration will be cleared after config_reload.

#### How did you do it?
Check whether the MACsec is enabled, if yes, call MACsec setup functions for recovering MACsec after config reload
#### How did you verify/test it?
After PR: https://github.com/Azure/sonic-mgmt/pull/5737
Check Azp status.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
