### PR TITLE
[Mellanox]Get a valid mac adderss for Mellanox switch in test_host_vlan

### DIFF
--- a/tests/vlan/test_host_vlan.py
+++ b/tests/vlan/test_host_vlan.py
@@ -63,12 +63,30 @@ def verify_host_port_vlan_membership(duthosts, rand_one_dut_hostname, testbed_pa
         if vlan_member_port not in bridge_vlan_host_ports:
             raise ValueError("Port %s not in host bridge VLAN %s" % (vlan_member_port, vlan_id))
 
+def get_new_vlan_intf_mac_mellanox(dut_vlan_intf_mac):
+    '''
+        Get a new dut vlan interface mac address for Mellanox dut
+        Args:
+            dut_vlan_intf_mac: the original mac address of the switch
+        Returns:
+            new_dut_vlan_intf_mac: the new mac address
+    '''
+    dut_vlan_intf_mac_last_octet = dut_vlan_intf_mac.split(':')[-1]
+    # Get a different mac address under the same mac prefix, flap the bits in the last octet
+    new_dut_vlan_intf_mac_last_octet = hex(int(dut_vlan_intf_mac_last_octet, 16) ^ 255).strip('0x')
+    new_dut_vlan_intf_mac = dut_vlan_intf_mac.split(':')
+    new_dut_vlan_intf_mac[-1] = new_dut_vlan_intf_mac_last_octet
+    new_dut_vlan_intf_mac = ':'.join(new_dut_vlan_intf_mac)
+    return new_dut_vlan_intf_mac
 
 @pytest.fixture(scope="module")
 def setup_host_vlan_intf_mac(duthosts, rand_one_dut_hostname, testbed_params, verify_host_port_vlan_membership):
     vlan_intf, _ = testbed_params
     duthost = duthosts[rand_one_dut_hostname]
     dut_vlan_mac = duthost.get_dut_iface_mac('%s' % vlan_intf["attachto"])
+    # There is a restriction in configuring interface mac address on Mellanox asics, assign a valid value for the vlan interface mac address
+    if duthost.get_facts()['asic_type'] == 'mellanox':
+        DUT_VLAN_INTF_MAC = get_new_vlan_intf_mac_mellanox(dut_vlan_mac)
     duthost.shell('redis-cli -n 4 hmset "VLAN|%s" mac %s' % (vlan_intf["attachto"], DUT_VLAN_INTF_MAC))
     wait_until(10, 2, 2, lambda: duthost.get_dut_iface_mac(vlan_intf["attachto"]) == DUT_VLAN_INTF_MAC)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The host vlan test now configures a new mac address(00:11:22:33:44:55) other than the switch mac on a vlan interface. 
But for Mellanox asics, there is a restriction that we don't support this kind of mac address, because this address is not under the same prefix(36-38 bits) of the switch mac. 
So need to add a new logic to get a valid mac address for the vlan interface on Mellanox duts.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Run host vlan test successfully on Mellanox asics.
#### How did you do it?
Adding a new logic, if the asic is Mellanox, flap the bits in the last octet to generate a new mac address for the test instead of "00:11:22:33:44:55".
#### How did you verify/test it?
Run test on spc1/spc2/spc3 duts, all passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
