### PR TITLE
[dualtor][active-active] Fix `restart-ptf`

### DIFF
--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -133,6 +133,7 @@
       duts_name: "{{ duts_name.split(',') }}"
       fp_mtu: "{{ fp_mtu_size }}"
       max_fp_num: "{{ max_fp_num }}"
+      netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
     become: yes
 
   - name: Change MAC address for PTF interfaces


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
On a dualtor-mixed testbed, the `show arp` command output:
```
root@demo-switch:~# show arp
Address       MacAddress         Iface           Vlan
------------  -----------------  --------------  ------
10.0.0.61     2a:77:d0:fe:c3:08  PortChannel103  -
10.0.0.63     12:3b:84:02:53:9b  PortChannel104  -
10.206.144.1  00:00:5e:00:01:90  eth0            -
10.206.144.7  06:60:bc:7b:e3:e7  eth0            -
192.168.0.3   b6:6e:70:63:9a:c8  Ethernet4       1000
192.168.0.4   92:75:ca:f9:ab:02  Ethernet8       1000
192.168.0.5   b6:6e:70:63:9a:c8  Ethernet4       1000
192.168.0.7   b6:6e:70:63:9a:c8  Ethernet4       1000
192.168.0.10  ae:42:2e:65:27:05  Ethernet20      1000
192.168.0.13  b6:6e:70:63:9a:c8  Ethernet4       1000
192.168.0.17  b6:6e:70:63:9a:c8  Ethernet4       1000
192.168.0.19  b6:6e:70:63:9a:c8  Ethernet4       1000
192.168.0.20  22:58:c8:d8:d6:0a  Ethernet40      1000
192.168.0.21  b6:6e:70:63:9a:c8  Ethernet4       1000
192.168.0.24  ca:77:84:eb:7c:0c  Ethernet48      1000
Total number of entries 27
```
* All arp entries from the netns are received from the same interface `Ethernet4`
* the root cause is that `restart-ptf` will try to add ports to netns and assign IP address to it, when `restart-ptf` tries to assign IP addresses to interfaces in the netns, it will flush the address first, which will break the policy-based routing.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
* enable `restart-ptf` to remove/add netns, so the routing policies in the netns will be resumed.
* modify the routing table logic to check the routing table existence first before adding it.

#### How did you verify/test it?
* run `restart-ptf` multiple times and verify the arp:
```
admin@demo-switch:~$ show arp
Address       MacAddress         Iface           Vlan
------------  -----------------  --------------  ------
10.0.0.57     1a:7f:6d:1c:03:b1  PortChannel101  -
10.0.0.59     06:80:64:48:d4:0e  PortChannel102  -
10.0.0.61     0a:27:6f:d3:64:aa  PortChannel103  -
10.0.0.63     2a:bc:09:96:d7:f7  PortChannel104  -
10.206.144.1  00:00:5e:00:01:90  eth0            -
10.206.144.7  06:60:bc:7b:e3:e7  eth0            -
192.168.0.3   d2:66:7f:22:de:67  Ethernet4       1000
192.168.0.5   76:04:2b:c6:7b:ee  Ethernet8       1000
192.168.0.7   0a:00:98:b4:03:a5  Ethernet12      1000
192.168.0.9   1e:3d:5a:76:a5:cf  Ethernet16      1000
192.168.0.11  02:f1:f8:80:96:3b  Ethernet20      1000
192.168.0.13  b6:9b:cd:db:ea:12  Ethernet24      1000
192.168.0.15  06:ed:3a:d3:62:cb  Ethernet28      1000
192.168.0.17  f2:bd:68:fd:ba:5d  Ethernet32      1000
192.168.0.19  86:db:f6:7e:f5:b6  Ethernet36      1000
192.168.0.21  d6:86:33:f1:2f:28  Ethernet40      1000
192.168.0.23  ea:f4:65:4f:39:6c  Ethernet44      1000
192.168.0.25  1e:57:a2:40:5f:38  Ethernet48      1000
Total number of entries 18
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
