### PR TITLE
[dualtor] Add sanity check support for `active-active` ports

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1396,7 +1396,13 @@ Totals               6450                 6449
             corresponding to one content line under the header in the output. Keys of the dictionary are the column
             headers in lowercase.
         """
+        start_line_index = kwargs.pop("start_line_index", 0)
+        end_line_index = kwargs.pop("end_line_index", None)
         output = self.shell(show_cmd, **kwargs)["stdout_lines"]
+        if end_line_index is None:
+            output = output[start_line_index:]
+        else:
+            output = output[start_line_index:end_line_index]
         return self._parse_show(output)
 
     @cached(name='mg_facts')

--- a/tests/common/dualtor/dual_tor_common.py
+++ b/tests/common/dualtor/dual_tor_common.py
@@ -9,6 +9,7 @@ class CableType(object):
     """Dualtor cable type."""
     active_active = "active-active"
     active_standby = "active-standby"
+    default_type = "active-standby"
 
 
 @pytest.fixture(params=[CableType.active_standby])

--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -1,11 +1,16 @@
 """Control utilities to interacts with nic_simulator."""
+import logging
 import pytest
+import time
 
+from tests.common import utilities
 from tests.common.dualtor.dual_tor_common import cable_type                     # lgtm[py/unused-import]
 from tests.common.dualtor.dual_tor_common import CableType
 
 __all__ = [
     "nic_simulator_info",
+    "restart_nic_simulator_session",
+    "restart_nic_simulator",
     "nic_simulator_url",
     "toggle_all_ports_both_tors_admin_forwarding_state_to_active"
 ]
@@ -20,7 +25,37 @@ class ForwardingState(object):
 @pytest.fixture(scope="session")
 def nic_simulator_info(request, tbinfo):
     """Fixture to gather nic_simulator related infomation."""
-    pass
+    if "dualtor-mixed" not in tbinfo["topo"]["name"]:
+        return None, None, None
+
+    server = tbinfo["server"]
+    vmset_name = tbinfo["group-name"]
+    inv_files = request.config.option.ansible_inventory
+    ip = utilities.get_test_server_vars(inv_files, server).get('ansible_host')
+    _port_map = utilities.get_group_visible_vars(inv_files, server).get('nic_simulator_grpc_port')
+    port = _port_map[tbinfo['conf-name']]
+    return ip, port, vmset_name
+
+
+def _restart_nic_simulator(vmhost, vmset_name):
+    if vmset_name is not None:
+        vmhost.command("systemctl restart nic-simulator-%s" % vmset_name)
+        time.sleep(5)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def restart_nic_simulator_session(nic_simulator_info, vmhost):
+    """Session level fixture to restart nic_simulator service on the VM server host."""
+    _, _, vmset_name = nic_simulator_info
+    _restart_nic_simulator(vmhost, vmset_name)
+
+
+@pytest.fixture(scope="module")
+def restart_nic_simulator(nic_simulator_info, vmhost):
+    """Fixture to restart nic_simulator service on the VM server host."""
+    _, _, vmset_name = nic_simulator_info
+
+    return lambda: _restart_nic_simulator(vmhost, vmset_name)
 
 
 @pytest.fixture(scope="session")

--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -1,5 +1,4 @@
 """Control utilities to interacts with nic_simulator."""
-import logging
 import pytest
 import time
 

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -526,11 +526,12 @@ def _check_dut_mux_status(duthosts, duts_minigraph_facts):
             err_msg = "Unknown error occured inside the check"
         return False, err_msg, {}
 
-    for dut_mux_status in duts_parsed_mux_status.values():
-        for port_mux_status in dut_mux_status.values():
-            if "hwstatus" in port_mux_status and port_mux_status["hwstatus"].lower() != "consistent":
-                err_msg = "'show mux status' shows inconsistent for HWSTATUS"
-                return False, err_msg, {}
+    # FIXME: Enable the check for hwstatus
+    # for dut_mux_status in duts_parsed_mux_status.values():
+    #     for port_mux_status in dut_mux_status.values():
+    #         if "hwstatus" in port_mux_status and port_mux_status["hwstatus"].lower() != "consistent":
+    #             err_msg = "'show mux status' shows inconsistent for HWSTATUS"
+    #             return False, err_msg, {}
 
     return True, "", duts_parsed_mux_status
 

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -6,7 +6,9 @@ import time
 
 from tests.common.utilities import wait, wait_until
 from tests.common.dualtor.mux_simulator_control import get_mux_status, reset_simulator_port
+from tests.common.dualtor.nic_simulator_control import restart_nic_simulator
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR, NIC
+from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.cache import FactsCache
 from tests.common.plugins.sanity_check.constants import STAGE_PRE_TEST, STAGE_POST_TEST
 from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
@@ -442,6 +444,47 @@ def _check_single_intf_status(intf_status, expected_side):
 
 
 def _check_dut_mux_status(duthosts, duts_minigraph_facts):
+
+    def _verify_show_mux_status():
+        duts_mux_status = duthosts.show_and_parse("show mux status")
+
+        duts_parsed_mux_status.clear()
+        for dut_hostname, dut_mux_status in duts_mux_status.items():
+            logger.info('Verify that "show mux status" has output ON {}'.format(dut_hostname))
+            if len(dut_mux_status) != len(port_cable_types):
+                err_msg_from_mux_status.append("Some ports doesn't have 'show mux status' output")
+                return False
+
+            dut_parsed_mux_status = {}
+            for row in dut_mux_status:
+                if row["status"] not in ("active", "standby"):
+                    err_msg_from_mux_status.append('Unexpected mux status "{}", please check output of "show mux status"'.format(row['status']))
+                    return False
+
+                port_name = row['port']
+                port_idx = str(duts_minigraph_facts[dut_hostname][0]['minigraph_port_indices'][port_name])
+                mux_status = 0 if row["status"] == "standby" else 1
+                dut_parsed_mux_status[port_idx] = {"status": mux_status, "cable_type": port_cable_types[port_idx]}
+                if "hwstatus" in row:
+                    dut_parsed_mux_status[port_idx]["hwstatus"] = row["hwstatus"]
+
+            duts_parsed_mux_status[dut_hostname] = dut_parsed_mux_status
+
+        logger.info('Verify that the mux status on both ToRs are consistent')
+        upper_tor_mux_status = duts_parsed_mux_status[duthosts[0].hostname]
+        lower_tor_mux_status = duts_parsed_mux_status[duthosts[1].hostname]
+
+        logger.info('Verify that mux status is consistent on both ToRs.')
+        for port_idx, cable_type in port_cable_types.items():
+            if cable_type == CableType.active_standby:
+                if (upper_tor_mux_status[port_idx]['status'] ^ lower_tor_mux_status[port_idx]['status']) == 0:
+                    err_msg_from_mux_status.append('Inconsistent mux status for active-standby ports on dualtors, please check output of "show mux status"')
+                    return False
+
+        logger.info('Check passed, return parsed mux status')
+        err_msg_from_mux_status.append("")
+        return True
+
     dut_upper_tor = duthosts[0]
     dut_lower_tor = duthosts[1]
 
@@ -449,70 +492,55 @@ def _check_dut_mux_status(duthosts, duts_minigraph_facts):
         err_msg = 'Multi-asic hwsku not supported for DualTor Topology as of now'
         return False, err_msg, {}
 
-    # Run "show mux status" on dualtor DUTs to collect mux status
-    duts_mux_status = duthosts.show_and_parse('show mux status')
+    duts_mux_config = duthosts.show_and_parse("show mux config", start_line_index=3)
+    upper_tor_mux_config = duts_mux_config[dut_upper_tor.hostname]
+    lower_tor_mux_config = duts_mux_config[dut_lower_tor.hostname]
+    if upper_tor_mux_config != lower_tor_mux_config:
+        err_msg = "'show mux config' output differs between two ToRs"
+        return False, err_msg, {}
 
-    # Parse and basic check
+    port_cable_types = {}
+    has_active_active_ports = False
+    for row in upper_tor_mux_config:
+        port_name = row["port"]
+        port_idx = str(duts_minigraph_facts[dut_upper_tor.hostname][0]['minigraph_port_indices'][port_name])
+        if "cable_type" in row:
+            if row["cable_type"] and row["cable_type"] not in (CableType.active_active, CableType.active_standby):
+                err_msg = "Unsupported cable type %s for %s" % (row["cable_type"], port_name)
+                return False, err_msg, {}
+            elif row["cable_type"]:
+                port_cable_types[port_idx] = row["cable_type"]
+            else:
+                port_cable_types[port_idx] = CableType.default_type
+        else:
+            port_cable_types[port_idx] = CableType.default_type
+        if port_cable_types[port_idx] == CableType.active_active:
+            has_active_active_ports = True
+
     duts_parsed_mux_status = {}
-    for dut_hostname, dut_mux_status in duts_mux_status.items():
+    err_msg_from_mux_status = []
+    if (has_active_active_ports and not wait_until(30, 5, 0, _verify_show_mux_status)) or (not _verify_show_mux_status()):
+        if err_msg_from_mux_status:
+            err_msg = err_msg_from_mux_status[-1]
+        else:
+            err_msg = "Unknown error occured inside the check"
+        return False, err_msg_from_mux_status[-1], {}
 
-        logger.info('Verify that "show mux status" has output ON {}'.format(dut_hostname))
-        if len(dut_mux_status) == 0:
-            err_msg = 'No mux status in output of "show mux status"'
-            return False, err_msg, {}
-
-        logger.info('Verify that mux ports match vlan interfaces of DUT.')
-        vlan_intf_names = set()
-        for vlan in duts_minigraph_facts[dut_hostname][0]['minigraph_vlans'].values():
-            vlan_intf_names = vlan_intf_names.union(set(vlan['members']))
-        dut_mux_intfs = []
-        for row in dut_mux_status:
-            dut_mux_intfs.append(row['port'])
-        if vlan_intf_names != set(dut_mux_intfs):
-            err_msg = 'Mux ports mismatch vlan interfaces, please check output of "show mux status"'
-            return False, err_msg, {}
-
-        logger.info('Verify mux status and parse active/standby side')
-        dut_parsed_mux_status = {}
-        for row in dut_mux_status:
-            # Verify that mux status is either active or standby
-            if row['status'] not in ['active', 'standby']:
-                err_msg = 'Unexpected mux status "{}", please check output of "show mux status"'.format(row['status'])
+    for dut_mux_status in duts_parsed_mux_status.values():
+        for port_mux_status in dut_mux_status.values():
+            if "hwstatus" in port_mux_status and port_mux_status["hwstatus"].lower() != "consistent":
+                err_msg = "'show mux status' shows inconsistent for HWSTATUS"
                 return False, err_msg, {}
 
-            # Parse mux status, transform port name to port index, which is also mux index
-            port_name = row['port']
-            port_idx = duts_minigraph_facts[dut_hostname][0]['minigraph_port_indices'][port_name]
-
-            # Transform "active" and "standby" to active side which is "upper_tor" or "lower_tor"
-            status = row['status']
-            if dut_hostname == dut_upper_tor.hostname:
-                # On upper tor, mux status "active" means that active side of mux is upper_tor
-                # mux status "standby" means that active side of mux is lower_tor
-                active_side = UPPER_TOR if status == 'active' else LOWER_TOR
-            else:
-                # On lower tor, mux status "active" means that active side of mux is lower_tor
-                # mux status "standby" means that active side of mux is upper_tor
-                active_side = UPPER_TOR if status == 'standby' else LOWER_TOR
-            dut_parsed_mux_status[str(port_idx)] = active_side
-        duts_parsed_mux_status[dut_hostname] = dut_parsed_mux_status
-
-    logger.info('Verify that the mux status on both ToRs are consistent')
-    upper_tor_mux_status = duts_parsed_mux_status[dut_upper_tor.hostname]
-    lower_tor_mux_status = duts_parsed_mux_status[dut_lower_tor.hostname]
-
-    logger.info('Verify that mux status is consistent on both ToRs.')
-    for port_idx in upper_tor_mux_status:
-        if upper_tor_mux_status[port_idx] != lower_tor_mux_status[port_idx]:
-            err_msg = 'Inconsistent mux status on dualtors, please check output of "show mux status"'
-            return False, err_msg, {}
-
-    logger.info('Check passed, return parsed mux status')
-    return True, "", upper_tor_mux_status
+    return True, "", duts_parsed_mux_status
 
 
 @pytest.fixture(scope='module')
-def check_mux_simulator(duthosts, duts_minigraph_facts, get_mux_status, reset_simulator_port):
+def check_mux_simulator(tbinfo, duthosts, duts_minigraph_facts, get_mux_status, reset_simulator_port, restart_nic_simulator):
+
+    def _recover():
+        reset_simulator_port()
+        restart_nic_simulator()
 
     def _check(*args, **kwargs):
         """
@@ -536,31 +564,32 @@ def check_mux_simulator(duthosts, duts_minigraph_facts, get_mux_status, reset_si
         failed = False
         reason = ''
 
-        check_passed, err_msg, dut_mux_status = _check_dut_mux_status(duthosts, duts_minigraph_facts)
+        check_passed, err_msg, duts_mux_status = _check_dut_mux_status(duthosts, duts_minigraph_facts)
         if not check_passed:
             logger.warning(err_msg)
             results['failed'] = True
             results['failed_reason'] = err_msg
             results['hosts'] = [ dut.hostname for dut in duthosts ]
-            results['action'] = reset_simulator_port
+            results['action'] = _recover
             return results
 
         mux_simulator_status = get_mux_status()
+        upper_tor_mux_status = duts_mux_status[duthosts[0].hostname]
 
         for status in mux_simulator_status.values():
             port_index = str(status['port_index'])
 
             # Some host interfaces in dualtor topo are disabled.
             # We only care about status of mux for the enabled host interfaces
-            if port_index in dut_mux_status:
-                active_side = dut_mux_status[port_index]
+            if port_index in upper_tor_mux_status and upper_tor_mux_status[port_index]["cable_type"] == CableType.active_standby:
+                active_side = UPPER_TOR if upper_tor_mux_status[port_index]["status"] == 1 else LOWER_TOR
                 failed, reason = _check_single_intf_status(status, expected_side=active_side)
 
             if failed:
                 logger.warning('Mux sanity check failed for status:\n{}'.format(status))
                 results['failed'] = failed
                 results['failed_reason'] = reason
-                results['action'] = reset_simulator_port
+                results['action'] = _recover
                 return results
 
         return results

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -524,7 +524,7 @@ def _check_dut_mux_status(duthosts, duts_minigraph_facts):
             err_msg = err_msg_from_mux_status[-1]
         else:
             err_msg = "Unknown error occured inside the check"
-        return False, err_msg_from_mux_status[-1], {}
+        return False, err_msg, {}
 
     for dut_mux_status in duts_parsed_mux_status.values():
         for port_mux_status in dut_mux_status.values():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,8 +24,9 @@ from tests.common.devices.duthosts import DutHosts
 from tests.common.devices.vmhost import VMHost
 from tests.common.devices.base import NeighborDevice
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_session
-from tests.common.fixtures.ptfhost_utils import ptf_portmap_file  # lgtm[py/unused-import]
-
+from tests.common.fixtures.ptfhost_utils import ptf_portmap_file                # lgtm[py/unused-import]
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder_session      # lgtm[py/unused-import]
+ 
 from tests.common.helpers.constants import (
     ASIC_PARAM_TYPE_ALL, ASIC_PARAM_TYPE_FRONTEND, DEFAULT_ASIC_ID,
 )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Add sanity check support for `active-active` ports.

#### How did you do it?
1. Start running `icmp_responder` at session-level is topology is of `dualtor-mixed`.
2. Check the `active-active` port status is either `active` or `standby`.
3. Restart the `nic_simulator` service as recovery if the check fails.

#### How did you verify/test it?
Run pretest on both `dualtor` and `dualtor-mixed` testbeds:
```
test_pretest.py::test_cleanup_testbed[str2-demo-10] PASSED                                                                                                                                                                                                      [ 50%]
test_pretest.py::test_cleanup_testbed[str2-demo-11] PASSED                                                                                                                                                                                                      [100%]

========================================================================================================================= 2 passed in 159.01 seconds =========================================================================================================================
```
```
test_pretest.py::test_cleanup_testbed[svcstr-demo-1] PASSED                                                                                                                                                                                                        [ 50%]
test_pretest.py::test_cleanup_testbed[svcstr-demo-2] PASSED                                                                                                                                                                                                        [100%]

========================================================================================================================= 2 passed in 207.07 seconds =========================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
