### PR TITLE
[VXLAN_ECMP] Workaround to have separate setup and teardown for each supported encap type

### DIFF
--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -524,9 +524,15 @@ def get_ethernet_ports(intf_list, minigraph_data):
 
     return ret_list
 
+
+@pytest.fixture(scope="module", params=SUPPORTED_ENCAP_TYPES)
+def encap_type(request):
+    yield request.param
+
+
 @pytest.fixture(scope="module")
 def setUp(duthosts, ptfhost, request, rand_one_dut_hostname, minigraph_facts,
-          tbinfo):
+          tbinfo, encap_type):
 
     global Constants
     # Should I keep the temporary files copied to DUT?
@@ -542,6 +548,8 @@ def setUp(duthosts, ptfhost, request, rand_one_dut_hostname, minigraph_facts,
     Constants['DUT_HOSTID'] = request.config.option.dut_hostid
 
     logger.info("Constants to be used in the script:%s", Constants)
+
+    SUPPORTED_ENCAP_TYPES = [encap_type]
 
     data = {}
     data['ptfhost'] = ptfhost
@@ -643,7 +651,7 @@ def setUp(duthosts, ptfhost, request, rand_one_dut_hostname, minigraph_facts,
     for tunnel in tunnel_names.values():
         data['duthost'].shell("redis-cli -n 4 del \"VXLAN_TUNNEL|{}\"".format(tunnel))
 
-@pytest.mark.parametrize("encap_type", SUPPORTED_ENCAP_TYPES)
+
 class Test_VxLAN:
 
     def dump_self_info_and_run_ptf(self, tcname, encap_type, expect_encap_success, packet_count=4):


### PR DESCRIPTION
### Description of PR

Summary: 
Separate configuration and teardown for each supported encapsulation type: ['v4_in_v4', 'v4_in_v6', 'v6_in_v4', 'v6_in_v6']

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix the test issue when two types of tunnels (v4 and v6) configured at the same time

#### How did you do it?
By using an additional fixture, which allows to do setup and teardown for each encap type

#### How did you verify/test it?
By running test in the nightly regression
