### PR TITLE
Updated approach for installing nanomsg in copp TC

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -150,7 +150,7 @@ def restore_ptf(ptf):
 
     ptf.supervisorctl(name="ptf_nn_agent", state="restarted")
 
-def configure_syncd(dut, nn_target_port, nn_target_interface, nn_target_namespace, nn_target_vlanid, creds):
+def configure_syncd(dut, nn_target_port, nn_target_interface, nn_target_namespace, nn_target_vlanid, swap_syncd, creds):
     """
         Configures syncd to run the NN agent on the specified port.
 
@@ -178,7 +178,8 @@ def configure_syncd(dut, nn_target_port, nn_target_interface, nn_target_namespac
 
     syncd_docker_name = asichost.get_docker_name("syncd")
 
-    _install_nano(dut, creds, syncd_docker_name)
+    if not swap_syncd:
+        _install_nano(dut, creds, syncd_docker_name)
 
     dut.template(src=_SYNCD_NN_TEMPLATE, dest=_SYNCD_NN_DEST)
 
@@ -205,25 +206,46 @@ def _install_nano(dut, creds,  syncd_docker_name):
             dut (SonicHost): The target device.
             creds (dict): Credential information according to the dut inventory
     """
-
-    output = dut.command("docker exec {} bash -c '[ -d /usr/local/include/nanomsg ] || echo copp'".format(syncd_docker_name))
+    output = dut.command("docker exec {} bash -c '[ -d /usr/local/include/nanomsg ] && [ -d /opt/ptf ] || echo copp'".format(syncd_docker_name))
 
     if output["stdout"] == "copp":
         http_proxy = creds.get('proxy_env', {}).get('http_proxy', '')
         https_proxy = creds.get('proxy_env', {}).get('https_proxy', '')
+        check_cmd = "docker exec -i {} bash -c 'cat /etc/os-release'".format(syncd_docker_name)
 
-        cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
-                rm -rf /var/lib/apt/lists/* \
-                && apt-get update \
-                && apt-get install -y python-pip build-essential libssl-dev libffi-dev python-dev python-setuptools wget cmake \
-                && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
-                && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
-                && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
-                && rm -f 1.0.0.tar.gz && pip2 install cffi==1.7.0 && pip2 install --upgrade cffi==1.7.0 && pip2 install nnpy \
-                && mkdir -p /opt && cd /opt && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-                && mkdir ptf && cd ptf && wget https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
-                " '''.format(http_proxy, https_proxy, syncd_docker_name)
-        dut.command(cmd)
+        if "bullseye" in dut.shell(check_cmd)['stdout'].lower():
+            cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
+                    rm -rf /var/lib/apt/lists/* \
+                    && apt-get update \
+                    && apt-get install -y python3-pip build-essential libssl-dev libffi-dev python3-dev python-setuptools wget cmake \
+                    && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+                    && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
+                    && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
+                    && rm -f 1.0.0.tar.gz && pip3 install cffi && pip3 install --upgrade cffi && pip3 install nnpy \
+                    && mkdir -p /opt && cd /opt && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
+                    && mkdir ptf && cd ptf && wget https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
+                    " '''.format(http_proxy, https_proxy, syncd_docker_name)
+        else:
+            cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
+                    rm -rf /var/lib/apt/lists/* \
+                    && apt-get update \
+                    && apt-get install -y python-pip build-essential libssl-dev libffi-dev python-dev python-setuptools wget cmake \
+                    && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+                    && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
+                    && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
+                    && rm -f 1.0.0.tar.gz && pip2 install cffi==1.7.0 && pip2 install --upgrade cffi==1.7.0 && pip2 install nnpy \
+                    && mkdir -p /opt && cd /opt && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
+                    && mkdir ptf && cd ptf && wget https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
+                    " '''.format(http_proxy, https_proxy, syncd_docker_name)
+
+        try:
+            # Stop bgp sessions
+            dut.command("sudo config feature autorestart bgp disabled")
+            dut.command("sudo config feature state bgp disabled")
+            dut.command(cmd)
+        finally:
+            dut.command("sudo config feature state bgp enabled")
+            dut.command("sudo config feature autorestart bgp enabled")
 
 def _map_port_number_to_interface(dut, nn_target_port):
     """

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -372,7 +372,8 @@ def _setup_testbed(dut, creds, ptf, test_params, tbinfo):
 
     logging.info("Configure syncd RPC for testing")
     copp_utils.configure_syncd(dut, test_params.nn_target_port, test_params.nn_target_interface,
-                               test_params.nn_target_namespace, test_params.nn_target_vlanid, creds)
+                               test_params.nn_target_namespace, test_params.nn_target_vlanid,
+                               test_params.swap_syncd, creds)
 
 def _teardown_testbed(dut, creds, ptf, test_params, tbinfo):
     """


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
- Updated checking availability of the nanomsg in the syncd container 
- Added check Debian version before installation of nano
- Added approach for disabling bgp before installation of nano

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
syncd container was upgraded to Debian 11 Bullseye. test_copp uses Python 2 to install nano in syncd container, but Debian 11 doesn't support Python 2. #5905 PR of sonic-mgmt added approach for installing the correct version of Python, but this doesn't cover the case when python isn't available. So that approach was updated.
#### How did you do it?
Updated approach for installing nanomsg in copp TC
#### How did you verify/test it?
Run test cases. Tests passed.
```
copp/test_copp.py::TestCOPP::test_policer[cab18-4-dut-ARP] PASSED                                                                                                                   [  7%]
copp/test_copp.py::TestCOPP::test_policer[cab18-4-dut-IP2ME] PASSED                                                                                                                 [ 14%]
copp/test_copp.py::TestCOPP::test_policer[cab18-4-dut-SNMP] PASSED                                                                                                                  [ 21%]
copp/test_copp.py::TestCOPP::test_policer[cab18-4-dut-SSH] PASSED                                                                                                                   [ 28%]
copp/test_copp.py::TestCOPP::test_no_policer[cab18-4-dut-BGP] PASSED                                                                                                                [ 35%]
copp/test_copp.py::TestCOPP::test_no_policer[cab18-4-dut-DHCP] PASSED                                                                                                               [ 42%]
copp/test_copp.py::TestCOPP::test_no_policer[cab18-4-dut-DHCP6] PASSED                                                                                                              [ 50%]
copp/test_copp.py::TestCOPP::test_no_policer[cab18-4-dut-LACP] PASSED                                                                                                               [ 57%]
copp/test_copp.py::TestCOPP::test_no_policer[cab18-4-dut-LLDP] PASSED                                                                                                               [ 64%]
copp/test_copp.py::TestCOPP::test_no_policer[cab18-4-dut-UDLD] PASSED                                                                                                               [ 71%]
copp/test_copp.py::TestCOPP::test_add_new_trap[cab18-4-dut] PASSED                                                                                                                  [ 78%]
copp/test_copp.py::TestCOPP::test_remove_trap[cab18-4-dut-delete_feature_entry] PASSED                                                                                              [ 85%]
copp/test_copp.py::TestCOPP::test_remove_trap[cab18-4-dut-disable_feature_status] PASSED                                                                                            [ 92%]
copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot[cab18-4-dut] PASSED                                                                                                 [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
