### PR TITLE
Run tests only on asics that are detected in supervisor card

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -36,7 +36,9 @@ class MultiAsicSonicHost(object):
         # Get the frontend and backend asics in a multiAsic device.
         self.frontend_asics = []
         self.backend_asics = []
-        if self.sonichost.is_multi_asic:
+        if self.sonichost.is_supervisor_node():
+            self.backend_asics = [SonicAsic(self.sonichost, asic_index) for asic_index in self.sonichost.facts["detected_asics"]]
+        elif self.sonichost.is_multi_asic:
             for asic in self.asics:
                 if asic.is_it_frontend():
                     self.frontend_asics.append(asic)

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -15,6 +15,7 @@ from ansible.plugins.loader import connection_loader
 
 from tests.common.devices.base import AnsibleHostBase
 from tests.common.helpers.dut_utils import is_supervisor_node
+from tests.common.utilities import get_host_visible_vars
 from tests.common.cache import cached
 from tests.common.helpers.constants import DEFAULT_ASIC_ID, DEFAULT_NAMESPACE
 from tests.common.helpers.platform_api.chassis import is_inband_port
@@ -182,6 +183,8 @@ class SonicHost(AnsibleHostBase):
         facts["modular_chassis"] = self._get_modular_chassis()
         facts["mgmt_interface"] = self._get_mgmt_interface()
         facts["switch_type"] = self._get_switch_type()
+        detected_asics = self.get_detected_asics()
+        facts["detected_asics"] = detected_asics if len(detected_asics) != 0 else facts["num_asic"]
 
         platform_asic = self._get_platform_asic(facts["platform"])
         if platform_asic:
@@ -339,6 +342,14 @@ class SonicHost(AnsibleHostBase):
             if len(fields) >= 2:
                 result[fields[0]] = fields[1]
         return result
+
+    def get_detected_asics(self):
+        im = self.host.options['inventory_manager']
+        inv_files = im._sources
+        dut_vars = get_host_visible_vars(inv_files, self.hostname)
+        if dut_vars and 'detected_asics' in dut_vars:
+            return dut_vars['detected_asics']
+        return []
 
     def is_supervisor_node(self):
         """Check if the current node is a supervisor node in case of multi-DUT.

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -184,7 +184,7 @@ class SonicHost(AnsibleHostBase):
         facts["mgmt_interface"] = self._get_mgmt_interface()
         facts["switch_type"] = self._get_switch_type()
         detected_asics = self.get_detected_asics()
-        facts["detected_asics"] = detected_asics if len(detected_asics) != 0 else facts["num_asic"]
+        facts["detected_asics"] = detected_asics if len(detected_asics) != 0 else range(facts["num_asic"])
 
         platform_asic = self._get_platform_asic(facts["platform"])
         if platform_asic:

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -4,3 +4,4 @@ DEFAULT_NAMESPACE = None
 NAMESPACE_PREFIX = 'asic'
 ASIC_PARAM_TYPE_ALL = 'num_asics'
 ASIC_PARAM_TYPE_FRONTEND = 'frontend_asics'
+DETECTED_ASICS = 'detected_asics'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -938,7 +938,9 @@ def generate_param_asic_index(request, dut_hostnames, param_type, random_asic=Fa
         # if the params are not present treat the device as a single asic device
         dut_asic_params = [DEFAULT_ASIC_ID]
         if inv_data:
-            if param_type == ASIC_PARAM_TYPE_ALL and ASIC_PARAM_TYPE_ALL in inv_data:
+            if param_type == ASIC_PARAM_TYPE_ALL and DETECTED_ASICS in inv_data:
+                dut_asic_params = inv_data[DETECTED_ASICS]
+            elif param_type == ASIC_PARAM_TYPE_ALL and ASIC_PARAM_TYPE_ALL in inv_data:
                 if int(inv_data[ASIC_PARAM_TYPE_ALL]) == 1:
                     dut_asic_params = [DEFAULT_ASIC_ID]
                 else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_ses
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file  # lgtm[py/unused-import]
 
 from tests.common.helpers.constants import (
-    ASIC_PARAM_TYPE_ALL, ASIC_PARAM_TYPE_FRONTEND, DEFAULT_ASIC_ID,
+    ASIC_PARAM_TYPE_ALL, ASIC_PARAM_TYPE_FRONTEND, DEFAULT_ASIC_ID, DETECTED_ASICS,
 )
 from tests.common.helpers.dut_ports import encode_dut_port_name
 from tests.common.helpers.dut_utils import encode_dut_and_container_name


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The tests uses asic_index related fixtures, run on MAX number of asics in a supervisor card and some of the tests might expect dockers of all asic namespaces to be present. supervisor card might not have all fabric cards inserted, so not all dockers will be running causing test cases to fail if run on the asics that are not detected in supervisor. This PR is to fix this by adding a inventory field specifying the list of detected asic indices.
#### How did you do it?
1. Add detected_asics field in inventory file
2. Modify conftest to use detected asics field to generate enum_asic_index fixture.
3. Modify facts of sonic host to include detected asics list.
4. Modify generation of backend_asics list for multi_asic host to use detected_asics list if it is a supervisor.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
