### PR TITLE
[kvmtest.sh]: Change macsec profile to 128_SCI

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -200,7 +200,7 @@ test_t0_sonic() {
       macsec/test_macsec.py"
 
     pushd $SONIC_MGMT_DIR/tests
-    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e "--neighbor_type=sonic --enable_macsec --macsec_profile=128,256_XPN_SCI"
+    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"
     popd
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Due to the kernel patch: [[PATCH 5.10 41/74] net: macsec: Verify that send_sci is on when setting Tx sci explicitly - Greg Kroah-Hartman (kernel.org)](https://lore.kernel.org/all/20220207103758.573403731@linuxfoundation.org/), the `send_sci = false` is no longer supported by vSONiC.

#### How did you do it?
So, change the profile from 128(send_sci = false) to 128_SCI(send_sci = true).

#### How did you verify/test it?
Check Azp

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
