### PR TITLE
[advanced-reboot] Add upgrade path data to report and kusto upload

### DIFF
--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -205,9 +205,9 @@ class KustoConnector(ReportDBConnector):
         reboot_timing_dict = validate_json_file(path_name)
         reboot_timing_data.update(reboot_timing_dict)
         print("Uploading {} report with contents: {}".format(path_name, reboot_timing_data))
-        if "reboot_summary" in path_name:
+        if "summary.json" in path_name:
             self._ingest_data(self.REBOOT_TIMING_TABLE, reboot_timing_data)
-        elif "reboot_report" in path_name:
+        elif "report.json" in path_name:
              self._ingest_data(self.RAW_REBOOT_TIMING_TABLE, reboot_timing_data)
 
     def upload_expected_runs(self, expected_runs: List) -> None:

--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import sys
 import uuid
+import re
 
 from junit_xml_parser import (
     validate_junit_json_file,
@@ -39,7 +40,8 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
         tracking_id = args.external_id if args.external_id else ""
         report_guid = str(uuid.uuid4())
         for path_name in args.path_list:
-            if "reboot_summary" in path_name or "reboot_report" in path_name:
+            reboot_data_regex = re.compile('.*test.*_(reboot|sad.*|upgrade_path)_(summary|report).json')
+            if reboot_data_regex.match(path_name):
                 kusto_db.upload_reboot_report(path_name, report_guid)
             else:
                 if args.json:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Append upgrade path data to advanced-reboot test report. Make Kusto upload generic to allow both reboot and upgrade reports upload.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
At present only reboot data is uploaded to Kusto. To allow better analytics, add upgrade path attributes to report.

#### How did you do it?
Added base, target image versions to report. Make report uploader check generic to accept upgrade path report upload.

#### How did you verify/test it?
Tested on a physical testbed on AZP pipeline.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
