### PR TITLE
Add macsec counter test

### DIFF
--- a/tests/macsec/macsec_helper.py
+++ b/tests/macsec/macsec_helper.py
@@ -3,6 +3,7 @@ import struct
 import binascii
 import time
 import re
+import ast
 
 import cryptography.exceptions
 import ptf
@@ -26,6 +27,8 @@ __all__ = [
     'get_appl_db',
     'get_macsec_attr',
     'get_mka_session',
+    'get_macsec_sa_name',
+    'get_macsec_counters',
     'get_sci'
 ]
 
@@ -65,6 +68,19 @@ def getns_prefix(host, intf):
         ns_prefix = "-n {}".format(ns)
 
     return ns_prefix
+
+def get_macsec_sa_name(host, host_port_name, egress = True):
+    if egress:
+        table = 'MACSEC_EGRESS_SA_TABLE'
+    else:
+        table = 'MACSEC_INGRESS_SA_TABLE'
+
+    cmd = "sonic-db-cli {} APPL_DB KEYS '{}:{}:*'"
+    names = sonic_db_cli(host, cmd.format(
+        getns_prefix(host, host_port_name), table, host_port_name))
+    names.sort()
+    return names[0].removeprefix(table + ":")
+
 
 def get_appl_db(host, host_port_name, peer, peer_port_name):
     port_table = sonic_db_cli(
@@ -358,6 +374,19 @@ def macsec_dp_poll(test, device_number=0, port_number=None, timeout=None, exp_pk
         if timeout <= 0:
             break
     return test.dataplane.PollFailure(exp_pkt, recent_packets,packet_count)
+
+
+def get_macsec_counters(host, host_port_name, name):
+    lines = [
+        'from swsscommon.swsscommon import DBConnector, CounterTable, MacsecCounter',
+        'counterTable = CounterTable(DBConnector("COUNTERS_DB", 0))',
+        '_, values = counterTable.get(MacsecCounter(), "{}")'.format(name),
+        'print(dict(values))'
+        ]
+    cmd = "python -c '{}'".format(';'.join(lines))
+    asic = host.get_port_asic_instance(host_port_name)
+    output = asic.command(cmd)["stdout_lines"][0]
+    return ast.literal_eval(output)
 
 
 __origin_dp_poll = testutils.dp_poll

--- a/tests/macsec/macsec_helper.py
+++ b/tests/macsec/macsec_helper.py
@@ -386,7 +386,7 @@ def get_macsec_counters(sonic_asic, name):
         ]
     cmd = "python -c '{}'".format(';'.join(lines))
     output = sonic_asic.command(cmd)["stdout_lines"][0]
-    return ast.literal_eval(output)
+    return {k:int(v) for k,v in ast.literal_eval(output).items()}
 
 
 __origin_dp_poll = testutils.dp_poll

--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -189,7 +189,7 @@ class TestDataPlane():
 
         for up_port, up_link in upstream_links.items():
             asic = duthost.get_port_asic_instance(up_port)
-            egress_sa_name = get_macsec_sa_name(asic up_port, True)
+            egress_sa_name = get_macsec_sa_name(asic, up_port, True)
             ingress_sa_name = get_macsec_sa_name(asic, up_port, False)
             if not egress_sa_name or not ingress_sa_name:
                 continue

--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -4,6 +4,7 @@ import logging
 import re
 import scapy.all as scapy
 import ptf.testutils as testutils
+from collections import Counter
 
 from tests.common.utilities import wait_until
 from tests.common.devices.eos import EosHost
@@ -172,7 +173,7 @@ class TestDataPlane():
             requester["host"].shell("ip route del 0.0.0.0/0 via {}".format(
                 requester["peer_ipv4_addr"]), module_ignore_errors=True)
 
-    def test_counters(self, duthost, upstream_links):
+    def test_counters(self, duthost, ctrl_links, upstream_links):
         EGRESS_SA_COUNTERS = (
                 'SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED',
                 'SAI_MACSEC_SA_STAT_OUT_PKTS_ENCRYPTED',
@@ -184,41 +185,69 @@ class TestDataPlane():
         PKT_NUM = 5
         PKT_OCTET = 1024
 
-        for up_port, up_link in upstream_links.items():
+        # Select some one macsec link
+        port_name = list(ctrl_links)[0]
+        nbr_ip_addr = upstream_links[port_name]['local_ipv4_addr']
+        pc = find_portchannel_from_member(port_name, get_portchannel(duthost))
+        if pc:
+            assert pc["status"] == "Up"
+            up_ports = pc["members"]
+        else:
+            up_ports = [port_name]
+
+        # Sum up start counter
+        egress_start_counters = Counter()
+        ingress_start_counters = Counter()
+        for up_port in up_ports:
+            assert up_port in ctrl_links
+
             asic = duthost.get_port_asic_instance(up_port)
             egress_sa_name = get_macsec_sa_name(asic, up_port, True)
             ingress_sa_name = get_macsec_sa_name(asic, up_port, False)
             if not egress_sa_name or not ingress_sa_name:
                 continue
 
-            egress_start_counters = get_macsec_counters(asic, egress_sa_name)
-            ingress_start_counters = get_macsec_counters(asic, ingress_sa_name)
-            ret = duthost.command(
-                "ping -c {} -s {} {}".format(PKT_NUM, PKT_OCTET, up_link['local_ipv4_addr']))
-            assert not ret['failed']
-            sleep(10) # wait 10s for polling counters
-            egress_end_counters = get_macsec_counters(asic, egress_sa_name)
-            ingress_end_counters = get_macsec_counters(asic, ingress_sa_name)
+            egress_start_counters += Counter(get_macsec_counters(asic, egress_sa_name))
+            ingress_start_counters += Counter(get_macsec_counters(asic, ingress_sa_name))
 
-            i = 'SAI_MACSEC_SA_ATTR_CURRENT_XPN'
-            assert int(egress_end_counters[i]) - int(egress_start_counters[i]) >= PKT_NUM
-            assert int(ingress_end_counters[i]) - int(ingress_start_counters[i]) >= PKT_NUM
+        # Launch traffic
+        ret = duthost.command(
+            "ping -c {} -s {} {}".format(PKT_NUM, PKT_OCTET, nbr_ip_addr))
+        assert not ret['failed']
+        sleep(10) # wait 10s for polling counters
 
-            if duthost.facts["asic_type"] == "vs":
-                # vsonic only has xpn counter
+        # Sum up end counter
+        egress_end_counters = Counter()
+        ingress_end_counters = Counter()
+        for up_port in up_ports:
+            asic = duthost.get_port_asic_instance(up_port)
+            egress_sa_name = get_macsec_sa_name(asic, up_port, True)
+            ingress_sa_name = get_macsec_sa_name(asic, up_port, False)
+            if not egress_sa_name or not ingress_sa_name:
                 continue
 
-            for i in EGRESS_SA_COUNTERS:
-                if 'OCTETS' in i:
-                    assert int(egress_end_counters[i]) - int(egress_start_counters[i]) >= PKT_NUM * PKT_OCTET
-                else:
-                    assert int(egress_end_counters[i]) - int(egress_start_counters[i]) >= PKT_NUM
+            egress_end_counters += Counter(get_macsec_counters(asic, egress_sa_name))
+            ingress_end_counters += Counter(get_macsec_counters(asic, ingress_sa_name))
 
-            for i in INGRESS_SA_COUNTERS:
-                if 'OCTETS' in i:
-                    assert int(ingress_end_counters[i]) - int(ingress_start_counters[i]) >= PKT_NUM * PKT_OCTET
-                else:
-                    assert int(ingress_end_counters[i]) - int(ingress_start_counters[i]) >= PKT_NUM
+        i = 'SAI_MACSEC_SA_ATTR_CURRENT_XPN'
+        assert egress_end_counters[i] - egress_start_counters[i] >= PKT_NUM
+        assert ingress_end_counters[i] - ingress_start_counters[i] >= PKT_NUM
+
+        if duthost.facts["asic_type"] == "vs":
+            # vsonic only has xpn counter
+            return
+
+        for i in EGRESS_SA_COUNTERS:
+            if 'OCTETS' in i:
+                assert egress_end_counters[i] - egress_start_counters[i] >= PKT_NUM * PKT_OCTET
+            else:
+                assert egress_end_counters[i] - egress_start_counters[i] >= PKT_NUM
+
+        for i in INGRESS_SA_COUNTERS:
+            if 'OCTETS' in i:
+                assert ingress_end_counters[i] - ingress_start_counters[i] >= PKT_NUM * PKT_OCTET
+            else:
+                assert ingress_end_counters[i] - ingress_start_counters[i] >= PKT_NUM
 
 
 class TestFaultHandling():

--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -172,6 +172,42 @@ class TestDataPlane():
             requester["host"].shell("ip route del 0.0.0.0/0 via {}".format(
                 requester["peer_ipv4_addr"]), module_ignore_errors=True)
 
+    def test_counters(self, duthost, ctrl_links, upstream_links):
+        EGRESS_SA_COUNTERS = (
+                'SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED',
+                'SAI_MACSEC_SA_STAT_OCTETS_PROTECTED',
+                'SAI_MACSEC_SA_STAT_OUT_PKTS_ENCRYPTED',
+                'SAI_MACSEC_SA_STAT_OUT_PKTS_PROTECTED'
+                )
+        INGRESS_SA_COUNTERS = (
+                'SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED',
+                'SAI_MACSEC_SA_STAT_OCTETS_PROTECTED',
+                'SAI_MACSEC_SA_STAT_IN_PKTS_OK',
+                )
+        PKT_NUM = 5
+
+        for up_port, up_link in upstream_links.items():
+            egress_sa_name = get_macsec_sa_name(duthost, up_port, True)
+            ingress_sa_name = get_macsec_sa_name(duthost, up_port, False)
+
+            egress_start_counters = get_macsec_counters(duthost, up_port, egress_sa_name)
+            ingress_start_counters = get_macsec_counters(duthost, up_port, ingress_sa_name)
+            ret = duthost.command(
+                "ping -c {} {}".format(PKT_NUM, up_link['local_ipv4_addr']))
+            sleep(10) # wait 10s for polling counters
+            egress_end_counters = get_macsec_counters(duthost, up_port, egress_sa_name)
+            ingress_end_counters = get_macsec_counters(duthost, up_port, ingress_sa_name)
+
+            for i in EGRESS_SA_COUNTERS:
+                assert int(egress_end_counters[i]) - int(egress_start_counters[i]) >= PKT_NUM
+
+            for i in INGRESS_SA_COUNTERS:
+                assert int(ingress_end_counters[i]) - int(ingress_start_counters[i]) >= PKT_NUM
+
+            i = 'SAI_MACSEC_SA_ATTR_CURRENT_XPN'
+            assert int(egress_end_counters[i]) - int(egress_start_counters[i]) >= PKT_NUM
+            assert int(ingress_end_counters[i]) - int(ingress_start_counters[i]) >= PKT_NUM
+
 
 class TestFaultHandling():
     MKA_TIMEOUT = 6

--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -173,9 +173,6 @@ class TestDataPlane():
                 requester["peer_ipv4_addr"]), module_ignore_errors=True)
 
     def test_counters(self, duthost, upstream_links):
-        if duthost.facts["asic_type"] == "vs":
-            pytest.skip("macsec counter test is not supported on dut vsonic")
-
         EGRESS_SA_COUNTERS = (
                 'SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED',
                 'SAI_MACSEC_SA_STAT_OUT_PKTS_ENCRYPTED',
@@ -203,6 +200,14 @@ class TestDataPlane():
             egress_end_counters = get_macsec_counters(asic, egress_sa_name)
             ingress_end_counters = get_macsec_counters(asic, ingress_sa_name)
 
+            i = 'SAI_MACSEC_SA_ATTR_CURRENT_XPN'
+            assert int(egress_end_counters[i]) - int(egress_start_counters[i]) >= PKT_NUM
+            assert int(ingress_end_counters[i]) - int(ingress_start_counters[i]) >= PKT_NUM
+
+            if duthost.facts["asic_type"] == "vs":
+                # vsonic only has xpn counter
+                continue
+
             for i in EGRESS_SA_COUNTERS:
                 if 'OCTETS' in i:
                     assert int(egress_end_counters[i]) - int(egress_start_counters[i]) >= PKT_NUM * PKT_OCTET
@@ -214,10 +219,6 @@ class TestDataPlane():
                     assert int(ingress_end_counters[i]) - int(ingress_start_counters[i]) >= PKT_NUM * PKT_OCTET
                 else:
                     assert int(ingress_end_counters[i]) - int(ingress_start_counters[i]) >= PKT_NUM
-
-            i = 'SAI_MACSEC_SA_ATTR_CURRENT_XPN'
-            assert int(egress_end_counters[i]) - int(egress_start_counters[i]) >= PKT_NUM
-            assert int(ingress_end_counters[i]) - int(ingress_start_counters[i]) >= PKT_NUM
 
 
 class TestFaultHandling():

--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -173,7 +173,9 @@ class TestDataPlane():
             requester["host"].shell("ip route del 0.0.0.0/0 via {}".format(
                 requester["peer_ipv4_addr"]), module_ignore_errors=True)
 
-    def test_counters(self, duthost, ctrl_links, upstream_links):
+    def test_counters(self, duthost, ctrl_links, upstream_links, rekey_period):
+        if rekey_period:
+            pytest.skip("Counter increase is not guaranteed in case rekey is happening")
         EGRESS_SA_COUNTERS = (
                 'SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED',
                 'SAI_MACSEC_SA_STAT_OUT_PKTS_ENCRYPTED',

--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -198,6 +198,7 @@ class TestDataPlane():
             ingress_start_counters = get_macsec_counters(asic, ingress_sa_name)
             ret = duthost.command(
                 "ping -c {} -s {} {}".format(PKT_NUM, PKT_OCTET, up_link['local_ipv4_addr']))
+            assert not ret['failed']
             sleep(10) # wait 10s for polling counters
             egress_end_counters = get_macsec_counters(asic, egress_sa_name)
             ingress_end_counters = get_macsec_counters(asic, ingress_sa_name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Add macsec counter test
#### How did you do it?

#### How did you verify/test it?
```
junhuazhai@e25918d5b081:/var/src/sonic-mgmt-int/tests$ ./run_tests.sh -u -n vms28-t0-7280-4 -d str2-a7280cr3-4 -c macsec/test_macsec.py::TestDataPlane::test_counters -f ../ansible/testbed.yaml -i ../ansible/str2,../ansible/veos -e "--skip_sanity --disable_loganalyzer -x --enable_macsec --macsec_profile=128_SCI"
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
===================================================================================================================== test session starts ======================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.11.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, repeat-0.9.1, allure-pytest-2.8.22, ansible-2.2.2
collecting ... /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 1 item                                                                                                                                                                                                                                               

macsec/test_macsec.py::TestDataPlane::test_counters PASSED                                                                                                                                                                                               [100%]

------------------------------------------------------------------------------------------------ generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------------------------------------
================================================================================================================== 1 passed in 64.65 seconds ===================================================================================================================
INFO:root:Can not get Allure report URL. Please check logs
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
