### PR TITLE
Remove key "router_macs" in test_decap.py.

### DIFF
--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -211,7 +211,6 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url, set_mu
                             "inner_ipv6": setup_info["inner_ipv6"],
                             "lo_ips": setup_info["lo_ips"],
                             "lo_ipv6s": setup_info["lo_ipv6s"],
-                            "router_macs": setup_info["router_macs"],
                             "ttl_mode": ttl_mode,
                             "dscp_mode": dscp_mode,
                             "ignore_ttl": setup_info["ignore_ttl"],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The key `router_macs` is not defined in fixture `setup_teardown`, and it will case an error. In `master` branch, we no more need this key, so remove it. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The key `router_macs` is not defined in fixture `setup_teardown`, and it will case an error. In `master` branch, we no more need this key, so remove it. 

#### How did you do it?
Remove the key `router_macs` in `ptf_runner` in `test_decap.py`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
