### PR TITLE
[interface_utils] Fix the IndentationError in tests/common/platform/interface_utils.py

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -7,7 +7,7 @@ This script contains re-usable functions for checking status of interfaces on SO
 import re
 import logging
 from natsort import natsorted
-from transceiver_utils import all_transceivers_detected
+from .transceiver_utils import all_transceivers_detected
 
 
 def parse_intf_status(lines):
@@ -167,16 +167,16 @@ def get_physical_port_indices(duthost, logical_intfs=None):
         logging.info("physical interfaces = {}".format(logical_intfs))
 
     for asic_index in duthost.get_frontend_asic_ids():
-	# Get interfaces of this asic
-	interface_list = get_port_map(duthost, asic_index)
-	interfaces_per_asic = {k:v for k, v in interface_list.items() if k in logical_intfs}
-	#logging.info("ASIC index={} interfaces = {}".format(asic_index, interfaces_per_asic))
-	for intf in interfaces_per_asic:
+        # Get interfaces of this asic
+        interface_list = get_port_map(duthost, asic_index)
+        interfaces_per_asic = {k: v for k, v in interface_list.items() if k in logical_intfs}
+        # logging.info("ASIC index={} interfaces = {}".format(asic_index, interfaces_per_asic))
+        for intf in interfaces_per_asic:
             if asic_index is not None:
                 cmd = 'sonic-db-cli -n asic{} CONFIG_DB HGET "PORT|{}" index'.format(asic_index, intf)
             else:
                 cmd = 'sonic-db-cli CONFIG_DB HGET "PORT|{}" index'.format(intf)
-	    index = duthost.command(cmd)["stdout"]
-	    physical_port_index_dict[intf] = (int(index))
+            index = duthost.command(cmd)["stdout"]
+            physical_port_index_dict[intf] = (int(index))
 
     return physical_port_index_dict


### PR DESCRIPTION
Fix the IndentationError issue; change the module import method which work for both python2 and python3

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix the IndentationError issue; change the module import method which work for both python2 and python3
Fixes # (issue) IndentationError: unexpected indent

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Fix the IndentationError. and change the the module import method which can be executed in both python2 and python3
#### How did you do it?
Use space instead of tab in the code; change "from transceiver_utils import all_transceivers_detected" to "from .transceiver_utils import all_transceivers_detected"
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
