### PR TITLE
skip encapsulation protocol when hashing ip_proto

### DIFF
--- a/ansible/roles/test/files/ptftests/hash_test.py
+++ b/ansible/roles/test/files/ptftests/hash_test.py
@@ -172,9 +172,10 @@ class HashTest(BaseTest):
 
     def _get_ip_proto(self, ipv6=False):
         # ip_proto 2 is IGMP, should not be forwarded by router
+        # ip_proto 4 and 41 are encapsulation protocol, ip payload will be malformat
         # ip_proto 254 is experimental
         # MLNX ASIC can't forward ip_proto 254, BRCM is OK, skip for all for simplicity
-        skip_protos = [2, 253, 254]
+        skip_protos = [2, 4, 41, 253, 254]
         if ipv6:
             # Skip ip_proto 0 for IPv6
             skip_protos.append(0)


### PR DESCRIPTION
**Description**
In our lab environment, sonic router will to hit the failure when running "test_hash" of hashing ip_proto as 4 and 41 on both ipv4 and ipv6 test cases.

**Steps to reproduce the issue:**
run the testcase "fib/test_fib.py::test_hash" on T0 or T1 testbed.
Describe the results you received:
Traceback (most recent call last):
File "ptf/hash_test.py", line 406, in runTest
self.check_hash(hash_key)
File "ptf/hash_test.py", line 158, in check_hash
(matched_index, _) = self.check_ip_route(hash_key, src_port, dst_ip, exp_port_list, pkt_cnt)
File "ptf/hash_test.py", line 168, in check_ip_route
(matched_index, received) = self.check_ipv4_route(hash_key, src_port, dst_port_list, pkt_cnt)
File "ptf/hash_test.py", line 251, in check_ipv4_route
send_packet(self, src_port, pkt)
File "/usr/lib/python2.7/dist-packages/ptf/testutils.py", line 2538, in verify_packet_any_port
% (ports, device_number, result.format()))

then,
set ptf_runner.py with debug level on below
set def ptf_runner(...., debug_level="debug"... )

not receiving any packets
dataplane : DEBUG : Poll timeout, no packet from device 0, port None
dataplane : DEBUG : Poll timeout, no packet from device 0, port None

**Describe the results you expected:**
testcase Pass

**Additional information you deem important:**
concluded as ptf testscript does form the tcp transport segment content by simple_tcp_packet(), but the ip network content does not have. testscript only locates ip_proto field (in this case: ip_proto is an encapsulation type if randomly selected with ip_proto is 4 as ipv4 and ip_proto is 41 as ipv6). data payload should have ipv4 and ipv6 network layer content (ex: by simple_ip_packet())

it could be a limitation on PTF when considering tcp/ip content together. Here is the wiki page for listing protocol meaning: **https://en.wikipedia.org/wiki/List_of_IP_protocol_numbers

the snippets base on sonic-mgmt 202012.
https://github.com/Azure/sonic-mgmt/blob/202012/ansible/roles/test/files/ptftests/hash_test.py#L207
Using simple_tcp_packet(), no taking simple_ip_packet()

https://github.com/Azure/sonic-mgmt/blob/202012/ansible/roles/test/files/ptftests/hash_test.py#L226
pkt['IP'].proto=ip_proto without IP content.

We also have 2 observations based on T0 setup with proposed solution as below.
(If u think it is okay, we can file a case on sonic-mgmt 202012 branch first)

**solution:**
https://github.com/Azure/sonic-mgmt/blob/202012/ansible/roles/test/files/ptftests/hash_test.py#L177
-skip_protos= [2, 253,254]
+skip_protos= [2, 4, 41, 253,254]

2 observations:
(A) the PTF pcap file:
checking on the packet with ip_proto field as 4, the ip raw payload represents as Bogus Ip Error/Protocol and with ip_proto field as 41, the ip raw payload represents as Ipv6 Ip Error/malformed.

(B) npu entry point:
assumption: testscript change with pdb breakpoint, we trigger first 4 packets to router. npu on slice2 cnt will increment by 4. when fixing the 5th packet as either 4 or 41 and trigging again, npu on slice2 cnt will not increment.

debug shell to observe the npu
Sending 1st, 2nd, 3rd, and 4th pkt
__Slice0|Slice1|Slice2|Slice3|Slice4|Slice5|
IFGB_RX0 packets = 0 IFG_RX2 = 0 IFG_RX4 = 4 IFG_RX6 = 0 IFG_RX8 = 0 IFG_RX10 = 58

Sending 5th pkt
__Slice0|Slice1|Slice2|Slice3|Slice4|Slice5|
IFGB_RX0 packets = 0 IFG_RX2 = 0 IFG_RX4 = 0 IFG_RX6 = 0 IFG_RX8 = 0 IFG_RX10