### PR TITLE
[python3] Migrate radv PTF scripts to Python 3

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/radv_ipv6_ra_test.py
+++ b/ansible/roles/test/files/ptftests/py3/radv_ipv6_ra_test.py
@@ -1,0 +1,1 @@
+../radv_ipv6_ra_test.py

--- a/ansible/roles/test/files/ptftests/py3/router_adv_mflag_test.py
+++ b/ansible/roles/test/files/ptftests/py3/router_adv_mflag_test.py
@@ -1,0 +1,1 @@
+../router_adv_mflag_test.py

--- a/tests/radv/test_radv_ipv6_ra.py
+++ b/tests/radv/test_radv_ipv6_ra.py
@@ -137,7 +137,7 @@ def test_radv_router_advertisement(
                            "downlink_vlan_ip6": vlan_intf['downlink_vlan_intf']['ip6'],
                            "ptf_port_index": vlan_intf['ptf_port']['port_idx'],
                            "max_ra_interval": RADV_MAX_RA_INTERVAL_SECS},
-                   log_file="/tmp/radv_ipv6_ra_test.RadvUnSolicitedRATest.log")
+                   log_file="/tmp/radv_ipv6_ra_test.RadvUnSolicitedRATest.log", is_python3=True)
 
 """
 @summary: Test validates the RADVd's solicited router advertisement sent on each VLAN interface
@@ -163,7 +163,7 @@ def test_solicited_router_advertisement(request, tbinfo, ptfhost, duthost, radv_
                            "ptf_port_index": vlan_intf['ptf_port']['port_idx'],
                            "ptf_port_ip6": vlan_intf['ptf_port']['ip6'],
                            "max_ra_interval": RADV_MAX_RA_INTERVAL_SECS},
-                   log_file="/tmp/radv_ipv6_ra_test.RadvSolicitedRATest.log")
+                   log_file="/tmp/radv_ipv6_ra_test.RadvSolicitedRATest.log", is_python3=True)
 
 
 """
@@ -192,7 +192,7 @@ def test_unsolicited_router_advertisement_with_m_flag(
                            "downlink_vlan_ip6": vlan_intf['downlink_vlan_intf']['ip6'],
                            "ptf_port_index": vlan_intf['ptf_port']['port_idx'],
                            "max_ra_interval": 180},
-                   log_file="/tmp/router_adv_mflag_test.RadvUnSolicitedRATest.log")
+                   log_file="/tmp/router_adv_mflag_test.RadvUnSolicitedRATest.log", is_python3=True)
 
 """
 @summary: Test validates the M flag in RADVd's solicited router advertisement sent on each VLAN interface
@@ -218,4 +218,4 @@ def test_solicited_router_advertisement_with_m_flag(request, tbinfo, ptfhost, du
                            "ptf_port_index": vlan_intf['ptf_port']['port_idx'],
                            "ptf_port_ip6": vlan_intf['ptf_port']['ip6'],
                            "max_ra_interval": RADV_MAX_RA_INTERVAL_SECS},
-                   log_file="/tmp/router_adv_mflag_test.RadvSolicitedRATest.log")
+                   log_file="/tmp/router_adv_mflag_test.RadvSolicitedRATest.log", is_python3=True)


### PR DESCRIPTION
Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

No changes were needed to the PTF scripts, so just create symlinks from
the py3 folder to the original script.

#### How did you verify/test it?

Ran `radv/test_radv_ipv6_ra.py` test cases on T0 KVM testbed, and all 4 testcases passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
