### PR TITLE
[po_update]fix local variable referenced before assignment issue

### DIFF
--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -200,6 +200,11 @@ def test_po_update_io_no_loss(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     pc_ip = out_pc[0]
     in_peer_ip = in_pc[1]
     out_peer_ip = out_pc[1]
+    remove_pc_members = False
+    remove_pc_ip = False
+    create_tmp_pc = False
+    add_tmp_pc_members = False
+    add_tmp_pc_ip = False
     try:
         # Step 1: Remove port channel members from port channel
         for member in pc_members:


### PR DESCRIPTION
In the test_po_update_io_no_loss, there is try-finally block, some local vars are defined in the try, and used in the finally, is there is some exception before the local var assigned, then it will throw exception local variable 'xxx' referenced before assignment

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fix local variable referenced before assignment issue
Fixes # (issue) fix local variable referenced before assignment issue

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Add default value for  following variables:
    remove_pc_members = False
    remove_pc_ip = False
    create_tmp_pc = False
    add_tmp_pc_members = False
    add_tmp_pc_ip = False
#### How did you verify/test it?
Run the test case, and the test will not hit local variable referenced before assignment issue
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
