### PR TITLE
[dualtor][minigraph] Support new minigraph schema for SoC IP

### DIFF
--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -265,7 +265,8 @@
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
-{% if mux_cable_facts is defined %}
+{% if mux_cable_facts is defined and mux_cable_facts %}
+{% if dual_tor_facts is defined and 'cables' in dual_tor_facts %}}
 {% for cable in dual_tor_facts['cables'] %}
 {% set intf_index = port_alias.index(cable['dut_intf'])|string %}
 		<DeviceDataPlaneInfo>
@@ -329,6 +330,7 @@
 			<DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution" />
 		</DeviceDataPlaneInfo>
 {% endfor %}
+{% endif %}
 {% endif %}
 {% include 'minigraph_dpg_asic.j2' %}
   </DpgDec>

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -266,7 +266,7 @@
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
 {% if mux_cable_facts is defined and mux_cable_facts %}
-{% if dual_tor_facts is defined and 'cables' in dual_tor_facts %}}
+{% if dual_tor_facts is defined and 'cables' in dual_tor_facts %}
 {% for cable in dual_tor_facts['cables'] %}
 {% set intf_index = port_alias.index(cable['dut_intf'])|string %}
 		<DeviceDataPlaneInfo>

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -265,6 +265,71 @@
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
+{% if mux_cable_facts is defined %}
+{% for cable in dual_tor_facts['cables'] %}
+{% set intf_index = port_alias.index(cable['dut_intf'])|string %}
+		<DeviceDataPlaneInfo>
+			<IPSecTunnels />
+			<LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+				<a:LoopbackIPInterface>
+					<ElementType>LoopbackInterface</ElementType>
+					<Name>HostIP</Name>
+					<AttachTo>Loopback0</AttachTo>
+					<a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+						<b:IPPrefix>{{ mux_cable_facts[intf_index]['server_ipv4'] }}</b:IPPrefix>
+					</a:Prefix>
+					<a:PrefixStr>{{ mux_cable_facts[intf_index]['server_ipv4'] }}</a:PrefixStr>
+				</a:LoopbackIPInterface>
+				<a:LoopbackIPInterface>
+					<ElementType>LoopbackInterface</ElementType>
+					<Name>HostIP1</Name>
+					<AttachTo>Loopback0</AttachTo>
+					<a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+						<b:IPPrefix>{{ mux_cable_facts[intf_index]['server_ipv6'] }}</b:IPPrefix>
+					</a:Prefix>
+					<a:PrefixStr>{{ mux_cable_facts[intf_index]['server_ipv6'] }}</a:PrefixStr>
+				</a:LoopbackIPInterface>
+{% if 'soc_ipv4' in mux_cable_facts[intf_index] %}
+				<a:LoopbackIPInterface>
+					<ElementType>LoopbackInterface</ElementType>
+					<Name>SoCHostIP0</Name>
+					<AttachTo>Servers{{ loop.index - 1 }}SOC</AttachTo>
+					<a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+						<b:IPPrefix>{{ mux_cable_facts[intf_index]['soc_ipv4'] }}</b:IPPrefix>
+					</a:Prefix>
+					<a:PrefixStr>{{ mux_cable_facts[intf_index]['soc_ipv4'] }}</a:PrefixStr>
+				</a:LoopbackIPInterface>
+{% endif %}
+{% if 'soc_ipv6' in mux_cable_facts[intf_index] %}
+				<a:LoopbackIPInterface>
+					<ElementType>LoopbackInterface</ElementType>
+					<Name>SoCHostIP1</Name>
+					<AttachTo>Servers{{ loop.index - 1 }}SOC</AttachTo>
+					<a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+						<b:IPPrefix>{{ mux_cable_facts[intf_index]['soc_ipv6'] }}</b:IPPrefix>
+					</a:Prefix>
+					<a:PrefixStr>{{ mux_cable_facts[intf_index]['soc_ipv6'] }}</a:PrefixStr>
+				</a:LoopbackIPInterface>
+			</LoopbackIPInterfaces>
+{% endif %}
+			<ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution" />
+			<ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution" />
+			<MplsInterfaces />
+			<MplsTeInterfaces />
+			<RsvpInterfaces />
+			<Hostname>Servers{{ loop.index - 1 }}</Hostname>
+			<PortChannelInterfaces />
+			<SubInterfaces />
+			<VlanInterfaces />
+			<IPInterfaces />
+			<DataAcls />
+			<AclInterfaces />
+			<NatInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution" />
+			<DownstreamSummaries />
+			<DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution" />
+		</DeviceDataPlaneInfo>
+{% endfor %}
+{% endif %}
 {% include 'minigraph_dpg_asic.j2' %}
   </DpgDec>
 

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -311,8 +311,8 @@
 					</a:Prefix>
 					<a:PrefixStr>{{ mux_cable_facts[intf_index]['soc_ipv6'] }}</a:PrefixStr>
 				</a:LoopbackIPInterface>
-			</LoopbackIPInterfaces>
 {% endif %}
+			</LoopbackIPInterfaces>
 			<ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution" />
 			<ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution" />
 			<MplsInterfaces />

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -28,6 +28,19 @@
             <a:Value>True</a:Value>
           </a:DeviceProperty>
 {% endif %}
+{% if 'dualtor-mixed' in topo %}
+          <a:DeviceProperty>
+            <a:Name>RedundancyType</a:Name>
+            <a:Reference i:nil="true" />
+            <a:Value>Mixed</a:Value>
+          </a:DeviceProperty>
+{% elif 'dualtor' in topo %}
+          <a:DeviceProperty>
+            <a:Name>RedundancyType</a:Name>
+            <a:Reference i:nil="true" />
+            <a:Value>Gemini</a:Value>
+          </a:DeviceProperty>
+{% endif %}
 {% if dhcp_servers %}
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -44,7 +44,10 @@
 {% endfor %}
 {% if 'dualtor' in topo %}
 {% set cable_position = 'U' if inventory_hostname == dual_tor_facts['positions']['upper'] else 'L' %}
+{% set mux_cable_facts = dual_tor_facts['mux_cable_facts'] if 'mux_cable_facts' in dual_tor_facts %}
 {% for cable in dual_tor_facts['cables'] %}
+{% set intf_index = port_alias.index(cable['dut_intf'])|string %}
+{% if mux_cable_facts is not defined or mux_cable_facts[intf_index]['cable_type'] == 'active-standby' %}
       <DeviceLinkBase>
         <ElementType>LogicalLink</ElementType>
         <EndDevice>{{ inventory_hostname }}</EndDevice>
@@ -52,6 +55,7 @@
         <StartDevice>{{ cable['hostname'] }}</StartDevice>
         <StartPort>{{ cable_position }}</StartPort>
       </DeviceLinkBase>
+{% endif %}
 {% endfor %}
 {% endif %}
 {% endif %}
@@ -139,21 +143,12 @@
 {% set server_base_address_v6 = (vlan_configs.values() | list)[0]['prefix_v6'] %}
 {% set server_base_address_v6 = server_base_address_v6 | ipaddr('network') %}
 {% set server_base_address_v6 = ':'.join(server_base_address_v6.split(':')[:-1]) + ':{:x}' %}
-{% set mux_cable_facts = dual_tor_facts['mux_cable_facts'] if 'mux_cable_facts' in dual_tor_facts %}
 {% for cable in dual_tor_facts['cables'] %}
-{% set intf_index = port_alias.index(cable['dut_intf'])|string %}
       <Device i:type="SmartCable">
         <ElementType>SmartCable</ElementType>
-{% if mux_cable_facts is defined %}
-        <SubType>{{ mux_cable_facts[intf_index]['cable_type'] }}</SubType>
-        <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
-          <d5p1:IPPrefix>{{ mux_cable_facts[intf_index]['soc_ipv4'] if 'soc_ipv4' in mux_cable_facts[intf_index] else '0.0.0.0/0' }}</d5p1:IPPrefix>
-        </Address>
-{% else %}
         <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>
         </Address>
-{% endif %}
         <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>::/0</d5p1:IPPrefix>
         </AddressV6>
@@ -168,21 +163,12 @@
       </Device>
       <Device i:type="Server">
         <ElementType>Server</ElementType>
-{% if mux_cable_facts is defined %}
-        <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
-          <d5p1:IPPrefix>{{ mux_cable_facts[intf_index]['server_ipv4'] }}</d5p1:IPPrefix>
-        </Address>
-        <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
-          <d5p1:IPPrefix>{{ mux_cable_facts[intf_index]['server_ipv6'] }}</d5p1:IPPrefix>
-        </AddressV6>
-{% else %}
         <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>{{ server_base_address_v4.format(loop.index + 1) }}/26</d5p1:IPPrefix>
         </Address>
         <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>{{ server_base_address_v6.format(loop.index + 1) }}/96</d5p1:IPPrefix>
         </AddressV6>
-{% endif %}
         <ManagementAddress xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>
         </ManagementAddress>


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Support the minigraph generation for the new schema for SoC IP.
Depends on: https://github.com/Azure/sonic-buildimage/pull/11207

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Add the SoC IP related information to `Dpg`

#### How did you verify/test it?
Test together with https://github.com/Azure/sonic-buildimage/pull/11207 to verify the mux cable table generation

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
