### PR TITLE
[cpu_mem_usage] update TC with wait for all critical services 

### DIFF
--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -7,6 +7,8 @@ from tests.platform_tests.counterpoll.cpu_memory_helper import counterpoll_type 
 from tests.platform_tests.counterpoll.counterpoll_helper import ConterpollHelper
 from tests.platform_tests.counterpoll.counterpoll_constants import CounterpollConstants
 from tests.common.mellanox_data import is_mellanox_device
+from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
 
 
 pytestmark = [
@@ -47,6 +49,9 @@ def setup_thresholds(duthosts, enum_rand_one_per_hwsku_hostname):
 def test_cpu_memory_usage(duthosts, enum_rand_one_per_hwsku_hostname, setup_thresholds):
     """Check DUT memory usage and process cpu usage are within threshold."""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    # Wait until all critical services is fully started
+    pytest_assert(wait_until(360, 20, 0, duthost.critical_services_fully_started),
+                             "All critical services must be fully started!{}".format(duthost.critical_services))
     MonitResult = namedtuple('MonitResult', ['processes', 'memory'])
     monit_results = duthost.monit_process(iterations=24)['monit_results']
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
During regression cpu_usage TC run's after TC that does config reload at the end. Due to this syncd CPU usage is higher than TC expects as not all services come up and syncd actively works at period after system reload (reboot).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Make TC persistent. Avoid failures after DUT reboot (reload)
#### How did you do it?
Add wait_until method for check if all critical services come up and than run TC
#### How did you verify/test it?
Run cpu_mem_usage test case when services up (normal DUT state) and when services has been restarted. TC passed.
#### Any platform specific information?
**NOTE:** 
if TC run when all services started it takes app 180 sec to pass TC. 
after reboot or config reload TC run takes 180 sec + time for critical services to be started (200 sec)
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
