### PR TITLE
[pfc] Fix compatable issue in unknown_mac

### DIFF
--- a/tests/pfc/test_unknown_mac.py
+++ b/tests/pfc/test_unknown_mac.py
@@ -207,10 +207,9 @@ class PreTestVerify(object):
         """
         Check if the FDB entry is missing for the port
         """
-        result = self.duthost.command("show mac -p {}".format(self.dst_port),
-                                      module_ignore_errors=True)
+        result = self.duthost.command("show mac")
         out = result['stdout']
-        pytest_assert("not in list" in out, "{} present in FDB".format(self.arp_entry[self.dst_ip]))
+        pytest_assert(self.arp_entry[self.dst_ip].lower() not in out.lower(), "{} present in FDB".format(self.arp_entry[self.dst_ip]))
         logger.info("'{}' not present in fdb as expected".format(self.arp_entry[self.dst_ip]))
 
     def verifyArpFdb(self):


### PR DESCRIPTION
What is the motivation for this PR?
The output is different on master and 202012 with CLI "show mac -p \<port\>" while the \<port\> doesn't exist.

How did you do it?
Use "show mac" rather than "show mac -p <port>", and find the target mac from the output to see if the target mac exists.

How did you verify/test it?
Run pfc/test_unknown_mac.py

Signed-off-by: Kevin Wang <shengkaiwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
