### PR TITLE
[T2] Skip generic_config_updater tests for T2 topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -128,6 +128,12 @@ generic_config_updater/test_eth_interface.py::test_replace_fec:
     conditions:
       - "platform in ['x86_64-kvm_x86_64-r0']"
 
+generic_config_updater:
+  skip:
+    reason: 'generic_config_updater is not a supported feature for T2'
+    conditions:
+      - "'t2' in topo_name"
+
 #######################################
 #####      iface_namingmode       #####
 #######################################


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
As per discussion with MSFT, the tests in generic_config_updater use YANG models which are not currently supported on a T2 chassis. So, need to skip these tests for T2 topology

#### How did you do it?
Adding check in tests_mark_conditional to skip generic_config_updater if 't2' in topology

#### How did you verify/test it?
Ran generic_config_updater against T2 topology and verified that all the tests are skipped.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
