### PR TITLE
[dualtor-mixed] Fix mux config minigraph generation issue

### DIFF
--- a/ansible/library/dual_tor_facts.py
+++ b/ansible/library/dual_tor_facts.py
@@ -88,11 +88,10 @@ class DualTorParser:
 
     def generate_mux_cable_facts(self):
         topo_name = self.testbed_facts["topo"]
-        # use mux_cable_facts only for dualtor mixed topologies
-        if "mixed" in topo_name:
-            topology = load_topo_file(topo_name)["topology"]
-            mux_cable_facts = generate_mux_cable_facts(topology=topology)
-            self.dual_tor_facts["mux_cable_facts"] = mux_cable_facts
+
+        topology = load_topo_file(topo_name)["topology"]
+        mux_cable_facts = generate_mux_cable_facts(topology=topology)
+        self.dual_tor_facts["mux_cable_facts"] = mux_cable_facts
 
     def get_dual_tor_facts(self):
         '''

--- a/ansible/module_utils/dualtor_utils.py
+++ b/ansible/module_utils/dualtor_utils.py
@@ -27,13 +27,18 @@ def generate_mux_cable_facts(topology):
     vlan_address_v6, netmask_v6 = vlan_prefix_v6.split("/")
     vlan_address_v4 = ipaddress.ip_address(vlan_address_v4.decode())
     vlan_address_v6 = ipaddress.ip_address(vlan_address_v6.decode())
-    for index, intf in enumerate(enabled_interfaces):
-        is_active_active = intf in host_interfaces_active_active
+    index = 1
+    for intf in enabled_interfaces:
         mux_cable_facts[intf] = dict(
-            server_ipv4=str(vlan_address_v4 + index * 2 + 1) + "/" + netmask_v4,
-            server_ipv6=str(vlan_address_v6 + index * 2 + 1) + "/" + netmask_v6,
-            cable_type="active-active" if is_active_active else "active-standby"
+            server_ipv4=str(vlan_address_v4 + index) + "/" + netmask_v4,
+            server_ipv6=str(vlan_address_v6 + index) + "/" + netmask_v6,
+            cable_type="active-standby"
         )
-        if is_active_active:
-            mux_cable_facts[intf]["soc_ipv4"] = str(vlan_address_v4 + (index + 1) * 2) + "/" + netmask_v4
+        index += 1
+
+        if intf in host_interfaces_active_active:
+            mux_cable_facts[intf]["cable_type"] = "active-active"
+            mux_cable_facts[intf]["soc_ipv4"] = str(vlan_address_v4 + index) + "/" + netmask_v4
+            index += 1
+
     return mux_cable_facts

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -137,13 +137,8 @@
       </Device>
 {% endif %}
 {% if 'cables' in dual_tor_facts %}
-{% set server_base_address_v4 = (vlan_configs.values() | list)[0]['prefix'] %}
-{% set server_base_address_v4 = server_base_address_v4 | ipaddr('network') %}
-{% set server_base_address_v4 = '.'.join(server_base_address_v4.split('.')[:-1]) + '.{}' %}
-{% set server_base_address_v6 = (vlan_configs.values() | list)[0]['prefix_v6'] %}
-{% set server_base_address_v6 = server_base_address_v6 | ipaddr('network') %}
-{% set server_base_address_v6 = ':'.join(server_base_address_v6.split(':')[:-1]) + ':{:x}' %}
 {% for cable in dual_tor_facts['cables'] %}
+{% set intf_index = port_alias.index(cable['dut_intf'])|string %}
       <Device i:type="SmartCable">
         <ElementType>SmartCable</ElementType>
         <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
@@ -164,10 +159,10 @@
       <Device i:type="Server">
         <ElementType>Server</ElementType>
         <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
-          <d5p1:IPPrefix>{{ server_base_address_v4.format(loop.index + 1) }}/26</d5p1:IPPrefix>
+          <d5p1:IPPrefix>{{ dual_tor_facts['mux_cable_facts'][intf_index]['server_ipv4'] }}/26</d5p1:IPPrefix>
         </Address>
         <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
-          <d5p1:IPPrefix>{{ server_base_address_v6.format(loop.index + 1) }}/96</d5p1:IPPrefix>
+          <d5p1:IPPrefix>{{ dual_tor_facts['mux_cable_facts'][intf_index]['server_ipv6'] }}/96</d5p1:IPPrefix>
         </AddressV6>
         <ManagementAddress xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
On `dualtor-mixed` testbeds, the SoC IPs and server IPs have some overlaps:
```
port        state    ipv4             ipv6               cable_type     soc_ipv4 
----------  -------  ---------------  -----------------  -------------  --------------- 
Ethernet4   auto     192.168.0.2/32   fc02:1000::2/128   active-active  192.168.0.3/32 
Ethernet8   auto     192.168.0.3/32   fc02:1000::3/128   active-active  192.168.0.5/32 
Ethernet12  auto     192.168.0.4/32   fc02:1000::4/128   active-active  192.168.0.7/32 
Ethernet16  auto     192.168.0.5/32   fc02:1000::5/128   active-active  192.168.0.9/32 
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Use `mux_cable_facts` as the only resource to get both server IP and soc IP.

#### How did you verify/test it?
Run `deploy-mg` on both `dualtor` and `dualtor-mixed` testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
