### PR TITLE
[vm_topology]: Fixing split multiple times at retry stage

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -1221,10 +1221,12 @@ class VMTopology(object):
             str: Output of the command.
         """
 
+        cmdline_ori = cmdline
+        grep_cmd_ori= grep_cmd
         for attempt in range(retry):
             logging.debug('*** CMD: %s, grep: %s, attempt: %d' % (cmdline, grep_cmd, attempt+1))
             if split_cmd:
-                cmdline = shlex.split(cmdline)
+                cmdline = shlex.split(cmdline_ori)
             process = subprocess.Popen(
                 cmdline,
                 stdin=subprocess.PIPE,
@@ -1233,7 +1235,7 @@ class VMTopology(object):
                 shell=shell)
             if grep_cmd:
                 if split_cmd:
-                    grep_cmd = shlex.split(grep_cmd)
+                    grep_cmd = shlex.split(grep_cmd_ori)
                 process_grep = subprocess.Popen(
                     grep_cmd,
                     stdin=process.stdout,


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
In the first time, the `cmdline` or `grep_cmd` has been split to a list, but at the retry stage, the list object will be applied `split` operation again so that get the following error.
```
'list' object has no attribute 'read'
```
#### How did you do it?
Use another variables to record the original variables.
#### How did you verify/test it?
Check Azp.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
