### PR TITLE
Added skip of drop counters TC for igmp on vlan members

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -93,6 +93,13 @@ drop_packets/test_drop_counters.py::test_loopback_filter:
   skip:
     reason: "SONiC can't enable loop-back filter feature"
 
+drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members:
+  # This test case may fail due to a known issue https://github.com/Azure/sonic-mgmt/issues/5207.
+  # Temporarily disabling the test case due to the this issue.
+  skip:
+    reason: "This test failed intermittent due to known issue in sonic-mgmt, skip for now."
+    conditions: https://github.com/Azure/sonic-mgmt/issues/5207
+
 drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[vlan_members]:
   skip:
     reason: "Image issue on Boradcom dualtor testbeds"
@@ -142,13 +149,3 @@ drop_packets/test_drop_counters.py::test_src_ip_link_local:
     reason: "Cisco 8000 platform does not drop SIP link local packets"
     conditions:
       - "asic_type=='cisco-8000'"
-
-drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members:
-  # This test case may fail due to a known issue https://github.com/Azure/sonic-mgmt/issues/5207.
-  # Temporarily disabling the test case due to the this issue.
-  skip:
-    reason: "This test failed intermittent due to known issue in sonic-mgmt, skip for now."
-    conditions: https://github.com/Azure/sonic-mgmt/issues/5207
-
-
-

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -143,5 +143,12 @@ drop_packets/test_drop_counters.py::test_src_ip_link_local:
     conditions:
       - "asic_type=='cisco-8000'"
 
+drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members:
+  # This test case may fail due to a known issue https://github.com/Azure/sonic-mgmt/issues/5207.
+  # Temporarily disabling the test case due to the this issue.
+  skip:
+    reason: "This test failed intermittent due to known issue in sonic-mgmt, skip for now."
+    conditions: https://github.com/Azure/sonic-mgmt/issues/5207
+
 
 


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added skip mark for test_non_routable_igmp_pkts on VLAN members TC according to https://github.com/Azure/sonic-mgmt/issues/5207.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Added temporary skip for test_non_routable_igmp_pkts[vlan_members] TC
#### How did you do it?
Updated mark_conditions file for drop packets TC
#### How did you verify/test it?
```
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v1-general_query] SKIPPED                                                          [ 16%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v3-general_query] SKIPPED                                                          [ 33%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v1-membership_report] SKIPPED                                                      [ 50%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v2-membership_report] SKIPPED                                                      [ 66%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v3-membership_report] SKIPPED                                                      [ 83%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-v2-leave_group] SKIPPED                                                            [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
