### PR TITLE
Fix wrong assert condition in delete_neighbor

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1134,7 +1134,7 @@ def delete_neighbor(duthost, neighbor):
         logging.info("Neighbor entry %s doesn't exist", neighbor)
 
     neighbor_details = get_neighbor(duthost, neighbor)
-    assert len(neighbor_details) > 0, "server ip {} hasn't been deleted from neighbor table.".format(neighbor)
+    assert not neighbor_details, "server ip {} hasn't been deleted from neighbor table.".format(neighbor)
 
 @pytest.fixture(scope="function")
 def rand_selected_interface(rand_selected_dut):

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1132,15 +1132,12 @@ def delete_neighbor(duthost, neighbor):
         duthost.shell("ip neighbor del %s dev %s" % (neighbor, neighbor_details['dev']))
     else:
         logging.info("Neighbor entry %s doesn't exist", neighbor)
-        return
+        return True
 
     neighbor_details = get_neighbor(duthost, neighbor)
-    # Try the deletion again if the first time failed.
     if neighbor_details:
-        duthost.shell("ip neighbor del %s dev %s" % (neighbor, neighbor_details['dev']))
-        time.sleep(2)
-
-    assert not neighbor_details, "server ip {} hasn't been deleted from neighbor table.".format(neighbor)
+        return False
+    return True
 
 @pytest.fixture(scope="function")
 def rand_selected_interface(rand_selected_dut):

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1132,8 +1132,14 @@ def delete_neighbor(duthost, neighbor):
         duthost.shell("ip neighbor del %s dev %s" % (neighbor, neighbor_details['dev']))
     else:
         logging.info("Neighbor entry %s doesn't exist", neighbor)
+        return
 
     neighbor_details = get_neighbor(duthost, neighbor)
+    # Try the deletion again if the first time failed.
+    if neighbor_details:
+        duthost.shell("ip neighbor del %s dev %s" % (neighbor, neighbor_details['dev']))
+        time.sleep(2)
+
     assert not neighbor_details, "server ip {} hasn't been deleted from neighbor table.".format(neighbor)
 
 @pytest.fixture(scope="function")

--- a/tests/dualtor/test_tunnel_memory_leak.py
+++ b/tests/dualtor/test_tunnel_memory_leak.py
@@ -22,6 +22,7 @@ from tests.common.dualtor.dual_tor_utils import build_packet_to_server
 from tests.common.dualtor.dual_tor_utils import delete_neighbor
 from tests.common.helpers.dut_utils import get_program_info
 from tests.common.fixtures.ptfhost_utils import run_garp_service, run_icmp_responder # lgtm[py/unused-import]
+from tests.common.utilities import wait_until
 
 
 pytestmark = [
@@ -150,7 +151,8 @@ def test_tunnel_memory_leak(toggle_all_simulator_ports_to_upper_tor,
 
             pkt, exp_pkt = build_packet_to_server(lower_tor_host, ptfadapter, server_ipv4)
 
-            delete_neighbor(upper_tor_host, server_ipv4)
+            pytest_assert(wait_until(3, 1, 0, delete_neighbor, upper_tor_host, server_ipv4),
+                    "server ip {} hasn't been deleted from neighbor table.".format(server_ipv4))
 
             server_traffic_monitor = ServerTrafficMonitor(
                 upper_tor_host, ptfhost, vmhost, tbinfo, iface,


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
`test_tunnel_memory_leak` failed at assert in `delete_neighbor` with wrong condition.
Neighbor was deleted but still threw exception.
#### How did you do it?
Fix wrong assert condition in delete_neighbor

#### How did you verify/test it?
run `dualtor/test_tunnel_memory_leak`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
