### PR TITLE
[nic_simulator] Use port `50075`

### DIFF
--- a/ansible/group_vars/all/nic_simulator_grpc_port_map.yml
+++ b/ansible/group_vars/all/nic_simulator_grpc_port_map.yml
@@ -2,4 +2,4 @@
 # mapping from testbed name to nic simulator gRPC binding port
 
 nic_simulator_grpc_port:
-  vms-kvm-dual-mixed: 8900
+  vms-kvm-dual-mixed: 50075


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Use port 50075 for kvm dualtor-mixed testbed nic_simulator.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?


#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
