### PR TITLE
Modified code to discount PSU voltage value after turn-off

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -651,7 +651,7 @@ def _check_psu_status_after_power_off(duthost, localhost, creds_all_duts):
                 sensor_oid = expect_oid + DEVICE_TYPE_POWER_MONITOR + sensor_tuple[2]
                 # entity_sensor_mib_info is only supported in image newer than 202012
                 if sensor_oid in entity_mib_info:
-                    if psu_info['current'] == '0.0' and psu_info['voltage'] == '0.0' and psu_info['power'] == '0.0':
+                    if psu_info['current'] == '0.0' and psu_info['power'] == '0.0':
                         power_off_psu_found = True
                         break
                 if is_sensor_test_supported(duthost):


### PR DESCRIPTION
### Description of PR

Since each vendor's implementation is different, the PSU's voltage value may be non-zero after shutdown. Additionally, the voltage might be non-zero for a few minutes even after shutdown on account of capacitor physics, i.e. slowly discharging current and bringing the voltage to zero. Accounting for these discrepancies, and seeing as current flow is a much better indictor of the state of the PSU anyway, voltage value is disregarded in making a decision about the power-state of the PSU.

Summary:
Fixes # [(issue)](https://msazure.visualstudio.com/One/_workitems/edit/13865185/)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Fixes snmp.test_snmp_phy_entity.test_turn_off_psu_and_check_psu_info on the following devices:

vms28-t1-8102-02
vms7-t0-dx010-5
vms20-t1-dx010-6
vms21-t1-z9332f-01
vms20-t0-7050cx3-1

#### How did you do it?
Modified test to disregard voltage value of PSU after shut-off

#### How did you verify/test it?
Ran the aforementioned test on the devices mentioned above and ensured that they passed.

