### PR TITLE
Fix vrf "KeyError: 'target_dest_mac'"

### DIFF
--- a/ansible/roles/test/files/ptftests/vrf_test.py
+++ b/ansible/roles/test/files/ptftests/vrf_test.py
@@ -23,9 +23,6 @@ import lpm
 import fib
 
 class FwdTest(FibTest):
-    _required_params = [
-        'router_macs',
-    ]
     class FwdDict(object):
         def __init__(self):
             self.ipv4 = {}
@@ -106,7 +103,6 @@ class FwdTest(FibTest):
 
 class CapTest(FwdTest):
     _required_params=[
-        'router_macs',
         'random_vrf_list',
         'src_base_vid',
         'dst_base_vid'

--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -479,10 +479,9 @@ def setup_vrf(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, localhost, skip_
 
 
 @pytest.fixture
-def partial_ptf_runner(request, ptfhost, tbinfo, dut_facts):
+def partial_ptf_runner(request, ptfhost, tbinfo):
     def _partial_ptf_runner(testname, **kwargs):
         params = {'testbed_type': tbinfo['topo']['name'],
-                  'router_macs': [dut_facts['router_mac']],
                   'ptf_test_port_map': PTF_TEST_PORT_MAP
                   }
         params.update(kwargs)
@@ -530,7 +529,8 @@ def ptf_test_port_map(tbinfo, duthosts, mg_facts, ptfhost, rand_one_dut_hostname
             target_mac = duthost.facts['router_mac']
         ptf_test_port_map[str(port)] = {
             'target_dut': 0,
-            'target_mac': target_mac
+            'target_dest_mac': target_mac,
+            'target_src_mac': duthost.facts['router_mac']
         }
     ptfhost.copy(content=json.dumps(ptf_test_port_map), dest=PTF_TEST_PORT_MAP)
 


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Vrf tests cases fail with `KeyError 'target_dest_mac'`, this issue started to appear after PR - [5456](https://github.com/Azure/sonic-mgmt/pull/5456)
Changes made in this PR should fix KeyError issue in vrf TC 
```
"fib_test.FibTest ... ERROR",
"",
"======================================================================",
"ERROR: fib_test.FibTest",
"----------------------------------------------------------------------",
"Traceback (most recent call last):",
" File \"ptftests/fib_test.py\", line 458, in runTest",
" self.check_ip_ranges()",
" File \"ptftests/fib_test.py\", line 163, in check_ip_ranges",
" self.check_ip_range(ip_range, dut_index, ipv4)",
" File \"ptftests/fib_test.py\", line 204, in check_ip_range",
" self.check_ip_route(src_port, dst_ip, exp_ports, ipv4)",
" File \"ptftests/fib_test.py\", line 237, in check_ip_route",
" res = self.check_ipv4_route(src_port, dst_ip_addr, dst_port_list)",
" File \"ptftests/fib_test.py\", line 267, in check_ipv4_route",
" router_mac = self.ptf_test_port_map[str(src_port)]['target_dest_mac']",
"KeyError: 'target_dest_mac'",
```

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix vrf  test cases
#### How did you do it?

#### How did you verify/test it?
Run `vrf/test_vrf.py::TestVrfNeigh`: 
```
vrf/test_vrf.py::TestVrfNeigh::test_ping_lag_neigh PASSED
vrf/test_vrf.py::TestVrfNeigh::test_ping_vlan_neigh PASSED
vrf/test_vrf.py::TestVrfNeigh::test_vrf1_neigh_ip_fwd PASSED
vrf/test_vrf.py::TestVrfNeigh::test_vrf2_neigh_ip_fwd PASSED
```
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.105614-dirty-20220602.130306
Distribution: Debian 11.3
Kernel: 5.10.0-12-2-amd64
Build commit: 0552d6b17
Build date: Thu Jun  2 19:00:06 UTC 2022
Built by: AzDevOps@sonic-build-workers-001KKZ
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
