### PR TITLE
[MASIC] [chassis] Test default route with bgp flap support for multi-asic

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -653,12 +653,20 @@ class MultiAsicSonicHost(object):
 
     def get_default_route_from_app_db(self, af='ipv4'):
         default_routes = dict()
-        for front_asic in self.frontend_asics:
-            default_routes[front_asic.namespace] = front_asic.get_default_route_from_app_db(af)
+        if self.sonichost.is_multi_asic:
+            for front_asic in self.frontend_asics:
+                default_routes[front_asic.namespace] = front_asic.get_default_route_from_app_db(af)
+        else:
+            default_routes = self.asic_instance(0).get_default_route_from_app_db(af)
         return default_routes
     
-    def is_default_route_removed_from_app_db(self, uplink_asics = asic0):
-        for ns in uplink_asics:
-            if not self.asic_instance_from_namespace(ns).is_default_route_removed_from_app_db():
+    def is_default_route_removed_from_app_db(self, uplink_asics = DEFAULT_NAMESPACE):
+        if self.sonichost.is_multi_asic:
+            for ns in uplink_asics:
+                if not self.asic_instance_from_namespace(ns).is_default_route_removed_from_app_db():
+                    return False
+        else:
+            if not self.asic_instance(0).is_default_route_removed_from_app_db():
                 return False
         return True
+        

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -638,3 +638,27 @@ class MultiAsicSonicHost(object):
         """Restart service on an asic passed or None(DEFAULT_ASIC_ID)"""
         self.asic_instance(asic_index).restart_service(service)
         
+    def get_bgp_name_to_ns_mapping(self):
+        """ This function returns mapping of bgp name -- namespace
+            e.g. {'ARISTAT2': 'asic0', ...}
+        """
+        mg_facts = self.sonichost.minigraph_facts(
+            host = self.sonichost.hostname
+        )['ansible_facts']
+        neighbors = mg_facts['minigraph_neighbors']
+        mapping = dict()
+        for neigh in neighbors.values():
+            mapping[neigh['name']] = neigh['namespace']        
+        return mapping
+
+    def get_default_route_from_app_db(self, af='ipv4'):
+        default_routes = dict()
+        for front_asic in self.frontend_asics:
+            default_routes[front_asic.namespace] = front_asic.get_default_route_from_app_db(af)
+        return default_routes
+    
+    def is_default_route_removed_from_app_db(self, uplink_asics):
+        for ns in uplink_asics:
+            if not self.asic_instance_from_namespace(ns).is_default_route_removed_from_app_db():
+                return False
+        return True

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -657,7 +657,7 @@ class MultiAsicSonicHost(object):
             default_routes[front_asic.namespace] = front_asic.get_default_route_from_app_db(af)
         return default_routes
     
-    def is_default_route_removed_from_app_db(self, uplink_asics):
+    def is_default_route_removed_from_app_db(self, uplink_asics = asic0):
         for ns in uplink_asics:
             if not self.asic_instance_from_namespace(ns).is_default_route_removed_from_app_db():
                 return False

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -595,5 +595,8 @@ class SonicAsic(object):
         for af in af_list:
             def_rt_json = self.get_default_route_from_app_db(af)
             if def_rt_json:
+                # For multi-asic duts, when bgps are down, docker bridge will come up, which we should ignore here
+                if def_rt_json.values()[0]['value']['ifname'] == 'eth0':
+                    continue
                 return False
         return True

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -596,7 +596,7 @@ class SonicAsic(object):
             def_rt_json = self.get_default_route_from_app_db(af)
             if def_rt_json:
                 # For multi-asic duts, when bgps are down, docker bridge will come up, which we should ignore here
-                if def_rt_json.values()[0]['value']['ifname'] == 'eth0':
+                if self.sonichost.is_multi_asic and def_rt_json.values()[0]['value']['ifname'] == 'eth0':
                     continue
                 return False
         return True

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -73,7 +73,7 @@ def get_uplink_ns(tbinfo, bgp_name_to_ns_mapping):
         asics.add(asic)
     return asics
 
-def verify_default_route_in_app_db(duthost, tbinfo, af, uplink_ns = asic0):
+def verify_default_route_in_app_db(duthost, tbinfo, af, uplink_ns):
     """
     Verify the nexthops for the default routes match the ip interfaces
     configured on the peer device 
@@ -83,7 +83,7 @@ def verify_default_route_in_app_db(duthost, tbinfo, af, uplink_ns = asic0):
     logging.info("default route from app db {}".format(default_route))
      
     nexthops = list() 
-    if duthost.is_multi_asic:
+    if uplink_ns:
         # multi-asic case: Now we have all routes on all asics, get the uplink routes only 
         for ns in uplink_ns:
             nexthops += default_route[ns].values()[0]['value']['nexthop'].split(',')

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -73,7 +73,7 @@ def get_uplink_ns(tbinfo, bgp_name_to_ns_mapping):
         asics.add(asic)
     return asics
 
-def verify_default_route_in_app_db(duthost, tbinfo, af, uplink_ns):
+def verify_default_route_in_app_db(duthost, tbinfo, af, uplink_ns = asic0):
     """
     Verify the nexthops for the default routes match the ip interfaces
     configured on the peer device 
@@ -172,9 +172,10 @@ def test_default_route_with_bgp_flap(duthosts, enum_rand_one_per_hwsku_frontend_
     config_facts  = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
     
-    # Get uplink namespaces/asics
-    bgp_name_to_ns_mapping = duthost.get_bgp_name_to_ns_mapping()
-    uplink_ns = get_uplink_ns(tbinfo, bgp_name_to_ns_mapping)
+    # Get uplink namespaces/asics for multi-asic
+    if duthost.is_multi_asic:
+        bgp_name_to_ns_mapping = duthost.get_bgp_name_to_ns_mapping()
+        uplink_ns = get_uplink_ns(tbinfo, bgp_name_to_ns_mapping)
     
     af_list = ['ipv4', 'ipv6']
 

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -73,12 +73,12 @@ def get_uplink_ns(tbinfo, bgp_name_to_ns_mapping):
         asics.add(asic)
     return asics
 
-def verify_default_route_in_app_db(asichost, tbinfo, af, uplink_ns):
+def verify_default_route_in_app_db(duthost, tbinfo, af, uplink_ns):
     """
     Verify the nexthops for the default routes match the ip interfaces
     configured on the peer device 
     """
-    default_route = asichost.get_default_route_from_app_db(af)
+    default_route = duthost.get_default_route_from_app_db(af)
     pytest_assert(default_route, "default route not present in APP_DB")
     logging.info("default route from app db {}".format(default_route))
     # Now we have all routes on all asics, get the uplink routes only   

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -91,10 +91,10 @@ def verify_default_route_in_app_db(duthost, tbinfo, af, uplink_ns):
         key = default_route.keys()[0]
         nexthop_list = default_route[key].get('value', {}).get('nexthop', None)
         nexthops += list(nexthop_list.split(','))
-        
-    pytest_assert(nexthop_list is not None, "Default route has not nexthops")
-    logging.info("nexthop list in app_db {}".format(nexthop_list) )
-    nexthops = set(nexthop_list.split(','))
+     
+    pytest_assert(nexthops is not None, "Default route has not nexthops")
+    logging.info("nexthops in app_db {}".format(nexthops) )
+    
     upstream_neigh = get_upstream_neigh(tbinfo)
     pytest_assert(upstream_neigh is not None, "No upstream neighbors in the testbed")
 

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -180,7 +180,7 @@ def test_default_route_with_bgp_flap(duthosts, enum_rand_one_per_hwsku_frontend_
 
     # verify the default route is correct in the app db
     for af in af_list:
-        verify_default_route_in_app_db(asichost, tbinfo, af, uplink_ns)
+        verify_default_route_in_app_db(duthost, tbinfo, af, uplink_ns)
 
     duthost.command("sudo config bgp shutdown all")
     if not wait_until(120, 2, 0, duthost.is_bgp_state_idle):
@@ -188,7 +188,7 @@ def test_default_route_with_bgp_flap(duthosts, enum_rand_one_per_hwsku_frontend_
             'BGP Shutdown Timeout: BGP sessions not shutdown after 120 seconds')
 
     # give some more time for default route to be removed
-    if not wait_until(120, 2, 0, asichost.is_default_route_removed_from_app_db, uplink_ns):
+    if not wait_until(120, 2, 0, duthost.is_default_route_removed_from_app_db, uplink_ns):
         pytest.fail(
             'Default route is not removed from APP_DB')
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR is to make test_default_route_with_bgp_flap work on multi-asic duts. It used to fail on matching "nexthop from app db" with "upstream neighbor ip", because "nexthop from app db" is done per asic, while "upstream neighbor ip" are all upstream neighbors, which could be on multiple asics on multi-asic devices.
Main change in this PR is, get all default routes from frontend asics, and filter out those routes that are from uplink asics.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Make this test support for multi-asic duts

#### How did you do it?
1. get_default_route_from_app_db on all frontend asics
2. get namespaces/asics that connects to upstream neighbors(uplink_ns)
3. filter out the nexthops that are only on uplink_ns, which are upstream neighbor ip from app db
4. compare with the upstream_neighbor_ip we got from testbed info.
5. is_default_route_removed_from_app_db are evaluated on uplin_ns only, also keep an eye on 'eth0', which is the bridge ip that comes up when bgp goes down, on multi-asic duts
#### How did you verify/test it?
Before:
2022-05-10T21:14:35.0469708Z         pytest_assert(len(nexthops) == len(upstream_neigh_ip), \
2022-05-10T21:14:35.0472877Z >                       "Default route nexthops doesn't match the testbed topology")
2022-05-10T21:14:35.0475830Z E       Failed: Default route nexthops doesn't match the testbed topology
2022-05-10T21:14:35.0477010Z 
2022-05-10T21:14:35.0479467Z af         = 'ipv4'
2022-05-10T21:14:35.0481833Z asichost   = <SonicAsic 0>
2022-05-10T21:14:35.0484811Z default_route = {'ROUTE_TABLE:0.0.0.0/0': {'type': 'hash', 'value': {'ifname': 'PortChannel102,PortChannel105', 'nexthop': '10.0.0.1,10.0.0.5'}}}
2022-05-10T21:14:35.0487940Z key        = 'ROUTE_TABLE:0.0.0.0/0'
2022-05-10T21:14:35.0490523Z neigh      = 'ARISTA03T2'
2022-05-10T21:14:35.0492966Z nexthop_list = '10.0.0.1,10.0.0.5'
2022-05-10T21:14:35.0495461Z nexthops   = set(['10.0.0.1', '10.0.0.5'])
2022-05-10T21:14:35.0502293Z upstream_neigh = {'ARISTA01T2': ('10.0.0.1', 'fc00::2'), 'ARISTA03T2': ('10.0.0.5', 'fc00::6'), 'ARISTA05T2': ('10.0.0.9', 'fc00::a'), 'ARISTA07T2': ('10.0.0.13', 'fc00::e')}
2022-05-10T21:14:35.0505653Z upstream_neigh_ip = set(['10.0.0.1', '10.0.0.13', '10.0.0.5', '10.0.0.9'])
2022-05-10T21:14:35.0506799Z 
2022-05-10T21:14:35.0509033Z route/test_default_route.py:95: Failed


After:
route/test_default_route.py::test_default_route_set_src[svcstr-xx-acs-1-0] PASSED                                                                                                [  7%]
route/test_default_route.py::test_default_ipv6_route_next_hop_global_address[svcstr-xx-acs-1-0] PASSED                                                                           [ 15%]
route/test_default_route.py::test_default_route_with_bgp_flap[svcstr-xx-acs-1] PASSED                                                                                            [ 23%]
route/test_default_route.py::test_default_route_set_src[svcstr-xx-acs-1-1] PASSED                                                                                                [ 30%]
route/test_default_route.py::test_default_ipv6_route_next_hop_global_address[svcstr-xx-acs-1-1] PASSED                                                                           [ 38%]
route/test_default_route.py::test_default_route_set_src[svcstr-xx-acs-1-2] PASSED                                                                                                [ 46%]
route/test_default_route.py::test_default_ipv6_route_next_hop_global_address[svcstr-xx-acs-1-2] PASSED                                                                           [ 53%]
route/test_default_route.py::test_default_route_set_src[svcstr-xx-acs-1-3] PASSED                                                                                                [ 61%]
route/test_default_route.py::test_default_ipv6_route_next_hop_global_address[svcstr-xx-acs-1-3] PASSED                                                                           [ 69%]
route/test_default_route.py::test_default_route_set_src[svcstr-xx-acs-1-4] PASSED                                                                                                [ 76%]
route/test_default_route.py::test_default_ipv6_route_next_hop_global_address[svcstr-xx-acs-1-4] PASSED                                                                           [ 84%]
route/test_default_route.py::test_default_route_set_src[svcstr-xx-acs-1-5] PASSED                                                                                                [ 92%]
route/test_default_route.py::test_default_ipv6_route_next_hop_global_address[svcstr-xx-acs-1-5] PASSED                                                                           [100%]

-------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml --------------------------------------------------------------
=============================================================================== 13 passed in 101.61 seconds ==============================================================================

#### Any platform specific information?
This change also does not impact single-asic behavior:

route/test_default_route.py::test_default_route_with_bgp_flap[str2-7050cx3-acs-01] PASSED                                                                                           [100%]

-------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml --------------------------------------------------------------
================================================================================ 1 passed in 66.96 seconds ===============================================================================
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
