### PR TITLE
skipped QoS multi-asic tests before swapping syncd

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -229,6 +229,12 @@ qos/test_buffer_traditional.py:
     conditions:
       - "is_multi_asic==True"
 
+qos/test_qos_masic.py:
+  skip:
+    reason: "QoS tests for multi-ASIC only. Supported topos: t1-lag, t1-64-lag, t1-backend."
+    conditions:
+      - "is_multi_asic==False or topo_name not in ['t1-lag', 't1-64-lag', 't1-backend']"
+
 qos/test_pfc_pause.py::test_pfc_pause_lossless:
   # For this test, we use the fanout connected to the DUT to send PFC pause frames.
   # The fanout needs to send PFC frames fast enough so that the queue remains completely paused for the entire duration

--- a/tests/qos/test_qos_masic.py
+++ b/tests/qos/test_qos_masic.py
@@ -13,20 +13,6 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(scope='module', autouse=True)
-def skip_for_single_asic(duthosts, rand_one_dut_hostname, enum_backend_asic_index):
-    duthost = duthosts[rand_one_dut_hostname]
-    pytest_require(duthost.is_multi_asic, "Test applies only to multi ASIC platform")
-    pytest_require(enum_backend_asic_index is not None, "Backend ASIC is None")
-
-@pytest.fixture(scope='module', autouse=True)
-def skip_for_unsupported_t1_topo(tbinfo):
-    supported_t1_topos = ["t1-lag", "t1-64-lag", "t1-backend"]
-
-    topo = tbinfo["topo"]["name"]
-    pytest_require(topo in supported_t1_topos, "unsupported topology {}".format(topo))
-
-
 class QosSaiBaseMasic:
 
 

--- a/tests/qos/test_qos_masic.py
+++ b/tests/qos/test_qos_masic.py
@@ -6,7 +6,7 @@ from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
-from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
     pytest.mark.topology('t1')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: skipped QoS multi-asic tests before swapping syncd
Fixes # (issue)

QoS multi-asic tests require syncd rpc. In case a DUT is single ASIC, a skip condition is executed only after syncd swap so syncd gets replaced but not used since the test is skipped for single ASIC DUT later. Made skip conditions to execute first

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Avoid any setup steps execution for a skipped test
#### How did you do it?
Made skip conditions to execute before any setup steps
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t1,any qos/test_qos_masic.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
