### PR TITLE
[202012][icmp_responder] Support checksum validation

### DIFF
--- a/tests/scripts/icmp_responder.py
+++ b/tests/scripts/icmp_responder.py
@@ -1,10 +1,23 @@
 import argparse
+import logging
+import sys
 
+from io import BytesIO
 from concurrent.futures.thread import ThreadPoolExecutor
 from scapy.all import conf, Ether, ICMP, IP
 from scapy.arch import get_if_hwaddr
 from scapy.data import ETH_P_IP
 from select import select
+
+
+root = logging.getLogger()
+root.setLevel(logging.DEBUG)
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+root.addHandler(handler)
 
 
 def respond_to_icmp_request(socket, request, dst_mac=None):
@@ -29,13 +42,34 @@ class ICMPSniffer(object):
     """Sniff ICMP packets."""
 
     TYPE_ECHO_REQUEST = 8
-    def __init__(self, ifaces, request_handler=None, dst_mac=None):
+
+    @staticmethod
+    def is_icmp_packet_checksum_valid(packet):
+        ip_chksum = packet[IP].chksum
+        icmp_chksum = packet[ICMP].chksum
+        packet[IP].chksum = None
+        packet[ICMP].chksum = None
+        rebuild_packet = Ether(packet.build())
+        return rebuild_packet[IP].chksum == ip_chksum and rebuild_packet[ICMP].chksum == icmp_chksum
+
+    @staticmethod
+    def dump_scapy_packet_show_output(packet):
+        """Dump packet show output to string."""
+        _stdout, sys.stdout = sys.stdout, BytesIO()
+        try:
+            packet.show()
+            return sys.stdout.getvalue()
+        finally:
+            sys.stdout = _stdout
+
+    def __init__(self, ifaces, request_handler=None, dst_mac=None, validate_checksum=False):
         """
         Init ICMP sniffer.
 
         @param ifaces: interfaces to listen for ICMP reqest
         @param request_handler: handler function that will be called when
                                 receives ICMP request
+        @param validate_checksum: validate checksum for received ICMP request before sending reply
         """
         self.sniff_sockets = []
         self.iface_hwaddr = {}
@@ -44,6 +78,7 @@ class ICMPSniffer(object):
             self.iface_hwaddr[iface] = get_if_hwaddr(iface)
         self.request_handler = request_handler
         self.dst_mac = dst_mac
+        self.validate_checksum = validate_checksum
 
     def __call__(self):
         try:
@@ -53,7 +88,16 @@ class ICMPSniffer(object):
                     packet = s.recv()
                     if packet is not None:
                         if ICMP in packet and packet[ICMP].type == self.TYPE_ECHO_REQUEST and self.request_handler:
-                            self.request_handler(s, packet, self.dst_mac)
+                            if self.validate_checksum:
+                                if ICMPSniffer.is_icmp_packet_checksum_valid(packet):
+                                    self.request_handler(s, packet, self.dst_mac)
+                                else:
+                                    logging.error(
+                                        "Receive ICMP echo message with invalid checksum:\n%s\n",
+                                        ICMPSniffer.dump_scapy_packet_show_output(packet)
+                                    )
+                            else:
+                                self.request_handler(s, packet, self.dst_mac)
         finally:
             for s in self.sniff_sockets:
                 s.close()
@@ -63,9 +107,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="ICMP responder")
     parser.add_argument("--intf", "-i", dest="ifaces", required=True, action="append", help="interface to listen for ICMP request")
     parser.add_argument("--dst_mac", "-m", dest="dst_mac", required=False, action="store", help="The destination MAC to use for ICMP echo replies")
+    parser.add_argument("--validate_checksum", "-c", dest="validate_checksum", required=False, default=False,
+                        action="store_true", help="validate received ICMP packet checksum before sending reply")
     args = parser.parse_args()
     ifaces = args.ifaces
     dst_mac = args.dst_mac
+    validate_checksum = args.validate_checksum
 
     max_workers = 24 if len(ifaces) > 24 else len(ifaces)
     sniffed_ifaces = [[] for _ in range(max_workers)]
@@ -74,5 +121,5 @@ if __name__ == "__main__":
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         for ifaces in sniffed_ifaces:
-            icmp_sniffer = ICMPSniffer(ifaces, request_handler=respond_to_icmp_request, dst_mac=dst_mac)
+            icmp_sniffer = ICMPSniffer(ifaces, request_handler=respond_to_icmp_request, dst_mac=dst_mac, validate_checksum=validate_checksum)
             executor.submit(icmp_sniffer)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Enable `icmp_responder` to validate the received ICMP echo request checksums in both IP and ICMP headers.
This aims to add a verification for the plausible wrong checksum ICMP echo requests sent by `linkmgrd`: https://github.com/Azure/sonic-linkmgrd/pull/88

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
1. Add a command-line option to turn on/off checksum validation.
2. If checksum validation is on and an ICMP echo request with an invalid checksum is received, `icmp_responder` will log this received packet only without sending the reply.

#### How did you verify/test it?
Run `icmp_responder` on a dualtor testbed, and run `config mux mode standby all` on the active ToR, verify the error ICMP pings are logged.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
