### PR TITLE
Revert add timestamp to report xml file and changes in junit xml parser

### DIFF
--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -76,16 +76,6 @@ REQUIRED_TESTCASE_ATTRIBUTES = [
     "name",
     "time",
 ]
-
-# Fields found in the testcase/properties section of the JUnit XML file.
-# FIXME: These are specific to pytest, needs to be extended to support spytest.
-TESTCASE_PROPERTIES_TAG = "properties"
-TESTCASE_PROPERTY_TAG = "property"
-REQUIRED_TESTCASE_PROPERTIES = [
-    "start",
-    "end",
-]
-
 REQUIRED_TESTCASE_JSON_FIELDS = ["result", "error", "summary"]
 
 
@@ -282,38 +272,6 @@ def _validate_test_metadata(root):
     if set(seen_properties) < set(REQUIRED_METADATA_PROPERTIES):
         raise JUnitXMLValidationError("missing metadata element(s)")
 
-def _validate_test_case_properties(root):
-    testcase_properties_element = root.find(TESTCASE_PROPERTIES_TAG)
-
-    if not testcase_properties_element:
-        return
-
-    seen_testcase_properties = []
-    for testcase_prop in testcase_properties_element.iterfind(TESTCASE_PROPERTY_TAG):
-        testcase_property_name = testcase_prop.get("name", None)
-
-        if not testcase_property_name:
-            continue
-
-        if testcase_property_name not in REQUIRED_TESTCASE_PROPERTIES:
-            continue
-
-        if testcase_property_name in seen_testcase_properties:
-            raise JUnitXMLValidationError(
-                f"duplicate metadata element: {testcase_property_name} seen more than once"
-            )
-
-        testcase_property_value = testcase_prop.get("value", None)
-
-        if testcase_property_value is None:  # Some fields may be empty
-            raise JUnitXMLValidationError(
-                f'invalid metadata element: no "value" field provided for {testcase_property_name}'
-            )
-
-        seen_testcase_properties.append(testcase_property_name)
-
-    if set(seen_testcase_properties) < set(REQUIRED_TESTCASE_PROPERTIES):
-        raise JUnitXMLValidationError("missing testcase property element(s)")
 
 def _validate_test_cases(root):
     def _validate_test_case(test_case):
@@ -323,7 +281,6 @@ def _validate_test_cases(root):
                     f'"{attribute}" not found in test case '
                     f"\"{test_case.get('name', 'Name Not Found')}\""
                 )
-        _validate_test_case_properties(test_case)
 
     cases = root.findall(TESTCASE_TAG)
 
@@ -395,18 +352,6 @@ def _parse_test_metadata(root):
 
     return test_result_metadata
 
-def _parse_testcase_properties(root):
-    testcase_properties_element = root.find(TESTCASE_PROPERTIES_TAG)
-
-    if not testcase_properties_element:
-        return {}
-
-    testcase_properties = {}
-    for testcase_prop in testcase_properties_element.iterfind(TESTCASE_PROPERTY_TAG):
-        if testcase_prop.get("value"):
-            testcase_properties[testcase_prop.get("name")] = testcase_prop.get("value")
-
-    return testcase_properties
 
 def _parse_test_cases(root):
     test_case_results = defaultdict(list)
@@ -420,10 +365,6 @@ def _parse_test_cases(root):
 
         for attribute in REQUIRED_TESTCASE_ATTRIBUTES:
             result[attribute] = test_case.get(attribute)
-        for attribute in REQUIRED_TESTCASE_PROPERTIES:
-            testcase_properties = _parse_testcase_properties(test_case)
-            if attribute in testcase_properties:
-                result[attribute] = testcase_properties[attribute]
 
         # NOTE: "if failure" and "if error" does not work with the ETree library.
         failure = test_case.find("failure")
@@ -597,7 +538,7 @@ def _validate_json_cases(test_result_json):
         raise TestResultJSONValidationError("test_cases section not found in provided JSON file")
 
     def _validate_test_case(test_case):
-        for attribute in REQUIRED_TESTCASE_ATTRIBUTES + REQUIRED_TESTCASE_JSON_FIELDS + REQUIRED_TESTCASE_PROPERTIES:
+        for attribute in REQUIRED_TESTCASE_ATTRIBUTES + REQUIRED_TESTCASE_JSON_FIELDS:
             if attribute not in test_case:
                 raise TestResultJSONValidationError(
                     f'"{attribute}" not found in test case '

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -710,14 +710,6 @@ def tag_test_report(request, pytestconfig, tbinfo, duthost, record_testsuite_pro
     record_testsuite_property("hwsku", duthost.facts["hwsku"])
     record_testsuite_property("os_version", duthost.os_version)
 
-def pytest_runtest_setup(item):
-    # Add start timestamp of testcase
-    item.user_properties.append(("start", datetime.utcnow()))
-
-def pytest_runtest_teardown(item):
-    # Add end timestamp of testcase
-    item.user_properties.append(("end", datetime.utcnow()))
-
 
 @pytest.fixture(scope="module", autouse=True)
 def clear_neigh_entries(duthosts, tbinfo):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
We found some issues in nightly and smoke test because of adding timestamp and changing in junit xml parser:
1)Some xml report didn't contain "start" but contain "end"
2)Test will fail if xml and json files do not contain "start" and "end"
#### How did you do it?
Revert changes and fix
#### How did you verify/test it?
Run a test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
