### PR TITLE
Added support for Cisco 8000 virtual sonic DUT

### DIFF
--- a/ansible/roles/vm_set/library/cisco_8000e_port.py
+++ b/ansible/roles/vm_set/library/cisco_8000e_port.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+
+from ansible.module_utils.basic import *
+
+DOCUMENTATION = '''
+module: cisco_8000e_port
+version_added: "0.1"
+author: Rafal Skorka (skorka@cisco.com)
+short_description: Gather management and front panel ports from 8000e-sonic DUT
+This is a stub, currently returns hardcoded values
+'''
+
+EXAMPLES = '''
+- name: Get front panel and mgmt port for 8000e-sonic sim
+  cisco_8000e_port:
+    vmname: "{{ dut_name }}"
+'''
+
+
+def main():
+
+    module = AnsibleModule(argument_spec=dict(
+        vmname = dict(required=False),
+    ))
+
+    vmname = module.params['vmname']
+
+    mgmt_port = None
+    fp_ports = {}
+
+    for i in range(0,64):
+        fp_ports[i] = "%s-%i" % (vmname, i+1)
+
+    mgmt_port = "%s-0" % vmname
+
+    module.exit_json(changed=False, ansible_facts={'dut_mgmt_port': mgmt_port, 'dut_fp_ports': fp_ports})
+
+if __name__ == "__main__":
+    main()

--- a/ansible/roles/vm_set/tasks/get_dut_port.yml
+++ b/ansible/roles/vm_set/tasks/get_dut_port.yml
@@ -23,6 +23,12 @@
   when: external_port is not defined and hostvars[dut_name].type is defined and hostvars[dut_name]['type'] == 'simx'
   become: yes
 
+- name: Get front panel and mgmt port for 8000e-sonic device
+  cisco_8000e_port:
+    vmname: "{{ dut_name }}"
+  when: external_port is not defined and hostvars[dut_name].type is defined and hostvars[dut_name]['type'] == '8000e'
+  become: yes
+
 - set_fact:
     duts_fp_ports: "{{ duts_fp_ports|default({}) | combine( { dut_name: dut_fp_ports } ) }}"
     duts_mgmt_port: "{{ duts_mgmt_port|default([]) + [ dut_mgmt_port ] }}"

--- a/ansible/roles/vm_set/tasks/manage_duts.yml
+++ b/ansible/roles/vm_set/tasks/manage_duts.yml
@@ -14,6 +14,15 @@
     - name: Stop SID
       include_tasks: stop_sid.yml
       when: action == 'stop_sid' and hostvars[dut_name]['type'] == 'simx'
+
+    - name: Start 8000e-sonic sim
+      include_tasks: start_8000e_sonic.yml
+      when: action == 'start_8000e_sonic' and hostvars[dut_name]['type'] == '8000e'
+
+    - name: Stop 8000e-sonic sim
+      include_tasks: stop_8000e_sonic.yml
+      when: action == 'stop_8000e_sonic' and hostvars[dut_name]['type'] == '8000e'
+
   when:
     - hostvars[dut_name] is defined
     - hostvars[dut_name].type is defined

--- a/ansible/roles/vm_set/tasks/start_8000e_sonic.yml
+++ b/ansible/roles/vm_set/tasks/start_8000e_sonic.yml
@@ -1,0 +1,116 @@
+- set_fact:
+        docker_image:  8000e-sonic
+        mgmt_ip_address: " {{ hostvars[dut_name]['ansible_host'] }}"
+        mgmt_gw: "{{ vm_mgmt_gw | default(mgmt_gw) }}"
+        sonic_image: "{{ home_path }}/8000e/images/sonic-cisco-8000.bin"
+        serial_port: "{{ hostvars[dut_name]['serial_port'] }}"
+
+- name: Check if cisco sonic image exists
+  stat: path={{ sonic_image }}
+  register: image_stat
+
+- name: Fail if cisco sonic image is missing
+  fail:
+     msg: "Missing cisco sonic image ({{ sonic_image }})"
+  when: image_stat.stat.exists == false
+
+- name: "Create 8000e-sonic container {{ dut_name }}"
+  become: yes
+  docker_container:
+    name: "{{ dut_name }}"
+    image: "{{ docker_image }}"
+    pull: no
+    recreate: yes
+    tty: yes
+    network_mode: none
+    detach: True
+    privileged: True
+    capabilities:
+      - net_admin
+    devices:
+    - /dev/kvm:/dev/kvm
+    volumes:
+    - /{{ sonic_image }}:/images/sonic-cisco-8000.bin
+    env:
+       CISCO_SDK_VER: "{{ hostvars[dut_name]['cisco_sdk_ver'] | default(omit) }}"
+       CISCO_NPSUITE_VER: "{{ hostvars[dut_name]['cisco_npsuite_ver'] | default(omit) }}"
+       MGMT_GATEWAY: "{{ mgmt_gw }}"
+       SONIC_LOGIN: "cisco"
+       SONIC_PASSWORD: "cisco123"
+       # 8000e device requires eth4 interface to be configured for for proper device operation (simulation artifact).
+       # Disable route check to prevent eth4 route check error ("missed_ROUTE_TABLE_routes": [ "192.168.123.0/24"])
+       SONIC_COMMANDS: |
+               sudo monit stop routeCheck
+               sudo monit unmonitor routeCheck
+
+- name: Get container info
+  docker_container_info:
+    name: "{{ dut_name }}"
+  register: ctninfo
+  become: yes
+
+- set_fact:
+    hwsku: "{{ hostvars[dut_name].hwsku }}"
+
+- debug:
+        msg: "hwsku:{{ hwsku }}"
+
+- set_fact:
+      max_fp_port: 64
+  when: hwsku == "Cisco-8102-C64"
+
+- name: capture all host interfaces
+  shell: ifconfig -a |egrep "^[0-9a-zA-Z]" | awk '{ print $1 }'
+  register: host_interfaces
+
+
+- name: capture host "up" interfaces
+  shell: ifconfig |egrep "^[0-9a-zA-Z]" | awk '{ print $1 }'
+  register: host_up_interfaces
+
+- name: Create veth pairs for 8000e-sonic mgmt. interface and front panel ports
+  shell: ip link add {{ item }} type veth peer name {{ item }}_x
+  with_sequence: start=0 end={{ max_fp_port }} stride=1 format={{ dut_name }}-%d
+  when: item + ':' not in host_interfaces.stdout_lines
+  become: yes
+
+- name: set interfaces up
+  shell: ip link set {{ item }} up
+  with_sequence: start=0 end={{ max_fp_port }} stride=1 format={{ dut_name }}-%d
+  when: item + ':' not in host_up_interfaces.stdout_lines
+  become: yes
+
+- name: pass interfaces to {{ dut_name }}
+  vars:
+     pid: "{{ ctninfo.container.State.Pid }}"
+     if_name: "{{ dut_name }}-{{ item }}_x"
+     new_if_name: "eth{{ item }}"
+
+  shell: |
+          ip link set {{ if_name }} netns {{ pid }}
+          nsenter -t {{ pid }} -n ip link set {{ if_name }} down
+          nsenter -t {{ pid }} -n ip link set {{ if_name }} name {{ new_if_name }}
+          nsenter -t {{ pid }} -n ip link set {{ new_if_name }} up
+  with_sequence: start=0 end={{ max_fp_port }} stride=1
+  become: yes
+
+- name: configure management interface (eth0) in the 8000e-sonic docker instance
+  vars:
+     pid: "{{ ctninfo.container.State.Pid }}"
+  shell: nsenter -t {{ pid }} -n ip address add {{ mgmt_ip_address }}/{{ mgmt_prefixlen }} dev eth0
+  become: yes
+
+- name: add {{ dut_name }} management interface to {{ mgmt_bridge }} bridge
+  shell: brctl addif {{ mgmt_bridge }} {{ dut_name }}-0
+  become: yes
+
+- name: boot 8000e-sonic device in {{ dut_name }} docker instance
+  shell: docker exec {{ dut_name }} /startup.sh {{ max_fp_port }}
+  become: yes
+
+- name: ping {{ dut_name }} managment interface
+  shell: ping {{ mgmt_ip_address }} -c 1
+  retries: 10
+  delay: 5
+  register: result
+  until: result.rc == 0

--- a/ansible/roles/vm_set/tasks/stop_8000e_sonic.yml
+++ b/ansible/roles/vm_set/tasks/stop_8000e_sonic.yml
@@ -1,0 +1,5 @@
+- name: "Remove 8000e-sonic container {{ dut_name }}"
+  become: yes
+  docker_container:
+    name: "{{ dut_name }}"
+    state: absent

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -98,6 +98,7 @@
     - { role: vm_set, action: 'stop_sonic_vm', when force_stop_sonic_vm is defined }
     - { role: vm_set, action: 'start_sonic_vm' }
     - { role: vm_set, action: 'start_sid' }
+    - { role: vm_set, action: 'start_8000e_sonic' }
     - { role: vm_set, action: 'add_topo' }
 
 - hosts: servers:&eos

--- a/ansible/testbed_remove_vm_topology.yml
+++ b/ansible/testbed_remove_vm_topology.yml
@@ -77,4 +77,5 @@
     - { role: vm_set, action: 'remove_topo' }
     - { role: vm_set, action: 'stop_sid' }
     - { role: vm_set, action: 'stop_sonic_vm' }
+    - { role: vm_set, action: 'stop_8000e_sonic' }
 

--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -48,6 +48,7 @@ all:
         vlab-10:
         vlab-11:
         vlab-12:
+        vlab-8k-01:
     ptf:
       hosts:
         ptf-01:
@@ -229,6 +230,20 @@ all:
           serial_port: 9024
           ansible_password: password
           ansible_user: admin
+        vlab-8k-01:
+          ansible_host: 10.250.0.201
+          ansible_hostv6: fec0::ffff:afa:1
+          type: 8000e
+          hwsku: Cisco-8102-C64
+          serial_port: 60000
+          ansible_password: password
+          ansible_user: admin
+          ansible_ssh_user: cisco
+          ansible_altpassword: cisco123
+          # sdk/npsuite override:
+          #cisco_sdk_ver: "1.50.10.4.22"
+          #cisco_npsuite_ver: "1.90.0"
+
 
 # The groups below are helpers to limit running playbooks to a specific server only
 server_1:

--- a/ansible/vtestbed.csv
+++ b/ansible/vtestbed.csv
@@ -11,5 +11,3 @@ vms-kvm-t2,vms6-4,t2-vs,docker-ptf,ptf-04,10.250.0.109/24,fec0::ffff:afa:9/64,se
 vms-kvm-t0-3,vms6-6,t0,docker-ptf,ptf-06,10.250.0.116/24,fec0::ffff:afb:2/64,server_1,VM0132,[vlab-09],veos_vtb,False,Tests virtual switch vm
 vms-kvm-t0-4,vms6-7,t0,docker-ptf,ptf-07,10.250.0.118/24,fec0::ffff:afb:4/64,server_1,VM0136,[vlab-10],veos_vtb,False,Tests virtual switch vm
 vms-kvm-dual-mixed,vms6-8,dualtor-mixed,docker-ptf,ptf-08,10.250.0.109/24,fec0::ffff:afa:9/64,server_1,VM0140,[vlab-11;vlab-12],veos_vtb,False,Dual-TOR-Mixed testbed
-8000e-t0,vms6-1,t0,docker-ptf,ptf-01,10.250.0.102/24,fec0::ffff:afa:2/64,server_1,VM0100,[vlab-8k-01],veos_vtb,False,Tests 8000e sonic device
-8000e-t1,vms6-1,t1,docker-ptf,ptf-01,10.250.0.102/24,fec0::ffff:afa:2/64,server_1,VM0100,[vlab-8k-01],veos_vtb,False,Tests 8000e sonic device

--- a/ansible/vtestbed.csv
+++ b/ansible/vtestbed.csv
@@ -11,3 +11,5 @@ vms-kvm-t2,vms6-4,t2-vs,docker-ptf,ptf-04,10.250.0.109/24,fec0::ffff:afa:9/64,se
 vms-kvm-t0-3,vms6-6,t0,docker-ptf,ptf-06,10.250.0.116/24,fec0::ffff:afb:2/64,server_1,VM0132,[vlab-09],veos_vtb,False,Tests virtual switch vm
 vms-kvm-t0-4,vms6-7,t0,docker-ptf,ptf-07,10.250.0.118/24,fec0::ffff:afb:4/64,server_1,VM0136,[vlab-10],veos_vtb,False,Tests virtual switch vm
 vms-kvm-dual-mixed,vms6-8,dualtor-mixed,docker-ptf,ptf-08,10.250.0.109/24,fec0::ffff:afa:9/64,server_1,VM0140,[vlab-11;vlab-12],veos_vtb,False,Dual-TOR-Mixed testbed
+8000e-t0,vms6-1,t0,docker-ptf,ptf-01,10.250.0.102/24,fec0::ffff:afa:2/64,server_1,VM0100,[vlab-8k-01],veos_vtb,False,Tests 8000e sonic device
+8000e-t1,vms6-1,t1,docker-ptf,ptf-01,10.250.0.102/24,fec0::ffff:afa:2/64,server_1,VM0100,[vlab-8k-01],veos_vtb,False,Tests 8000e sonic device

--- a/ansible/vtestbed.yaml
+++ b/ansible/vtestbed.yaml
@@ -186,12 +186,12 @@
   comment: Dual-TOR-Mixed testbed
 
 - conf-name: 8000e-t0
-  group-name: vms6-1
+  group-name: vms8-1
   topo: t0
   ptf_image_name: docker-ptf
-  ptf: ptf-01
-  ptf_ip: 10.250.0.102/24
-  ptf_ipv6: fec0::ffff:afa:2/64
+  ptf: ptf-8k-01
+  ptf_ip: 10.250.0.202/24
+  ptf_ipv6: fec0::ffff:afc:2/64
   server: server_1
   vm_base: VM0100
   dut:
@@ -201,12 +201,12 @@
   comment: Tests 8000e sonic device
 
 - conf-name: 8000e-t1
-  group-name: vms6-1
+  group-name: vms8-1
   topo: t1
   ptf_image_name: docker-ptf
-  ptf: ptf-01
-  ptf_ip: 10.250.0.102/24
-  ptf_ipv6: fec0::ffff:afa:2/64
+  ptf: ptf-8k-01
+  ptf_ip: 10.250.0.202/24
+  ptf_ipv6: fec0::ffff:afc:2/64
   server: server_1
   vm_base: VM0100
   dut:

--- a/ansible/vtestbed.yaml
+++ b/ansible/vtestbed.yaml
@@ -184,3 +184,33 @@
   inv_name: veos_vtb
   auto_recover: 'False'
   comment: Dual-TOR-Mixed testbed
+
+- conf-name: 8000e-t0
+  group-name: vms6-1
+  topo: t0
+  ptf_image_name: docker-ptf
+  ptf: ptf-01
+  ptf_ip: 10.250.0.102/24
+  ptf_ipv6: fec0::ffff:afa:2/64
+  server: server_1
+  vm_base: VM0100
+  dut:
+    - vlab-8k-01
+  inv_name: veos_vtb
+  auto_recover: 'False'
+  comment: Tests 8000e sonic device
+
+- conf-name: 8000e-t1
+  group-name: vms6-1
+  topo: t1
+  ptf_image_name: docker-ptf
+  ptf: ptf-01
+  ptf_ip: 10.250.0.102/24
+  ptf_ipv6: fec0::ffff:afa:2/64
+  server: server_1
+  vm_base: VM0100
+  dut:
+    - vlab-8k-01
+  inv_name: veos_vtb
+  auto_recover: 'False'
+  comment: Tests 8000e sonic device

--- a/docs/testbed/README.testbed.8000e.md
+++ b/docs/testbed/README.testbed.8000e.md
@@ -1,0 +1,65 @@
+# 8000e
+
+This document discusses how to use 8000e as DUT virtual device.
+8000e is a custom kvm based functional emulator of Cisco 8000 Series routers. The 8000e emulator is running inside a docker container for ease of deployment.
+
+
+## Installing 8000e sonic image
+Cisco customers can contact account team for 8000e image access.
+
+
+Download and unpack 8000e sonic tar files
+```
+tar -xvf 8000-emulator-<REL>.tar
+tar -xvf 8000-sonic-<REL>.tar
+```
+
+Move downloaded sonic image to 8000e sonic image directory
+```
+mkdir -p $HOME/8000e/images
+cd 8000-<REL>
+mv packages/images/8000/sonic/sonic-cisco-8000.bin $HOME/8000e/images/
+```
+
+Build 8000e-sonic docker image
+```
+scripts/build_docker_image.sh 8000e-sonic docker/sonic/Dockerfile
+```
+
+Verify that 8000e-sonic docker image is available
+```
+docker images |grep 8000e-sonic
+8000e-sonic    latest   f5f181cf2a51    27 minutes ago   6.58GB
+```
+
+Follow [instructions](README.testbed.VsSetup.md) to setup virtual sonic testbed. 
+
+
+## Bring up 8000e T0 topology 
+
+Start neighboring devices
+
+Note: while vEOS or cEOS can be used as neighboring devices, we used vsonic as neighboring devices in our example.
+```
+./testbed-cli.sh -m veos_vtb -n 4 -k vsonic start-vms server_1 password.txt
+```
+
+Deploy 8000e T0 topology
+```
+./testbed-cli.sh -k vsonic -t vtestbed.yaml -m veos_vtb add-topo 8000e-t0 password.txt
+```
+
+Deploy minigraph on the DUT
+```
+./testbed-cli.sh -t vtestbed.yaml -m veos_vtb deploy-mg 8000e-t0 veos_vtb password.txt
+```
+
+Run a simple bgp test
+```
+cd ../tests
+./run_tests.sh -n 8000e-t0 -d vlab-8k-01 -c bgp/test_bgp_fact.py -f vtestbed.yaml -i veos_vtb -e --disable_loganalyzer
+
+bgp/test_bgp_fact.py::test_bgp_facts[vlab-8k-01-None] PASSED
+```
+
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR 


<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add playbooks which allow to use T0/T1 virtual testbeds with Cisco 8000e emulator (functional emulator of Cisco 8000 Series routers).  

Note: Cisco provides Cisco 8000e emulator to its customers.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach

#### How did you do it?
Add start/stop playbooks for new DUT type: 8000e.
The playbook starts the emulator inside a docker container (for ease of deployment) and then vm-topology module can connect it to the topology.

#### How did you verify/test it?

./testbed-cli.sh -m veos_vtb -n 4 -k vsonic start-vms server_1 password.txt
./testbed-cli.sh -k vsonic -t vtestbed.yaml -m veos_vtb add-topo 8000e-t0 password.txt
./testbed-cli.sh -t vtestbed.yaml -m veos_vtb deploy-mg 8000e-t0 veos_vtb password.txt
cd ../tests
./run_tests.sh -n 8000e-t0 -d vlab-8k-01 -c bgp/test_bgp_fact.py -f ../ansible/vtestbed.yaml -i ../ansible/veos_vtb -e --disable_loganalyzer

bgp/test_bgp_fact.py::test_bgp_facts[vlab-8k-01-None] PASSED  

#### Any platform specific information?
While the 8000e emulator supports many Cisco 8000 platforms, the new 8000e playbooks support Cisco-8102-C64 platform specifically. Other 8000e platforms will be tested and enabled in the future.

 
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
