### PR TITLE
Fix junit xml parser failure in nightly test

### DIFF
--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -422,7 +422,7 @@ def _parse_test_cases(root):
             result[attribute] = test_case.get(attribute)
         for attribute in REQUIRED_TESTCASE_PROPERTIES:
             testcase_properties = _parse_testcase_properties(test_case)
-            if testcase_properties[attribute]:
+            if attribute in testcase_properties:
                 result[attribute] = testcase_properties[attribute]
 
         # NOTE: "if failure" and "if error" does not work with the ETree library.

--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -422,7 +422,8 @@ def _parse_test_cases(root):
             result[attribute] = test_case.get(attribute)
         for attribute in REQUIRED_TESTCASE_PROPERTIES:
             testcase_properties = _parse_testcase_properties(test_case)
-            result[attribute] = testcase_properties[attribute]
+            if testcase_properties[attribute]:
+                result[attribute] = testcase_properties[attribute]
 
         # NOTE: "if failure" and "if error" does not work with the ETree library.
         failure = test_case.find("failure")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
We added start and end timestamp for testcases in test report, and we
will parse start and end timestamp in junit xml parser.
However, some tests will not contain start and end timestamp, but the
parser will directly parse report file without checking, so it will fail
#### How did you do it?
Paser parses start and end timestamp only if they exist
#### How did you verify/test it?
Run a test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
