### PR TITLE
[tests/ecmp/inner_hashing] improve the restore test environment

### DIFF
--- a/tests/ecmp/inner_hashing/conftest.py
+++ b/tests/ecmp/inner_hashing/conftest.py
@@ -106,8 +106,9 @@ def config_facts(duthosts, rand_one_dut_hostname):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def setup(duthosts, rand_one_dut_hostname):
+def setup(duthosts, rand_one_dut_hostname, teardown):
     duthost = duthosts[rand_one_dut_hostname]
+    duthost.shell("cp /etc/sonic/config_db.json /etc/sonic/config_db.json.bak")
 
     vxlan_switch_config = [{
         "SWITCH_TABLE:switch": {
@@ -128,7 +129,7 @@ def backup_config_db_json(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     duthost.shell("cp /etc/sonic/config_db.json /etc/sonic/config_db.json.bak")
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module")
 def teardown(duthosts, rand_one_dut_hostname):
     """
     Teardown fixture to clean up DUT to initial state

--- a/tests/ecmp/inner_hashing/conftest.py
+++ b/tests/ecmp/inner_hashing/conftest.py
@@ -124,10 +124,6 @@ def setup(duthosts, rand_one_dut_hostname, teardown):
     duthost.shell("docker exec swss sh -c \"swssconfig /vxlan.switch.json\"")
     time.sleep(3)
 
-@pytest.fixture(scope="module", autouse=True)
-def backup_config_db_json(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    duthost.shell("cp /etc/sonic/config_db.json /etc/sonic/config_db.json.bak")
 
 @pytest.fixture(scope="module")
 def teardown(duthosts, rand_one_dut_hostname):


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
it is improvement of the change #5868. 
1. after the change 5868 was changed the order of fixtures in teardown.
1. config reload in teardown will use init config_db.json file and not current, which can be changed by test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
by test test_wr_inner_hashing_lag.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
