### PR TITLE
[tests/ecmp/inner_hashing] Add config_reload to restore test environment

### DIFF
--- a/tests/ecmp/inner_hashing/conftest.py
+++ b/tests/ecmp/inner_hashing/conftest.py
@@ -10,6 +10,7 @@ from datetime import datetime
 import pytest
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory, change_mac_addresses   # lgtm[py/unused-import]
+from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)
 
@@ -121,6 +122,20 @@ def setup(duthosts, rand_one_dut_hostname):
     duthost.shell("docker cp {} swss:/vxlan.switch.json".format(DUT_VXLAN_PORT_JSON_FILE))
     duthost.shell("docker exec swss sh -c \"swssconfig /vxlan.switch.json\"")
     time.sleep(3)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def teardown(duthosts, rand_one_dut_hostname):
+    """
+    Teardown fixture to clean up DUT to initial state
+
+    Args:
+        duthosts: All DUTs objects belonging to the testbed
+        rand_one_dut_hostname: Hostname of a random chosen dut to run test
+    """
+    yield
+    duthost = duthosts[rand_one_dut_hostname]
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
 
 @pytest.fixture(scope='module', autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add module level config reload in case it break test env.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
