### PR TITLE
fixed sanity check failure after test_lag tests

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -10,17 +10,23 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.dut_ports import decode_dut_port_name
-from tests.common.fixtures.duthost_utils import disable_route_checker_module
 
 logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('any'),
-    pytest.mark.usefixtures('disable_route_checker_module')
 ]
 
 # The dir will be deleted from host, so be sure not to use system dir
 TEST_DIR = "/tmp/acstests/"
+
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(rand_one_dut_hostname, loganalyzer):
+    """Ignore expected failures logs during test execution."""
+    if loganalyzer:
+        loganalyzer[rand_one_dut_hostname].ignore_regex.extend([".*missed_ROUTE_TABLE_routes.*"])
+
+    return
 
 @pytest.fixture(scope="module")
 def common_setup_teardown(ptfhost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fixed sanity check failure after test_lag tests
Fixes # (issue)

test_lag test stops `routeCheck` Monit service to prevent `LogAnalyzer` to fail the tests because of "missed_ROUTE_TABLE_routes" logs appearing when the test shutdowns neighbor links. The test starts `routeCheck` on finish but next tests may fail on sanity check because `routeCheck` did not have enough time to start.
The root cause here is that when the test attempts to start `routeCheck` on test finish, the service does not start immediately. Monit runs the `routeCheck` on each 5th cycle, where 1 Monit cycle is set to 1 min by default. So, when the `routeCheck` is requested to start, it will start only on the next 5th Monit cycle.
Fixed the issue by refusing to stop `routeCheck` and ignoring "missed_ROUTE_TABLE_routes" logs instead.

**routeCheck Monit config**

/etc/monit/conf.d/sonic-host
```
check program routeCheck with path "/usr/local/bin/route_check.py"
    every 5 cycles
```
/etc/monit/monitrc
```
set daemon 60
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Avoid impact on the other tests
#### How did you do it?
Fixed test setup
#### How did you verify/test it?
py.test --inventory=../ansible/lab,../ansible/veos --testbed_file=../ansible/testbed.csv --module-path=../ansible/library -v -rA --topology=t0,any pc/test_lag_2.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
