### PR TITLE
[test_gap] Add two test cases to check if the status of lag interfaces is in sync with state_db

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -261,7 +261,7 @@ platform_tests/test_auto_negotiation.py:
     conditions: https://github.com/Azure/sonic-mgmt/issues/5447
 
 #######################################
-#####             po              #####
+#####             pc              #####
 #######################################
 pc/test_lag_2.py::test_lag_db_status_with_po_update:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -261,6 +261,15 @@ platform_tests/test_auto_negotiation.py:
     conditions: https://github.com/Azure/sonic-mgmt/issues/5447
 
 #######################################
+#####             po              #####
+#######################################
+po/test_lag_2.py::test_lag_db_status_with_po_update:
+  skip:
+    reason: "Only support t1-lag topology"
+    conditions:
+        - "topo_name not in ['t1-lag']"
+
+#######################################
 #####           qos               #####
 #######################################
 qos/test_buffer_traditional.py:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -263,7 +263,7 @@ platform_tests/test_auto_negotiation.py:
 #######################################
 #####             po              #####
 #######################################
-po/test_lag_2.py::test_lag_db_status_with_po_update:
+pc/test_lag_2.py::test_lag_db_status_with_po_update:
   skip:
     reason: "Only support t1-lag topology"
     conditions:

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -362,12 +362,12 @@ def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level):
                 else:
                     pytest_require(dut_lag in lag_facts['names'], "No lag {} configuration found in {}".format(dut_lag, duthost.hostname))
                     test_lags = [ dut_lag ]
-                # 1. Check if interfaces' status synced with state_db after bootup.
+                # 1. Check if status of interface is in sync with state_db after bootup.
                 for lag_name in test_lags:
                     for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
                         check_status_is_syncd(duthost, po_intf, port_info, lag_name)
  
-                # 2. Check if interfaces' status synced with state_db after shutdown/no shutdown.
+                # 2. Check if status of interface is in sync with state_db after shutdown/no shutdown.
                 for lag_name in test_lags:
                     for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
                         duthost.shutdown(po_intf)
@@ -406,7 +406,7 @@ def test_lag_db_status_with_po_update(duthosts, enum_frontend_asic_index, teardo
                 pytest_require(dut_lag in lag_facts['names'], "No lag {} configuration found in {}".format(dut_lag, duthost.hostname))
                 test_lags = [ dut_lag ]
 
-            # Check if interfaces' status is synced with state_db after removing/adding member with shutdown/no shutdown operation.
+            # Check if status of interface is in sync with state_db after removing/adding member.
             for lag_name in test_lags:
                 for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
                     # 1 Remove port member from portchannel
@@ -422,7 +422,7 @@ def test_lag_db_status_with_po_update(duthosts, enum_frontend_asic_index, teardo
                     # 3 Add this port back into portchannel and check if status is synced
                     asichost.config_portchannel_member(lag_name, po_intf, "add")
 
-                    # 4 Retrieve lag_facts after shutdown interface
+                    # 4 Retrieve lag_facts after shutdown interface and check if status is synced
                     new_lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
                     port_info =  new_lag_facts['lags'][lag_name]['po_stats']['ports'][po_intf]
                     check_status_is_syncd(duthost, po_intf, port_info, lag_name)


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
test gap for https://github.com/Azure/sonic-buildimage/issues/11255

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
PR test didn't catch the issue https://github.com/Azure/sonic-buildimage/issues/11255.
`test_lldp.py` run to success because `netdev_oper_status` of interfaces is up in `state_db`.
But in physical testbed, `netdev_oper_status` of some interfaces is down and it impacts the lldp behavior. So `test_lldp.py` caught it.
Root cause is the `netdev_oper_status `in `state_db `is not synced with the real status of interface.
If the image has this issue, no matter you shutdown or no shutdown interface, the `netdev_oper_status`  can't be updated.

#### How did you do it?
Add two cases in `test_lag_2.py` to check if the status of lag interfaces is in sync with state_db.

1. `test_lag_db_status` is to check if status of lag's member interfaces is synced with port's `netdev_oper_status` in state_db. It can run on any topology.
1). Check if status of interface is in sync with state_db after bootup.
2). Check if status of interface is in sync with state_db after shutdown/no shutdown.

2. `test_lag_db_status_with_po_update` is to check if status of lag's member interfaces is synced with port's `netdev_oper_status` in state_db with add/delete operation for lag member. It only supports t1-lag topology.

1) Remove port member from portchannel
2) Shutdown this port to check if status is down
3) Add this port back into portchannel and check if status is synced
4) Retrieve lag_facts after shutdown interface and check if status is synced
5) No shutdown this port to check if status is up 
6) Retrieve lag_facts after no shutdown interface to check if status is synced

Since there are so many interfaces in t1-lag, we can define `--completeness_level confident` to pick up some interface to run it.

#### How did you verify/test it?
run `test_lag_2.py::test_lag_db_status` and `test_lag_2.py::test_lag_db_status_with_po_update`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
