### PR TITLE
Add rand_one_dut_hostname for fixtures in test_critical_process_monitoring

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -31,13 +31,14 @@ POST_CHECK_THRESHOLD_SECS = 360
 
 
 @pytest.fixture(autouse=True, scope='module')
-def config_reload_after_tests(duthost):
+def config_reload_after_tests(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
     yield
     config_reload(duthost)
 
 
 @pytest.fixture(autouse=True, scope='module')
-def disable_and_enable_autorestart(duthost):
+def disable_and_enable_autorestart(duthosts, rand_one_dut_hostname):
     """Changes the autorestart of containers from `enabled` to `disabled` before testing.
        and Rolls them back after testing.
 
@@ -47,6 +48,7 @@ def disable_and_enable_autorestart(duthost):
     Returns:
         None.
     """
+    duthost = duthosts[rand_one_dut_hostname]
     containers_autorestart_states = duthost.get_container_autorestart_states()
     disabled_autorestart_containers = []
 
@@ -71,7 +73,7 @@ def disable_and_enable_autorestart(duthost):
 
 
 @pytest.fixture(autouse=True, scope="module")
-def check_image_version(duthost):
+def check_image_version(duthosts, rand_one_dut_hostname):
     """Skips this test if the SONiC image installed on DUT is 20191130.70 or older image version.
 
     Args:
@@ -80,13 +82,14 @@ def check_image_version(duthost):
     Returns:
         None.
     """
+    duthost = duthosts[rand_one_dut_hostname]
     pytest_require(("20191130" in duthost.os_version and parse_version(duthost.os_version) > parse_version("20191130.72"))
                    or parse_version(duthost.kernel_version) > parse_version("4.9.0"),
                    "Test is not supported for 20191130.72 and older image versions!")
 
 
 @pytest.fixture(autouse=True, scope="module")
-def modify_monit_config_and_restart(duthost):
+def modify_monit_config_and_restart(duthosts, rand_one_dut_hostname):
     """Backup Monit configuration file, then customize and restart it before testing. Restore original
     Monit configuration file and restart it after testing.
 
@@ -96,6 +99,7 @@ def modify_monit_config_and_restart(duthost):
     Returns:
         None.
     """
+    duthost = duthosts[rand_one_dut_hostname]
     logger.info("Back up Monit configuration file ...")
     duthost.shell("sudo cp -f /etc/monit/monitrc /tmp/")
 


### PR DESCRIPTION

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
`process_monitoring.test_critical_process_monitoring.test_monitoring_critical_processes` always failed with this error “Failed: Failed to find program 'lldp-syncd' in container 'lldp'”.

The issue persists for these conditions:
Topo: dualtor
Image: all, including 202012, 202205 and master
DUT: Only happened on Lower Tor

It’s easy to reproduce:
1.	Login lower Tor, docker exec lldp supervisorctl status, get the lldpd’s PID
2.	Kill lldpd with this command: docker exec lldp kill -SIGKILL 24
3.	Run docker exec lldp supervisorctl status again, it threw error xmlrpc.client.Fault, lldpmgrd exited and lldpd container restarted.
admin@str2-7050cx3-acs-09:~$ docker exec lldp supervisorctl status
error: <class 'xmlrpc.client.Fault'>, <Fault 6: 'SHUTDOWN_STATE'>: file: /usr/lib/python3.7/xmlrpc/client.py line: 656
admin@str2-7050cx3-acs-09:~$ docker exec lldp supervisorctl status   
Error response from daemon: Container b95505bce7db735617b96eeb4c1c962daf3b1444f9d8c6949d142a144fa1a788 is not running
#### How did you do it?
Fixtures in test_critical_process_monitoring select `duthost`, but in TC `test_monitoring_critical_processes`, it selects duthost = duthosts[rand_one_dut_hostname]. If it randomly chooses Lower Tor, auto_restart is not disable for container and container will restart, the test case will fail.

So, add rand_one_dut_hostname for fixtures in test_critical_process_monitoring to keep duthost is same for fixtures and TC.

#### How did you verify/test it?
Run `process_monitoring/test_critical_process_monitoring.py::test_monitoring_critical_processes`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

