### PR TITLE
[Vxlan ECMP] Increase wait time to check BGP session status

### DIFF
--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -478,7 +478,7 @@ def bgp_established(duthost, down_list=[]):
                 return False
 
     # Now wait for the routes to be updated.
-    time.sleep(10)
+    time.sleep(30)
     return True
 
 def get_downed_bgp_neighbors(shut_intf_list, minigraph_data):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [-] Test case(new/improvement)


### Back port request
- [ ] 201911
- [-] 202012

### Approach
#### What is the motivation for this PR?
On some platforms, the time needed for BGP session to go down and update status is higher. Hence the test needs to wait longer to see change in status.
#### How did you do it?
Increase the sleep time
#### How did you verify/test it?
Vxlan ECMP test cases are now passing with the change
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
