### PR TITLE
[dualtor] Leave `icmp_responder` running on `dualtor-mixed` testbeds

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -229,9 +229,10 @@ def run_icmp_responder_session(duthosts, duthost, ptfhost, tbinfo):
 
     yield
 
-    logging.info("Stop running icmp_responder")
-    ptfhost.shell("supervisorctl stop icmp_responder")
-    icmp_responder_session_started = False
+    # FIXME: Leave icmp_responder running for dualtor-mixed topology
+    # logging.info("Stop running icmp_responder")
+    # ptfhost.shell("supervisorctl stop icmp_responder")
+    # icmp_responder_session_started = False
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -229,10 +229,8 @@ def run_icmp_responder_session(duthosts, duthost, ptfhost, tbinfo):
 
     yield
 
-    # FIXME: Leave icmp_responder running for dualtor-mixed topology
-    # logging.info("Stop running icmp_responder")
-    # ptfhost.shell("supervisorctl stop icmp_responder")
-    # icmp_responder_session_started = False
+    # NOTE: Leave icmp_responder running for dualtor-mixed topology
+    return
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
On `dualtor-mixed` testbeds, leave `icmp_responder` running to avoid introducing unnecessary toggles.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Comment out the teardown to stop `icmp_responder`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
