### PR TITLE
[ACL]Always load_minigraph after acl test

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -109,18 +109,16 @@ def remove_dataacl_table(duthosts):
             if TABLE_NAME in line:
                 data_acl_existing = True
                 break
-        if not data_acl_existing:
-            yield
-            return
-        # Remove DATAACL
-        logger.info("Removing ACL table {}".format(TABLE_NAME))
-        cmds = [
-            "config acl remove table {}".format(TABLE_NAME),
-            "config save -y"
-        ]
-        duthost.shell_cmds(cmds=cmds)
+        if data_acl_existing:
+            # Remove DATAACL
+            logger.info("Removing ACL table {}".format(TABLE_NAME))
+            cmds = [
+                "config acl remove table {}".format(TABLE_NAME),
+                "config save -y"
+            ]
+            duthost.shell_cmds(cmds=cmds)
     yield
-    # Recover DATAACL by reloading minigraph
+    # Recover DUT by reloading minigraph
     for duthost in duthosts:
         config_reload(duthost, config_source="minigraph")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to improve `test_acl` to always load_minigraph at the end of test.

`load_minigraph` is required because the ACL rule configuration is written to `config_db.json` during test. Before this change, we only load_minigraph when `DATAACL` exists. So it's probably that the ACL configuration is left on DUT if `DATAACL` is absent (on dualtor).

This PRT addressed the issue by always load minigraph.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
This PR is to improve `test_acl` to always load_minigraph at the end of test.

#### How did you do it?
Always load minigraph at the end of `test_acl`.

#### How did you verify/test it?
Verified by running `test_acl`.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
No.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
