### PR TITLE
Skip TSA, TSB error check in no_neighbor test

### DIFF
--- a/tests/bgp/templates/bgp_no_export.j2
+++ b/tests/bgp/templates/bgp_no_export.j2
@@ -20,7 +20,7 @@ enable password zebra
 ! bgp multiple-instance
 !
 {% if 'LeafRouter' in DEVICE_METADATA['localhost']['type'] %}
-route-map TO_TIER0_V4 permit 30
+route-map TO_TIER0_V4 permit 40
  set community no-export additive
 !
 {% endif %}

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -229,21 +229,8 @@ def test_TSA_B_C_with_no_neighbors(duthost, bgpmon_setup_teardown, nbrhosts, tbi
         # Remove the Neighbors for the particular BGP instance
         bgp_neighbors = remove_bgp_neighbors(duthost, asic_index)
 
-        # Issue TSA on DUT
-        output = duthost.shell("TSA")['stdout_lines']
-
-        # Set the DUT in maintenance state
-        # Verify ASIC0 has no neighbors message.
-        pytest_assert(verify_traffic_shift_per_asic(duthost, output, TS_NO_NEIGHBORS, asic_index), "ASIC is not having no neighbors")
-
-        # Recover to Normal state
-        duthost.shell("TSB")['stdout_lines']
-
-        # Verify DUT is in Normal state, and ASIC0 has no neighbors message.
-        pytest_assert(verify_traffic_shift_per_asic(duthost, output, TS_NO_NEIGHBORS, asic_index), "ASIC is not having no neighbors")
-
         # Check the traffic state
-        duthost.shell("TSC")['stdout_lines']
+        output = duthost.shell("TSC")['stdout_lines']
 
         # Verify DUT is in Normal state, and ASIC0 has no neighbors message.
         pytest_assert(verify_traffic_shift_per_asic(duthost, output, TS_NO_NEIGHBORS, asic_index), "ASIC is not having no neighbors")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Currently, TSA & TSB script throw an error - "System Mode: No external BGP neighbors" if there are no neighbors configured.  test_TSA_B_C_with_no_neighbors executes TSA and TSB command with no BGP neighbors configured on the device and looks for this error messsage.

With the TSA persistence changes in https://github.com/Azure/sonic-buildimage/pull/11257/files, TSA/B state is now stored in configDB when the commands are executed. As such, there is no need to throw an error if there are no BGP neighbors currently, since the state will get applied if the neighbors are added later. 

This PR is to change test_TSA_B_C_with_no_neighbors to only check TSC to ensure 'no neighbor' state.
Also changed the sample config used by bgp/test_bgp_bounce.j2 to avoid conflict with TSA/B route-maps

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Change in TSA/B command behavior introduced by https://github.com/Azure/sonic-buildimage/pull/11257/files

#### How did you do it?
Changed test to skip error log check when there are no BGP neighbors configured
Also changed the sample config used by bgp/test_bgp_bounce.j2 to avoid conflict with TSA/B route-maps

#### How did you verify/test it?
Manual execution of test_TSA_B_C_with_no_neighbors

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
