### PR TITLE
Added barefoot asic type to conditional mark of sub_port_interfaces TC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -331,7 +331,7 @@ sub_port_interfaces:
   skip:
     reason: "Unsupported platform or asic"
     conditions:
-      - "is_multi_asic==True or asic_gen not in ['td2', 'spc1', 'spc2', 'spc3']"
+      - "is_multi_asic==True or asic_gen not in ['td2', 'spc1', 'spc2', 'spc3'] and asic_type not in ['barefoot']"
 
 sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports:
   skip:


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added barefoot asic type to conditional marks of sub_port_interfaces TC

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Sub port interfaces are supported on Barefoot ASIC. So was added barefoot ASIC type to conditional mark of sub_port_interfaces TC according to changes from #5721
#### How did you do it?
Added barefoot asic type to tests_mark_conditions.yaml file for sub_port TC
#### How did you verify/test it?
```
sub_port_interfaces/test_show_subinterface.py::test_subinterface_status[port] PASSED                                                                                                [  3%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_packet_routed_with_valid_vlan[port] PASSED                                                                      [  6%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_packet_routed_with_valid_vlan[port_in_lag] PASSED                                                               [  9%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_packet_routed_with_invalid_vlan[port] PASSED                                                                    [ 12%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_packet_routed_with_invalid_vlan[port_in_lag] PASSED                                                             [ 16%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_untagged_packet_not_routed[port] PASSED                                                                         [ 19%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_admin_status_down_disables_forwarding[port] PASSED                                                              [ 22%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_admin_status_down_disables_forwarding[port_in_lag] PASSED                                                       [ 25%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_max_numbers_of_sub_ports[port] PASSED                                                                           [ 29%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_max_numbers_of_sub_ports[port_in_lag] PASSED                                                                    [ 32%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_mtu_inherited_from_parent_port[port] PASSED                                                                     [ 35%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_mtu_inherited_from_parent_port[port_in_lag] PASSED                                                              [ 38%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_vlan_config_impact[port] PASSED                                                                                 [ 41%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_vlan_config_impact[port_in_lag] PASSED                                                                          [ 45%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports[same-port-TCP-UDP-ICMP] PASSED                                                        [ 48%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports[same-port_in_lag-TCP-UDP-ICMP] PASSED                                                 [ 51%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports[different-port-TCP-UDP-ICMP] PASSED                                                   [ 54%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports[different-port_in_lag-TCP-UDP-ICMP] PASSED                                            [ 58%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_unaffected_by_sub_ports_removal[same-TCP-UDP-ICMP-PORT] PASSED                        [ 61%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_unaffected_by_sub_ports_removal[different-TCP-UDP-ICMP-PORT] PASSED                   [ 64%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[svi-port-TCP-UDP-ICMP] PASSED                                                [ 67%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[svi-port_in_lag-TCP-UDP-ICMP] PASSED                                         [ 70%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[l3-port-TCP-UDP-ICMP] PASSED                                                 [ 74%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[l3-port_in_lag-TCP-UDP-ICMP] PASSED                                          [ 77%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports[same-port] PASSED                                                                   [ 80%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports[same-port_in_lag] PASSED                                                            [ 83%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports[different-port] PASSED                                                              [ 87%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports[different-port_in_lag] PASSED                                                       [ 90%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_balancing_sub_ports[port] PASSED                                                                                [ 93%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_balancing_sub_ports[port_in_lag] PASSED                                                                         [ 96%]
sub_port_interfaces/test_sub_port_l2_forwarding.py::test_sub_port_l2_forwarding[port] PASSED                                                                                        [100%]
```
#### Any platform specific information?
SONiC Software Version: SONiC.master.67698-dirty-20220125.180710
Distribution: Debian 11.2
Kernel: 5.10.0-8-2-amd64
Build commit: 49a036e90
Build date: Tue Jan 25 18:15:01 UTC 2022
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
