### PR TITLE
[Mellanox]Fix the cpu core number for 4600c in platform info thermal test

### DIFF
--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -555,7 +555,7 @@ SWITCH_MODELS = {
         "thermals": {
             "cpu_core": {
                 "start": 0,
-                "number": 2
+                "number": 4
             },
             "module": {
                 "start": 1,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
4600C was using wrong thermal profile and it displays 2 CPU core thermal in show platform temperature output, there should be 4 CPU core thermal. The PR in sonic-buildimage has fixed this: https://github.com/Azure/sonic-buildimage/pull/10258
The sonic-mgmt platform thermal test should also be fixed to align with the output change.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Fix cpu core number for 4600c in platform info thermal test.
#### How did you do it?
Correcting the thermal cpu core number for 4600c to 4 in  tests/common/mellanox_data.py.
#### How did you verify/test it?
Run test case in master and 202012 branch on 4600c by automation, all passed.
#### Any platform specific information?
The change is only for 4600c.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
