### PR TITLE
[drop_counters] fix parsing of fanout trunk ports

### DIFF
--- a/tests/common/helpers/drop_counters/fanout_drop_counter.py
+++ b/tests/common/helpers/drop_counters/fanout_drop_counter.py
@@ -51,7 +51,7 @@ class FanoutOnyxDropCounter(FanoutDropCounter):
         fanout_trunk_port = None
         for iface, iface_info in self.fanout_graph_facts[self.onyx_switch.hostname][DEVICE_PORT_VLANS].items():
             if iface_info[MODE] == TRUNK:
-                fanout_trunk_port = iface.split('/')[-1]
+                fanout_trunk_port = '/'.join(iface.split('/')[1:])
                 break
         return fanout_trunk_port
 


### PR DESCRIPTION
Signed-off-by: Anton <antonh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
the previous parsing of interface name was not support the split interfaces.

```
iface = 'ethernet 1/26/2'
expected:  fanout_trunk_port  = '26/2'
actual:  fanout_trunk_port  = '2'
```

now the actual as expected.




### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
stabilize the tests

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
