### PR TITLE
[dualtor] Fix `test_radv_ipv6_ra`

### DIFF
--- a/tests/radv/test_radv_ipv6_ra.py
+++ b/tests/radv/test_radv_ipv6_ra.py
@@ -1,16 +1,15 @@
 import ipaddress
 import logging
-import time
 
 import pytest
 
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import run_garp_service # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import run_icmp_responder # lgtm[py/unused-import]
-from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr # lgtm[py/unused-import]
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
-from tests.common.dualtor.dual_tor_common import cable_type 
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                         # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses                            # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_garp_service                                # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder                              # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr                         # lgtm[py/unused-import]
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor  # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_common import cable_type                                     # lgtm[py/unused-import]
 from tests.common.helpers.assertions import pytest_assert
 from tests.ptf_runner import ptf_runner
 
@@ -29,6 +28,7 @@ RADV_MAX_RA_INTERVAL_SECS = 4
 the connected PTF port(s) required to setup the RADV tests
 
 """
+
 
 @pytest.fixture(scope="module", autouse=True)
 def radv_test_setup(request, duthosts, ptfhost, tbinfo, toggle_all_simulator_ports_to_upper_tor):
@@ -50,7 +50,7 @@ def radv_test_setup(request, duthosts, ptfhost, tbinfo, toggle_all_simulator_por
         res = duthost.shell(cmd)
         ip6 = ipaddress.IPv6Address(unicode(res['stdout']))
         pytest_assert(ip6.is_link_local,
-                "ip6 address:{} of {} is not a link-local address".format(str(ip6), downlink_vlan_iface['name']))
+                      "ip6 address:{} of {} is not a link-local address".format(str(ip6), downlink_vlan_iface['name']))
         downlink_vlan_iface['ip6'] = str(ip6)
 
         # Obtain link-local IPv6 address of the connected PTF port (Eg eth0)
@@ -62,7 +62,7 @@ def radv_test_setup(request, duthosts, ptfhost, tbinfo, toggle_all_simulator_por
         res = ptfhost.shell(cmd)
         ip6 = ipaddress.IPv6Address(unicode(res['stdout']))
         pytest_assert(ip6.is_link_local,
-                "ip6 address:{} of {} is not a link-local address".format(str(ip6), ptf_port['name']))
+                      "ip6 address:{} of {} is not a link-local address".format(str(ip6), ptf_port['name']))
         ptf_port['ip6'] = str(ip6)
 
         vlan_intf_data = {}
@@ -72,21 +72,26 @@ def radv_test_setup(request, duthosts, ptfhost, tbinfo, toggle_all_simulator_por
 
     return vlan_interfaces_list
 
+
 """
 @summary: Updates min/max RA interval in RADVd's config file
 
 """
+
 
 def dut_update_ra_interval(duthost, ra, interval):
     logging.info("Updating %s to %d in RADVd's config file:%s", ra, int(interval), RADV_CONF_FILE)
     cmd = "sed -ie 's/\(.*\)\({}\) \([[:digit:]]\+\)/\\1\\2 {}/' {}".format(ra, interval, RADV_CONF_FILE)
     duthost.shell("docker exec radv {}".format(cmd))
 
+
 """
 @summary: A fixture that updates the RADVd's periodic RA update intervals and restores the
 intervals to old values after the test
 
 """
+
+
 @pytest.fixture
 def dut_update_radv_periodic_ra_interval(duthost):
     pytest_assert(duthost.is_service_fully_started('radv'), "radv service not running")
@@ -111,20 +116,23 @@ def dut_update_radv_periodic_ra_interval(duthost):
     duthost.shell("docker exec radv supervisorctl signal SIGHUP radvd")
     logging.info("Successfully restored RADVd's config back to original")
 
+
 """
 @summary: Test validates the RADVd's periodic router advertisement sent on each VLAN interface
 
 """
+
+
 def test_radv_router_advertisement(
-                    request, tbinfo,
-                    duthost, ptfhost,
-                    radv_test_setup,
-                    dut_update_radv_periodic_ra_interval):
+        request, tbinfo,
+        duthost, ptfhost,
+        radv_test_setup,
+        dut_update_radv_periodic_ra_interval):
     for vlan_intf in radv_test_setup:
         # Run the RADV test on the PTF host
         logging.info("Verifying RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
-                                                vlan_intf['downlink_vlan_intf']['name'],
-                                                vlan_intf['ptf_port']['port_idx'])
+                     vlan_intf['downlink_vlan_intf']['name'],
+                     vlan_intf['ptf_port']['port_idx'])
         ptf_runner(ptfhost,
                    "ptftests",
                    "radv_ipv6_ra_test.RadvUnSolicitedRATest",
@@ -136,17 +144,19 @@ def test_radv_router_advertisement(
                            "max_ra_interval": RADV_MAX_RA_INTERVAL_SECS},
                    log_file="/tmp/radv_ipv6_ra_test.RadvUnSolicitedRATest.log", is_python3=True)
 
+
 """
 @summary: Test validates the RADVd's solicited router advertisement sent on each VLAN interface
 
 """
 
+
 def test_solicited_router_advertisement(request, tbinfo, ptfhost, duthost, radv_test_setup):
     for vlan_intf in radv_test_setup:
         # Run the RADV solicited RA test on the PTF host
         logging.info("Verifying solicited RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
-                                                        vlan_intf['downlink_vlan_intf']['name'],
-                                                        vlan_intf['ptf_port']['port_idx'])
+                     vlan_intf['downlink_vlan_intf']['name'],
+                     vlan_intf['ptf_port']['port_idx'])
         ptf_runner(ptfhost,
                    "ptftests",
                    "radv_ipv6_ra_test.RadvSolicitedRATest",
@@ -164,16 +174,18 @@ def test_solicited_router_advertisement(request, tbinfo, ptfhost, duthost, radv_
 @summary: Test validates the M flag in RADVd's periodic router advertisement sent on each VLAN interface 
 
 """
+
+
 def test_unsolicited_router_advertisement_with_m_flag(
-                    request, tbinfo,
-                    duthost, ptfhost,
-                    radv_test_setup,
-                    ):
+    request, tbinfo,
+    duthost, ptfhost,
+    radv_test_setup,
+):
     for vlan_intf in radv_test_setup:
         # Run the RADV test on the PTF host
         logging.info("Verifying RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
-                                                vlan_intf['downlink_vlan_intf']['name'],
-                                                vlan_intf['ptf_port']['port_idx'])
+                     vlan_intf['downlink_vlan_intf']['name'],
+                     vlan_intf['ptf_port']['port_idx'])
         ptf_runner(ptfhost,
                    "ptftests",
                    "router_adv_mflag_test.RadvUnSolicitedRATest",
@@ -185,17 +197,19 @@ def test_unsolicited_router_advertisement_with_m_flag(
                            "max_ra_interval": 180},
                    log_file="/tmp/router_adv_mflag_test.RadvUnSolicitedRATest.log", is_python3=True)
 
+
 """
 @summary: Test validates the M flag in RADVd's solicited router advertisement sent on each VLAN interface
 
 """
 
+
 def test_solicited_router_advertisement_with_m_flag(request, tbinfo, ptfhost, duthost, radv_test_setup):
     for vlan_intf in radv_test_setup:
         # Run the RADV solicited RA test on the PTF host
         logging.info("Verifying solicited RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
-                                                        vlan_intf['downlink_vlan_intf']['name'],
-                                                        vlan_intf['ptf_port']['port_idx'])
+                     vlan_intf['downlink_vlan_intf']['name'],
+                     vlan_intf['ptf_port']['port_idx'])
         ptf_runner(ptfhost,
                    "ptftests",
                    "router_adv_mflag_test.RadvSolicitedRATest",

--- a/tests/radv/test_radv_ipv6_ra.py
+++ b/tests/radv/test_radv_ipv6_ra.py
@@ -31,7 +31,7 @@ the connected PTF port(s) required to setup the RADV tests
 """
 
 @pytest.fixture(scope="module", autouse=True)
-def radv_test_setup(request, duthosts, ptfhost, tbinfo):
+def radv_test_setup(request, duthosts, ptfhost, tbinfo, toggle_all_simulator_ports_to_upper_tor):
     duthost = duthosts[0]
     logging.info("radv_test_setup() DUT {}".format(duthost.hostname))
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
@@ -120,9 +120,6 @@ def test_radv_router_advertisement(
                     duthost, ptfhost,
                     radv_test_setup,
                     dut_update_radv_periodic_ra_interval):
-    if 'dualtor' in tbinfo['topo']['name']:
-        request.getfixturevalue('toggle_all_simulator_ports_to_upper_tor')
-
     for vlan_intf in radv_test_setup:
         # Run the RADV test on the PTF host
         logging.info("Verifying RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
@@ -145,9 +142,6 @@ def test_radv_router_advertisement(
 """
 
 def test_solicited_router_advertisement(request, tbinfo, ptfhost, duthost, radv_test_setup):
-    if 'dualtor' in tbinfo['topo']['name']:
-        request.getfixturevalue('toggle_all_simulator_ports_to_upper_tor')
-
     for vlan_intf in radv_test_setup:
         # Run the RADV solicited RA test on the PTF host
         logging.info("Verifying solicited RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
@@ -175,9 +169,6 @@ def test_unsolicited_router_advertisement_with_m_flag(
                     duthost, ptfhost,
                     radv_test_setup,
                     ):
-    if 'dualtor' in tbinfo['topo']['name']:
-        request.getfixturevalue('toggle_all_simulator_ports_to_upper_tor')
-
     for vlan_intf in radv_test_setup:
         # Run the RADV test on the PTF host
         logging.info("Verifying RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
@@ -200,9 +191,6 @@ def test_unsolicited_router_advertisement_with_m_flag(
 """
 
 def test_solicited_router_advertisement_with_m_flag(request, tbinfo, ptfhost, duthost, radv_test_setup):
-    if 'dualtor' in tbinfo['topo']['name']:
-        request.getfixturevalue('toggle_all_simulator_ports_to_upper_tor')
-
     for vlan_intf in radv_test_setup:
         # Run the RADV solicited RA test on the PTF host
         logging.info("Verifying solicited RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
On dualtor testbed, `test_radv_ipv6_ra` complains about not able to find fixture `cable_type`.
The root cause is that `request.getfixturevalue` doesn't support parameterized fixtures.

#### How did you do it?
Direct call `toggle_all_simulator_ports_to_upper_tor` instead.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
