### PR TITLE
Modify neighbor flush in test_tunnel_memory_leak

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1135,7 +1135,6 @@ def delete_neighbor(duthost, neighbor):
 
     neighbor_details = get_neighbor(duthost, neighbor)
     assert(not neighbor_details, "server ip {} hasn't been deleted from neighbor table.".format(neighbor))
-    return
 
 @pytest.fixture(scope="function")
 def rand_selected_interface(rand_selected_dut):

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1123,6 +1123,19 @@ def flush_neighbor(duthost, neighbor, restore=True):
             logging.info("restore neighbor entry for %s", neighbor)
             duthost.shell("ip neighbor replace %s lladdr %s dev %s" % (neighbor, neighbor_details['lladdr'], neighbor_details['dev']))
 
+def delete_neighbor(duthost, neighbor):
+    """Delete neighbor entry for server in duthost, ignore it if doesn't exist."""
+    neighbor_details = get_neighbor(duthost, neighbor)
+    if neighbor_details:
+        logging.info("neighbor details for %s: %s", neighbor, neighbor_details)
+        logging.info("remove neighbor entry for %s", neighbor)
+        duthost.shell("ip neighbor del %s dev %s" % (neighbor, neighbor_details['dev']))
+    else:
+        logging.info("Neighbor entry %s doesn't exist", neighbor)
+
+    neighbor_details = get_neighbor(duthost, neighbor)
+    assert(not neighbor_details, "server ip {} hasn't been deleted from neighbor table.".format(neighbor))
+    return
 
 @pytest.fixture(scope="function")
 def rand_selected_interface(rand_selected_dut):

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1134,7 +1134,7 @@ def delete_neighbor(duthost, neighbor):
         logging.info("Neighbor entry %s doesn't exist", neighbor)
 
     neighbor_details = get_neighbor(duthost, neighbor)
-    assert(not neighbor_details, "server ip {} hasn't been deleted from neighbor table.".format(neighbor))
+    assert len(neighbor_details) > 0, "server ip {} hasn't been deleted from neighbor table.".format(neighbor)
 
 @pytest.fixture(scope="function")
 def rand_selected_interface(rand_selected_dut):

--- a/tests/dualtor/test_tunnel_memory_leak.py
+++ b/tests/dualtor/test_tunnel_memory_leak.py
@@ -21,7 +21,6 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.dual_tor_utils import build_packet_to_server
-from tests.common.dualtor.dual_tor_utils import flush_neighbor
 from tests.common.helpers.dut_utils import get_program_info
 from tests.common.fixtures.ptfhost_utils import run_garp_service, run_icmp_responder # lgtm[py/unused-import]
 


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Test case `test_tunnel_memory_leak` sometimes failed with error "`AssertionError: No dev found for neighbor 192.168.0.3`".
It's because toggle_all_simulator_ports_to_upper_tor runs after run_arp_responder and garp_service, so low Tor may be active Tor and receives arp responder packets and garp packets before toggling, ip neighbors may exist in low Tor.
But we check ip neighbors on upper Tor and delete them. 
#### How did you do it?
If there is no neighbor on upper Tor, we should not fail the test case, it doesn't impact test function. `tunnel_packet_handler` will trigger neighbor added back.
Just delete neighbor if neighbor exists, otherwise ignore it and continue the test.

#### How did you verify/test it?
Run `dualtor/test_tunnel_memory_leak.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
