### PR TITLE
[auto-ts] Updated regex in test_auto_techsupport

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -1,4 +1,3 @@
-import re
 import pytest
 import time
 import logging


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
In PR - [10433](https://github.com/Azure/sonic-buildimage/pull/10433) were added changes that add automatic techsupport invocation in case memory usage is too high. After this PR output of Cli cmd's `(show auto-techsupport global, show auto-techsupport-feature, show auto-techsupport history)` changed and TC's are failing to parse the output on SONiC images `SONiC.master.112803-dirty-20220621.160636` or higher .

```
     if since:
            with allure.step('Checking global since'):
>               assert str(current_since) == str(since), \
                    'Wrong configuration for since: {} expected: {}'.format(current_since, since)
E               AssertionError: Wrong configuration for since: 10                             200                       2 days ago expected: 2 days ago
E               assert '10          ...   2 days ago' == '2 days ago'
E                 - 10                             200                       2 days ago
E                 + 2 days ago
```
This PR updates the regex to properly parse the output in both cases (when TC will run on Sonic image that doesn't include changes in [10433](https://github.com/Azure/sonic-buildimage/pull/10433) or in case when Sonic image have this changes `SONiC.master.112803-dirty-20220621.160636` or higher)

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Update the regex to properly parse the output of cli cmd's on newer SONiC images
#### How did you do it?

#### How did you verify/test it?
Run TC on Sonic image `SONiC.master.112803-dirty-20220621.160636` and `SONiC.master.105614-dirty-20220602.215204`
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.117621-dirty-20220703.113429
Distribution: Debian 11.3
Kernel: 5.10.0-12-2-amd64
Build commit: 23d68883f
Build date: Sun Jul  3 16:43:57 UTC 2022
Built by: AzDevOps@sonic-build-workers-001PX8
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
