### PR TITLE
[platform_tests]Fix psu test for mgmttstor

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -240,8 +240,8 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
     all_outlet_status = pdu_ctrl.get_outlet_status()
     pytest_require(all_outlet_status and len(all_outlet_status) >= 2, 'Skip the test, cannot get at least 2 outlet status: {}'.format(all_outlet_status))
     if tbinfo["topo"]["properties"]["configuration_properties"]["common"]["dut_type"] == "MgmtTsToR":
-        all_outlet_status = all_outlet_status[0:2]
-        logging.info("DUT is MgmtTsToR, only the first 2 outlets are visible from DUT.")
+        all_outlet_status = all_outlet_status[0:-2]
+        logging.info("DUT is MgmtTsToR, the last 2 outlets are reserved for Console Switch and are not visible from DUT.")
     for outlet in all_outlet_status:
         psu_under_test = None
 

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -239,6 +239,9 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
     logging.info("Start testing turn off/on PSUs")
     all_outlet_status = pdu_ctrl.get_outlet_status()
     pytest_require(all_outlet_status and len(all_outlet_status) >= 2, 'Skip the test, cannot get at least 2 outlet status: {}'.format(all_outlet_status))
+    if tbinfo["topo"]["properties"]["configuration_properties"]["common"]["dut_type"] == "MgmtTsToR":
+        all_outlet_status = all_outlet_status[0:2]
+        logging.info("DUT is MgmtTsToR, only the first 2 outlets are visible from DUT.")
     for outlet in all_outlet_status:
         psu_under_test = None
 


### PR DESCRIPTION
MgmtTsToR has 4 power outlets but only 2 is visible from the DUT. The
other 2 outlets are reserved for C0 device.

Signed-off-by: Xichen Lin <xichenlin@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
MgmtTsToR has 4 power outlets but only 2 is visible from the DUT. The other 2 outlets are reserved for C0 device. Before the fix, tests fail because the other 2 PSUs were turned off and DUT did not observe any change. We will exclude the other 2 outlets for MgmtTsToR devices.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
Same as summary.

#### How did you do it?

#### How did you verify/test it?
Run manual tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
