### PR TITLE
[test_configurable_drop_counters]Ignore loganalyzer exceptions

### DIFF
--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -59,6 +59,21 @@ def vlan_mac(duthost):
         dut_vlan_mac = duthost.facts['router_mac']
     return dut_vlan_mac
 
+
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exception(duthosts, rand_one_dut_hostname, loganalyzer):
+    if loganalyzer:
+        ignore_regex_list = [
+            ".*ERR swss[0-9]*#orchagent.*meta_sai_validate_fdb_entry.*object key SAI_OBJECT_TYPE_FDB_ENTRY.*doesn't exist.*",
+            ".*ERR swss[0-9]*#orchagent.*removeFdbEntry: FdbOrch RemoveFDBEntry: Failed to remove FDB entry. mac=.*, bv_id=.*",
+            ".*ERR swss[0-9]*#orchagent.*handleSaiRemoveStatus: Encountered failure in remove operation, exiting orchagent, SAI API: SAI_API_FDB, status: SAI_STATUS_INVALID_PARAMETER.*",
+            ".*ERR syncd[0-9]*#syncd.*SAI_API_DEBUG_COUNTER:_brcm_sai_debug_counter_value_get.*No debug_counter at index.*found.*",
+            ".*ERR syncd[0-9]*#syncd.*collectPortDebugCounters: Failed to get stats of port.*"
+        ]
+        duthost = duthosts[rand_one_dut_hostname]
+        loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_list)
+
+
 def apply_fdb_config(duthost, vlan_id, iface, mac_address, op, type):
     """ Generate FDB config file to apply it using 'swssconfig' tool.
     Generated config file template:
@@ -83,7 +98,7 @@ def apply_fdb_config(duthost, vlan_id, iface, mac_address, op, type):
     fdb_config_json.append(fdb_entry_json)
 
     with tempfile.NamedTemporaryFile(suffix=".json", prefix="fdb_config") as fp:
-        logging.info("Generating FDB config")
+        logging.info("Generating FDB config: {}".format(fdb_config_json))
         json.dump(fdb_config_json, fp)
         fp.flush()
 
@@ -167,7 +182,7 @@ def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_d
         # FIXME: Add config reload on t0-backend as a workaround to keep DUT healthy because the following
         # drop packet testcases will suffer from the brcm_sai_get_port_stats errors flooded in syslog
         if "backend" in tbinfo["topo"]["name"]:
-            config_reload(duthost)
+            config_reload(duthost, safe_reload=True)
 
 
 @pytest.mark.parametrize("drop_reason", ["DIP_LINK_LOCAL"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix loganalyzer exception of test_configurable_drop_counters.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix loganalyzer exception of test_configurable_drop_counters.
#### How did you do it?
For the error log 1-3:
I checked the trigger of the logs, likely it's because of the double delete([sonic-clear fdb all and arp], swssconfig ) of the cleanup commands.
The second delete command(swssconfig)  is used to remove the static mac record in fdb, I can see a certain record is deleted even though it's saying can't delete a non-exist record. 
It may be related to the async executing of swssconfig and sonic-clear(https://github.com/sonic-net/SONiC/wiki/SONiC-Clear-FDB-CLI-Design), if I execute 'show arp' and 'show mac' between the two cleanups, the exception will not be raised.
Since a double delete has no bad effect on DUT, we can safely ignore it.

For the error log 4-5:
It should be related to debug things, we can safely ignore it too.

So we can ignore the 5 error logs.

#### How did you verify/test it?
Run on physical testbeds
drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[PORT_INGRESS_DROPS-L3_EGRESS_LINK_DOWN] PASSED [ 16%]
drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[SWITCH_INGRESS_DROPS-L3_EGRESS_LINK_DOWN] SKIPPED [ 33%]
drop_packets/test_configurable_drop_counters.py::test_dip_link_local[PORT_INGRESS_DROPS-DIP_LINK_LOCAL] PASSED [ 50%]
drop_packets/test_configurable_drop_counters.py::test_dip_link_local[SWITCH_INGRESS_DROPS-DIP_LINK_LOCAL] SKIPPED [ 66%]
drop_packets/test_configurable_drop_counters.py::test_sip_link_local[PORT_INGRESS_DROPS-SIP_LINK_LOCAL] PASSED [ 83%]
drop_packets/test_configurable_drop_counters.py::test_sip_link_local[SWITCH_INGRESS_DROPS-SIP_LINK_LOCAL] SKIPPED [100%]
