### PR TITLE
Add 2 test cases for tunnel QoS remapping

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1332,4 +1332,5 @@ def is_port_with_4_lossless_queues(duthost, port, tbinfo):
     if port in config_facts['DEVICE_NEIGHBOR'] and peer_name in config_facts['DEVICE_NEIGHBOR'][port]['name'].lower():
         return True
     return False
-    
+   
+   

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1072,6 +1072,7 @@ def dualtor_info(ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo):
     res = {}
     res['ptfhost'] = ptfhost
     res['standby_tor_mac'] = standby_tor.facts['router_mac']
+    res['active_tor_mac'] = active_tor.facts['router_mac']
     vlan_name = standby_tor_mg_facts['minigraph_vlans'].keys()[0]
     res['vlan_mac'] = standby_tor.get_dut_iface_mac(vlan_name)
     res['standby_tor_ip'] = _get_iface_ip(standby_tor_mg_facts, 'Loopback0')
@@ -1301,3 +1302,34 @@ def increase_linkmgrd_probe_interval(duthosts, tbinfo):
                     .format(probe_interval_ms))
     cmds.append("config save -y")
     duthosts.shell_cmds(cmds=cmds)
+
+def is_tunnel_qos_remap_enabled(duthost):
+    """
+    Check whether tunnel_qos_remap is enabled or not
+    """
+    try:
+        tunnel_qos_remap_status = duthost.shell('sonic-cfggen -d -v \'SYSTEM_DEFAULTS.tunnel_qos_remap.status\'', module_ignore_errors=True)["stdout_lines"][0].decode("utf-8")
+    except IndexError:
+        return False
+    return "enabled" == tunnel_qos_remap_status
+
+def is_port_with_4_lossless_queues(duthost, port, tbinfo):
+    """
+    Check whether the port has 4 lossless queues
+    If tunnel_qos_ramap is enables, there are 4 lossless queues for ports between T0 and T1
+    """
+    if not is_tunnel_qos_remap_enabled(duthost):
+        return False
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    topo = tbinfo['topo']['type']
+    if 't1' in topo:
+        peer_name = 't0'
+    elif 't0' in topo:
+        peer_name = 't1'
+    else:
+        return False
+
+    if port in config_facts['DEVICE_NEIGHBOR'] and peer_name in config_facts['DEVICE_NEIGHBOR'][port]['name'].lower():
+        return True
+    return False
+    

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -1,0 +1,173 @@
+import logging
+import pytest
+import time
+from tests.common.helpers.assertions import pytest_require, pytest_assert
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_lower_tor # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, dualtor_info, get_t1_active_ptf_ports, is_tunnel_qos_remap_enabled
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses, run_icmp_responder, run_garp_service # lgtm[py/unused-import]
+import ptf.packet as scapy
+from ptf.mask import Mask
+from ptf import testutils
+from ptf.testutils import simple_tcp_packet, simple_ipv4ip_packet
+
+pytestmark = [
+    pytest.mark.topology('t0')
+]
+
+logger = logging.getLogger(__name__)
+
+SERVER_IP = "192.168.0.2"
+DUMMY_IP = "1.1.1.1"
+DUMMY_MAC = "aa:aa:aa:aa:aa:aa"
+
+@pytest.fixture(scope='module', autouse=True)
+def check_running_condition(tbinfo, duthost):
+    """
+    The test can only be running on tunnel_qos_remap enabled dualtor testbed
+    """
+    # Check dualtor topo
+    pytest_require("dualtor" in tbinfo["topo"]["name"], "Only run on dualtor testbed.", True)
+    
+    # Check tunnel_qos_remap is enabled
+    pytest_require(is_tunnel_qos_remap_enabled(duthost), "Only run when tunnel_qos_remap is enabled", True)
+
+
+def _build_testing_packet(src_ip, dst_ip, active_tor_mac, standby_tor_mac, active_tor_ip, standby_tor_ip, inner_dscp, outer_dscp, ecn=1):
+    pkt = simple_tcp_packet(
+                eth_dst=standby_tor_mac,
+                ip_src=src_ip,
+                ip_dst=dst_ip,
+                ip_dscp=inner_dscp,
+                ip_ecn=ecn,
+                ip_ttl=64
+            )
+    # The ttl of inner_frame is decreased by 1
+    pkt.ttl -= 1
+    ipinip_packet = simple_ipv4ip_packet(
+                eth_dst=active_tor_mac,
+                eth_src=standby_tor_mac,
+                ip_src=standby_tor_ip,
+                ip_dst=active_tor_ip,
+                ip_dscp=outer_dscp,
+                ip_ecn=ecn,
+                inner_frame=pkt[IP]
+            )
+    pkt.ttl += 1
+    exp_tunnel_pkt = Mask(ipinip_packet)
+    exp_tunnel_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+    exp_tunnel_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+    exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "id") # since src and dst changed, ID would change too
+    exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "ttl") # ttl in outer packet is set to 255
+    exp_tunnel_pkt.set_do_not_care_scapy(scapy.IP, "chksum") # checksum would differ as the IP header is not the same
+
+    return pkt, exp_tunnel_pkt
+
+
+def test_encap_dscp_rewrite(ptfhost, upper_tor_host, lower_tor_host, toggle_all_simulator_ports_to_lower_tor, tbinfo, ptfadapter):
+    """
+    The test is to verify the dscp rewriting of encapped packets.
+    Test steps
+    1. Toggle mux to lower tor, so all mux ports are standby on upper_tor
+    2. Generate packets with certain DSCP value
+    3. Send the generated packets via portchannels
+    4. Verify the packets are encapped with expected DSCP value 
+    """
+    DSCP_COMBINATIONS = [
+        # DSCP in generated packets, expected DSCP in encapped packets
+        (8, 8),
+        (0, 0),
+        (33, 33),
+        (3, 2),
+        (4, 6),
+        (46, 46),
+        (48, 48)
+    ]
+    dualtor_meta = dualtor_info(ptfhost, upper_tor_host, lower_tor_host, tbinfo)
+    
+    t1_ports = get_t1_active_ptf_ports(upper_tor_host, tbinfo)
+    # Always select the first port in first LAG as src_port
+    src_port = list(t1_ports.values())[0][0]
+    dst_ports = []
+    for ports in t1_ports.values():
+        dst_ports.extend(ports)
+
+    for dscp_combination in DSCP_COMBINATIONS:
+        pkt, expected_pkt = _build_testing_packet(src_ip=DUMMY_IP,
+                                                  dst_ip=SERVER_IP,
+                                                  active_tor_mac=dualtor_meta['active_tor_mac'],
+                                                  standby_tor_mac=dualtor_meta['standby_tor_mac'],
+                                                  active_tor_ip=dualtor_meta['active_tor_ip'],
+                                                  standby_tor_ip=dualtor_meta['standby_tor_ip'],
+                                                  inner_dscp=dscp_combination[0],
+                                                  outer_dscp=dscp_combination[1],
+                                                  ecn=1)
+        ptfadapter.dataplane.flush()
+        # Send original packet
+        testutils.send(ptfadapter, src_port, pkt)
+        # Verify encaped packet
+        testutils.verify_packet_any_port(ptfadapter, expected_pkt, dst_ports)
+
+def _check_queue_counter(duthost, intfs, queue, counter):
+    output = duthost.shell('show queue counters')['stdout_lines']
+
+    for intf in intfs:
+        for line in output:
+            fields = line.split()
+            if len(fields) == 6 and fields[0] == intf and fields[1] == 'UC{}'.format(queue):
+                if int(fields[2]) >= counter:
+                    return True
+    
+    return False
+
+def test_bounced_back_traffic_in_expected_queue(ptfhost, upper_tor_host, lower_tor_host, toggle_all_simulator_ports_to_lower_tor, tbinfo, ptfadapter):
+    """
+    The test case is to verify the encapped packet is mapped to the correct queue
+    Test steps:
+    1. Toggle mux to lower tor, so all mux ports are standby on upper_tor
+    2. Generate packets with certain DSCP value
+    3. Send the generated packets via portchannels
+    4. Verify the packets are outgoing from expected queue 
+    """
+    TEST_DATA = [
+        #DSCP QUEUE
+        (8, 0),
+        (0, 1),
+        (33, 1),
+        (3, 2),
+        (4, 6),
+        (46, 5),
+        (48, 7)
+    ]
+    dualtor_meta = dualtor_info(ptfhost, upper_tor_host, lower_tor_host, tbinfo)
+    
+    t1_ports = get_t1_active_ptf_ports(upper_tor_host, tbinfo)
+    # Always select the first port in first LAG as src_port
+    src_port = list(t1_ports.values())[0][0]
+    mg_facts = upper_tor_host.get_extended_minigraph_facts(tbinfo)
+    portchannel_info = mg_facts['minigraph_portchannels']
+    tor_pc_intfs = list()
+    for pc in portchannel_info.values():
+        for member in pc['members']:
+            tor_pc_intfs.append(member)
+    PKT_NUM = 100
+
+    for dscp, queue in TEST_DATA:
+        pkt, _ = _build_testing_packet(src_ip=DUMMY_IP,
+                                        dst_ip=SERVER_IP,
+                                        active_tor_mac=dualtor_meta['active_tor_mac'],
+                                        standby_tor_mac=dualtor_meta['standby_tor_mac'],
+                                        active_tor_ip=dualtor_meta['active_tor_ip'],
+                                        standby_tor_ip=dualtor_meta['standby_tor_ip'],
+                                        inner_dscp=dscp,
+                                        outer_dscp=0,
+                                        ecn=1)
+        # Clear queuecounters before sending traffic
+        upper_tor_host.shell('sonic-clear queuecounters')
+        # Send original packet
+        testutils.send_packet(ptfadapter, src_port, pkt, PKT_NUM)
+        # Verify queue counters in all possible interfaces
+        time.sleep(15)
+
+        pytest_assert(_check_queue_counter(upper_tor_host, tor_pc_intfs, queue, PKT_NUM),
+                         "The queue counter for DSCP {} Queue {} is not as expected".format(dscp, queue))
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to add two test cases for verifying tunnel QoS remapping.
Test plan: https://github.com/Azure/sonic-mgmt/pull/5508

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
This PR is to add two test cases for tunnel QoS remapping.
1. TC1 test_encap_dscp_rewrite
The test is to verify the dscp rewriting of encapped packets.
2. TC2 test_bounced_back_traffic_in_expected_queue
The test case is to verify the encapped packet is mapped to the correct queue
 
#### How did you do it?
Please see test plan.

#### How did you verify/test it?
Verified on a dualtor testbed.
```
collected 2 items                                                                                                                                                                                     

qos/test_tunnel_qos_remap.py::test_encap_dscp_rewrite PASSED                                                                                                                                    [ 50%]
qos/test_tunnel_qos_remap.py::test_bounced_back_traffic_in_expected_queue PASSED                                                                                                                [100%]
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
Dualtor testbed specified.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
