### PR TITLE
[bgp_helpers] wait for swss to start when restarting bgp

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -32,6 +32,7 @@ def apply_bgp_config(duthost, template_name):
     duthost.docker_copy_to_all_asics('bgp', template_name, DEFAULT_BGP_CONFIG)
     duthost.restart_service("bgp")
     pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started_per_asic_or_host, "bgp"), "BGP not started.")
+    pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started_per_asic_or_host, "swss"), "SWSS not started.")
 
 def define_config(duthost, template_src_path, template_dst_path):
     """


### PR DESCRIPTION
What I did: added an assert to wait for swss to come back up after restarting
bgp

Why I did it: PR in sonic buildimage adds bgp as a dependent of swss. This was
causing PR test failures due to swss not restarting in time in vms-kvm-t1-lag
tests.

Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>

https://github.com/Azure/sonic-buildimage/pull/11168 and https://github.com/Azure/sonic-buildimage/pull/11000
