### PR TITLE
Parse added timestamp of testcases and add kusto support

### DIFF
--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -76,6 +76,16 @@ REQUIRED_TESTCASE_ATTRIBUTES = [
     "name",
     "time",
 ]
+
+# Fields found in the testcase/properties section of the JUnit XML file.
+# FIXME: These are specific to pytest, needs to be extended to support spytest.
+TESTCASE_PROPERTIES_TAG = "properties"
+TESTCASE_PROPERTY_TAG = "property"
+REQUIRED_TESTCASE_PROPERTIES = [
+    "start",
+    "end",
+]
+
 REQUIRED_TESTCASE_JSON_FIELDS = ["result", "error", "summary"]
 
 
@@ -272,6 +282,38 @@ def _validate_test_metadata(root):
     if set(seen_properties) < set(REQUIRED_METADATA_PROPERTIES):
         raise JUnitXMLValidationError("missing metadata element(s)")
 
+def _validate_test_case_properties(root):
+    testcase_properties_element = root.find(TESTCASE_PROPERTIES_TAG)
+
+    if not testcase_properties_element:
+        return
+
+    seen_testcase_properties = []
+    for testcase_prop in testcase_properties_element.iterfind(TESTCASE_PROPERTY_TAG):
+        testcase_property_name = testcase_prop.get("name", None)
+
+        if not testcase_property_name:
+            continue
+
+        if testcase_property_name not in REQUIRED_TESTCASE_PROPERTIES:
+            continue
+
+        if testcase_property_name in seen_testcase_properties:
+            raise JUnitXMLValidationError(
+                f"duplicate metadata element: {testcase_property_name} seen more than once"
+            )
+
+        testcase_property_value = testcase_prop.get("value", None)
+
+        if testcase_property_value is None:  # Some fields may be empty
+            raise JUnitXMLValidationError(
+                f'invalid metadata element: no "value" field provided for {testcase_property_name}'
+            )
+
+        seen_testcase_properties.append(testcase_property_name)
+
+    if set(seen_testcase_properties) < set(REQUIRED_TESTCASE_PROPERTIES):
+        raise JUnitXMLValidationError("missing testcase property element(s)")
 
 def _validate_test_cases(root):
     def _validate_test_case(test_case):
@@ -281,6 +323,7 @@ def _validate_test_cases(root):
                     f'"{attribute}" not found in test case '
                     f"\"{test_case.get('name', 'Name Not Found')}\""
                 )
+        _validate_test_case_properties(test_case)
 
     cases = root.findall(TESTCASE_TAG)
 
@@ -352,6 +395,18 @@ def _parse_test_metadata(root):
 
     return test_result_metadata
 
+def _parse_testcase_properties(root):
+    testcase_properties_element = root.find(TESTCASE_PROPERTIES_TAG)
+
+    if not testcase_properties_element:
+        return {}
+
+    testcase_properties = {}
+    for testcase_prop in testcase_properties_element.iterfind(TESTCASE_PROPERTY_TAG):
+        if testcase_prop.get("value"):
+            testcase_properties[testcase_prop.get("name")] = testcase_prop.get("value")
+
+    return testcase_properties
 
 def _parse_test_cases(root):
     test_case_results = defaultdict(list)
@@ -365,6 +420,9 @@ def _parse_test_cases(root):
 
         for attribute in REQUIRED_TESTCASE_ATTRIBUTES:
             result[attribute] = test_case.get(attribute)
+        for attribute in REQUIRED_TESTCASE_PROPERTIES:
+            testcase_properties = _parse_testcase_properties(test_case)
+            result[attribute] = testcase_properties[attribute]
 
         # NOTE: "if failure" and "if error" does not work with the ETree library.
         failure = test_case.find("failure")
@@ -538,7 +596,7 @@ def _validate_json_cases(test_result_json):
         raise TestResultJSONValidationError("test_cases section not found in provided JSON file")
 
     def _validate_test_case(test_case):
-        for attribute in REQUIRED_TESTCASE_ATTRIBUTES + REQUIRED_TESTCASE_JSON_FIELDS:
+        for attribute in REQUIRED_TESTCASE_ATTRIBUTES + REQUIRED_TESTCASE_JSON_FIELDS + REQUIRED_TESTCASE_PROPERTIES:
             if attribute not in test_case:
                 raise TestResultJSONValidationError(
                     f'"{attribute}" not found in test case '

--- a/test_reporting/kusto/setup.kql
+++ b/test_reporting/kusto/setup.kql
@@ -41,12 +41,14 @@
         Result = tostring(cases["result"]),
         ReportId = tostring(cases["id"]),
 	    Error = tobool(cases["error"]),
-        Summary = tostring(cases["summary"])
+        Summary = tostring(cases["summary"]),
+        StartTime = todatetime(cases["start"]),
+        EndTime = todatetime(cases["end"])
 }
 
 .create table TestCases (Feature: string, TestCase: string, ModulePath: string,
                          FilePath: string, StartLine: int, Runtime: double, Result: string,
-                         ReportId: string, Error: bool, Summary: string)
+                         ReportId: string, Error: bool, Summary: string, StartTime: datetime, EndTime: datetime)
 
 .alter table TestCases policy update @'[{"Source": "RawTestCases", "Query": "ExpandTestCases()", "IsEnabled": "True"}]'
 
@@ -61,6 +63,8 @@
                                                                      '{"column":"ReportId","Properties":{"path":"$.id"}},'
                                                                      '{"column":"Error","Properties":{"path":"$.error"}},'
                                                                      '{"column":"Summary","Properties":{"path":"$.summary"}},'
+                                                                     '{"column":"StartTime","Properties":{"path":"$.start"}},'
+                                                                     '{"column":"EndTime","Properties":{"path":"$.end"}},'
                                                                      ']'
 
 ###############################################################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Timestamp of testcases has been added and will be shown in tr.xml, and
it's necessary to show that in kusto
#### How did you do it?
In parser, I consider timestamp as testcase attributes, so I parse that
with testcase attributes like classname, file..., not testcase properties
In kusto, I added 2 columns StartTime and EndTime for timestamp
#### How did you verify/test it?
Run a test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
