### PR TITLE
[ iface_namingmode ] update regex for queue counters

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -436,15 +436,15 @@ class TestShowQueue():
         per the configured naming mode
         """
         dutHostGuest, mode, ifmode = setup_config_mode
-        queue_counter = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo show queue counters | grep "UC\|MC"'.format(ifmode))['stdout']
+        queue_counter = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo show queue counters | grep "UC\|MC\|ALL"'.format(ifmode))['stdout']
         logger.info('queue_counter:\n{}'.format(queue_counter))
 
         if mode == 'alias':
             for alias in setup['port_alias']:
-                assert (re.search(r'{}\s+[U|M]C\d\s+\S+\s+\S+\s+\S+\s+\S+'.format(alias), queue_counter) is not None) and (setup['port_alias_map'][alias] not in queue_counter)
+                assert (re.search(r'{}\s+[U|M]C|ALL\d\s+\S+\s+\S+\s+\S+\s+\S+'.format(alias), queue_counter) is not None) and (setup['port_alias_map'][alias] not in queue_counter)
         elif mode == 'default':
             for intf in setup['default_interfaces']:
-                assert (re.search(r'{}\s+[U|M]C\d\s+\S+\s+\S+\s+\S+\s+\S+'.format(intf), queue_counter) is not None) and (setup['port_name_map'][intf] not in queue_counter)
+                assert (re.search(r'{}\s+[U|M]C|ALL\d\s+\S+\s+\S+\s+\S+\s+\S+'.format(intf), queue_counter) is not None) and (setup['port_name_map'][intf] not in queue_counter)
 
     def test_show_queue_counters_interface(self, setup_config_mode, sample_intf):
         """
@@ -453,11 +453,11 @@ class TestShowQueue():
         """
         dutHostGuest, mode, ifmode = setup_config_mode
         test_intf = sample_intf[mode]
-        queue_counter_intf = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo show queue counters {} | grep "UC\|MC"'.format(ifmode, test_intf))
+        queue_counter_intf = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo show queue counters {} | grep "UC\|MC\|ALL"'.format(ifmode, test_intf))
         logger.info('queue_counter_intf:\n{}'.format(queue_counter_intf))
 
         for i in range(len(queue_counter_intf['stdout_lines'])):
-            assert re.search(r'{}\s+[U|M]C{}\s+\S+\s+\S+\s+\S+\s+\S+'.format(test_intf, i), queue_counter_intf['stdout']) is not None
+            assert re.search(r'{}\s+[U|M]C|ALL{}\s+\S+\s+\S+\s+\S+\s+\S+'.format(test_intf, i), queue_counter_intf['stdout']) is not None
 
     def test_show_queue_persistent_watermark_multicast(self, setup, setup_config_mode):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Intel (Barefoot ) updated the SDE to use queue type “ALL” instead of “UNICAST” . So, this changed the output for Sonic queue CLIs.
![image](https://user-images.githubusercontent.com/25028638/171572561-4902c3a0-03ca-48b9-8516-f23e306116ec.png)
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Make iface naming mode TC passing related to queue counters command
#### How did you do it?
Add ALL pattern to regex that parsed show queue counters output
#### How did you verify/test it?
![image](https://user-images.githubusercontent.com/25028638/171572790-20029daa-edee-4bed-9f68-0d03afc4fa10.png)
#### Any platform specific information?
SONiC Software Version: SONiC.master.94647-dirty-20220429.215159
Distribution: Debian 11.3
Kernel: 5.10.0-8-2-amd64
Build commit: d258db8aa
Build date: Fri Apr 29 21:58:12 UTC 2022
Built by: AzDevOps@sonic-build-workers-001GZ0
Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
