### PR TITLE
[MASIC] [master] Skip gbsyncd in modify_syslog_rate_limit

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -1,5 +1,4 @@
 import copy
-
 import ipaddress
 import json
 import logging

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -1,4 +1,5 @@
 import copy
+
 import ipaddress
 import json
 import logging
@@ -429,7 +430,8 @@ class MultiAsicSonicHost(object):
                     services.append(service_name)
 
         for docker in services:
-            if docker == "gbsyncd":
+            #TODO: https://github.com/Azure/sonic-mgmt/issues/5970
+            if self.sonichost.is_multi_asic and docker == "gbsyncd":
                 continue
             cmd_disable_rate_limit = (
                 r"docker exec -i {} sed -i "

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -429,6 +429,8 @@ class MultiAsicSonicHost(object):
                     services.append(service_name)
 
         for docker in services:
+            if docker == "gbsyncd":
+                continue
             cmd_disable_rate_limit = (
                 r"docker exec -i {} sed -i "
                 r"'s/^\$SystemLogRateLimit/#\$SystemLogRateLimit/g' "

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -31,7 +31,7 @@ class SonicHost(AnsibleHostBase):
     This type of host contains information about the SONiC device (device info, services, etc.),
     and also provides the ability to run Ansible modules on the SONiC device.
     """
-    DEFAULT_ASIC_SERVICES =  ["bgp", "database", "lldp", "swss", "syncd", "teamd", "gbsyncd"]
+    DEFAULT_ASIC_SERVICES =  ["bgp", "database", "lldp", "swss", "syncd", "teamd"]
 
 
     def __init__(self, ansible_adhoc, hostname,

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -31,7 +31,7 @@ class SonicHost(AnsibleHostBase):
     This type of host contains information about the SONiC device (device info, services, etc.),
     and also provides the ability to run Ansible modules on the SONiC device.
     """
-    DEFAULT_ASIC_SERVICES =  ["bgp", "database", "lldp", "swss", "syncd", "teamd"]
+    DEFAULT_ASIC_SERVICES =  ["bgp", "database", "lldp", "swss", "syncd", "teamd", "gbsyncd"]
 
 
     def __init__(self, ansible_adhoc, hostname,


### PR DESCRIPTION
Skip gbsyncd in modify_syslog_rate_limit.
gbsyncd could not be added in DEFAULT_ASIC_SERVICES as gbsyncdmgrd is not running and adding it will cause monit status to fail on any type of testbed. Detail described in https://github.com/Azure/sonic-mgmt/issues/5970
This PR will fix pretest failure in modify_syslog_rate_limit

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Before:
duthosts = [<MultiAsicSonicHost vlab-08>], enum_dut_hostname = 'vlab-08'

    def test_disable_rsyslog_rate_limit(duthosts, enum_dut_hostname):
        duthost = duthosts[enum_dut_hostname]
        features_dict, succeed = duthost.get_feature_status()
        if not succeed:
            # Something unexpected happened.
            # We don't want to fail here because it's an util
            logging.warn("Failed to retrieve feature status")
            return
        for feature_name, state in features_dict.items():
            if 'enabled' not in state:
                continue
>           duthost.modify_syslog_rate_limit(feature_name, rl_option='disable')

duthost    = <MultiAsicSonicHost vlab-08>
duthosts   = [<MultiAsicSonicHost vlab-08>]
enum_dut_hostname = 'vlab-08'
feature_name = 'gbsyncd'
features_dict = {'bgp': 'enabled', 'database': 'always_enabled', 'dhcp_relay': 'disabled', 'gbsyncd': 'enabled', ...}
state      = 'enabled'
succeed    = True

test_pretest.py:160: 


After:

test_pretest.py::test_features_state[vlab-08] PASSED                                                                                                                                                                                               [ 11%]
test_pretest.py::test_cleanup_testbed[vlab-08] PASSED                                                                                                                                                                                              [ 22%]
test_pretest.py::test_disable_container_autorestart[vlab-08] PASSED                                                                                                                                                                                [ 33%]
test_pretest.py::test_disable_rsyslog_rate_limit[vlab-08] PASSED                                                                                                                                                                                   [ 44%]
test_pretest.py::test_stop_pfcwd[vlab-08] SKIPPED                                                                                                                                                                                                  [ 55%]
test_pretest.py::test_cleanup_cache PASSED                                                                                                                                                                                                         [ 66%]
test_pretest.py::test_update_testbed_metadata PASSED                                                                                                                                                                                               [ 77%]
test_pretest.py::test_collect_testbed_prio PASSED                                                                                                                                                                                                  [ 88%]
test_pretest.py::test_update_saithrift_ptf SKIPPED                                                                                                                                                                                                 [100%]

----------------------------------------------------------------------------------- generated xml file: /data/sonic-mgmt/tests/logs/multi_asic_t1_lag/test_pretest.xml -----------------------------------------------------------------------------------
================================================================================================================ short test summary info =================================================================================================================
SKIPPED [1] /data/sonic-mgmt/tests/test_pretest.py:251: Skip this test on non dualTOR testbeds
SKIPPED [1] /data/sonic-mgmt/tests/test_pretest.py:236: No URL specified for python saithrift package
========================================================================================================= 7 passed, 2 skipped in 142.82 seconds =======================================================================
#### Any platform specific information?
it does not impact single asic pretest result:
test_pretest.py::test_features_state[str2-7050cx3-acs-02]
PASSED                                                                                                                                                                                   [  8%]
test_pretest.py::test_cleanup_testbed[str2-7050cx3-acs-02] PASSED                                                                                                                                                                                  [ 16%]
test_pretest.py::test_disable_container_autorestart[str2-7050cx3-acs-02] PASSED                                                                                                                                                                    [ 25%]
test_pretest.py::test_disable_rsyslog_rate_limit[str2-7050cx3-acs-02] PASSED                                                                                                                                                                       [ 33%]
test_pretest.py::test_stop_pfcwd[str2-7050cx3-acs-02] SKIPPED                                                                                                                                                                                      [ 41%]
test_pretest.py::test_connect_to_internal_nameserver[str2-7050cx3-acs-02] PASSED                                                                                                                                                                   [ 50%]
test_pretest.py::test_update_buffer_template[str2-7050cx3-acs-02] SKIPPED                                                                                                                                                                          [ 58%]
test_pretest.py::test_cleanup_cache PASSED                                                                                                                                                                                                         [ 66%]
test_pretest.py::test_update_testbed_metadata PASSED                                                                                                                                                                                               [ 75%]
test_pretest.py::test_collect_testbed_prio PASSED                                                                                                                                                                                                  [ 83%]
test_pretest.py::test_update_saithrift_ptf SKIPPED                                                                                                                                                                                                 [ 91%]
test_pretest.py::test_conn_graph_valid PASSED                                                                                                                                                                                                      [100%]

--------------------------------------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml ----------------------------------------------------------------------------------------------
================================================================================================================ short test summary info =================================================================================================================
SKIPPED [1] /var/src/sonic-mgmt-int/tests/common/helpers/assertions.py:13: Skip updating templates for 20201231.72
SKIPPED [1] /var/src/sonic-mgmt-int/tests/test_pretest.py:254: Skip this test on non dualTOR testbeds
SKIPPED [1] /var/src/sonic-mgmt-int/tests/test_pretest.py:239: No URL specified for python saithrift package
========================================================================================================= 9 passed, 3 skipped in 129.02 seconds ==========================================================================================================
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
