### PR TITLE
Fix test_dhcpv6_relay_counter, added src MAC to unknown DHCP pkt

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
@@ -153,6 +153,7 @@ class DHCPCounterTest(DataplaneBaseTest):
             testutils.send_packet(self, self.server_port_indices[0], packet)
 
         unknown_packet = self.create_unknown_server_packet()
+        unknown_packet.src = self.dataplane.get_mac(0, self.server_port_indices[0])
         testutils.send_packet(self, self.server_port_indices[0], unknown_packet)
 
     def runTest(self):


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: **dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter** failed when checked that counter for relayed Unknown DHCP message didn't increment after unknown pkt was sent:
```
> assert int(message_count) > 0, "Missing {} count".format(message)
E AssertionError: Missing Unknown count
E assert 0 > 0
E + where 0 = int(u'0')

$ show dhcp6relay_counters counts 
       Message Type    Vlan1000
-------------------  ----------
            Unknown           0
            Solicit           1
          Advertise           2
            Request           1
            Confirm           1
              Renew           1
             Rebind           1
              Reply           1
            Release           1
            Decline           1
        Reconfigure           1
Information-Request           1
      Relay-Forward          32
        Relay-Reply           5
          Malformed           1
```
It looks that the unknown DHCP pkt was crafted without specifying the src MAC address:
```
###[ Ethernet ]### 
  dst       = fc:bd:67:62:4b:60
  src       = 00:00:00:00:00:00
  type      = IPv6
```
This change add src MAC address to the pkt and pkt successfully arrive at DUT and counter for Unknown DHCP gets incremented:
```
$ show dhcp6relay_counters counts 
       Message Type    Vlan1000
-------------------  ----------
            Unknown           1
            Solicit           1
          Advertise           2
            Request           1
            Confirm           1
              Renew           1
             Rebind           1
              Reply           1
            Release           1
            Decline           1
        Reconfigure           1
Information-Request           1
      Relay-Forward          32
        Relay-Reply           5
          Malformed           1


08:10:32.175719 Ethernet116 In  IP6 (hlim 64, next-header UDP (17) payload length: 42) fc02:2000::1.547 > fc02:1000::1.547: [udp sum ok] dhcp6 relay-reply (linkaddr=fc02:1000::1 peeraddr=fe80::42a6:b7ff:fe22:af01)
08:10:32.175719 PortChannel102 In  IP6 (hlim 64, next-header UDP (17) payload length: 42) fc02:2000::1.547 > fc02:1000::1.547: [udp sum ok] dhcp6 relay-reply (linkaddr=fc02:1000::1 peeraddr=fe80::42a6:b7ff:fe22:af01)
```
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter TC
#### How did you do it?

#### How did you verify/test it?
Run **dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter** TC on t0 topo:
`PASSED dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter`
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.105614-dirty-20220602.130306
Distribution: Debian 11.3
Kernel: 5.10.0-12-2-amd64
Build commit: 0552d6b17
Build date: Thu Jun  2 19:00:06 UTC 2022
Built by: AzDevOps@sonic-build-workers-001KKZ
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
