### PR TITLE
[log analyzer] Support ignoring syslog temporarily by setting ignore markers

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -2,6 +2,8 @@ import time
 import logging
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.plugins.loganalyzer.utils import ignore_loganalyzer
+from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import wait_until
 from tests.configlet.util.common import chk_for_pfc_wd
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
@@ -56,6 +58,8 @@ def config_force_option_supported(duthost):
         return True
     return False
 
+
+@ignore_loganalyzer
 def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True, safe_reload=False,
                   check_intf_up_ports=False):
     """
@@ -105,6 +109,7 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
         # function will return sooner.
         pytest_assert(wait_until(wait + 300, 20, 0, duthost.critical_services_fully_started),
                 "All critical services should be fully started!")
+        wait_critical_processes(duthost)
         if config_source == 'minigraph':
             pytest_assert(wait_until(300, 20, 0, chk_for_pfc_wd, duthost),
                     "PFC_WD is missing in CONFIG-DB")

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -235,6 +235,31 @@ class LogAnalyzer:
 
         return self._setup_marker(log_files=log_files)
 
+    def add_start_ignore_mark(self, log_files=None):
+        """
+        Adds the start ignore marker to the log files
+        """
+        add_start_ignore_mark = ".".join((self.marker_prefix, time.strftime("%Y-%m-%d-%H:%M:%S", time.gmtime())))
+        cmd = "python {run_dir}/loganalyzer.py --action add_start_ignore_mark --run_id {add_start_ignore_mark}".format(run_dir=self.dut_run_dir, add_start_ignore_mark=add_start_ignore_mark)
+        if log_files:
+            cmd += " --logs {}".format(','.join(log_files))
+
+        logging.debug("Adding start ignore marker '{}'".format(add_start_ignore_mark))
+        self.ansible_host.command(cmd)
+        self._markers.append(add_start_ignore_mark)
+
+    def add_end_ignore_mark(self, log_files=None):
+        """
+        Adds the end ignore marker to the log files
+        """
+        marker = self._markers.pop()
+        cmd = "python {run_dir}/loganalyzer.py --action add_end_ignore_mark --run_id {marker}".format(run_dir=self.dut_run_dir, marker=marker)
+        if log_files:
+            cmd += " --logs {}".format(','.join(log_files))
+
+        logging.debug("Adding end ignore marker '{}'".format(marker))
+        self.ansible_host.command(cmd)
+
     def _setup_marker(self, log_files=None):
         """
         Adds the marker to the log files

--- a/tests/common/plugins/loganalyzer/utils.py
+++ b/tests/common/plugins/loganalyzer/utils.py
@@ -4,11 +4,14 @@ from functools import wraps
 def ignore_loganalyzer(func):
     @wraps(func)
     def decorated(*args, **kwargs):
-        # try to fetch loganalyzer instance from kwargs
-        # if ignore_loganalyzer is not passed, do nothing but execute the decorated funtion
-        # if ignore_loganalyzer is passed, to avoid 'unexpected keyword argument error',
-        # delete the ignore_loganalyzer from kwargs so that it would not be passed to the decorated function
-        # and set ignore_loganalyzer markers before and after the decorated function on all log analyzer instances.
+        """
+        try to fetch loganalyzer instances from kwargs:
+        if ignore_loganalyzer is not passed, do nothing but execute the decorated function.
+        if ignore_loganalyzer is passed, to avoid 'unexpected keyword argument error',
+            delete the ignore_loganalyzer from kwargs so that it would not be passed to the decorated function,
+            and set ignore_loganalyzer markers before and after the decorated function on all log analyzer instances.
+        """
+
         loganalyzer = None
         if 'ignore_loganalyzer' in kwargs and kwargs['ignore_loganalyzer'] is not None:
             loganalyzer = kwargs['ignore_loganalyzer']

--- a/tests/common/plugins/loganalyzer/utils.py
+++ b/tests/common/plugins/loganalyzer/utils.py
@@ -1,0 +1,29 @@
+from functools import wraps
+
+
+def ignore_loganalyzer(func):
+    @wraps(func)
+    def decorated(*args, **kwargs):
+        # try to fetch loganalyzer instance from kwargs
+        # if ignore_loganalyzer is not passed, do nothing but execute the decorated funtion
+        # if ignore_loganalyzer is passed, to avoid 'unexpected keyword argument error',
+        # delete the ignore_loganalyzer from kwargs so that it would not be passed to the decorated function
+        # and set ignore_loganalyzer markers before and after the decorated function on all log analyzer instances.
+        loganalyzer = None
+        if 'ignore_loganalyzer' in kwargs and kwargs['ignore_loganalyzer'] is not None:
+            loganalyzer = kwargs['ignore_loganalyzer']
+            kwargs.pop('ignore_loganalyzer')
+
+        if loganalyzer:
+            for _, dut_loganalyzer in loganalyzer.items():
+                dut_loganalyzer.add_start_ignore_mark()
+
+        res = func(*args, **kwargs)
+
+        if loganalyzer:
+            for _, dut_loganalyzer in loganalyzer.items():
+                dut_loganalyzer.add_end_ignore_mark()
+
+        return res
+
+    return decorated

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -47,7 +47,7 @@ def ignore_expected_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_host
 
 
 @pytest.fixture(scope="function")
-def reload_testbed_on_failed(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+def reload_testbed_on_failed(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
     """
         Reload dut after test function finished
     """
@@ -56,8 +56,7 @@ def reload_testbed_on_failed(request, duthosts, enum_rand_one_per_hwsku_frontend
     if request.node.rep_call.failed:
         # if test case failed, means bgp session down or port channel status not recovered, execute config reload
         logging.info("Reloading config and restarting swss...")
-        config_reload(duthost)
-        wait_critical_processes(duthost)
+        config_reload(duthost, safe_reload=True, ignore_loganalyzer=loganalyzer)
 
 
 def test_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, tbinfo):

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -11,7 +11,6 @@ from ptf import testutils, mask, packet
 from tests.common import config_reload
 import ipaddress
 
-from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.voq.voq_helpers import verify_no_routes_from_nexthop


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. Enhance log analyzer to support ignoring syslog temporarily by setting ignore markers
2. Provide a new decorator to ignore all the syslog during the decorated function elegantly
3. Ignore the syslog during config_reload

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Loganalyzer captures all the syslog in our test session, and raise exception whenever an unexpected err log is found.
Sometimes a config_reload is required during the test case, a config_reload would raise some err log which is expected and acceptable, but the err log significantly misleads the loganalyzer.
So we need a mechanism in loganalyzer to be muted temporarily.
#### How did you do it?
1. Enhance log analyzer to support ignoring syslog temporarily by setting ignore markers
2. Provide a new decorator to ignore all the syslog during the decorated function elegantly
3. Ignore the syslog during config_reload
#### How did you verify/test it?
Run on physical testbeds, it works as expected.

