### PR TITLE
[Mellanox] Add ignore error log for test_show_platform_temperature_mocked

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -54,6 +54,7 @@ SKIP_ERROR_LOG_SHOW_PLATFORM_TEMP = ['.*ERR pmon#thermalctld.*int\(\) argument m
                                      '.*ERR pmon#thermalctld.*invalid literal for int\(\) with base 10.*',
                                      '.*ERR pmon#thermalctld.*Failed to get minimum ambient temperature, use pessimistic instead.*',
                                      '.*ERR pmon#thermalctld.*Failed to read from file /run/hw-management/thermal.*',
+                                     '.*ERR pmon#thermalctld.*Failed to read from file /var/run/hw-management/thermal.*',
                                      '.*ERR pmon#thermalctld.*Failed to run thermal policy.*']
 
 SKIP_ERROR_LOG_PSU_ABSENCE = ['.*Error getting sensor data: dps460.*Kernel interface error.*',


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Some errors are ignored for test  test_show_platform_temperature_mocked in a previous PR: https://github.com/Azure/sonic-mgmt/pull/5750
But there was one error missing, need to ignore it too.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Add missing error log to ignore for PR: https://github.com/Azure/sonic-mgmt/pull/5750
#### How did you do it?
Add one new error log to ignore list for case test_show_platform_temperature_mocked
#### How did you verify/test it?
Manual run
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
