### PR TITLE
Added SAI_STP_ATTR_BRIDGE_ID to common ignore log analyzer

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -25,6 +25,7 @@ r, ".* ERR syncd#SDK: :- setQueueCounterList: Queue RID oid:.* can't provide the
 r, ".* INFO kernel:.*"
 r, ".* INFO systemd.*"
 r, ".* ERR kernel:.* Module gpio_ich is blacklisted.*"
+r, ".* skipping since it causes crash: SAI_STP_ATTR_BRIDGE_ID.*"
 
 # White list below messages found on KVM for now. Need to address them later.
 r, ".* ERR macsec#wpa_supplicant.*l2_packet_send.*Network is down.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
When run test container auto restart we do see errors in loganalyzer "sonic WARNING syncd[24]: :- discover: skipping since it causes crash: SAI_STP_ATTR_BRIDGE_ID"
This caused by [SaiDiscovery.cpp](https://github.com/Azure/sonic-sairedis/blob/1942d730e0e774c4af9cfb4c00d8735e1558b4dd/syncd/SaiDiscovery.cpp#L130)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Avoid loganalyzer failure due to "crash" in syslog message
#### How did you do it?
added message to common ignore file
#### How did you verify/test it?
Run container autorestart TC, TC passed
#### Any platform specific information?
ONiC Software Version: SONiC.master.105614-dirty-20220602.215204
Distribution: Debian 11.3
Kernel: 5.10.0-12-2-amd64
Build commit: 0552d6b17
Build date: Thu Jun 2 21:58:41 UTC 2022
Built by: AzDevOps@sonic-build-workers-001KKZ

Platform: x86_64-accton_wedge100bf_32x-r0
HwSKU: montara
ASIC: barefoot
ASIC Count: 1
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
