### PR TITLE
[Mellanox] Use the correct way to check the release of DUT in "check_sysfs"

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -129,7 +129,7 @@ def check_sysfs(dut):
                 assert "Invalid PSU fan speed value {} for PSU {}, exception: {}".format(psu_info["fan_speed"],
                                                                                          psu_id, e)
 
-            if "201911" not in dut.os_version and "202012" not in dut.os_version:
+            if "201911" not in dut.sonic_release and "202012" not in dut.sonic_release:
                 # Check consistency between voltage capability and sysfs
                 all_capabilities = platform_data["psus"].get("capabilities")
                 if all_capabilities:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Use the correct way to check the branch of DUT in "check_sysfs"

Signed-off-by: Stephen Sun <stephens@nvidia.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

Use the correct way to check the release of DUT in "check_sysfs"
`dut.os_version` is generated from the branch name. There is no guarantee that branch name always includes the release name. For example, a developer can create a branch `my-fix` based on `202012` branch. In this case, the test will fail.

#### How did you do it?

#### How did you verify/test it?
Run sonic-mgmt test which noticed this issue

#### Any platform specific information?
Mellanox

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
