### PR TITLE
Fix the fib hash testing on dualtor testbed

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -79,7 +79,7 @@ class HashTest(BaseTest):
         self.balancing_test_times = self.test_params.get('balancing_test_times', self.BALANCING_TEST_TIMES)
 
         self.ignore_ttl = self.test_params.get('ignore_ttl', False)
-        self.single_fib = self.test_params.get('single_fib_for_duts', False)
+        self.single_fib = self.test_params.get('single_fib_for_duts', 'multiple-fib')
 
         # set the base mac here to make it persistent across calls of check_ip_route
         self.base_mac = self.dataplane.get_mac(*random.choice(list(self.dataplane.ports.keys())))
@@ -87,10 +87,10 @@ class HashTest(BaseTest):
     def get_src_and_exp_ports(self, dst_ip):
         while True:
             src_port = int(random.choice(self.src_ports))
-            if self.single_fib:
-                active_dut_index = 0
-            else:
+            if self.single_fib == "multiple-fib":
                 active_dut_index = self.ptf_test_port_map[str(src_port)]['target_dut']
+            else:
+                active_dut_index = 0
             next_hop = self.fibs[active_dut_index][dst_ip]
             exp_port_list = next_hop.get_next_hop_list()
             if src_port in exp_port_list:
@@ -113,10 +113,10 @@ class HashTest(BaseTest):
         ports = list(set(self.src_ports) - set(exp_port_list))
         filtered_ports = []
         for port in ports:
-            if self.single_fib:
-                active_dut_index = 0
-            else:
+            if self.single_fib == "multiple-fib":
                 active_dut_index = self.ptf_test_port_map[str(port)]['target_dut']
+            else:
+                active_dut_index = 0
             next_hop = self.fibs[active_dut_index][dst_ip]
             possible_exp_port_list = next_hop.get_next_hop_list()
             if possible_exp_port_list == exp_port_list:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The fib hash testing is broken on dualtor testbed.

PR https://github.com/Azure/sonic-mgmt/pull/5456 updated the return
value of fixture `single_fib_for_duts`. It is no longer just True of False. The
new value will be different strings.

The fib_test.py ptf script has been updated for this change. However, the
hash_test.py ptf script was not.

#### How did you do it?
This change udpated the fib_test.py script accordingly. Now the fib hash
testing can pass on dualtor testbed.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
