### PR TITLE
[MASIC] Update bgp/conftest.py on usage of "show ip int"

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -183,7 +183,7 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
                 intf_name = fields[-1]
                 duthost.shell("config interface %s ip remove %s %s" % (namespace, intf_name, ip))
 
-        ip_intfs = duthost.show_and_parse('show ip {} interface'.format(namespace))
+        ip_intfs = duthost.show_and_parse('show ip interface {}'.format(namespace))
 
         # For interface that has two IP configured, the output looks like:
         #       admin@vlab-03:~$ show ip int


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Usage of " show ip interface -n {namespace}" in bgp/conftest is wrong for multi-asic devices, which caused error in show_and_parse():
'Failed to find separation line in the show command output'

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
on a multi-asic device:
admin@svcstr-masic-acs-1:~$ show ip interface -n asic0
Interface       Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
--------------  --------  -------------------  ------------  --------------  -------------
Loopback0                 10.1.0.32/32         up/up         N/A             N/A
PortChannel102            10.0.0.0/31          up/up         ARISTA01T2      10.0.0.1
PortChannel105            10.0.0.4/31          up/up         ARISTA03T2      10.0.0.5
docker0                   240.127.1.1/24       up/up         N/A             N/A
eth0                      10.206.144.15/24     up/up         N/A             N/A
lo                        127.0.0.1/8          up/up         N/A             N/A

but
admin@svcstr-masic-acs-1:~$ show ip -n asic0 interface
Usage: show ip [OPTIONS] COMMAND [ARGS]...

  Show IP (IPv4) commands

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  bgp          Show IPv4 BGP (Border Gateway Protocol)...
  interfaces
  prefix-list  show ip prefix-list
  protocol     Show IPv4 protocol information
  route        Show IP (IPv4) routing table
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
