### PR TITLE
Add loopback 4096 ip address in inventory for multi-asic VS hwsku

### DIFF
--- a/ansible/lab
+++ b/ansible/lab
@@ -140,6 +140,8 @@ sonic_multi_asic:
     num_asics: 6
     start_topo_service: True
     frontend_asics: [0,1,2,3]
+    loopback4096_ip: [8.0.0.0/32, 8.0.0.1/32, 8.0.0.2/32, 8.0.0.3/32, 8.0.0.4/32, 8.0.0.5/32]
+    loopback4096_ipv6: [2603:10e2:400::/128, 2603:10e2:400::1/128, 2603:10e2:400::2/128, 2603:10e2:400::3/128, 2603:10e2:400::4/128, 2603:10e2:400::5/128]
   hosts:
     vlab-07:
       ansible_host: 10.250.0.109
@@ -152,6 +154,8 @@ sonic_multi_asic_2:
     num_asics: 4
     start_topo_service: True
     frontend_asics: [0,1]
+    loopback4096_ip: [8.0.0.0/32, 8.0.0.1/32, 8.0.0.2/32, 8.0.0.3/32]
+    loopback4096_ipv6: [2603:10e2:400::/128, 2603:10e2:400::1/128, 2603:10e2:400::2/128, 2603:10e2:400::3/128]
   hosts:
     vlab-08:
       ansible_host: 10.250.0.112


### PR DESCRIPTION
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The internal BGP sessions were not coming up in multi-asic VS because Loopback4096 interface was not added for ASICs in multi-asic minigraph if ansible/lab was used in inventory file.

sonic-mgmt/tests/kvmtest.sh uses ./testbed-cli.sh -t vtestbed.yaml -m veos_vtb deploy-mg vms-kvm-four-asic-t1-lag **lab** password.txt to generate the minigraph .
Rerefence:
https://github.com/Azure/sonic-buildimage/blob/87425a5b2b02ecd75f3de7e5174e37e053e31790/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py#L128
#### How did you do it?
Add loopback_4096 ip addresses for asic in ansible/lab inventory
#### How did you verify/test it?
Bring up multi-asic KVM testbed.
./testbed-cli.sh -t vtestbed.yaml -m veos_vtb -k ceos add-topo vms-kvm-four-asic-t1-lag password.txt
./testbed-cli.sh -t vtestbed.yaml -m veos_vtb -k ceos add-topo vms-kvm-four-asic-t1-lag password.txt
Ensure all BGP sessions are up
```
admin@vlab-08:~$ show ip bgp summary -n asic0 -d all

IPv4 Unicast Summary:
asic0: BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 12781
RIB entries 12795, using 2354280 bytes of memory
Peers 4, using 2963232 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  65200       3197       3201         0      0       0  00:00:13             6370  ARISTA01T2
10.0.0.5       4  65200       3197       3201         0      0       0  00:00:13             6370  ARISTA03T2
10.1.0.0       4  65100       3212       3202         0      0       0  00:00:18             6398  ASIC2
10.1.0.2       4  65100       3213       3202         0      0       0  00:00:18             6398  ASIC3

Total number of neighbors 4
admin@vlab-08:~$ show ip bgp summary -n asic1 -d all

IPv4 Unicast Summary:
asic1: BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 12771
RIB entries 12795, using 2354280 bytes of memory
Peers 6, using 4444848 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.33      4  64001         14       5259         0      0       0  00:00:19                3  ARISTA01T0
10.0.0.35      4  64002         15       5257         0      0       0  00:00:19                3  ARISTA02T0
10.0.0.37      4  64003         16       5257         0      0       0  00:00:19                4  ARISTA03T0
10.0.0.39      4  64004         15       5257         0      0       0  00:00:19                3  ARISTA04T0
10.1.0.4       4  65100       3213         23         0      0       0  00:00:23             6398  ASIC2
10.1.0.6       4  65100       3214         23         0      0       0  00:00:23             6398  ASIC3

Total number of neighbors 6
admin@vlab-08:~$ show ip bgp summary -n asic2 -d all

IPv4 Unicast Summary:
asic2: BGP router identifier 8.0.0.2, local AS number 65100 vrf-id 0
BGP table version 6398
RIB entries 12793, using 2353912 bytes of memory
Peers 2, using 1481616 KiB of memory
Peer groups 2, using 128 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.1.0.1       4  65100       3206       3220         0      0       0  00:00:27             6377  ASIC0
10.1.0.5       4  65100         25       3217         0      0       0  00:00:27               21  ASIC1

Total number of neighbors 2
admin@vlab-08:~$ show ip bgp summary -n asic3 -d all

IPv4 Unicast Summary:
asic3: BGP router identifier 8.0.0.3, local AS number 65100 vrf-id 0
BGP table version 6398
RIB entries 12793, using 2353912 bytes of memory
Peers 2, using 1481616 KiB of memory
Peer groups 2, using 128 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.1.0.3       4  65100       3206       3217         0      0       0  00:00:30             6377  ASIC0
10.1.0.7       4  65100         29       3219         0      0       0  00:00:30               21  ASIC1

Total number of neighbors 2
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
