### PR TITLE
Check the version of python in syncd container then run command accordingly

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -211,18 +211,31 @@ def _install_nano(dut, creds,  syncd_docker_name):
     if output["stdout"] == "copp":
         http_proxy = creds.get('proxy_env', {}).get('http_proxy', '')
         https_proxy = creds.get('proxy_env', {}).get('https_proxy', '')
-
-        cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
-                rm -rf /var/lib/apt/lists/* \
-                && apt-get update \
-                && apt-get install -y python-pip build-essential libssl-dev libffi-dev python-dev python-setuptools wget cmake \
-                && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
-                && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
-                && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
-                && rm -f 1.0.0.tar.gz && pip2 install cffi==1.7.0 && pip2 install --upgrade cffi==1.7.0 && pip2 install nnpy \
-                && mkdir -p /opt && cd /opt && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-                && mkdir ptf && cd ptf && wget https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
-                " '''.format(http_proxy, https_proxy, syncd_docker_name)
+        check_cmd = "docker exec -i {} bash -c 'python --version'".format(syncd_docker_name)
+        if "python 3" in dut.shell(check_cmd)['stdout'].lower():
+            cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
+                    rm -rf /var/lib/apt/lists/* \
+                    && apt-get update \
+                    && apt-get install -y python3-pip build-essential libssl-dev libffi-dev python3-dev python-setuptools wget cmake \
+                    && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+                    && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
+                    && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
+                    && rm -f 1.0.0.tar.gz && pip3 install cffi && pip3 install --upgrade cffi && pip3 install nnpy \
+                    && mkdir -p /opt && cd /opt && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
+                    && mkdir ptf && cd ptf && wget https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
+                    " '''.format(http_proxy, https_proxy, syncd_docker_name)
+        else:
+            cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
+                    rm -rf /var/lib/apt/lists/* \
+                    && apt-get update \
+                    && apt-get install -y python-pip build-essential libssl-dev libffi-dev python-dev python-setuptools wget cmake \
+                    && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+                    && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
+                    && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
+                    && rm -f 1.0.0.tar.gz && pip2 install cffi==1.7.0 && pip2 install --upgrade cffi==1.7.0 && pip2 install nnpy \
+                    && mkdir -p /opt && cd /opt && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
+                    && mkdir ptf && cd ptf && wget https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
+                    " '''.format(http_proxy, https_proxy, syncd_docker_name)
         dut.command(cmd)
 
 def _map_port_number_to_interface(dut, nn_target_port):


### PR DESCRIPTION


Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
`test_copp` failed on 202205 image, because `python-pip` doesn't exist.

#### How did you do it?
syncd container on 202205 image was upgraded to bullseyes on mellanox testbeds.
`test_copp` uses `python-pip` to install nano in syncd container.
Check python version before installation of nano, then run command accordingly.

#### How did you verify/test it?
Run `copp/test_copp.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
