### PR TITLE
Revert "loganalyzer ignore"

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -143,5 +143,3 @@ r, ".*ERR syncd[0-9]*#syncd.*updateSupportedBufferPoolCounters.*BUFFER_POOL_WATE
 
 # https://dev.azure.com/msazure/One/_workitems/edit/14482841
 r, ".* ERR dhcp_relay#dhcpmon.*Invalid number of interfaces, downlink/south 1, uplink/north 0.*"
-
-r, ".* ERR monit.* Expected containers not running: acms.*"


### PR DESCRIPTION
Reverts Azure/sonic-mgmt#5819

No longer needed. Image fix is in.