### PR TITLE
[cacl] only add extra source rules for specific branches

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -367,7 +367,9 @@ def generate_expected_rules(duthost, docker_network, asic_index):
     # Allow all incoming BGP traffic
     iptables_rules.append("-A INPUT -p tcp -m tcp --dport 179 -j ACCEPT")
     ip6tables_rules.append("-A INPUT -p tcp -m tcp --dport 179 -j ACCEPT")
-    if "master" not in duthost.os_version:
+
+    extra_rule_branches = ['201911', '202012', '202111']
+    if any(branch in duthost.os_version for branch in extra_rule_branches):
         iptables_rules.append("-A INPUT -p tcp -m tcp --sport 179 -j ACCEPT")
         ip6tables_rules.append("-A INPUT -p tcp -m tcp --sport 179 -j ACCEPT")
 


### PR DESCRIPTION
Summary:
Fix 202205 PR test failure

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
202205 branch PR test failing on cacl application tests:
E       Failed: Missing expected iptables rules: set(['-A INPUT -p tcp -m tcp --sport 179 -j ACCEPT'])

#### How did you do it?
The extra rules only show up on older branches. All new branches will have the change to not having them.

#### How did you verify/test it?
Tested the rule adding logic.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
