### PR TITLE
Add start and end timestamp for testcases

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -710,6 +710,14 @@ def tag_test_report(request, pytestconfig, tbinfo, duthost, record_testsuite_pro
     record_testsuite_property("hwsku", duthost.facts["hwsku"])
     record_testsuite_property("os_version", duthost.os_version)
 
+def pytest_runtest_setup(item):
+    # Add start timestamp of testcase
+    item.user_properties.append(("start", datetime.utcnow()))
+
+def pytest_runtest_teardown(item):
+    # Add end timestamp of testcase
+    item.user_properties.append(("end", datetime.utcnow()))
+
 
 @pytest.fixture(scope="module", autouse=True)
 def clear_neigh_entries(duthosts, tbinfo):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Add start and end timestamp for testcases would help analysis time cost
of testcases, and then help optimize testcases.
#### How did you do it?
Record start/end timestamp in setup/teardown, and append to
user_properties, so we could get start/end timestamp in logs/tr.xml
#### How did you verify/test it?
Run a test.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
