### PR TITLE
[nic_simulator] Correct port id mapping for upper/lower ToR

### DIFF
--- a/ansible/dualtor/nic_simulator/nic_simulator.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator.py
@@ -324,12 +324,12 @@ class OVSBridge(object):
         self._init_ports()
         self._init_flows()
         self.states_getter = {
-            0: self.upstream_ecmp_flow.get_upper_tor_forwarding_state,
-            1: self.upstream_ecmp_flow.get_lower_tor_forwarding_state
+            1: self.upstream_ecmp_flow.get_upper_tor_forwarding_state,
+            0: self.upstream_ecmp_flow.get_lower_tor_forwarding_state
         }
         self.states_setter = {
-            0: self.upstream_ecmp_flow.set_upper_tor_forwarding_state,
-            1: self.upstream_ecmp_flow.set_lower_tor_forwarding_state
+            1: self.upstream_ecmp_flow.set_upper_tor_forwarding_state,
+            0: self.upstream_ecmp_flow.set_lower_tor_forwarding_state
         }
 
     def _init_ports(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
port id 1 should be mapped to the upper ToR while port id 0 should be the lower ToR.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Correct the port id mapping.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
