### PR TITLE
[platform] revert skip oom test for celestica-dx010 and force10-s6000

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -572,7 +572,7 @@ platform_tests/test_memory_exhaustion.py:
   skip:
     reason: "Skip this test case until vendors fix the issue"
     conditions:
-      - "(hwsku in ['Celestica-DX010-C32', 'Celestica-E1031-T48S4'] and https://github.com/Azure/sonic-buildimage/issues/10339) or (hwsku in ['Force10-S6000'] and https://github.com/Azure/sonic-buildimage/issues/10921)"
+      - "hwsku in ['Celestica-E1031-T48S4'] and https://github.com/Azure/sonic-buildimage/issues/10339"
 
 #######################################
 #####    test_platform_info.py    #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Revert the skip of `platform_tests.test_memory_exhaustion` for `celestica-dx010` and `force10-s6000`.

1. `celestica-dx010` no longer fails on this test case. (Azure/sonic-buildimage#10339)
2. Only one `force10-s6000` device fails on this test case. We can continue run it on `force10-s6000` platform. (Azure/sonic-buildimage#10921)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

Revert the skip of `platform_tests.test_memory_exhaustion` for `celestica-dx010` and `force10-s6000`.

1. `celestica-dx010` no longer fails on this test case.
2. Only one `force10-s6000` device fails on this test case. We can continue run it on `force10-s6000` platform.

#### How did you do it?

Update configurations in `tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml`.

#### How did you verify/test it?

Verified on physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
