### PR TITLE
Fix GCU update speed case to use supported speed get from the dut

### DIFF
--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -2,6 +2,7 @@ import ipaddress
 import logging
 import pytest
 import re
+import random
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_op_failure
@@ -9,7 +10,6 @@ from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfi
 from tests.generic_config_updater.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
 
 logger = logging.getLogger(__name__)
-
 
 @pytest.fixture(autouse=True)
 def ensure_dut_readiness(duthost):
@@ -75,6 +75,24 @@ def get_ethernet_port_not_in_portchannel(duthost):
             break
     return port_name
 
+def get_port_speeds_for_test(duthost):
+    """
+    Get the speeds parameters for case test_update_speed, including 2 valid speeds and 1 invalid speed
+
+    Args:
+        duthost: DUT host object
+    """
+    speeds_to_test = []
+    invalid_speed = ("20a", False)
+    if duthost.get_facts()['asic_type'] == 'vs':
+        valid_speeds = ['20000', '40000']
+    else:
+        valid_speeds = duthost.get_supported_speeds('Ethernet0')
+    pytest_assert(valid_speeds, "Failed to get any valid port speed to test.")
+    valid_speeds_to_test = random.sample(valid_speeds, 2 if len(valid_speeds) >= 2 else len(valid_speeds))
+    speeds_to_test = [(speed, True) for speed in valid_speeds_to_test]
+    speeds_to_test.append(invalid_speed)
+    return speeds_to_test
 
 def test_remove_lanes(duthost, ensure_dut_readiness):
     json_patch = [
@@ -214,33 +232,30 @@ def test_update_valid_invalid_index(duthost, ensure_dut_readiness, index, is_val
         delete_tmpfile(duthost, tmpfile)
 
 
-@pytest.mark.parametrize("speed, is_valid", [
-    ("20000", True),
-    ("40000", True),
-    ("20a", False)
-])
-def test_update_speed(duthost, ensure_dut_readiness, speed, is_valid):
-    json_patch = [
-        {
-            "op": "replace",
-            "path": "/PORT/Ethernet0/speed",
-            "value": "{}".format(speed)
-        }
-    ]
+def test_update_speed(duthost, ensure_dut_readiness):
+    speed_params = get_port_speeds_for_test(duthost)
+    for speed, is_valid in speed_params:
+        json_patch = [
+            {
+                "op": "replace",
+                "path": "/PORT/Ethernet0/speed",
+                "value": "{}".format(speed)
+            }
+        ]
 
-    tmpfile = generate_tmpfile(duthost)
-    logger.info("tmpfile {}".format(tmpfile))
+        tmpfile = generate_tmpfile(duthost)
+        logger.info("tmpfile {}".format(tmpfile))
 
-    try:
-        output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
-        if is_valid:
-            expect_op_success(duthost, output)
-            current_status_speed = check_interface_status(duthost, "Speed").replace("G", "000")
-            pytest_assert(current_status_speed == speed, "Failed to properly configure interface speed to requested value {}".format(speed))
-        else:
-            expect_op_failure(output)
-    finally:
-        delete_tmpfile(duthost, tmpfile)
+        try:
+            output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+            if is_valid:
+                expect_op_success(duthost, output)
+                current_status_speed = check_interface_status(duthost, "Speed").replace("G", "000")
+                pytest_assert(current_status_speed == speed, "Failed to properly configure interface speed to requested value {}".format(speed))
+            else:
+                expect_op_failure(output)
+        finally:
+            delete_tmpfile(duthost, tmpfile)
 
 
 def test_update_description(duthost, ensure_dut_readiness):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Summary:
The test_update_speed case now uses hard coded speed parameters, the speed params may not be supported by some DUTs(e.g. 20G speed is not supported by all nvidia platforms), need to be fixed.
This PR combines multiple commits in https://github.com/Azure/sonic-mgmt/pull/5766 (Closed)
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The test_update_speed case now uses hard coded speed parameters, the speed params may not be supported by some DUTs(e.g. 20G speed is not supported by all nvidia platforms).  In order to run this case on all testbeds, need to use supported speeds got from the dut instead of the hardcoded speeds. 
#### How did you do it?
Add a function to get the supported speeds from the dut, and use them in the test case.
The fix uses 2 valid speeds(randomly selected from all supported speeds) and 1 invalid speed(the value is not changed) just as it was before.
For vs setups, because there is no actual supported speed to get, still use the original hard coded valid speed params(20000, 40000).
#### How did you verify/test it?
Have run this case on 2 different testbeds with nvidia switches, all passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
