### PR TITLE
Fix lambda TypeError in ptfhost_utils

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -180,12 +180,10 @@ def ptf_portmap_file(duthosts, rand_one_dut_hostname, ptfhost):
     portMapFile = "/tmp/default_interface_to_front_map.ini"
     with open(portMapFile, 'w') as file:
         file.write("# ptf host interface @ switch front port name\n")
-        file.writelines(
-            map(
-                    lambda index, port: "{0}@{1}\n".format(index, port),
-                    enumerate(portList)
-                )
-            )
+        ptf_port_map = []
+        for i in range(len(portList)):
+            ptf_port_map.append("{}@{}\n".format(i, portList[i]))
+        file.writelines(ptf_port_map)
 
     ptfhost.copy(src=portMapFile, dest="/root/")
 


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix the issue reported in #4867, failures: TypeError: () takes exactly 2 arguments (1 given)
The fix in #5605 still uses lambda which is not easy to read and may have compatibility issue.

#### How did you do it?
Use for loop and concentrate string together and append them to a list.

#### How did you verify/test it?
run `tests/test_qos_sai.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
