### PR TITLE
Enhance config_system_checks_passed

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -14,6 +14,8 @@ def config_system_checks_passed(duthost):
     logging.info("Checking if system is running")
     out=duthost.shell("systemctl is-system-running")
     if "running" not in out['stdout']:
+        out=duthost.shell("systemctl --failed")
+        logging.info("Encounter failed service: {}".format(out['stdout_lines']))
         return False
 
     logging.info("Checking if Orchagent up for at least 2 min")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Enhance the config_system_checks_passed function to show the failed service when the "systemctl is-system-running" is degraded.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

Show some more detailed information when the checking failed.

#### How did you do it?

Get the failed service from "systemctl --failed" command.

#### How did you verify/test it?

Re-run the test_reload_config.py and make sure the failed services are listed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
