### PR TITLE
[test_macsec]: neighbor to neighbor for EOS

### DIFF
--- a/tests/macsec/test_macsec.py
+++ b/tests/macsec/test_macsec.py
@@ -155,22 +155,38 @@ class TestDataPlane():
             assert portchannels[i]["members"]
             requester = upstream_links[portchannels[i]["members"][0]]
             # Set DUT as the gateway of requester
-            requester["host"].shell("ip route add 0.0.0.0/0 via {}".format(
-                requester["peer_ipv4_addr"]), module_ignore_errors=True)
+            if isinstance(requester["host"], EosHost):
+                requester["host"].eos_config(lines=["ip route 0.0.0.0/0 {}".format(
+                    requester["peer_ipv4_addr"])], module_ignore_errors=True)
+            else:
+                requester["host"].shell("ip route add 0.0.0.0/0 via {}".format(
+                    requester["peer_ipv4_addr"]), module_ignore_errors=True)
             for j in range(i + 1, len(portchannels)):
                 if portchannels[i]["members"][0] not in ctrl_links and portchannels[j]["members"][0] not in ctrl_links:
                     continue
                 responser = upstream_links[portchannels[j]["members"][0]]
                 # Set DUT as the gateway of responser
-                responser["host"].shell("ip route add 0.0.0.0/0 via {}".format(
-                    responser["peer_ipv4_addr"]), module_ignore_errors=True)
+                if isinstance(responser["host"], EosHost):
+                    responser["host"].eos_config(lines=["ip route 0.0.0.0/0 {}".format(
+                        responser["peer_ipv4_addr"])], module_ignore_errors=True)
+                else:
+                    responser["host"].shell("ip route add 0.0.0.0/0 via {}".format(
+                        responser["peer_ipv4_addr"]), module_ignore_errors=True)
                 # Ping from requester to responser
                 assert not requester["host"].shell(
                     "ping -c 6 -v {}".format(responser["local_ipv4_addr"]))["failed"]
-                responser["host"].shell("ip route del 0.0.0.0/0 via {}".format(
-                    responser["peer_ipv4_addr"]), module_ignore_errors=True)
-            requester["host"].shell("ip route del 0.0.0.0/0 via {}".format(
-                requester["peer_ipv4_addr"]), module_ignore_errors=True)
+                if isinstance(responser["host"], EosHost):
+                    responser["host"].eos_config(lines=["no ip route 0.0.0.0/0 {}".format(
+                        responser["peer_ipv4_addr"])], module_ignore_errors=True)
+                else:
+                    responser["host"].shell("ip route del 0.0.0.0/0 via {}".format(
+                        responser["peer_ipv4_addr"]), module_ignore_errors=True)
+            if isinstance(requester["host"], EosHost):
+                requester["host"].eos_config(lines=["no ip route 0.0.0.0/0 {}".format(
+                    requester["peer_ipv4_addr"])], module_ignore_errors=True)
+            else:
+                requester["host"].shell("ip route del 0.0.0.0/0 via {}".format(
+                    requester["peer_ipv4_addr"]), module_ignore_errors=True)
 
 
 class TestFaultHandling():


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The neighbor to neighbor test of MACsec cannot adapt to EOS as neighbor. This PR is for adapting EOS topology.

#### How did you do it?
Use EOS commands to configure the route.

#### How did you verify/test it?
Check Azp status.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
