### PR TITLE
Restart swss after injecting `DualToR` subtype

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1455,7 +1455,8 @@ Totals               6450                 6449
         elif ("Broadcom Limited Device b850" in output or
               "Broadcom Limited Broadcom BCM56850" in output):
             asic = "td2"
-        elif "Broadcom Limited Device b870" in output:
+        elif ("Broadcom Limited Device b870" in output or 
+                "Broadcom Inc. and subsidiaries Device b870" in output):
             asic = "td3"
         elif "Broadcom Limited Device b980" in output:
             asic = "th3"

--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -343,8 +343,10 @@ def apply_peer_switch_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mo
     cmd = 'redis-cli -n 4 HSET "{}" "{}" "{}"'.format(device_meta_key, 'subtype', 'DualToR')
     dut.shell(cmd=cmd)
     if dut.get_asic_name() in ['th2', 'td3']:
-        # Restart swss on TH2 or TD3 platform to regenerate config.bcm
-        logger.info("Restarting swss service")
+        # Restart swss on TH2 or TD3 platform to trigger syncd restart to regenerate config.bcm
+        # We actually need to restart syncd only, but restarting syncd will also trigger swss
+        # being restarted, and it costs more time than restarting swss
+        logger.info("Restarting swss service to regenerate config.bcm")
         dut.shell('systemctl restart swss')
         time.sleep(120)
 

--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -340,12 +340,19 @@ def apply_peer_switch_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mo
     peer_switch_key = 'PEER_SWITCH|{}'.format(peer_switch_hostname)
     device_meta_key = 'DEVICE_METADATA|localhost'
 
+    cmd = 'redis-cli -n 4 HSET "{}" "{}" "{}"'.format(device_meta_key, 'subtype', 'DualToR')
+    dut.shell(cmd=cmd)
+    if dut.get_asic_name() in ['th2', 'td3']:
+        # Restart swss on TH2 or TD3 platform to regenerate config.bcm
+        logger.info("Restarting swss service")
+        dut.shell('systemctl restart swss')
+        time.sleep(120)
+
     cmds = ['redis-cli -n 4 HSET "{}" "address_ipv4" "{}"'.format(peer_switch_key, mock_peer_switch_loopback_ip.ip),
-            'redis-cli -n 4 HSET "{}" "{}" "{}"'.format(device_meta_key, 'subtype', 'DualToR'),
             'redis-cli -n 4 HSET "{}" "{}" "{}"'.format(device_meta_key, 'peer_switch', peer_switch_hostname)]
     dut.shell_cmds(cmds=cmds)
-    if dut.get_asic_name() == 'th2':
-        # Restart swss on TH2 platform
+    if dut.get_asic_name() in ['th2', 'td3']:
+        # Restart swss on TH2 or TD3 platform to apply changes
         logger.info("Restarting swss service")
         dut.shell('systemctl restart swss')
         time.sleep(120)
@@ -357,8 +364,8 @@ def apply_peer_switch_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mo
           'redis-cli -n 4 HDEL"{}" "{}" "{}"'.format(device_meta_key, 'subtype', 'DualToR'),
           'redis-cli -n 4 HDEL "{}" "{}" "{}"'.format(device_meta_key, 'peer_switch', peer_switch_hostname)]
     dut.shell_cmds(cmds=cmds)
-    if dut.get_asic_name() == 'th2':
-        # Restart swss on TH2 platform
+    if dut.get_asic_name() in ['th2', 'td3']:
+        # Restart swss on TH2 or TD3 platform to remove changes
         logger.info("Restarting swss service")
         dut.shell('systemctl restart swss')
         time.sleep(120)

--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -339,10 +339,12 @@ def apply_peer_switch_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mo
     peer_switch_hostname = 'switch_hostname'
     peer_switch_key = 'PEER_SWITCH|{}'.format(peer_switch_hostname)
     device_meta_key = 'DEVICE_METADATA|localhost'
-
+    restart_swss = False
+    if dut.get_asic_name() in ['th2', 'td3']:
+        restart_swss = True
     cmd = 'redis-cli -n 4 HSET "{}" "{}" "{}"'.format(device_meta_key, 'subtype', 'DualToR')
     dut.shell(cmd=cmd)
-    if dut.get_asic_name() in ['th2', 'td3']:
+    if restart_swss:
         # Restart swss on TH2 or TD3 platform to trigger syncd restart to regenerate config.bcm
         # We actually need to restart syncd only, but restarting syncd will also trigger swss
         # being restarted, and it costs more time than restarting swss
@@ -353,7 +355,7 @@ def apply_peer_switch_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mo
     cmds = ['redis-cli -n 4 HSET "{}" "address_ipv4" "{}"'.format(peer_switch_key, mock_peer_switch_loopback_ip.ip),
             'redis-cli -n 4 HSET "{}" "{}" "{}"'.format(device_meta_key, 'peer_switch', peer_switch_hostname)]
     dut.shell_cmds(cmds=cmds)
-    if dut.get_asic_name() in ['th2', 'td3']:
+    if restart_swss:
         # Restart swss on TH2 or TD3 platform to apply changes
         logger.info("Restarting swss service")
         dut.shell('systemctl restart swss')

--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -368,7 +368,7 @@ def apply_peer_switch_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mo
           'redis-cli -n 4 HDEL"{}" "{}" "{}"'.format(device_meta_key, 'subtype', 'DualToR'),
           'redis-cli -n 4 HDEL "{}" "{}" "{}"'.format(device_meta_key, 'peer_switch', peer_switch_hostname)]
     dut.shell_cmds(cmds=cmds)
-    if dut.get_asic_name() in ['th2', 'td3']:
+    if restart_swss:
         # Restart swss on TH2 or TD3 platform to remove changes
         logger.info("Restarting swss service")
         dut.shell('systemctl restart swss')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix the mux tunnel creation issue in mocked dualtor testbed.

On Broadcom platform, the mux tunnel depends on SAI property ` sai_remap_prio_on_tnl_egress=1`
However, the `sai_remap_prio_on_tnl_egress=1` property is generated only when ` DEVICE_METADATA['localhost']['subtype'] = DualToR`.  ( Please find details in PR https://github.com/Azure/sonic-buildimage/pull/10962)
Therefore, the property is not available on single tor deployment, and as a result, we will see error when running mocked dualtor test on single tor testbed.
```
Jun 27 23:19:57.859974 str2-7050cx3-acs-01 ERR syncd#syncd: [none] SAI_API_TUNNEL:_brcm_sai_mptnl_xgs_common_create_ifp_misc_entry_tnl_loopback:1976 bcm_field_entry_create failed with error Entry not found (0xfffffff9).
Jun 27 23:19:57.859974 str2-7050cx3-acs-01 ERR syncd#syncd: [none] SAI_API_TUNNEL:_brcm_sai_xgs_mptnl_loopbk_cls_ingr_egr_add:2054 _brcm_sai_mptnl_xgs_common_create_ifp_misc_entry_tnl_loopback failed with error -7.
Jun 27 23:19:57.859974 str2-7050cx3-acs-01 ERR syncd#syncd: [none] SAI_API_TUNNEL:mptnl_xgs_ipinip_create_sipdip_tnl:785 sdk fp add failed with error -7.
Jun 27 23:19:57.859974 str2-7050cx3-acs-01 ERR syncd#syncd: [none] SAI_API_TUNNEL:_brcm_sai_mptnl_sipdip_tnl_hw_create:2470 mptnl_hw_create_sipdip_tnl  failed with error -7.
Jun 27 23:19:57.859974 str2-7050cx3-acs-01 ERR syncd#syncd: [none] SAI_API_TUNNEL:brcm_sai_tnl_mp_create_tunnel:3796 _brcm_sai_mptnl_sipdip_tnl_hw_create failed with error -7.
Jun 27 23:19:57.859974 str2-7050cx3-acs-01 ERR syncd#syncd: :- sendApiResponse: api SAI_COMMON_API_CREATE failed in syncd mode: SAI_STATUS_ITEM_NOT_FOUND
```

This PR is to fix the issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
This PR is to fix the mux tunnel creation issue on mocked dualtor testbed.

#### How did you do it?
Restart `swss` after injecting ` DEVICE_METADATA['localhost']['subtype'] = DualToR`.
Actually, restarting `syncd` has the same effect. But restarting will cost more time than restarting swss.

#### How did you verify/test it?
Verified by checking syslog after running mocked dualtor test. Confirmed that the ERROR is not seen any more.

#### Any platform specific information?
Only applicable to mocked dualtor testbed.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
