### PR TITLE
[sFlow]Add import for subprocess in sflow_test

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/py3/sflow_test.py
@@ -18,6 +18,8 @@ import select
 from collections import Counter
 import logging
 import ast
+import subprocess
+
 
 class SflowTest(BaseTest):
     def __init__(self):


### PR DESCRIPTION
In the test file, the subprocess is used without importing this lib

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: In the test file, the subprocess is used without importing this lib
Fixes # (issue) Fix the exception issue

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
In the test file, the subprocess is used without importing this lib
#### How did you do it?
Add the import for subprocess
#### How did you verify/test it?
Run the sflow test, and no exception.
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
