### PR TITLE
[platform] Support PDU reboot when DUT crash after OOM reboot

### DIFF
--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -52,7 +52,7 @@ class TestMemoryExhaustion:
         cmd = 'nohup tail /dev/zero &'
         res = duthost.shell(cmd)
         if not res.is_successful:
-            pytest.error('DUT {} run command {} failed'.format(hostname, cmd))
+            pytest.fail('DUT {} run command {} failed'.format(hostname, cmd))
 
         # Waiting for SSH connection shutdown
         pytest_assert(self.check_ssh_state(localhost, dut_ip, SSH_STATE_ABSENT, SSH_SHUTDOWN_TIMEOUT),

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -66,7 +66,7 @@ class TestMemoryExhaustion:
         dut_uptime = duthost.get_up_time()
         pytest_assert(dut_uptime > dut_datetime, "Device {} did not reboot".format(hostname))
 
-    def check_ssh_state(self, localhost, dut_ip, expected_state, timeout=10):
+    def check_ssh_state(self, localhost, dut_ip, expected_state, timeout=60):
         """
         Check the SSH state of DUT.
 

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -87,6 +87,10 @@ class TestMemoryExhaustion:
         return not res.is_failed and 'Timeout' not in res.get('msg', '')
 
     def pdu_reboot(self, pdu_controller):
-        pdu_controller.turn_off_outlet()
-        time.sleep(1)  # sleep 1 second to ensure there is gap between power off and on
-        pdu_controller.turn_on_outlet()
+        hostname = pdu_controller.dut_hostname
+        if not pdu_controller.turn_off_outlet():
+            logging.error("Turn off the PDU outlets of {} failed".format(hostname))
+            return
+        time.sleep(10)  # sleep 10 second to ensure there is gap between power off and on
+        if not pdu_controller.turn_on_outlet():
+            logging.error("Turn on the PDU outlets of {} failed".format(hostname))

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
@@ -13,48 +14,79 @@ pytestmark = [
 SSH_SHUTDOWN_TIMEOUT = 360
 SSH_STARTUP_TIMEOUT = 360
 
+SSH_STATE_ABSENT = "absent"
+SSH_STATE_STARTED = "started"
 
-def test_memory_exhaustion(duthosts, enum_frontend_dut_hostname, localhost):
-    """validate kernel will panic and reboot the DUT when runs out of memory and hits oom event"""
 
-    duthost = duthosts[enum_frontend_dut_hostname]
-    dut_ip = duthost.mgmt_ip
-    hostname = duthost.hostname
-    dut_datetime = duthost.get_now_time()
+class TestMemoryExhaustion:
+    """
+    This test case is used to verify that DUT will reboot when it runs out of memory.
+    """
 
-    # Use `tail /dev/zero` to run out of memory completely. Since this command will cause DUT reboot,
-    # we need to run it in the background (using &) to avoid pytest getting stuck. We also need to
-    # add `nohup` to protect it.
-    cmd = 'nohup tail /dev/zero &'
-    res = duthost.shell(cmd)
-    if not res.is_successful:
-        raise Exception('DUT {} run command {} failed'.format(hostname, cmd))
+    @pytest.fixture(autouse=True)
+    def teardown(self, duthost, localhost, pdu_controller):
+        yield
+        # If the SSH connection is not established, or any critical process is exited,
+        # try to recover the DUT by PDU reboot.
+        dut_ip = duthost.mgmt_ip
+        hostname = duthost.hostname
+        if not self.check_ssh_state(localhost, dut_ip, SSH_STATE_STARTED):
+            if pdu_controller is None:
+                logging.error("No PDU controller for {}, failed to recover DUT!".format(hostname))
+                return
+            self.pdu_reboot(pdu_controller)
+            # Waiting for SSH connection startup
+            pytest_assert(self.check_ssh_state(localhost, dut_ip, SSH_STATE_STARTED, SSH_STARTUP_TIMEOUT),
+                          'Recover {} by PDU reboot failed'.format(hostname))
+            # Wait until all critical processes are healthy.
+            wait_critical_processes(duthost)
 
-    logging.info('waiting for ssh to drop on {}'.format(hostname))
-    res = localhost.wait_for(host=dut_ip,
-                             port=SONIC_SSH_PORT,
-                             state='absent',
-                             search_regex=SONIC_SSH_REGEX,
-                             delay=10,
-                             timeout=SSH_SHUTDOWN_TIMEOUT,
-                             module_ignore_errors=True)
-    pytest_assert(not res.is_failed and 'Timeout' not in res.get('msg', ''),
-                  'DUT {} did not shutdown'.format(hostname))
+    def test_memory_exhaustion(self, duthost, localhost):
+        dut_ip = duthost.mgmt_ip
+        hostname = duthost.hostname
+        dut_datetime = duthost.get_now_time()
 
-    logging.info('waiting for ssh to startup on {}'.format(hostname))
-    res = localhost.wait_for(host=dut_ip,
-                             port=SONIC_SSH_PORT,
-                             state='started',
-                             search_regex=SONIC_SSH_REGEX,
-                             delay=10,
-                             timeout=SSH_STARTUP_TIMEOUT,
-                             module_ignore_errors=True)
-    pytest_assert(not res.is_failed and 'Timeout' not in res.get('msg', ''),
-                  'DUT {} did not startup'.format(hostname))
+        # Use `tail /dev/zero` to run out of memory completely. Since this command will cause the
+        # DUT reboot, we need to run it in the background (using &) to avoid pytest getting stuck.
+        # We also need to add `nohup` to protect it.
+        cmd = 'nohup tail /dev/zero &'
+        res = duthost.shell(cmd)
+        if not res.is_successful:
+            pytest.error('DUT {} run command {} failed'.format(hostname, cmd))
 
-    # Wait until all critical processes are healthy.
-    wait_critical_processes(duthost)
+        # Waiting for SSH connection shutdown
+        pytest_assert(self.check_ssh_state(localhost, dut_ip, SSH_STATE_ABSENT, SSH_SHUTDOWN_TIMEOUT),
+                      'DUT {} did not shutdown'.format(hostname))
+        # Waiting for SSH connection startup
+        pytest_assert(self.check_ssh_state(localhost, dut_ip, SSH_STATE_STARTED, SSH_STARTUP_TIMEOUT),
+                      'DUT {} did not startup'.format(hostname))
+        # Wait until all critical processes are healthy.
+        wait_critical_processes(duthost)
+        # Verify DUT uptime is later than the time when the test case started running.
+        dut_uptime = duthost.get_up_time()
+        pytest_assert(dut_uptime > dut_datetime, "Device {} did not reboot".format(hostname))
 
-    # Verify DUT uptime is later than the time when the test case started running.
-    dut_uptime = duthost.get_up_time()
-    pytest_assert(dut_uptime > dut_datetime, "Device {} did not reboot".format(hostname))
+    def check_ssh_state(self, localhost, dut_ip, expected_state, timeout=10):
+        """
+        Check the SSH state of DUT.
+
+        :param localhost: A `tests.common.devices.local.Localhost` Object.
+        :param dut_ip: A string, the IP address of DUT.
+        :param expected_state: A string, the expected SSH state.
+        :param timeout: An integer, the maximum number of seconds to wait for.
+        :return: A boolean, True if SSH state is the same as expected
+                          , False otherwise.
+        """
+        res = localhost.wait_for(host=dut_ip,
+                                 port=SONIC_SSH_PORT,
+                                 state=expected_state,
+                                 search_regex=SONIC_SSH_REGEX,
+                                 delay=10,
+                                 timeout=timeout,
+                                 module_ignore_errors=True)
+        return not res.is_failed and 'Timeout' not in res.get('msg', '')
+
+    def pdu_reboot(self, pdu_controller):
+        pdu_controller.turn_off_outlet()
+        time.sleep(1)  # sleep 1 second to ensure there is gap between power off and on
+        pdu_controller.turn_on_outlet()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Some DUTs crashed on test case `platform_tests.test_memory_exhaustion`. We can try to recover the DUT by PDU reboot. In this PR, we add PDU reboot to the `teardwon` phase.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Some DUTs crashed on test case `platform_tests.test_memory_exhaustion`. We can try to recover the DUT by PDU reboot. In this PR, we add PDU reboot to the `teardwon` phase.

#### How did you do it?
Add PDU reboot to the `teardwon` phase.

#### How did you verify/test it?
Tested on physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
