### PR TITLE
[pc]Fix the test_po_update_io_no_loss test unstable issue

### DIFF
--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -206,7 +206,7 @@ def check_no_routes_from_nexthop(asic, nexthop):
         ver = '-6'
     else:
         ver = '-4'
-    special_nexthop = nexthop.replace('.', '\.')
+    special_nexthop = nexthop.replace('.', '\\\.')
     cmd = "ip {} route show | grep -w {} | wc -l".format(ver, special_nexthop)
     if asic.namespace is not None:
         fullcmd = "sudo ip netns exec {} {}".format(asic.namespace, cmd)


### PR DESCRIPTION
The regex to grep the route from the "ip 4|6 route show" for the nexthop is not correct. 
For example, if the output of "ip 4 route show" like following:

> nexthop via 10.0.0.25 dev PortChannel1020 weight 1
> 193.10.0.0/25 proto bgp src 10.1.0.32 metric 20

Using the original regex to grep, it will also match the 

> 193.10.0.0/25 proto bgp src 10.1.0.32 metric 20

which should not. 
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The regex to grep the route from the "ip 4|6 route show" for the nexthop is not correct. 
Fixes # (issue) The regex to grep the route from the "ip 4|6 route show" for the nexthop is not correct. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Change the regex used to grep the route from the "ip 4|6 route show" for the nexthop.
#### How did you verify/test it?
Ru the test_po_update_io_no_loss, it will not get failure due to this issue.
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
No
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
