### PR TITLE
[Skip Condition]Don't skip subinterface test on Nvidia platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -103,7 +103,7 @@ def read_asic_name(hwsku):
             asic_name = yaml.safe_load(f)
 
         for key, value in asic_name.items():
-            if ('td' not in key) and ('th' not in key):
+            if ('td' not in key) and ('th' not in key) and ('spc' not in key):
                 asic_name.pop(key)
 
         for name, hw in asic_name.items():

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -278,7 +278,7 @@ sub_port_interfaces:
   skip:
     reason: "Unsupported platform or asic"
     conditions:
-      - "is_multi_asic==True or asic_gen not in ['td2']"
+      - "is_multi_asic==True or asic_gen not in ['td2', 'spc1', 'spc2', 'spc3]"
 
 sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_tunneling_between_sub_ports:
   skip:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Community has recently added a skip condition for subinterface test, the test only run on td2 asic.
Nvidia platforms also support subinterface feature, so fix the condition to run the test also on spc1/2/3 asic.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Run sub interface test on Nvidia platforms.
#### How did you do it?
1. For read_asic_name(hwsku) method, If the asic name contains 'spc', also return the asic generation name.
2. Update the skip condition for spc asics.
#### How did you verify/test it?
Run sub interface test on a t0 setup, it is no longer skipped.

#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
