### PR TITLE
Adding support for updating ecn config file based on testcase.

### DIFF
--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -1,2 +1,78 @@
+import json
+from tests.common.reboot import reboot
+
 def is_cisco_device(dut):
     return dut.facts["asic_type"] == "cisco-8000"
+
+def get_markings_config_file(duthost):
+    """
+        Get the config file where the ECN markings are enabled or disabled.
+    """
+    platform = duthost.facts['platform']
+    if platform != 'x86_64-8102_64h_o-r0':
+        raise RuntimeError("This is applicable only to cisco platforms.")
+
+    hwsku = duthost.facts['hwsku']
+    match = re.search("\-([^-_]+)_", platform)
+    if match:
+       model = match.group(1)
+    else:
+       raise RuntimeError("Couldn't get the model from platform:{}".format(platform))
+    config_file = "/usr/share/sonic/device/{}/{}/{}.json".format(platform, hwsku, model)
+    return config_file
+
+def get_ecn_markings_dut(duthost, key_list=['ecn_dequeue_marking', 'ecn_latency_marking', 'voq_allocation_mode']):
+    """
+        Get the ecn marking values from the duthost.
+    """
+    config_file = get_markings_config_file(duthost)
+    dest_file = "/tmp/"
+    contents = duthost.fetch(src=config_file, dest = dest_file)
+    local_file = contents['dest']
+    with open(local_file) as fd:
+        json_contents = json.load(fd)
+    required_entry = None
+    for i in range(len(json_contents['devices'])):
+        try:
+             json_contents['devices'][i].get('id')
+             required_entry = i
+        except KeyError:
+             continue
+
+    if required_entry is None:
+        raise RuntimeError("Couldnot find the required entry(id) in the config file:{}".format(config_file))
+    original_values = {}
+    for key in key_list:
+        original_values[key] = json_contents['devices'][i][key]
+    return original_values
+
+def setup_ecn_markings_dut(duthost, localhost, **kwargs):
+    """
+        Setup dequeue or latency depending on arguments.
+        Applicable to cisco-8000 Platforms only.
+    """
+    config_file = get_markings_config_file(duthost)
+    dest_file = "/tmp/"
+    contents = duthost.fetch(src=config_file, dest = dest_file)
+    local_file = contents['dest']
+    with open(local_file) as fd:
+        json_contents = json.load(fd)
+    required_entry = None
+    for i in range(len(json_contents['devices'])):
+        try:
+             json_contents['devices'][i].get('id')
+             required_entry = i
+        except KeyError:
+             continue
+
+    if required_entry is None:
+        raise RuntimeError("Couldnot find the required entry(id) in the config file:{}".format(config_file))
+    reboot_required = False
+    for k,v in kwargs.iteritems():
+        if json_contents['devices'][required_entry][k] != v:
+            reboot_required = True
+            json_contents['devices'][required_entry][k] = v
+
+    if reboot_required:
+        duthost.copy(content=json.dumps(json_contents, sort_keys=True, indent=4), dest=config_file)
+        reboot(duthost, localhost)

--- a/tests/ixia/ecn/files/helper.py
+++ b/tests/ixia/ecn/files/helper.py
@@ -1,6 +1,5 @@
 import time
 import dpkt
-import json
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
@@ -11,7 +10,6 @@ from tests.common.ixia.ixia_helpers import get_dut_port_id
 from tests.common.ixia.common_helpers import pfc_class_enable_vector, config_wred,\
     enable_ecn, config_ingress_lossless_buffer_alpha, stop_pfcwd, disable_packet_aging
 from tests.common.ixia.port import select_ports, select_tx_port
-from tests.common.reboot import reboot
 
 from abstract_open_traffic_generator.capture import CustomFilter, Capture,\
     BasicFilter
@@ -374,78 +372,3 @@ def is_ecn_marked(ip_pkt):
     """
 
     return (ip_pkt.tos & 3) == 3
-
-
-def get_markings_config_file(duthost):
-    """
-        Get the config file where the ECN markings are enabled or disabled.
-    """
-    platform = duthost.facts['platform']
-    if platform != 'x86_64-8102_64h_o-r0':
-        raise RuntimeError("This is applicable only to cisco platforms.")
-
-    hwsku = duthost.facts['hwsku']
-    match = re.search("\-([^-_]+)_", platform)
-    if match:
-       model = match.group(1)
-    else:
-       raise RuntimeError("Couldn't get the model from platform:{}".format(platform))
-    config_file = "/usr/share/sonic/device/{}/{}/{}.json".format(platform, hwsku, model)
-    return config_file
-
-def get_ecn_markings_dut(duthost, key_list=['ecn_dequeue_marking', 'ecn_latency_marking', 'voq_allocation_mode']):
-    """
-        Get the ecn marking values from the duthost.
-    """
-    config_file = get_markings_config_file(duthost)
-    dest_file = "/tmp/"
-    contents = duthost.fetch(src=config_file, dest = dest_file)
-    local_file = contents['dest']
-    with open(local_file) as fd:
-        json_contents = json.load(fd)
-    required_entry = None
-    for i in range(len(json_contents['devices'])):
-        try:
-             json_contents['devices'][i].get('id')
-             required_entry = i
-        except KeyError:
-             continue
-
-    if required_entry is None:
-        raise RuntimeError("Couldnot find the required entry(id) in the config file:{}".format(config_file))
-    original_values = {}
-    for key in key_list:
-        original_values[key] = json_contents['devices'][i][key]
-    return original_values
-
-def setup_ecn_markings_dut(duthost, localhost, **kwargs):
-    """
-        Setup dequeue or latency depending on arguments.
-        Applicable to cisco-8000 Platforms only.
-    """
-    config_file = get_markings_config_file(duthost)
-    dest_file = "/tmp/"
-    contents = duthost.fetch(src=config_file, dest = dest_file)
-    local_file = contents['dest']
-    with open(local_file) as fd:
-        json_contents = json.load(fd)
-    required_entry = None
-    for i in range(len(json_contents['devices'])):
-        try:
-             json_contents['devices'][i].get('id')
-             required_entry = i
-        except KeyError:
-             continue
-
-    if required_entry is None:
-        raise RuntimeError("Couldnot find the required entry(id) in the config file:{}".format(config_file))
-    reboot_required = False
-    for k,v in kwargs.iteritems():
-        if json_contents['devices'][required_entry][k] != v:
-            reboot_required = True
-            json_contents['devices'][required_entry][k] = v
-
-    if reboot_required:
-        duthost.copy(content=json.dumps(json_contents, sort_keys=True, indent=4), dest=config_file)
-        reboot(duthost, localhost)
-

--- a/tests/ixia/ecn/files/helper.py
+++ b/tests/ixia/ecn/files/helper.py
@@ -1,5 +1,6 @@
 import time
 import dpkt
+import json
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
@@ -10,6 +11,7 @@ from tests.common.ixia.ixia_helpers import get_dut_port_id
 from tests.common.ixia.common_helpers import pfc_class_enable_vector, config_wred,\
     enable_ecn, config_ingress_lossless_buffer_alpha, stop_pfcwd, disable_packet_aging
 from tests.common.ixia.port import select_ports, select_tx_port
+from tests.common.reboot import reboot
 
 from abstract_open_traffic_generator.capture import CustomFilter, Capture,\
     BasicFilter
@@ -372,3 +374,78 @@ def is_ecn_marked(ip_pkt):
     """
 
     return (ip_pkt.tos & 3) == 3
+
+
+def get_markings_config_file(duthost):
+    """
+        Get the config file where the ECN markings are enabled or disabled.
+    """
+    platform = duthost.facts['platform']
+    if platform != 'x86_64-8102_64h_o-r0':
+        raise RuntimeError("This is applicable only to cisco platforms.")
+
+    hwsku = duthost.facts['hwsku']
+    match = re.search("\-([^-_]+)_", platform)
+    if match:
+       model = match.group(1)
+    else:
+       raise RuntimeError("Couldn't get the model from platform:{}".format(platform))
+    config_file = "/usr/share/sonic/device/{}/{}/{}.json".format(platform, hwsku, model)
+    return config_file
+
+def get_ecn_markings_dut(duthost, key_list=['ecn_dequeue_marking', 'ecn_latency_marking', 'voq_allocation_mode']):
+    """
+        Get the ecn marking values from the duthost.
+    """
+    config_file = get_markings_config_file(duthost)
+    dest_file = "/tmp/"
+    contents = duthost.fetch(src=config_file, dest = dest_file)
+    local_file = contents['dest']
+    with open(local_file) as fd:
+        json_contents = json.load(fd)
+    required_entry = None
+    for i in range(len(json_contents['devices'])):
+        try:
+             json_contents['devices'][i].get('id')
+             required_entry = i
+        except KeyError:
+             continue
+
+    if required_entry is None:
+        raise RuntimeError("Couldnot find the required entry(id) in the config file:{}".format(config_file))
+    original_values = {}
+    for key in key_list:
+        original_values[key] = json_contents['devices'][i][key]
+    return original_values
+
+def setup_ecn_markings_dut(duthost, localhost, **kwargs):
+    """
+        Setup dequeue or latency depending on arguments.
+        Applicable to cisco-8000 Platforms only.
+    """
+    config_file = get_markings_config_file(duthost)
+    dest_file = "/tmp/"
+    contents = duthost.fetch(src=config_file, dest = dest_file)
+    local_file = contents['dest']
+    with open(local_file) as fd:
+        json_contents = json.load(fd)
+    required_entry = None
+    for i in range(len(json_contents['devices'])):
+        try:
+             json_contents['devices'][i].get('id')
+             required_entry = i
+        except KeyError:
+             continue
+
+    if required_entry is None:
+        raise RuntimeError("Couldnot find the required entry(id) in the config file:{}".format(config_file))
+    reboot_required = False
+    for k,v in kwargs.iteritems():
+        if json_contents['devices'][required_entry][k] != v:
+            reboot_required = True
+            json_contents['devices'][required_entry][k] = v
+
+    if reboot_required:
+        duthost.copy(content=json.dumps(json_contents, sort_keys=True, indent=4), dest=config_file)
+        reboot(duthost, localhost)
+

--- a/tests/ixia/ecn/test_dequeue_ecn.py
+++ b/tests/ixia/ecn/test_dequeue_ecn.py
@@ -7,7 +7,8 @@ from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config
 from tests.common.ixia.qos_fixtures import prio_dscp_map, lossless_prio_list
 
-from files.helper import run_ecn_test, is_ecn_marked
+from files.helper import run_ecn_test, is_ecn_marked, get_ecn_markings_dut,\
+    setup_ecn_markings_dut
 
 pytestmark = [ pytest.mark.topology('tgen') ]
 
@@ -17,6 +18,7 @@ def test_dequeue_ecn(request,
                      conn_graph_facts,
                      fanout_graph_facts,
                      duthosts,
+                     localhost,
                      rand_one_dut_hostname,
                      rand_one_dut_portname_oper_up,
                      rand_one_dut_lossless_prio,
@@ -51,6 +53,7 @@ def test_dequeue_ecn(request,
     testbed_config, port_config_list = ixia_testbed_config
     duthost = duthosts[rand_one_dut_hostname]
     lossless_prio = int(lossless_prio)
+    cisco_platform = (duthost.facts['asic_type'] == "cisco-8000")
 
     kmin = 50000
     kmax = 51000
@@ -58,7 +61,21 @@ def test_dequeue_ecn(request,
     pkt_size = 1024
     pkt_cnt = 100
 
-    ip_pkts = run_ecn_test(api=ixia_api,
+    pkt_size = 1024
+    if cisco_platform:
+        original_ecn_markings = get_ecn_markings_dut(duthost)
+        setup_ecn_markings_dut(duthost, localhost, ecn_dequeue_marking = True, ecn_latency_marking = False)
+        oq_cell_count = 100      # Number of cells in OQ for this lossless priority 
+        cell_size = 384
+        cell_per_pkt = (pkt_size + cell_size - 1) // cell_size
+        margin_cells = 25
+        margin = margin_cells // cell_per_pkt
+        pkt_to_oq = (oq_cell_count//cell_per_pkt) + margin # Packets forwarded to OQ
+        pkt_to_check = pkt_to_oq + 1
+    else:
+        cell_size = 0
+    try:
+        ip_pkts = run_ecn_test(api=ixia_api,
                            testbed_config=testbed_config,
                            port_config_list=port_config_list,
                            conn_data=conn_graph_facts,
@@ -75,13 +92,16 @@ def test_dequeue_ecn(request,
                            iters=1)[0]
 
 
-    """ Check if we capture all the packets """
-    pytest_assert(len(ip_pkts) == pkt_cnt,
-                  'Only capture {}/{} IP packets'.format(len(ip_pkts), pkt_cnt))
+        """ Check if we capture all the packets """
+        pytest_assert(len(ip_pkts) == pkt_cnt,
+                      'Only capture {}/{} IP packets'.format(len(ip_pkts), pkt_cnt))
 
-    """ Check if the first packet is marked """
-    pytest_assert(is_ecn_marked(ip_pkts[0]), "The first packet should be marked")
+        """ Check if the first packet is marked """
+        pytest_assert(is_ecn_marked(ip_pkts[0]), "The first packet should be marked")
 
-    """ Check if the last packet is not marked """
-    pytest_assert(not is_ecn_marked(ip_pkts[-1]),
-                  "The last packet should not be marked")
+        """ Check if the last packet is not marked """
+        pytest_assert(not is_ecn_marked(ip_pkts[-1]),
+                      "The last packet should not be marked")
+    finally:
+         if cisco_platform:
+            setup_ecn_markings_dut(duthost, localhost, **original_ecn_markings)

--- a/tests/ixia/ecn/test_dequeue_ecn.py
+++ b/tests/ixia/ecn/test_dequeue_ecn.py
@@ -7,8 +7,8 @@ from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config
 from tests.common.ixia.qos_fixtures import prio_dscp_map, lossless_prio_list
 
-from files.helper import run_ecn_test, is_ecn_marked, get_ecn_markings_dut,\
-    setup_ecn_markings_dut
+from files.helper import run_ecn_test, is_ecn_marked
+from tests.common.cisco_data import  get_ecn_markings_dut, setup_ecn_markings_dut
 
 pytestmark = [ pytest.mark.topology('tgen') ]
 

--- a/tests/ixia/ecn/test_dequeue_ecn.py
+++ b/tests/ixia/ecn/test_dequeue_ecn.py
@@ -73,6 +73,7 @@ def test_dequeue_ecn(request,
         pkt_to_check = pkt_to_oq + 1
     else:
         pkt_to_check = 0
+
     try:
         ip_pkts = run_ecn_test(api=ixia_api,
                            testbed_config=testbed_config,

--- a/tests/ixia/ecn/test_red_accuracy.py
+++ b/tests/ixia/ecn/test_red_accuracy.py
@@ -8,7 +8,9 @@ from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config
 from tests.common.ixia.qos_fixtures import prio_dscp_map, lossless_prio_list
 
-from files.helper import run_ecn_test, is_ecn_marked
+from files.helper import run_ecn_test, is_ecn_marked, get_ecn_markings_dut,\
+    setup_ecn_markings_dut
+
 
 pytestmark = [ pytest.mark.topology('tgen') ]
 
@@ -18,6 +20,7 @@ def test_red_accuracy(request,
                       conn_graph_facts,
                       fanout_graph_facts,
                       duthosts,
+                      localhost,
                       rand_one_dut_hostname,
                       rand_one_dut_portname_oper_up,
                       rand_one_dut_lossless_prio,
@@ -53,6 +56,7 @@ def test_red_accuracy(request,
     testbed_config, port_config_list = ixia_testbed_config
     duthost = duthosts[rand_one_dut_hostname]
     lossless_prio = int(lossless_prio)
+    cisco_platform = (duthost.facts['asic_type'] == "cisco-8000")
 
     kmin = 500000
     kmax = 2000000
@@ -62,7 +66,12 @@ def test_red_accuracy(request,
     iters = 100
     result_file_name = 'result.txt'
 
-    ip_pkts_list = run_ecn_test(api=ixia_api,
+    if cisco_platform:
+        original_ecn_markings = get_ecn_markings_dut(duthost)
+        setup_ecn_markings_dut(duthost, localhost, dequeue = True, latency = False)
+
+    try:
+        ip_pkts_list = run_ecn_test(api=ixia_api,
                                 testbed_config=testbed_config,
                                 port_config_list=port_config_list,
                                 conn_data=conn_graph_facts,
@@ -78,31 +87,35 @@ def test_red_accuracy(request,
                                 prio_dscp_map=prio_dscp_map,
                                 iters=iters)
 
-    """ Check if we capture packets of all the rounds """
-    pytest_assert(len(ip_pkts_list) == iters,
-                  'Only capture {}/{} rounds of packets'.format(len(ip_pkts_list), iters))
+        """ Check if we capture packets of all the rounds """
+        pytest_assert(len(ip_pkts_list) == iters,
+                      'Only capture {}/{} rounds of packets'.format(len(ip_pkts_list), iters))
 
-    queue_mark_cnt = {}
-    for i in range(pkt_cnt):
-        queue_len = (pkt_cnt - i) * pkt_size
-        queue_mark_cnt[queue_len] = 0
+        queue_mark_cnt = {}
+        for i in range(pkt_cnt):
+            queue_len = (pkt_cnt - i) * pkt_size
+            queue_mark_cnt[queue_len] = 0
 
-    for i in range(iters):
-        ip_pkts = ip_pkts_list[i]
-        """ Check if we capture all the packets in each round """
-        pytest_assert(len(ip_pkts) == pkt_cnt,
-                      'Only capture {}/{} packets in round {}'.format(len(ip_pkts), pkt_cnt, i))
+        for i in range(iters):
+            ip_pkts = ip_pkts_list[i]
+            """ Check if we capture all the packets in each round """
+            pytest_assert(len(ip_pkts) == pkt_cnt,
+                          'Only capture {}/{} packets in round {}'.format(len(ip_pkts), pkt_cnt, i))
 
-        for j in range(pkt_cnt):
-            ip_pkt = ip_pkts[j]
-            queue_len = (pkt_cnt - j) * pkt_size
+            for j in range(pkt_cnt):
+                ip_pkt = ip_pkts[j]
+                queue_len = (pkt_cnt - j) * pkt_size
 
-            if is_ecn_marked(ip_pkt):
-                queue_mark_cnt[queue_len] += 1
+                if is_ecn_marked(ip_pkt):
+                    queue_mark_cnt[queue_len] += 1
 
-    """ Dump queue length vs. ECN marking probability into a file """
-    queue_mark_cnt = collections.OrderedDict(sorted(queue_mark_cnt.items()))
-    f = open(result_file_name, 'w')
-    for queue, mark_cnt in queue_mark_cnt.iteritems():
-        f.write('{} {}\n'.format(queue, float(mark_cnt)/iters))
-    f.close()
+        """ Dump queue length vs. ECN marking probability into a file """
+        queue_mark_cnt = collections.OrderedDict(sorted(queue_mark_cnt.items()))
+        f = open(result_file_name, 'w')
+        for queue, mark_cnt in queue_mark_cnt.iteritems():
+            f.write('{} {}\n'.format(queue, float(mark_cnt)/iters))
+        f.close()
+    finally:
+        if cisco_platform:
+            setup_ecn_markings_dut(duthost, localhost, **original_ecn_markings)
+

--- a/tests/ixia/ecn/test_red_accuracy.py
+++ b/tests/ixia/ecn/test_red_accuracy.py
@@ -8,9 +8,8 @@ from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config
 from tests.common.ixia.qos_fixtures import prio_dscp_map, lossless_prio_list
 
-from files.helper import run_ecn_test, is_ecn_marked, get_ecn_markings_dut,\
-    setup_ecn_markings_dut
-
+from files.helper import run_ecn_test, is_ecn_marked
+from tests.common.cisco_data import get_ecn_markings_dut, setup_ecn_markings_dut
 
 pytestmark = [ pytest.mark.topology('tgen') ]
 


### PR DESCRIPTION
This PR is to add the following for cisco 8000 platform only:
1. Add support for enabling the ECN marking configs in the DUT.
2. Update the test_dequeue_ecn.py to call the above functions.
3. Restore the configs after the test is done.