### PR TITLE
Fixing the documentation for scale run with VxLAN ECMP script and checking we have enough nexthops for ECMP requirements.

### DIFF
--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -10,9 +10,9 @@
     To test ECMP with 2 paths per destination:
     ./run_tests.sh -n ucs-m5-2 -d mth64-m5-2 -O -u -e -s -e --disable_loganalyzer -m individual -p /home/vxr/vxlan/logs/    -c 'vxlan/test_vxlan_ecmp.py' -e '--nhs_per_destination=2'
 
-    To test ECMP+Scale:
-    ./run_tests.sh -n ucs-m5-2 -d mth64-m5-2 -O -u -e -s -e --disable_loganalyzer -m individual -p /home/vxr/vxlan/logs/    -c 'vxlan/test_vxlan_ecmp.py' \
-                    -e '--ecmp_nhs_per_destination=128' -e '--total_number_of_nexthops=128000'
+    To test ECMP+Scale(for all 4 types of encap):
+    ./run_tests.sh -n ucs-m5-2 -d mth64-m5-2 -O -u -e -s -e --disable_loganalyzer -m individual -p /home/vxr/vxlan/logs/    -c  'vxlan/test_vxlan_ecmp.py::Test_VxLAN_route_tests::test_vxlan_single_endpoint' \
+                    -e '--ecmp_nhs_per_destination=128' -e '--total_number_of_nexthops=32000' -e '--total_number_of_endpoints=1024'
 
     To keep the temporary config files created in the DUT:
     ./run_tests.sh -n ucs-m5-2 -d mth64-m5-2 -O -u -e -s -e --keep_temp_files -c 'vxlan/test_vxlan_ecmp.py'
@@ -22,7 +22,7 @@
         debug_enabled               : Enable debug mode, for debugging script. The temp files will not have timestamped names. Default: False
         dut_hostid                  : An integer in the range of 1 - 100 to be used as the host part of the IP address for DUT. Default: 1
         ecmp_nhs_per_destination    : Number of ECMP next-hops per destination.
-        total_number_of_endpoints : Number of Endpoints (a pool of this number of ip addresses will used for next-hops).
+        total_number_of_endpoints   : Number of Endpoints (a pool of this number of ip addresses will used for next-hops). Default:2
         total_number_of_nexthops    : Maximum number of all nexthops for every destination combined(per encap_type).
         vxlan_port                                : Global vxlan port (UDP port) to be used for the DUT. Default: 4789
 '''
@@ -367,6 +367,10 @@ def create_vnet_routes(duthost, vnet_list, dest_af, nh_af, nhs_per_destination=1
             nhs_per_destination                    : Number of ECMP nexthops to use per destination.
             number_of_ecmp_nhs                     : Maximum number of all NextHops put together(for all destinations).
     '''
+    if number_of_available_nexthops < nhs_per_destination:
+        raise RuntimeError("The number of available nexthops ip addresses is not enough to cover even one destination." \
+                           "Pls rerun with total_number_of_endpoints({}) > ecmp_nhs_per_destination({})".format(number_of_available_nexthops, nhs_per_destination))
+
     available_nexthops = get_list_of_nexthops(number=number_of_available_nexthops, af=nh_af, prefix=nexthop_prefix)
 
     number_of_destinations = int(number_of_ecmp_nhs / nhs_per_destination)


### PR DESCRIPTION
Addressing [5860]. The issue was that the documentation was wrong for scale run.
And added an error check if the user gives lesser number of nexthops than required.

If run without meeting the required criteria, we get an error:
            raise RuntimeError("The number of available nexthops ip addresses is not enough to cover even one destination." \
>                              "Pls rerun with total_number_of_endpoints({}) > ecmp_nhs_per_destination({})".format(number_of_available_nexthops, nhs_per_destination))
E           RuntimeError: The number of available nexthops ip addresses is not enough to cover even one destination.Pls rerun with total_number_of_endpoints(2) > ecmp_nhs_per_destination(128)

