### PR TITLE
[pc/test_lag_2.py & enum_dut_portchannel] Support different completeness_level to reduce test time

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1039,8 +1039,12 @@ def generate_port_lists(request, port_scope, with_completeness_level=False):
     if with_completeness_level:
         completeness_level = get_completeness_level_metadata(request)
         # if completeness_level in ["debug", "basic", "confident"],
-        # enumerate at most 4 ports on every DUT to save test time
-        if completeness_level in ["debug", "basic", "confident"]:
+        # only select several ports on every DUT to save test time
+        if completeness_level in ["debug"]:
+            for dut, dut_ports in dut_port_map.items():
+                if len(dut_ports) > 1:
+                    dut_port_map[dut] = dut_ports[:1]
+        elif completeness_level in ["basic", "confident"]:
             for dut, dut_ports in dut_port_map.items():
                 if len(dut_ports) > 4:
                     dut_port_map[dut] = dut_ports[:2] + dut_ports[-2:]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1040,14 +1040,21 @@ def generate_port_lists(request, port_scope, with_completeness_level=False):
         completeness_level = get_completeness_level_metadata(request)
         # if completeness_level in ["debug", "basic", "confident"],
         # only select several ports on every DUT to save test time
+
+        def trim_dut_port_lists(dut_port_list, target_len):
+            if len(dut_port_list) <= target_len:
+                return dut_port_list
+            # for diversity, fetch the ports from both the start and the end of the original list
+            pos1 = target_len / 2
+            pos2 = target_len - pos1
+            return dut_ports[:pos1] + dut_ports[-pos2:]
+
         if completeness_level in ["debug"]:
             for dut, dut_ports in dut_port_map.items():
-                if len(dut_ports) > 1:
-                    dut_port_map[dut] = dut_ports[:1]
+                dut_port_map[dut] = trim_dut_port_lists(dut_ports, 1)
         elif completeness_level in ["basic", "confident"]:
             for dut, dut_ports in dut_port_map.items():
-                if len(dut_ports) > 4:
-                    dut_port_map[dut] = dut_ports[:2] + dut_ports[-2:]
+                dut_port_map[dut] = trim_dut_port_lists(dut_ports, 4)
 
     ret = reduce(lambda dut_ports_1, dut_ports_2: dut_ports_1 + dut_ports_2, dut_port_map.values())
     logger.info("Generate port_list: {}".format(ret))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1045,9 +1045,9 @@ def generate_port_lists(request, port_scope, with_completeness_level=False):
             if len(dut_port_list) <= target_len:
                 return dut_port_list
             # for diversity, fetch the ports from both the start and the end of the original list
-            pos1 = target_len / 2
-            pos2 = target_len - pos1
-            return dut_ports[:pos1] + dut_ports[-pos2:]
+            pos_1 = target_len / 2
+            pos_2 = target_len - pos_1
+            return dut_ports[:pos_1] + dut_ports[-pos_2:]
 
         if completeness_level in ["debug"]:
             for dut, dut_ports in dut_port_map.items():

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -261,14 +261,14 @@ def skip_if_no_lags(duthosts):
 @pytest.mark.parametrize("testcase", ["single_lag",
                                       "lacp_rate",
                                       "fallback"])
-def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts, conn_graph_facts, enum_dut_portchannel, testcase):
+def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts, conn_graph_facts, enum_dut_portchannel_with_completeness_level, testcase):
     # We can't run single_lag test on vtestbed since there is no leaffanout
     if testcase == "single_lag" and is_vtestbed(duthosts[0]):
         pytest.skip("Skip single_lag test on vtestbed")
 
     ptfhost = common_setup_teardown
 
-    dut_name, dut_lag = decode_dut_port_name(enum_dut_portchannel)
+    dut_name, dut_lag = decode_dut_port_name(enum_dut_portchannel_with_completeness_level)
 
     some_test_ran = False
     for duthost in duthosts:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Reduce the test time of pc/test_lag_2.py by supporting different completeness_level

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
pc/test_lag_2.py will enumerate all PCs on the DUTs, it could take 52+ mins on a large topology.
We need to support different completeness_level, like:
1. Run with 'confident' level every weekday, it enumerates at most 4 PCs.
2. Run with 'thorought' level every weekend, it enumerates all PCs.
#### How did you do it?
Modify tests/conftest.py and pc/test_lag_2.py to support different completeness_level.
If completeness_level is not set, run as default level('thorough'), it's the same behavior as before this pr.
#### How did you verify/test it?
Run on a physical testbed and it runs as expected.

