### PR TITLE
Enhance test_cpu_memory_usage to show full process parameters

### DIFF
--- a/ansible/library/monit_process.py
+++ b/ansible/library/monit_process.py
@@ -83,6 +83,7 @@ def monit_process(module, interval, iterations):
             time.sleep(interval)
             processes = []
             for proc in psutil.process_iter(['pid', 'name',
+                                             'cmdline',
                                              'cpu_percent',
                                              'memory_percent',
                                              'status']):

--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -205,7 +205,7 @@ def check_cpu_usage(cpu_threshold, outstanding_procs, outstanding_procs_counter,
     if proc['cpu_percent'] >= cpu_threshold:
         logging.debug("process %s(%d) cpu usage exceeds %d%%.",
                       proc['name'], proc['pid'], cpu_threshold)
-        outstanding_procs[proc['pid']] = proc['name']
+        outstanding_procs[proc['pid']] = proc.get('cmdline', proc['name'])
         outstanding_procs_counter[proc['pid']] += 1
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Show the full process parameters when detect some high CPU usage process.
Originally, it will only show something like
```
>           pytest.fail(failure_message)
E           Failed: Processes that persistently exceed CPU usage (50%): [u'python3']
```

Now, it can display more content like
```
>           pytest.fail(failure_message)
E           Failed: Processes that persistently exceed CPU usage (50%): [[u'python3', u'/usr/local/bin/xcvrd']]
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

Show more content when the pytest is failed.
Hard to find the problem when only "python3" show inside the failure log.

#### How did you do it?

Modify the monit_process module to let it collect cmdline column.

#### How did you verify/test it?

Write a busy python program and run it during test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
