### PR TITLE
[platform] revert skip oom test for celestica-e1031

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -572,15 +572,6 @@ platform_tests/fwutil/test_fwutil.py::test_fwutil_auto:
     reason: "Command not yet merged into sonic-utilites"
 
 #######################################
-#####  test_memory_exhaustion.py  #####
-#######################################
-platform_tests/test_memory_exhaustion.py:
-  skip:
-    reason: "Skip this test case until vendors fix the issue"
-    conditions:
-      - "hwsku in ['Celestica-E1031-T48S4'] and https://github.com/Azure/sonic-buildimage/issues/10339"
-
-#######################################
 #####    test_platform_info.py    #####
 #######################################
 platform_tests/test_platform_info.py::test_thermal_control_fan_status:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Revert the skip of `platform_tests.test_memory_exhaustion` for `celestica-e1031`. Only one device fails on this test case, we will continue run it on this platform. (Azure/sonic-buildimage#10339)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

Revert the skip of `platform_tests.test_memory_exhaustion` for `celestica-e1031`. Only one device fails on this test case, we will continue run it on this platform.

#### How did you do it?

Update configurations in `tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml`.

#### How did you verify/test it?

Verified on physical testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
