### PR TITLE
[Mellanox] Add ignore error log for test_show_platform_temperature_mocked

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -52,7 +52,9 @@ SKIP_ERROR_LOG_COMMON = ['.*ERR syncd#syncd:.*SAI_API_QUEUE:_brcm_sai_cosq_stat_
 
 SKIP_ERROR_LOG_SHOW_PLATFORM_TEMP = ['.*ERR pmon#thermalctld.*int\(\) argument must be a string.* or a number.*',
                                      '.*ERR pmon#thermalctld.*invalid literal for int\(\) with base 10.*',
-                                     '.*ERR pmon#thermalctld.*Failed to get minimum ambient temperature, use pessimistic instead.*']
+                                     '.*ERR pmon#thermalctld.*Failed to get minimum ambient temperature, use pessimistic instead.*',
+                                     '.*ERR pmon#thermalctld.*Failed to read from file /run/hw-management/thermal.*',
+                                     '.*ERR pmon#thermalctld.*Failed to run thermal policy.*']
 
 SKIP_ERROR_LOG_PSU_ABSENCE = ['.*Error getting sensor data: dps460.*Kernel interface error.*',
                               '.*ERR pmon#psud:.*Fail to read model number: No key PN_VPD_FIELD in.*',


### PR DESCRIPTION
Change-Id: I22079da5aa72ecc044d535b07c9ede3575a6e802

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Ignore possible error logs while doing sysfs file mocking.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

Ignore possible error logs while doing sysfs file mocking.

#### How did you do it?

Add two new error logs to ignore list for case test_show_platform_temperature_mocked

#### How did you verify/test it?

Manual run

#### Any platform specific information?

Mellanox

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
