### PR TITLE
enum_asic fixtures to use only asics that are present instead of all asics based on num_asics

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -639,8 +639,8 @@ class MultiAsicSonicHost(object):
         """This function iterate for ALL asics and execute cmds"""
         duthost = self.sonichost
         if duthost.is_multi_asic:
-            for n in range(duthost.facts['num_asic']):
-                container = container_name + str(n)
+            for a_asic in self.asics:
+                container = container_name + str(a_asic.asic_index)
                 self.shell(argv=["docker", "exec", container, "bash", "-c", cmd])
         else:
             self.shell(argv=["docker", "exec", container_name, "bash", "-c", cmd])
@@ -649,8 +649,8 @@ class MultiAsicSonicHost(object):
         """This function copy from host to ALL asics"""
         duthost = self.sonichost
         if duthost.is_multi_asic:
-            for n in range(duthost.facts['num_asic']):
-                container = container_name + str(n)
+            for a_asic in self.asics:
+                container = container_name + str(a_asic.asic_index)
                 self.shell("sudo docker cp {} {}:{}".format(src, container, dst))
         else:
             self.shell("sudo docker cp {} {}:{}".format(src, container_name, dst))
@@ -666,8 +666,8 @@ class MultiAsicSonicHost(object):
         """This function tell if service is fully started base on multi-asic/single-asic"""
         duthost = self.sonichost
         if duthost.is_multi_asic:
-            for asic_index in range(duthost.facts["num_asic"]):
-                docker_name = self.asic_instance(asic_index).get_docker_name(service)
+            for asic in self.asics:
+                docker_name = asic.get_docker_name(service)
                 if not duthost.is_service_fully_started(docker_name): 
                     return False
             return True

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -718,4 +718,4 @@ class MultiAsicSonicHost(object):
             if not self.asic_instance(0).is_default_route_removed_from_app_db():
                 return False
         return True
-        
+

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -640,7 +640,7 @@ class MultiAsicSonicHost(object):
         duthost = self.sonichost
         if duthost.is_multi_asic:
             for a_asic in self.asics:
-                container = container_name + str(a_asic.asic_index)
+                container = a_asic.get_docker_name(container_name)
                 self.shell(argv=["docker", "exec", container, "bash", "-c", cmd])
         else:
             self.shell(argv=["docker", "exec", container_name, "bash", "-c", cmd])
@@ -650,7 +650,7 @@ class MultiAsicSonicHost(object):
         duthost = self.sonichost
         if duthost.is_multi_asic:
             for a_asic in self.asics:
-                container = container_name + str(a_asic.asic_index)
+                container = a_asic.get_docker_name(container_name)
                 self.shell("sudo docker cp {} {}:{}".format(src, container, dst))
         else:
             self.shell("sudo docker cp {} {}:{}".format(src, container_name, dst))

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -31,7 +31,7 @@ class MultiAsicSonicHost(object):
             hostname: Name of the host in the ansible inventory
         """
         self.sonichost = SonicHost(ansible_adhoc, hostname)
-        self.asics = [SonicAsic(self.sonichost, asic_index) for asic_index in range(self.sonichost.facts["num_asic"])]
+        self.asics = [SonicAsic(self.sonichost, asic_index) for asic_index in self.sonichost.facts["asics_present"]]
 
         # Get the frontend and backend asics in a multiAsic device.
         self.frontend_asics = []

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -7,7 +7,7 @@ from tests.common.errors import RunAnsibleModuleFail
 from tests.common.devices.sonic import SonicHost
 from tests.common.devices.sonic_asic import SonicAsic
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.constants import DEFAULT_ASIC_ID, DEFAULT_NAMESPACE
+from tests.common.helpers.constants import DEFAULT_ASIC_ID, DEFAULT_NAMESPACE, ASICS_PRESENT
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ class MultiAsicSonicHost(object):
             hostname: Name of the host in the ansible inventory
         """
         self.sonichost = SonicHost(ansible_adhoc, hostname)
-        self.asics = [SonicAsic(self.sonichost, asic_index) for asic_index in self.sonichost.facts["asics_present"]]
+        self.asics = [SonicAsic(self.sonichost, asic_index) for asic_index in self.sonichost.facts[ASICS_PRESENT]]
 
         # Get the frontend and backend asics in a multiAsic device.
         self.frontend_asics = []

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -166,7 +166,13 @@ class MultiAsicSonicHost(object):
     def asic_instance(self, asic_index=None):
         if asic_index is None:
             return self.asics[0]
-        return self.asics[asic_index]
+        # if asics_present is defined in the host_vars of the host (in the inventory), then
+        # self.asics is populated based on asics_present (PR# 5828). In this case, self.asics is a list of only
+        # asics present, and not all possible asics. Thus, need to find asic with the right asic_index.
+        for a_asic in self.asics:
+            if a_asic.asic_index == asic_index:
+                return a_asic
+        return None
 
     def asic_instance_from_namespace(self, namespace=DEFAULT_NAMESPACE):
         if not namespace:

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -4,3 +4,4 @@ DEFAULT_NAMESPACE = None
 NAMESPACE_PREFIX = 'asic'
 ASIC_PARAM_TYPE_ALL = 'num_asics'
 ASIC_PARAM_TYPE_FRONTEND = 'frontend_asics'
+ASIC_PRESENT = 'asics_present'

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -4,4 +4,4 @@ DEFAULT_NAMESPACE = None
 NAMESPACE_PREFIX = 'asic'
 ASIC_PARAM_TYPE_ALL = 'num_asics'
 ASIC_PARAM_TYPE_FRONTEND = 'frontend_asics'
-ASIC_PRESENT = 'asics_present'
+ASICS_PRESENT = 'asics_present'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ from tests.common.fixtures.ptfhost_utils import ptf_portmap_file                
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder_session      # lgtm[py/unused-import]
  
 from tests.common.helpers.constants import (
-    ASIC_PARAM_TYPE_ALL, ASIC_PARAM_TYPE_FRONTEND, DEFAULT_ASIC_ID,
+    ASIC_PARAM_TYPE_ALL, ASIC_PARAM_TYPE_FRONTEND, DEFAULT_ASIC_ID, ASIC_PRESENT
 )
 from tests.common.helpers.dut_ports import encode_dut_port_name
 from tests.common.helpers.dut_utils import encode_dut_and_container_name
@@ -955,7 +955,10 @@ def generate_param_asic_index(request, dut_hostnames, param_type, random_asic=Fa
                 if int(inv_data[ASIC_PARAM_TYPE_ALL]) == 1:
                     dut_asic_params = [DEFAULT_ASIC_ID]
                 else:
-                    dut_asic_params = range(int(inv_data[ASIC_PARAM_TYPE_ALL]))
+                    if ASIC_PRESENT in inv_data:
+                        dut_asic_params = inv_data[ASIC_PRESENT]
+                    else:
+                        dut_asic_params = range(int(inv_data[ASIC_PARAM_TYPE_ALL]))
             elif param_type == ASIC_PARAM_TYPE_FRONTEND and ASIC_PARAM_TYPE_FRONTEND in inv_data:
                 dut_asic_params = inv_data[ASIC_PARAM_TYPE_FRONTEND]
             logging.info("dut name {}  asics params = {}".format(dut, dut_asic_params))
@@ -1134,8 +1137,8 @@ def generate_dut_feature_list(request, duts_selected, asics_selected):
                 else:
                     tuple_list.append((a_dut, a_asic, None))
         else:
-            if "features" in meta[dut]:
-                for a_feature in meta[dut]["features"].keys():
+            if "features" in meta[a_dut]:
+                for a_feature in meta[a_dut]["features"].keys():
                     if a_feature not in skip_feature_list:
                         tuple_list.append((a_dut, None, a_feature))
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ from tests.common.fixtures.ptfhost_utils import ptf_portmap_file                
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder_session      # lgtm[py/unused-import]
  
 from tests.common.helpers.constants import (
-    ASIC_PARAM_TYPE_ALL, ASIC_PARAM_TYPE_FRONTEND, DEFAULT_ASIC_ID, ASIC_PRESENT
+    ASIC_PARAM_TYPE_ALL, ASIC_PARAM_TYPE_FRONTEND, DEFAULT_ASIC_ID, ASICS_PRESENT
 )
 from tests.common.helpers.dut_ports import encode_dut_port_name
 from tests.common.helpers.dut_utils import encode_dut_and_container_name
@@ -955,8 +955,8 @@ def generate_param_asic_index(request, dut_hostnames, param_type, random_asic=Fa
                 if int(inv_data[ASIC_PARAM_TYPE_ALL]) == 1:
                     dut_asic_params = [DEFAULT_ASIC_ID]
                 else:
-                    if ASIC_PRESENT in inv_data:
-                        dut_asic_params = inv_data[ASIC_PRESENT]
+                    if ASICS_PRESENT in inv_data:
+                        dut_asic_params = inv_data[ASICS_PRESENT]
                     else:
                         dut_asic_params = range(int(inv_data[ASIC_PARAM_TYPE_ALL]))
             elif param_type == ASIC_PARAM_TYPE_FRONTEND and ASIC_PARAM_TYPE_FRONTEND in inv_data:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
enum_asic fixtures to use only asics that are present instead of all asics based on num_asics
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Tests that are parameterized using the enum_asic fixtures fail when the selected asic index is not present (operational) in the DUT.

Example of this is on the supervisor card in a chassis, where we could have not all SFMs in the chassis. In this case, only asics
corresponding to the SFMs present in the chassis are operational, but not the others. For example, on a Nokia chassis, if we have only 3 SFM's then 
only 6 (2 per SFM) out of the possible max 16 asics are operational.

#### How did you do it?
1. Added optional "asics_present" to the inventory data of the DUT in the inventory file. This represents the list of asics that are operational on the DUT.
2. If asics_present is present in the inventory data, we would use that list for generating the list of asics to use. Else, we use range of 'num_asics' defined in the inventory data to generate the list of asics to use.

Example inventory data for a supervisor card 

  supervisor1:
      num_asics: 16
      asics_present: [12,13]

In the above case, the asic list will be only 12 and 13 and not 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15

#### How did you verify/test it?
Tested the code on a dut that did not have all fabric-cards for the following fixtures:
  - enum_dut_hostname
  - enum_asic_index
  - enum_frontend_asic_index
  - enum_backend_asic_index
  - enum_rand_one_asic_index
  - enum_rand_one_frontend_asic_index

Ran autorestart container test against the same chassis - which used enum_rand_one_asic_index and it picked the asic that was operational.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
