### PR TITLE
Add a new column testbed name for reachability table in Kusto

### DIFF
--- a/ansible/health_checker.py
+++ b/ansible/health_checker.py
@@ -1,0 +1,79 @@
+import argparse
+import subprocess
+import imp
+import os
+import logging
+import sys
+import json
+from datetime import datetime
+
+ANSIBLE_DIR = os.path.abspath(os.path.dirname(__file__))
+SONIC_MGMT_DIR = os.path.dirname(ANSIBLE_DIR)
+TESTBED_FILE = 'testbed.yaml'
+SONIC_TESTBED_HEALTH_FILE = 'testbed_ping.json'
+
+root = logging.getLogger()
+root.setLevel(logging.DEBUG)
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+root.addHandler(handler)
+
+def get_dut_tbname_map():
+    """Return a dictionary containing mapping from dut hostname to testbed name."""
+    testbed = imp.load_source('testbed', os.path.join(SONIC_MGMT_DIR, 'tests/common/testbed.py'))
+    dut_tbname_map = {}
+    for tbname, tb in testbed.TestbedInfo(TESTBED_FILE).testbed_topo.items():
+        for duthost in tb['duts']:
+            dut_tbname_map[duthost] = tbname
+
+    return dut_tbname_map
+
+def parse_ping_result(ping_results, dut_tbname_map):
+    """Parse ping results of devutils to kusto table data format."""
+    final_results = []
+    for dut_ping_result in ping_results:
+        dut_result = {}
+        ping_time = str(datetime.utcnow())
+        dut_result['UTCTimestamp'] = ping_time
+        dut_result['DeviceName'] = dut_ping_result['Host']
+        dut_result['IP'] = dut_ping_result['Hostname']
+        dut_result['IcmpReachability'] = 1 if dut_ping_result['Ping result'] == 'Success' else 0
+        dut_result['ConsoleReachability'] = 0
+        dut_result['SshReachability'] = 0
+        if dut_result['DeviceName'] in dut_tbname_map:
+            dut_result['TestbedName'] = dut_tbname_map[dut_result['DeviceName']]
+        else:
+            logging.error("Didn't find the match testbed name for host {}".format(dut_result['DeviceName']))
+
+        final_results.append(dut_result)
+    return final_results
+
+def run_devutils():
+    """Run devutils to check icmp reachability for testbeds"""
+    groups = ['str', 'str2', 'strsvc']
+
+    health_results = []
+    dut_tbname_map = get_dut_tbname_map()
+
+    for group in groups:
+        input_file_name ='ping_{}.json'.format(group)
+        command = './devutils -i {} -a ping -g sonic -j > {}'.format(group, input_file_name)
+        output = os.system(command)
+
+        with open(input_file_name) as input_file:
+            ping_results = json.load(input_file)
+
+        results = parse_ping_result(ping_results, dut_tbname_map)
+        health_results.extend(results)
+ 
+    with open(SONIC_TESTBED_HEALTH_FILE, 'w') as fp:
+        json.dump(health_results, fp, indent=4)
+    return
+
+
+if __name__ == '__main__':
+
+    run_devutils()

--- a/ansible/health_checker.py
+++ b/ansible/health_checker.py
@@ -1,11 +1,9 @@
-import argparse
-import subprocess
 import imp
 import os
 import logging
 import sys
 import json
-from datetime import datetime
+
 
 ANSIBLE_DIR = os.path.abspath(os.path.dirname(__file__))
 SONIC_MGMT_DIR = os.path.dirname(ANSIBLE_DIR)
@@ -36,8 +34,6 @@ def parse_ping_result(ping_results, dut_tbname_map):
     final_results = []
     for dut_ping_result in ping_results:
         dut_result = {}
-        ping_time = str(datetime.utcnow())
-        dut_result['UTCTimestamp'] = ping_time
         dut_result['DeviceName'] = dut_ping_result['Host']
         dut_result['IP'] = dut_ping_result['Hostname']
         dut_result['IcmpReachability'] = 1 if dut_ping_result['Ping result'] == 'Success' else 0

--- a/ansible/health_checker.py
+++ b/ansible/health_checker.py
@@ -38,8 +38,9 @@ def parse_ping_result(ping_results, dut_tbname_map, skip_testbeds):
         dut_result['DeviceName'] = dut_ping_result['Host']
         dut_result['IP'] = dut_ping_result['Hostname']
         dut_result['IcmpReachability'] = 1 if dut_ping_result['Ping result'] == 'Success' else 0
-        dut_result['ConsoleReachability'] = 0
-        dut_result['SshReachability'] = 0
+        # TODO Currently, ConsoleReachability and SshReachability is not used.
+        dut_result['ConsoleReachability'] = None
+        dut_result['SshReachability'] = None
         if dut_result['DeviceName'] in dut_tbname_map:
             testbed_name = dut_tbname_map[dut_result['DeviceName']]
             if skip_testbeds and skip_testbeds != '' and testbed_name in skip_testbeds:

--- a/test_reporting/README.md
+++ b/test_reporting/README.md
@@ -24,6 +24,9 @@ You need to add the following environment variables first:
 
 Check out [this doc from Kusto](https://docs.microsoft.com/en-us/azure/data-explorer/provision-azure-ad-app) for more details about setting up AAD client applications for accessing Kusto.
 
+If you want to upload data into a new table, please add the related create table commands in setup.kql file and run them manually in Kusto.
+Make sure the table is created and mapping is generated sucessfully.
+
 Once these have been added, you can use the `report_uploader.py` script to upload test report data to Kusto:
 ```
 % python3 report_uploader.py -c "test_result" <path to JUnit XML files produced by pytest> <database name>

--- a/test_reporting/kusto/setup.kql
+++ b/test_reporting/kusto/setup.kql
@@ -186,3 +186,22 @@
                                                             '{"column":"RebootType", "Properties":{"Path":"$[\'reboot_type\']"}},'
                                                             '{"column":"DataplaneLostPackets", "Properties":{"Path":"$[\'dataplane\'][\'lost_packets\']"}},'
                                                             '{"column":"DataplaneDowntime", "Properties":{"Path":"$[\'dataplane\'][\'downtime\']"}}]'
+
+###############################################################################
+# TESTBEDREACHABILITY TABLE SETUP                                             #
+# 1. Create a TestbedReachability table to store testbed health info          #
+# 2. Add a JSON mapping for the table                                         #
+###############################################################################
+.create table TestbedReachability (UTCTimestamp: datetime, TestbedName: string,
+                                  DeviceName: string, IP: string,
+                                  IcmpReachability: bool, ConsoleReachability: bool,
+                                  SshReachability: bool)
+
+.create table TestbedReachability ingestion json mapping 'TestbedReachabilityMapping' @'[{"column":"UTCTimestamp","Properties":{"path":"$.UTCTimestamp"}},'
+                                                                     '{"column":"TestbedName","Properties":{"path":"$.TestbedName"}},'
+                                                                     '{"column":"DeviceName","Properties":{"path":"$.DeviceName"}},'
+                                                                     '{"column":"IP","Properties":{"path":"$.IP"}},'
+                                                                     '{"column":"IcmpReachability","Properties":{"path":"$.IcmpReachability"}},'
+                                                                     '{"column":"ConsoleReachability","Properties":{"path":"$.ConsoleReachability"}},'
+                                                                     '{"column":"SshReachability","Properties":{"path":"$.SshReachability"}},'
+                                                                     ']'

--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -177,6 +177,9 @@ class KustoConnector(ReportDBConnector):
         self._upload_test_cases(report_json, report_guid)
 
     def upload_reachability_data(self, ping_output: List) -> None:
+        ping_time = str(datetime.utcnow())
+        for result in ping_output:
+            result.update({"UTCTimestamp": ping_time})
         self._ingest_data(self.TESTBEDREACHABILITY_TABLE, ping_output)
 
     def upload_pdu_status_data(self, pdu_status_output: List) -> None:

--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -88,6 +88,7 @@ class KustoConnector(ReportDBConnector):
     SUMMARY_TABLE = "TestReportSummary"
     RAW_CASE_TABLE = "RawTestCases"
     RAW_REACHABILITY_TABLE = "RawReachabilityData"
+    TESTBEDREACHABILITY_TABLE = "TestbedReachability"
     RAW_PDU_STATUS_TABLE = "RawPduStatusData"
     RAW_REBOOT_TIMING_TABLE = "RawRebootTimingData"
     REBOOT_TIMING_TABLE = "RebootTimingData"
@@ -99,6 +100,7 @@ class KustoConnector(ReportDBConnector):
         SUMMARY_TABLE: DataFormat.JSON,
         RAW_CASE_TABLE: DataFormat.MULTIJSON,
         RAW_REACHABILITY_TABLE: DataFormat.MULTIJSON,
+        TESTBEDREACHABILITY_TABLE:DataFormat.JSON,
         RAW_PDU_STATUS_TABLE: DataFormat.MULTIJSON,
         RAW_REBOOT_TIMING_TABLE: DataFormat.JSON,
         REBOOT_TIMING_TABLE: DataFormat.MULTIJSON,
@@ -111,6 +113,7 @@ class KustoConnector(ReportDBConnector):
         SUMMARY_TABLE: "FlatSummaryMappingV1",
         RAW_CASE_TABLE: "RawCaseMappingV1",
         RAW_REACHABILITY_TABLE: "RawReachabilityMappingV1",
+        TESTBEDREACHABILITY_TABLE: "TestbedReachabilityMapping",
         RAW_PDU_STATUS_TABLE: "RawPduStatusMapping",
         RAW_REBOOT_TIMING_TABLE: "RawRebootTimingDataMapping",
         REBOOT_TIMING_TABLE: "RebootTimingDataMapping",
@@ -174,12 +177,7 @@ class KustoConnector(ReportDBConnector):
         self._upload_test_cases(report_json, report_guid)
 
     def upload_reachability_data(self, ping_output: List) -> None:
-        ping_time = str(datetime.utcnow())
-        for result in ping_output:
-            result.update({"Timestamp": ping_time})
-
-        reachability_data = {"data": ping_output}
-        self._ingest_data(self.RAW_REACHABILITY_TABLE, reachability_data)
+        self._ingest_data(self.TESTBEDREACHABILITY_TABLE, ping_output)
 
     def upload_pdu_status_data(self, pdu_status_output: List) -> None:
         time = str(datetime.utcnow())


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Add a new column testbed name for reachability table in Kusto.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Currently, Reachability table for testbeds in Kusto doesn't have testbed name column, only device name.

#### How did you do it?
Create a new table named TestbedReachability in Kusto, which has a new column testbed name.
Add a new script `health_checker.py` to collect icmp reachability for testbeds and save results into json file.

#### How did you verify/test it?
```
cd ansible
python health_checker.py

source /var/AzDevOps/env-python3/bin/activate
cd ../test_reporting
python3 report_uploader.py -c "reachability" ../ansible/testbed_ping.json kusodb
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
