### PR TITLE
remove ONIE downgrade from fwutil tests

### DIFF
--- a/tests/platform_tests/fwutil/conftest.py
+++ b/tests/platform_tests/fwutil/conftest.py
@@ -45,7 +45,8 @@ def fw_pkg(fw_pkg_name):
 def random_component(duthost, fw_pkg):
     chass = show_firmware(duthost)["chassis"].keys()[0]
     components = fw_pkg["chassis"].get(chass, {}).get("component", []).keys()
-
+    if 'ONIE' in components:
+        components.remove('ONIE')
     if len(components) == 0:
         pytest.skip("No suitable components found in config file for platform {}.".format(duthost.facts['platform']))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The current ONIE release has a new E2FS package that is not compatible with the old E2FS package version 
that existed in previous ONIE versions.

As a result, it was decided to remove the ONIE downgrade from fwutil tests.


### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
we had a bug where the switch doesn't reboot back to sonic after ONIE update, Upon further investigation this bug reproduces on a downgrade from ONIE 5.3.007 to a prior version of ONIE. 

the cause for this bug is that the current ONIE release (ONIE 5.3.007) has a new E2FS package that is not compatible with the old E2FS package version that existed in previous ONIE versions.

as we do not expect this flow to occur in production, only in testing, it was decided to remove the ONIE downgrade from fwutil tests.

#### How did you do it?
by removing the ONIE from the random components used in the tests.

#### How did you verify/test it?
run the fwutil tests with the change

#### Any platform specific information?
no

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
