### PR TITLE
Enhance test_cacl_application to support dualtor

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -5,8 +5,8 @@ import pytest
 
 from tests.common.config_reload import config_reload
 from tests.common.utilities import wait_until
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor
-from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host # lgtm[py/unused-import]
 from tests.common.helpers.assertions import pytest_assert
 
 logger = logging.getLogger(__name__)
@@ -33,7 +33,6 @@ def ignore_hardcoded_cacl_rule_on_dualtor(tbinfo):
 
 @pytest.fixture(scope="function", params=["active_tor", "standby_tor"])
 def duthost_dualtor(request, upper_tor_host, lower_tor_host, toggle_all_simulator_ports_to_upper_tor):
-    global expect_dhcp_rules
     which_tor = request.param
 
     # Add expected DHCP mark iptable rules for standby tor, not for active tor.

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -18,7 +18,6 @@ pytestmark = [
 
 ignored_iptable_rules = []
 
-expect_dhcp_rules = []
 
 @pytest.fixture(scope="module", autouse=True)
 def ignore_hardcoded_cacl_rule_on_dualtor(tbinfo):
@@ -32,23 +31,35 @@ def ignore_hardcoded_cacl_rule_on_dualtor(tbinfo):
         ]
         ignored_iptable_rules += rules_to_ignore
 
-@pytest.fixture(scope="function")
-def add_dhcp_rule_on_dualtor(tbinfo, duthosts, rand_one_dut_hostname, upper_tor_host, lower_tor_host,
-        toggle_all_simulator_ports_to_upper_tor):
+@pytest.fixture(scope="function", params=["active_tor", "standby_tor"])
+def duthost_dualtor(request, upper_tor_host, lower_tor_host, toggle_all_simulator_ports_to_upper_tor):
     global expect_dhcp_rules
-    # There are some hardcoded cacl rule for dualtot testbed, which should be ignored
-    if "dualtor" in tbinfo['topo']['name']:
-        if rand_one_dut_hostname == lower_tor_host.hostname:
-            logger.info("This DUT is standby tor, have to add some expected DHCP rules")
-            duthost = duthosts[rand_one_dut_hostname]
-            mark_keys = duthost.shell('/usr/bin/redis-cli -n 6  --raw keys "DHCP_PACKET_MARK*"', module_ignore_errors=True)['stdout']
-            mark_keys = mark_keys.split("\n")
-            for key in mark_keys:
-                mark = duthost.shell('/usr/bin/redis-cli -n 6 --raw hget "{}" "mark"'.format(key), module_ignore_errors=False)['stdout']
-                rule = "-A DHCP -m mark --mark {} -j DROP".format(mark)
-                expect_dhcp_rules.append(rule)
-        logger.info("generate expected dhcp iptables rules for standby tor.{}".format(expect_dhcp_rules))
+    which_tor = request.param
 
+    # Add expected DHCP mark iptable rules for standby tor, not for active tor.
+    if which_tor == 'standby_tor':
+        dut = lower_tor_host
+        logger.info("Select standby tor, generate expected DHCP iptables rules for standby tor.")
+    else:
+        logger.info("Select active tor, don't need to add expected DHCP mark rules.")
+        dut = upper_tor_host
+    return dut
+
+@pytest.fixture
+def expected_dhcp_rules_for_standby(duthost_dualtor, lower_tor_host):
+    if duthost_dualtor.hostname == lower_tor_host.hostname:
+        expected_dhcp_rules = []
+        mark_keys = duthost_dualtor.shell('/usr/bin/redis-cli -n 6  --raw keys "DHCP_PACKET_MARK*"', module_ignore_errors=True)['stdout']
+        mark_keys = mark_keys.split("\n")
+        for key in mark_keys:
+            mark = duthost_dualtor.shell('/usr/bin/redis-cli -n 6 --raw hget "{}" "mark"'.format(key), module_ignore_errors=False)['stdout']
+            if not mark:
+                continue
+            rule = "-A DHCP -m mark --mark {} -j DROP".format(mark)
+            expected_dhcp_rules.append(rule)
+        return expected_dhcp_rules
+    else:
+        return
 
 @pytest.fixture(scope="module")
 def docker_network(duthost):
@@ -318,7 +329,7 @@ def generate_and_append_block_ip2me_traffic_rules(duthost, iptables_rules, ip6ta
                         pytest.fail("Unrecognized IP address type on interface '{}': {}".format(iface_name, ip_ntwrk))
 
 
-def generate_expected_rules(duthost, docker_network, asic_index):
+def generate_expected_rules(duthost, docker_network, asic_index, expected_dhcp_rules_for_standby):
     iptables_rules = []
     ip6tables_rules = []
 
@@ -384,8 +395,8 @@ def generate_expected_rules(duthost, docker_network, asic_index):
     ip6tables_rules.append("-A INPUT -p udp -m udp --dport 546:547 -j ACCEPT")
 
     # On standby tor, it has expected dhcp mark iptables rules.
-    if len(expect_dhcp_rules) > 0:
-        iptables_rules.extend(expect_dhcp_rules)
+    if expected_dhcp_rules_for_standby:
+        iptables_rules.extend(expected_dhcp_rules_for_standby)
 
     # Allow all incoming BGP traffic
     iptables_rules.append("-A INPUT -p tcp -m tcp --dport 179 -j ACCEPT")
@@ -713,8 +724,8 @@ def generate_scale_rules(duthost, ip_type):
     # add ACCEPT rule for SSH to make sure testbed access
     duthost.command("iptables -I INPUT 3 -p tcp -m tcp --dport 22 -j ACCEPT")
 
-def verify_cacl(duthost, localhost, creds, docker_network, asic_index = None):
-    expected_iptables_rules, expected_ip6tables_rules = generate_expected_rules(duthost, docker_network, asic_index)
+def verify_cacl(duthost, localhost, creds, docker_network, expected_dhcp_rules_for_standby, asic_index = None):
+    expected_iptables_rules, expected_ip6tables_rules = generate_expected_rules(duthost, docker_network, asic_index, expected_dhcp_rules_for_standby)
 
     stdout = duthost.get_asic_or_sonic_host(asic_index).command("iptables -S")["stdout"]
     actual_iptables_rules = stdout.strip().split("\n")
@@ -781,7 +792,7 @@ def verify_nat_cacl(duthost, localhost, creds, docker_network, asic_index):
     unexpected_ip6tables_rules = set(actual_ip6tables_rules) - set(expected_ip6tables_rules)
     pytest_assert(len(unexpected_ip6tables_rules) == 0, "Unexpected ip6tables nat rules: {}".format(repr(unexpected_ip6tables_rules)))
 
-def test_cacl_application(duthosts, rand_one_dut_hostname, add_dhcp_rule_on_dualtor, localhost, creds, docker_network):
+def test_cacl_application_nondualtor(duthosts, rand_one_dut_hostname, localhost, creds, docker_network):
     """
     Test case to ensure caclmgrd is applying control plane ACLs properly
 
@@ -790,13 +801,22 @@ def test_cacl_application(duthosts, rand_one_dut_hostname, add_dhcp_rule_on_dual
     actual iptables/ip6tables rules on the DuT.
     """
     duthost = duthosts[rand_one_dut_hostname]
-    verify_cacl(duthost, localhost, creds, docker_network)
+    verify_cacl(duthost, localhost, creds, docker_network, None)
+
+def test_cacl_application_dualtor(duthost_dualtor, localhost, creds, docker_network, expected_dhcp_rules_for_standby):
+    """
+    Test case to ensure caclmgrd is applying control plane ACLs properly on dualtor.
+
+    This is done by generating our own set of expected iptables and ip6tables
+    rules based on the DuT's configuration and comparing them against the
+    actual iptables/ip6tables rules on the DuT.
+    """
+    verify_cacl(duthost_dualtor, localhost, creds, docker_network, expected_dhcp_rules_for_standby)
 
 def test_multiasic_cacl_application(duthosts, rand_one_dut_hostname, localhost, creds,docker_network, enum_frontend_asic_index):
-
-    if enum_frontend_asic_index is None:
-        pytest.skip("Not Multi-asic platform. Skipping !!")
-
+    """
+    Test case to ensure caclmgrd is applying control plane ACLs properly on multi-ASIC platform.
+    """
     duthost = duthosts[rand_one_dut_hostname]
     verify_cacl(duthost, localhost, creds, docker_network, enum_frontend_asic_index)
     verify_nat_cacl(duthost, localhost, creds, docker_network, enum_frontend_asic_index)

--- a/tests/common/dualtor/__init__.py
+++ b/tests/common/dualtor/__init__.py
@@ -1,3 +1,4 @@
 from tests.common.dualtor.dual_tor_utils import *
 from tests.common.dualtor.mux_simulator_control import *
 from tests.common.dualtor.nic_simulator_control import *
+from tests.common.dualtor.dual_tor_common import *

--- a/tests/common/dualtor/dual_tor_common.py
+++ b/tests/common/dualtor/dual_tor_common.py
@@ -1,6 +1,9 @@
 """DualToR related common utilities for other modules."""
 import pytest
 
+__all__ = [
+    'cable_type'
+]
 
 class CableType(object):
     """Dualtor cable type."""

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -19,6 +19,27 @@ bgp/test_bgp_slb.py:
      - "'backend' in topo_name or 'mgmttor' in topo_name"
 
 #######################################
+#####            cacl             #####
+#######################################
+cacl/test_cacl_application.py::test_cacl_application_nondualtor:
+  skip:
+    reason: "test_cacl_application is only supported on non dualtor topology"
+    conditions:
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
+
+cacl/test_cacl_application.py::test_cacl_application_dualtor:
+  skip:
+    reason: "test_cacl_application_dualtor is only supported on dualtor topology"
+    conditions:
+      - "topo_name not in ['dualtor', 'dualtor-56', 'dualtor-120']"
+
+cacl/test_cacl_application.py::test_multiasic_cacl_application:
+  skip:
+    reason: "test_multiasic_cacl_application is only supported on multi-ASIC platform"
+    conditions:
+      - "is_multi_asic==False"
+
+#######################################
 #####           configlet         #####
 #######################################
 configlet/test_add_rack.py:


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
`test_cacl_application` failed on dualtor, if it randomly selects standby tor to run test case, it will failed with this kind of error 
`Failed: Unexpected iptables rules: set([u'-A DHCP -m mark --mark 0x67024 -j DROP', u'-A DHCP -m mark --mark 0x67012 -j DROP', u'-A DHCP -m mark --mark 0x67003 -j DROP', u'-A DHCP -m mark --mark 0x67002 -j DROP', u'-A DHCP -m mark --mark 0x67022 -j DROP', u'-A DHCP -m mark --mark 0x67020 -j DROP', u'-A DHCP -m mark --mark 0x67018 -j DROP', u'-A DHCP -m mark --mark 0x67014 -j DROP', u'-A DHCP -m mark --mark 0x67017 -j DROP', u'-A DHCP -m mark --mark 0x67006 -j DROP', u'-A DHCP -m mark --mark 0x67016 -j DROP', u'-A DHCP -m mark --mark 0x67019 -j DROP', u'-A DHCP -m mark --mark 0x67021 -j DROP', u'-A DHCP -m mark --mark 0x67008 -j DROP', u'-A DHCP -m mark --mark 0x67001 -j DROP', u'-A DHCP -m mark --mark 0x67010 -j DROP', u'-A DHCP -m mark --mark 0x67013 -j DROP', u'-A DHCP -m mark --mark 0x67011 -j DROP', u'-A DHCP -m mark --mark 0x67009 -j DROP', u'-A DHCP -m mark --mark 0x67007 -j DROP', u'-A DHCP -m mark --mark 0x67004 -j DROP', u'-A DHCP -m mark --mark 0x67015 -j DROP', u'-A DHCP -m mark --mark 0x67023 -j DR
`
#### How did you do it?
The failed reason is on standby tor, it will add one rule DHCP mark rule for each standby interface.
Changes in this PR:
1. Add a new fixture `duthost_dualtor` to return duthost for dualtor test case `test_cacl_application_dualtor`, add another new fixture `expected_dhcp_rules_for_standby` to generate expected dhcp mark rules for standby tor.
2. Move pytest.skip to `tests_mark_conditions.yaml`
3. Add `from tests.common.dualtor.dual_tor_common import *` , otherwise it will throw error of fixture 'cable_type' not found.

#### How did you verify/test it?
Run `cacl/test_cacl_application.py`
```
cacl/test_cacl_application.py::test_cacl_application_nondualtor SKIPPED                                                                                                                                             [ 16%]
cacl/test_cacl_application.py::test_cacl_application_dualtor[active_tor] PASSED                                                                                                                          [ 33%]
cacl/test_cacl_application.py::test_cacl_application_dualtor[standby_tor] PASSED                                                                                                                         [ 50%]
cacl/test_cacl_application.py::test_multiasic_cacl_application[None] SKIPPED                                                                                                                             [ 66%]
cacl/test_cacl_application.py::test_cacl_scale_rules_ipv4 PASSED                                                                                                                                         [ 83%]
cacl/test_cacl_application.py::test_cacl_scale_rules_ipv6 PASSED                                                                                                                                         [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
