### PR TITLE
Fix ptf log and pcap file can't be fetch issue

### DIFF
--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -9,14 +9,13 @@ logger = logging.getLogger(__name__)
 def ptf_collect(host, log_file):
     pos = log_file.rfind('.')
     filename_prefix = log_file[0:pos] if pos > -1 else log_file
-    rename_prefix = filename_prefix.replace('/tmp/', '')
 
-    host.fetch(src=log_file, dest='./logs/ptf_collect/' + rename_prefix + '.' + str(datetime.utcnow()) + '.log', flat=True, fail_on_missing=False)
+    host.fetch(src=log_file, dest='./logs/ptf_collect/' + filename_prefix + '.' + str(datetime.utcnow()) + '.log', flat=True, fail_on_missing=False)
 
     pcap_file = filename_prefix + '.pcap'
     output = host.shell("[ -f {} ] && echo exist || echo null".format(pcap_file))['stdout']
     if output == 'exist':
-        host.fetch(src=pcap_file, dest='./logs/ptf_collect/' + rename_prefix + '.' + str(datetime.utcnow()) + '.pcap', flat=True, fail_on_missing=False)
+        host.fetch(src=pcap_file, dest='./logs/ptf_collect/' + filename_prefix + '.' + str(datetime.utcnow()) + '.pcap', flat=True, fail_on_missing=False)
 
 def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                platform="remote", qlen=0, relax=True, debug_level="info",

--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -10,12 +10,15 @@ def ptf_collect(host, log_file):
     pos = log_file.rfind('.')
     filename_prefix = log_file[0:pos] if pos > -1 else log_file
 
-    host.fetch(src=log_file, dest='./logs/ptf_collect/' + filename_prefix + '.' + str(datetime.utcnow()) + '.log', flat=True, fail_on_missing=False)
+    pos = log_file.rfind('/') + 1
+    rename_prefix = log_file[pos:] if pos > 0 else log_file
+
+    host.fetch(src=log_file, dest='./logs/ptf_collect/' + rename_prefix + '.' + str(datetime.utcnow()) + '.log', flat=True, fail_on_missing=False)
 
     pcap_file = filename_prefix + '.pcap'
     output = host.shell("[ -f {} ] && echo exist || echo null".format(pcap_file))['stdout']
     if output == 'exist':
-        host.fetch(src=pcap_file, dest='./logs/ptf_collect/' + filename_prefix + '.' + str(datetime.utcnow()) + '.pcap', flat=True, fail_on_missing=False)
+        host.fetch(src=pcap_file, dest='./logs/ptf_collect/' + rename_prefix + '.' + str(datetime.utcnow()) + '.pcap', flat=True, fail_on_missing=False)
 
 def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                platform="remote", qlen=0, relax=True, debug_level="info",

--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -1,17 +1,22 @@
 import pipes
 import traceback
 import logging
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
 
 def ptf_collect(host, log_file):
-    host.fetch(src=log_file, dest='./logs/ptf_collect/', flat=True, fail_on_missing=False)
     pos = log_file.rfind('.')
-    pcap_file = (log_file[0:pos] if pos > -1 else log_file) + '.pcap'
+    filename_prefix = log_file[0:pos] if pos > -1 else log_file
+    rename_prefix = filename_prefix.replace('/tmp/', '')
+
+    host.fetch(src=log_file, dest='./logs/ptf_collect/' + rename_prefix + '.' + str(datetime.utcnow()) + '.log', flat=True, fail_on_missing=False)
+
+    pcap_file = filename_prefix + '.pcap'
     output = host.shell("[ -f {} ] && echo exist || echo null".format(pcap_file))['stdout']
     if output == 'exist':
-        host.fetch(src=pcap_file, dest='./logs/ptf_collect/', flat=True, fail_on_missing=False)
+        host.fetch(src=pcap_file, dest='./logs/ptf_collect/' + rename_prefix + '.' + str(datetime.utcnow()) + '.pcap', flat=True, fail_on_missing=False)
 
 def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                platform="remote", qlen=0, relax=True, debug_level="info",
@@ -53,7 +58,6 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
 
     if log_file:
         cmd += " --log-file {}".format(log_file)
-        ptf_collect(host, log_file)
 
     if socket_recv_size:
         cmd += " --socket-recv-size {}".format(socket_recv_size)
@@ -70,10 +74,14 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
 
     try:
         result = host.shell(cmd, chdir="/root", module_ignore_errors=module_ignore_errors)
+        if log_file:
+            ptf_collect(host, log_file)
         if module_ignore_errors:
             if result["rc"] != 0:
                 return result
     except Exception:
+        if log_file:
+            ptf_collect(host, log_file)
         traceback_msg = traceback.format_exc()
         logger.error("Exception caught while executing case: {}. Error message: {}"\
             .format(testname, traceback_msg))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
1. ptf collect cannot fetch log and pcap file because it excute before
log file generate
2. new log and pcap files will cover old files if filenames are the same
defined in testcases
#### How did you do it?
1. fetch after log and pcap files generate whether test fails or not
2. add timestamp to filename in docker, and files in ptf will not be
changed
#### How did you verify/test it?
Run a test which would call ptf runner
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
