### PR TITLE
Added Support of attribute <Bandwidth> for external link to support port speed change.

### DIFF
--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -11,6 +11,9 @@
         <EndPort>{{ vm_intfs[if_index] }}</EndPort>
         <StartDevice>{{ inventory_hostname }}</StartDevice>
         <StartPort>{{ port_alias[dut_intfs[if_index]] }}</StartPort>
+{% if device_conn[inventory_hostname][port_alias_map[port_alias[dut_intfs[if_index]]]] is defined %}
+        <Bandwidth>{{ device_conn[inventory_hostname][port_alias_map[port_alias[dut_intfs[if_index]]]]['speed'] }}</Bandwidth>
+{% endif %}
       </DeviceLinkBase>
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
What/Why I did:
Added Support of attribute <Bandwidth> for external link to support port speed change operation. 
Ex: port_config.ini (HWSKU default speed) specify port speed as 100G which is mapped to <Speed> attribute of DeviceInfo but the actual connection is 40G which will get mapped to <Bandwidth> attribute of Png Section.

How I verify:-

Generated the minigraph with this change and did `load miningraph` and make sure port speed change is taken effect.

