### PR TITLE
[GCU] Improve GCU test from invalid initial config

### DIFF
--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -67,7 +67,7 @@ def reset_and_restore_test_environment(duthosts, rand_one_dut_hostname):
     duthost.shell("cp {} {}".format(CONFIG_DB, CONFIG_DB_BACKUP))
 
     if output['rc'] or "Patch applied successfully" not in output['stdout']:
-        logger.info("Current Config cannot pass Yang. Reset configDB: {}."
+        logger.info("Running config failed SONiC Yang validation. Reload minigraph. config: {}"
                     .format(output['stdout']))
         config_reload(duthost, config_source="minigraph", safe_reload=True)
 

--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -1,72 +1,99 @@
 import pytest
+import logging
 
 from tests.common.utilities import skip_release
+from tests.common.config_reload import config_reload
 from tests.generic_config_updater.gu_utils import apply_patch
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile
 
-@pytest.fixture(autouse=True)
-def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
-    """
-       Ignore expected yang validation failure during test execution
+CONFIG_DB = "/etc/sonic/config_db.json"
+CONFIG_DB_BACKUP = "/etc/sonic/config_db.json.before_gcu_test"
 
-       GCU will try several sortings of JsonPatch until the sorting passes yang validation
+logger = logging.getLogger(__name__)
 
-       Args:
-           loganalyzer: Loganalyzer utility fixture
-    """
-    # When loganalyzer is disabled, the object could be None
-    if loganalyzer:
-         ignoreRegex = [
-             ".*ERR sonic_yang.*",
-             ".*ERR.*Failed to start dhcp_relay container.*", # Valid test_dhcp_relay
-             ".*ERR GenericConfigUpdater: Service Validator: Service has been reset.*", # Valid test_dhcp_relay test_syslog
-             ".*ERR teamd[0-9].*get_dump: Can't get dump for LAG.*", # Valid test_portchannel_interface
-             ".*ERR swss[0-9]*#intfmgrd: :- setIntfVrf:.*", # Valid test_portchannel_interface
-             ".*ERR swss[0-9]*#orchagent.*removeLag.*", # Valid test_portchannel_interface
-             ".*ERR kernel.*Reset adapter.*", # Valid test_portchannel_interface replace mtu
-             ".*ERR swss[0-9]*#orchagent: :- getPortOperSpeed.*", # Valid test_portchannel_interface replace mtu
 
-             # sonic-swss/orchagent/crmorch.cpp
-             ".*ERR swss[0-9]*#orchagent.*getResAvailableCounters.*", # test_monitor_config
-             ".*ERR swss[0-9]*#orchagent.*objectTypeGetAvailability.*", # test_monitor_config
-             ".*ERR dhcp_relay[0-9]*#dhcrelay.*", # test_dhcp_relay
-         ]
-         loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
-
-@pytest.fixture(scope="module", autouse=True)
-def check_image_version(duthost):
-    """Skips this test if the SONiC image installed on DUT is older than 202112
-
-    Args:
-        duthost: DUT host object.
-
-    Returns:
-        None.
-    """
-    skip_release(duthost, ["201811", "201911", "202012", "202106", "202111"])
-
+# Module Fixture
 @pytest.fixture(scope="module")
 def cfg_facts(duthosts, rand_one_dut_hostname):
     """
     Config facts for selected DUT
     Args:
         duthosts: list of DUTs.
-        rand_selected_dut: The fixture returns a randomly selected DuT.
+        rand_one_dut_hostname: Hostname of a random chosen dut
     """
     duthost = duthosts[rand_one_dut_hostname]
     return duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
 
 
 @pytest.fixture(scope="module", autouse=True)
-def verify_configdb_with_empty_input(duthost):
-    """Fail immediately if empty input test failure
+def check_image_version(duthosts, rand_one_dut_hostname):
+    """Skips this test if the SONiC image installed on DUT is older than 202111
 
     Args:
-        duthost: Hostname of DUT.
+        duthosts: list of DUTs.
+        rand_one_dut_hostname: Hostname of a random chosen dut
 
     Returns:
         None.
     """
+    duthost = duthosts[rand_one_dut_hostname]
+    skip_release(duthost, ["201811", "201911", "202012", "202106", "202111"])
+
+
+@pytest.fixture(scope="module", autouse=True)
+def reset_and_restore_test_environment(duthosts, rand_one_dut_hostname):
+    """Reset and restore test env if initial Config cannot pass Yang
+
+    Back up the existing config_db.json file and restore it once the test ends.
+
+    Args:
+        duthosts: list of DUTs.
+        rand_one_dut_hostname: Hostname of a random chosen dut
+
+    Returns:
+        None.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    json_patch = []
+    tmpfile = generate_tmpfile(duthost)
+
+    try:
+        output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+    finally:
+        delete_tmpfile(duthost, tmpfile)
+
+    logger.info("Backup {} to {} on {}".format(
+        CONFIG_DB, CONFIG_DB_BACKUP, duthost.hostname))
+    duthost.shell("cp {} {}".format(CONFIG_DB, CONFIG_DB_BACKUP))
+
+    if output['rc'] or "Patch applied successfully" not in output['stdout']:
+        logger.info("Current Config cannot pass Yang. Reset configDB: {}."
+                    .format(output['stdout']))
+        config_reload(duthost, config_source="minigraph", safe_reload=True)
+
+    yield
+
+    logger.info("Restore {} with {} on {}".format(
+        CONFIG_DB, CONFIG_DB_BACKUP, duthost.hostname))
+    duthost.shell("mv {} {}".format(CONFIG_DB_BACKUP, CONFIG_DB))
+
+    if output['rc'] or "Patch applied successfully" not in output['stdout']:
+        logger.info("Restore Config after GCU test.")
+        config_reload(duthost)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def verify_configdb_with_empty_input(duthosts, rand_one_dut_hostname):
+    """Fail immediately if empty input test failure
+
+    Args:
+        duthosts: list of DUTs.
+        rand_one_dut_hostname: Hostname of a random chosen dut
+
+    Returns:
+        None.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
     json_patch = []
     tmpfile = generate_tmpfile(duthost)
 
@@ -80,3 +107,37 @@ def verify_configdb_with_empty_input(duthost):
 
     finally:
         delete_tmpfile(duthost, tmpfile)
+
+
+# Function Fixture
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loganalyzer):
+    """
+       Ignore expected yang validation failure during test execution
+
+       GCU will try several sortings of JsonPatch until the sorting passes yang validation
+
+       Args:
+            duthosts: list of DUTs.
+            rand_one_dut_hostname: Hostname of a random chosen dut
+           loganalyzer: Loganalyzer utility fixture
+    """
+    # When loganalyzer is disabled, the object could be None
+    duthost = duthosts[rand_one_dut_hostname]
+    if loganalyzer:
+        ignoreRegex = [
+            ".*ERR sonic_yang.*",
+            ".*ERR.*Failed to start dhcp_relay container.*",  # Valid test_dhcp_relay
+            ".*ERR GenericConfigUpdater: Service Validator: Service has been reset.*",  # Valid test_dhcp_relay test_syslog
+            ".*ERR teamd[0-9].*get_dump: Can't get dump for LAG.*",  # Valid test_portchannel_interface
+            ".*ERR swss[0-9]*#intfmgrd: :- setIntfVrf:.*",  # Valid test_portchannel_interface
+            ".*ERR swss[0-9]*#orchagent.*removeLag.*",  # Valid test_portchannel_interface
+            ".*ERR kernel.*Reset adapter.*",  # Valid test_portchannel_interface replace mtu
+            ".*ERR swss[0-9]*#orchagent: :- getPortOperSpeed.*",  # Valid test_portchannel_interface replace mtu
+
+            # sonic-swss/orchagent/crmorch.cpp
+            ".*ERR swss[0-9]*#orchagent.*getResAvailableCounters.*",  # test_monitor_config
+            ".*ERR swss[0-9]*#orchagent.*objectTypeGetAvailability.*",  # test_monitor_config
+            ".*ERR dhcp_relay[0-9]*#dhcrelay.*",  # test_dhcp_relay
+        ]
+        loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)

--- a/tests/generic_config_updater/test_bgp_speaker.py
+++ b/tests/generic_config_updater/test_bgp_speaker.py
@@ -93,8 +93,10 @@ def setup_env(duthosts, rand_one_dut_hostname):
         logger.info("Rolled back to original checkpoint")
         rollback_or_reload(duthost)
         current_bgp_speaker_config = get_bgp_speaker_runningconfig(duthost)
-        pytest_assert(set(original_bgp_speaker_config) == set(current_bgp_speaker_config),
-            "bgp speaker config are not suppose to change after test"
+        pytest_assert(
+            set(original_bgp_speaker_config) == set(current_bgp_speaker_config),
+            "bgp speaker config are not suppose to change after test org: {}, cur: {}"
+            .format(original_bgp_speaker_config, current_bgp_speaker_config)
         )
     finally:
         delete_checkpoint(duthost)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Improve GCU nightly test when initial config is invalid
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
GCU required the ConfigDB to pass YANG validation. But previous failing test may leave invalid residue to ConfigDB.
This PR is to make GCU test coud be tested in this case.
#### How did you do it?
Check initial ConfigDB and reload with minigraph if it is invalid.
#### How did you verify/test it?
Run kvm test with config with YANG validation failed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
