### PR TITLE
[mux simulator] allow adapative recovery for mux status issues on DUT

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -215,6 +215,9 @@ def sanity_check(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
                 for failed_result in failed_results:
                     if 'host' in failed_result:
                         dut_failed_results[failed_result['host']].append(failed_result)
+                    if 'hosts' in failed_result:
+                        for hostname in failed_result['hosts']:
+                            dut_failed_results[hostname].append(failed_result)
                     if failed_result['check_item'] in constants.INFRA_CHECK_ITEMS:
                         if 'action' in failed_result and failed_result['action'] is not None \
                             and callable(failed_result['action']):

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -541,6 +541,7 @@ def check_mux_simulator(duthosts, duts_minigraph_facts, get_mux_status, reset_si
             logger.warning(err_msg)
             results['failed'] = True
             results['failed_reason'] = err_msg
+            results['hosts'] = [ dut.hostname for dut in duthosts ]
             results['action'] = reset_simulator_port
             return results
 

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -65,7 +65,7 @@ def adaptive_recover(dut, localhost, fanouthosts, check_results, wait_time):
                 action = __recover_interfaces(dut, fanouthosts, result, wait_time)
             elif result['check_item'] == 'services':
                 action = __recover_services(dut, result)
-            elif result['check_item'] in [ 'processes', 'bgp' ]:
+            elif result['check_item'] in [ 'processes', 'bgp', 'mux_simulator' ]:
                 action = 'config_reload'
             else:
                 action = 'reboot'


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
When 'show mux status' returns error, current sanity check is unable to recover it unless the issue is on the mux simulator side.

#### How did you do it?
When dut shows error from 'show mux status' output, reload config to recover from DUT side.

#### How did you verify/test it?
Run test when DUT has mux in error status. Recovery happened and the test passed.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
