### PR TITLE
[Mellanox] Updated SN2201 platform info

### DIFF
--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -1,6 +1,6 @@
 
 SPC1_HWSKUS = ["ACS-MSN2700", "Mellanox-SN2700", "Mellanox-SN2700-D48C8", "ACS-MSN2740", "ACS-MSN2100", "ACS-MSN2410",
-               "ACS-MSN2010", "ACS-MSN2201"]
+               "ACS-MSN2010", "ACS-SN2201"]
 SPC2_HWSKUS = ["ACS-MSN3700", "ACS-MSN3700C", "ACS-MSN3800", "Mellanox-SN3800-D112C8", "ACS-MSN3420"]
 SPC3_HWSKUS = ["ACS-MSN4700", "ACS-MSN4600C", "ACS-MSN4410", "ACS-MSN4600", "Mellanox-SN4600C-D112C8", "Mellanox-SN4600C-C64"]
 SWITCH_HWSKUS = SPC1_HWSKUS + SPC2_HWSKUS + SPC3_HWSKUS
@@ -24,7 +24,7 @@ SWITCH_MODELS = {
         "psus": {
             "number": 2,
             "hot_swappable": True,
-            "capabilities": PSU_CAPABILITIES[0]
+            "capabilities": PSU_CAPABILITIES[1]
         },
         "cpu_pack": {
             "number": 1
@@ -41,14 +41,17 @@ SWITCH_MODELS = {
                 "number": 2
             },
             "module": {
-                "start": 1,
-                "number": 52
+                "start": 49,
+                "number": 4
             },
             "psu": {
                 "start": 1,
                 "number": 2
             },
             "cpu_pack": {
+                "number": 1
+            },
+            "cpu_ambient": {
                 "number": 1
             },
             "asic_ambient": {

--- a/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
+++ b/tests/platform_tests/mellanox/mellanox_thermal_control_test_helper.py
@@ -58,6 +58,10 @@ THERMAL_NAMING_RULE = {
     "comex_ambient": {
         "name": "Ambient COMEX Temp",
         "temperature": "comex_amb"
+    },
+    "cpu_ambient": {
+        "name": "Ambient CPU Board Temp",
+        "temperature": "cpu_amb"
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Updated SN2201 platform info
- Fixed HwSKU name
- Fixed PSU capabilities
- Fixed number of xSFP modules
- Added new sensor - "Ambient CPU Board Temp"

Summary: Updated SN2201 platform info
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix issue with number of xSPF ports and add support for new sensor

#### How did you do it?
See code

#### How did you verify/test it?
Executed platform tests

#### Any platform specific information?
SN2201 only

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
