### PR TITLE
Add test cases for TSA reload and load_minigraph

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -254,7 +254,7 @@ def test_TSA_B_C_with_no_neighbors(duthost, bgpmon_setup_teardown, nbrhosts, tbi
         pytest_assert(wait_until(300, 3, 0, verify_all_routes_announce_to_neighs,duthost, nbrhosts, routes_6, 6),
                       "Not all ipv6 routes are announced to neighbors")
 
-def test_TSA_TSB_with_config_reload(duthost, ptfhost, nbrhosts, traffic_shift_community):
+def test_TSA_TSB_with_config_reload(duthost, ptfhost, nbrhosts, bgpmon_setup_teardown, traffic_shift_community):
     """
     Test TSA after config save and config reload
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
@@ -295,7 +295,7 @@ def test_TSA_TSB_with_config_reload(duthost, ptfhost, nbrhosts, traffic_shift_co
         pytest_assert(verify_all_routes_announce_to_neighs(duthost, nbrhosts, parse_rib(duthost, 6), 6),
                     "Not all ipv6 routes are announced to neighbors")
 
-def test_load_minigraph_with_traffic_shift_away(duthost, ptfhost, nbrhosts, traffic_shift_community):
+def test_load_minigraph_with_traffic_shift_away(duthost, ptfhost, nbrhosts, bgpmon_setup_teardown, traffic_shift_community):
     """
     Test load_minigraph --traffic-shift-away
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -259,7 +259,7 @@ def test_TSA_TSB_with_config_reload(duthost, ptfhost, nbrhosts, traffic_shift_co
     Test TSA after config save and config reload
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
     """
-    tsa_in_configdb = duthost.shell('redis-cli -n 4 hget "BGP_DEVICE_GLOBAL" tsa_enabled', module_ignore_errors=True)
+    tsa_in_configdb = duthost.shell('redis-cli -n 4 hget "BGP_DEVICE_GLOBAL|STATE" tsa_enabled', module_ignore_errors=True)['stdout']
     if not tsa_in_configdb:
         pytest.skip("TSA persistence not supported in the image")
 
@@ -300,7 +300,7 @@ def test_load_minigraph_with_traffic_shift_away(duthost, ptfhost, nbrhosts, traf
     Test load_minigraph --traffic-shift-away
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
     """
-    tsa_in_configdb = duthost.shell('redis-cli -n 4 hget "BGP_DEVICE_GLOBAL" tsa_enabled', module_ignore_errors=True)
+    tsa_in_configdb = duthost.shell('redis-cli -n 4 hget "BGP_DEVICE_GLOBAL|STATE" tsa_enabled', module_ignore_errors=True)['stdout']
     if not tsa_in_configdb:
         pytest.skip("TSA persistence not supported in the image")
 

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -12,7 +12,7 @@ import re
 from tests.common.platform.processes_utils import wait_critical_processes
 
 pytestmark = [
-    pytest.mark.topology('t1')
+    pytest.mark.topology('t1','t2')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -61,7 +61,7 @@ def config_force_option_supported(duthost):
 
 @ignore_loganalyzer
 def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True, safe_reload=False,
-                  check_intf_up_ports=False):
+                  check_intf_up_ports=False, traffic_shift_away=False):
     """
     reload SONiC configuration
     :param duthost: DUT host object
@@ -88,7 +88,10 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
             is_buffer_model_dynamic = (output and output.get('stdout') == 'dynamic')
         else:
             is_buffer_model_dynamic = False
-        duthost.shell('config load_minigraph -y &>/dev/null', executable="/bin/bash")
+        if traffic_shift_away:
+            duthost.shell('config load_minigraph -y -t &>/dev/null', executable="/bin/bash")
+        else:
+            duthost.shell('config load_minigraph -y &>/dev/null', executable="/bin/bash")
         time.sleep(60)
         if start_bgp:
             duthost.shell('config bgp startup all')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add test cases to check device isolation using TSA after config reload and load_minigraph
Allow traffic-shift tests on T2

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
To test device isolation state (updated with TSA/TSB) after config reload/reboot and load_minigraph --traffic_shift_away

#### How did you do it?
1. Isolate device using TSA, execute config save and config reload. Validate that the device is still in maintenance and isolated
2. After test 1, un-isolate device using TSB, execute config save and config reload. Validate that the device is still out of maintenance and un-isolated
3. Configure 'load_minigraph --traffic_shift_away' and start all BGP sessions. Validate that the device is still in maintenance and isolated

Test is skipped if BGP_DEVICE_GLOBAL table is not in configDB

#### How did you verify/test it?
Test case execution on T1 device

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T1, T2

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
