### PR TITLE
Modify topo for msft_four_asic_vs testbed

### DIFF
--- a/ansible/minigraph/vlab-08.t1-8-lag.xml
+++ b/ansible/minigraph/vlab-08.t1-8-lag.xml
@@ -3,92 +3,14 @@
     <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     <PeeringSessions>
       <BGPSession>
-        <ElementType>BGPSession</ElementType>
         <MacSec>false</MacSec>
-        <StartRouter>ASIC2</StartRouter>
-        <StartPeer>10.1.0.0</StartPeer>
-        <EndRouter>ASIC0</EndRouter>
-        <EndPeer>10.1.0.1</EndPeer>
+        <StartRouter>vlab-08</StartRouter>
+        <StartPeer>10.0.0.32</StartPeer>
+        <EndRouter>ARISTA01T0</EndRouter>
+        <EndPeer>10.0.0.33</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>0</HoldTime>
-        <KeepAliveTime>0</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <ElementType>BGPSession</ElementType>
-        <MacSec>false</MacSec>
-        <StartRouter>ASIC2</StartRouter>
-        <StartPeer>10.1.0.4</StartPeer>
-        <EndRouter>ASIC1</EndRouter>
-        <EndPeer>10.1.0.5</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>0</HoldTime>
-        <KeepAliveTime>0</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <ElementType>BGPSession</ElementType>
-        <MacSec>false</MacSec>
-        <StartRouter>ASIC3</StartRouter>
-        <StartPeer>10.1.0.2</StartPeer>
-        <EndRouter>ASIC0</EndRouter>
-        <EndPeer>10.1.0.3</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>0</HoldTime>
-        <KeepAliveTime>0</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <ElementType>BGPSession</ElementType>
-        <MacSec>false</MacSec>
-        <StartRouter>ASIC3</StartRouter>
-        <StartPeer>10.1.0.6</StartPeer>
-        <EndRouter>ASIC1</EndRouter>
-        <EndPeer>10.1.0.7</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>0</HoldTime>
-        <KeepAliveTime>0</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <ElementType>BGPSession</ElementType>
-        <MacSec>false</MacSec>
-        <StartRouter>ASIC2</StartRouter>
-        <StartPeer>10.1.0.0</StartPeer>
-        <EndRouter>ASIC0</EndRouter>
-        <EndPeer>10.1.0.1</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>0</HoldTime>
-        <KeepAliveTime>0</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <ElementType>BGPSession</ElementType>
-        <MacSec>false</MacSec>
-        <StartRouter>ASIC2</StartRouter>
-        <StartPeer>10.1.0.4</StartPeer>
-        <EndRouter>ASIC1</EndRouter>
-        <EndPeer>10.1.0.5</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>0</HoldTime>
-        <KeepAliveTime>0</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <ElementType>BGPSession</ElementType>
-        <MacSec>false</MacSec>
-        <StartRouter>ASIC3</StartRouter>
-        <StartPeer>10.1.0.2</StartPeer>
-        <EndRouter>ASIC0</EndRouter>
-        <EndPeer>10.1.0.3</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>0</HoldTime>
-        <KeepAliveTime>0</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <ElementType>BGPSession</ElementType>
-        <MacSec>false</MacSec>
-        <StartRouter>ASIC3</StartRouter>
-        <StartPeer>10.1.0.6</StartPeer>
-        <EndRouter>ASIC1</EndRouter>
-        <EndPeer>10.1.0.7</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>0</HoldTime>
-        <KeepAliveTime>0</KeepAliveTime>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
       </BGPSession>
       <BGPSession>
         <MacSec>false</MacSec>
@@ -96,6 +18,15 @@
         <StartPeer>10.0.0.32</StartPeer>
         <EndRouter>ARISTA01T0</EndRouter>
         <EndPeer>10.0.0.33</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>vlab-08</StartRouter>
+        <StartPeer>FC00::41</StartPeer>
+        <EndRouter>ARISTA01T0</EndRouter>
+        <EndPeer>FC00::42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>10</HoldTime>
         <KeepAliveTime>3</KeepAliveTime>
@@ -111,10 +42,29 @@
       </BGPSession>
       <BGPSession>
         <MacSec>false</MacSec>
+        <StartRouter>vlab-08</StartRouter>
+        <StartPeer>10.0.0.0</StartPeer>
+        <EndRouter>ARISTA01T2</EndRouter>
+        <EndPeer>10.0.0.1</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
         <StartRouter>ASIC0</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>vlab-08</StartRouter>
+        <StartPeer>FC00::1</StartPeer>
+        <EndRouter>ARISTA01T2</EndRouter>
+        <EndPeer>FC00::2</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>10</HoldTime>
         <KeepAliveTime>3</KeepAliveTime>
@@ -131,84 +81,164 @@
       <BGPSession>
         <MacSec>false</MacSec>
         <StartRouter>ASIC1</StartRouter>
-        <StartPeer>10.0.0.34</StartPeer>
-        <EndRouter>ARISTA02T0</EndRouter>
-        <EndPeer>10.0.0.35</EndPeer>
+        <StartPeer>10.1.0.7</StartPeer>
+        <EndRouter>ASIC3</EndRouter>
+        <EndPeer>10.1.0.6</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>10</HoldTime>
-        <KeepAliveTime>3</KeepAliveTime>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
       </BGPSession>
       <BGPSession>
         <StartRouter>ASIC1</StartRouter>
-        <StartPeer>FC00::45</StartPeer>
-        <EndRouter>ARISTA02T0</EndRouter>
-        <EndPeer>FC00::46</EndPeer>
+        <StartPeer>2603:10E2:400:1::E</StartPeer>
+        <EndRouter>ASIC3</EndRouter>
+        <EndPeer>2603:10E2:400:1::D</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>10</HoldTime>
-        <KeepAliveTime>3</KeepAliveTime>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
       </BGPSession>
       <BGPSession>
         <MacSec>false</MacSec>
         <StartRouter>ASIC1</StartRouter>
-        <StartPeer>10.0.0.36</StartPeer>
-        <EndRouter>ARISTA03T0</EndRouter>
-        <EndPeer>10.0.0.37</EndPeer>
+        <StartPeer>10.1.0.5</StartPeer>
+        <EndRouter>ASIC2</EndRouter>
+        <EndPeer>10.1.0.4</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>10</HoldTime>
-        <KeepAliveTime>3</KeepAliveTime>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
       </BGPSession>
       <BGPSession>
         <StartRouter>ASIC1</StartRouter>
-        <StartPeer>FC00::49</StartPeer>
-        <EndRouter>ARISTA03T0</EndRouter>
-        <EndPeer>FC00::4A</EndPeer>
+        <StartPeer>2603:10E2:400:1::A</StartPeer>
+        <EndRouter>ASIC2</EndRouter>
+        <EndPeer>2603:10E2:400:1::9</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>10</HoldTime>
-        <KeepAliveTime>3</KeepAliveTime>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
+      </BGPSession>
+ 
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>ASIC0</StartRouter>
+        <StartPeer>10.1.0.3</StartPeer>
+        <EndRouter>ASIC3</EndRouter>
+        <EndPeer>10.1.0.2</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ASIC0</StartRouter>
+        <StartPeer>2603:10E2:400:1::6</StartPeer>
+        <EndRouter>ASIC3</EndRouter>
+        <EndPeer>2603:10E2:400:1::5</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
       </BGPSession>
       <BGPSession>
         <MacSec>false</MacSec>
         <StartRouter>ASIC0</StartRouter>
-        <StartPeer>10.0.0.4</StartPeer>
-        <EndRouter>ARISTA03T2</EndRouter>
-        <EndPeer>10.0.0.5</EndPeer>
+        <StartPeer>10.1.0.1</StartPeer>
+        <EndRouter>ASIC2</EndRouter>
+        <EndPeer>10.1.0.0</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>10</HoldTime>
-        <KeepAliveTime>3</KeepAliveTime>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
       </BGPSession>
       <BGPSession>
         <StartRouter>ASIC0</StartRouter>
-        <StartPeer>FC00::9</StartPeer>
-        <EndRouter>ARISTA03T2</EndRouter>
-        <EndPeer>FC00::A</EndPeer>
+        <StartPeer>2603:10E2:400:1::2</StartPeer>
+        <EndRouter>ASIC2</EndRouter>
+        <EndPeer>2603:10E2:400:1::1</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>10</HoldTime>
-        <KeepAliveTime>3</KeepAliveTime>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
+      </BGPSession>
+ 
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>ASIC3</StartRouter>
+        <StartPeer>10.1.0.6</StartPeer>
+        <EndRouter>ASIC1</EndRouter>
+        <EndPeer>10.1.0.7</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ASIC3</StartRouter>
+        <StartPeer>2603:10E2:400:1::D</StartPeer>
+        <EndRouter>ASIC1</EndRouter>
+        <EndPeer>2603:10E2:400:1::E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
       </BGPSession>
       <BGPSession>
         <MacSec>false</MacSec>
-        <StartRouter>ASIC1</StartRouter>
-        <StartPeer>10.0.0.38</StartPeer>
-        <EndRouter>ARISTA04T0</EndRouter>
-        <EndPeer>10.0.0.39</EndPeer>
+        <StartRouter>ASIC3</StartRouter>
+        <StartPeer>10.1.0.2</StartPeer>
+        <EndRouter>ASIC0</EndRouter>
+        <EndPeer>10.1.0.3</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>10</HoldTime>
-        <KeepAliveTime>3</KeepAliveTime>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>ASIC1</StartRouter>
-        <StartPeer>FC00::4D</StartPeer>
-        <EndRouter>ARISTA04T0</EndRouter>
-        <EndPeer>FC00::4E</EndPeer>
+        <StartRouter>ASIC3</StartRouter>
+        <StartPeer>2603:10E2:400:1::5</StartPeer>
+        <EndRouter>ASIC0</EndRouter>
+        <EndPeer>2603:10E2:400:1::6</EndPeer>
         <Multihop>1</Multihop>
-        <HoldTime>10</HoldTime>
-        <KeepAliveTime>3</KeepAliveTime>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
       </BGPSession>
+ 
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>ASIC2</StartRouter>
+        <StartPeer>10.1.0.4</StartPeer>
+        <EndRouter>ASIC1</EndRouter>
+        <EndPeer>10.1.0.5</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ASIC2</StartRouter>
+        <StartPeer>2603:10E2:400:1::9</StartPeer>
+        <EndRouter>ASIC1</EndRouter>
+        <EndPeer>2603:10E2:400:1::A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>ASIC2</StartRouter>
+        <StartPeer>10.1.0.0</StartPeer>
+        <EndRouter>ASIC0</EndRouter>
+        <EndPeer>10.1.0.1</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>ASIC2</StartRouter>
+        <StartPeer>2603:10E2:400:1::1</StartPeer>
+        <EndRouter>ASIC0</EndRouter>
+        <EndPeer>2603:10E2:400:1::2</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>0</HoldTime>
+        <KeepAliveTime>0</KeepAliveTime>
+      </BGPSession>
+ 
     </PeeringSessions>
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>vlab-07</a:Hostname>
+        <a:Hostname>vlab-08</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -218,154 +248,6 @@
           </BGPPeer>
           <BGPPeer>
             <Address>10.0.0.1</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.35</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.37</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.5</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.39</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-        </a:Peers>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-     <a:BGPRouterDeclaration>
-        <a:ASN>65100</a:ASN>
-        <a:BgpGroups/>
-        <a:Hostname>ASIC0</a:Hostname>
-        <a:Peers>
-          <BGPPeer>
-            <ElementType>BGPPeer</ElementType>
-            <Address>10.1.0.1</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <ElementType>BGPPeer</ElementType>
-            <Address>10.1.0.3</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.1</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.5</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-        </a:Peers>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65100</a:ASN>
-        <a:BgpGroups/>
-        <a:Hostname>ASIC1</a:Hostname>
-        <a:Peers>
-          <BGPPeer>
-            <ElementType>BGPPeer</ElementType>
-            <Address>10.1.0.5</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <ElementType>BGPPeer</ElementType>
-            <Address>10.1.0.7</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.33</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.35</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.37</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.39</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-        </a:Peers>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65100</a:ASN>
-        <a:BgpGroups/>
-        <a:Hostname>ASIC2</a:Hostname>
-        <a:Peers>
-          <BGPPeer>
-            <ElementType>BGPPeer</ElementType>
-            <Address>10.1.0.0</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <ElementType>BGPPeer</ElementType>
-            <Address>10.1.0.4</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-        </a:Peers>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65100</a:ASN>
-        <a:BgpGroups/>
-        <a:Hostname>ASIC3</a:Hostname>
-        <a:Peers>
-          <BGPPeer>
-            <ElementType>BGPPeer</ElementType>
-            <Address>10.1.0.2</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-            <Vrf i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <ElementType>BGPPeer</ElementType>
-            <Address>10.1.0.6</Address>
             <RouteMapIn i:nil="true"/>
             <RouteMapOut i:nil="true"/>
             <Vrf i:nil="true"/>
@@ -384,23 +266,91 @@
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
       <a:BGPRouterDeclaration>
-        <a:ASN>64002</a:ASN>
-        <a:Hostname>ARISTA02T0</a:Hostname>
+        <a:ASN>65100</a:ASN>
+        <a:Hostname>ASIC1</a:Hostname>
+        <a:Peers>
+          <BGPPeer>
+            <Address>10.0.0.33</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.1.0.6</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.1.0.4</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+        </a:Peers>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
       <a:BGPRouterDeclaration>
-        <a:ASN>64003</a:ASN>
-        <a:Hostname>ARISTA03T0</a:Hostname>
+        <a:ASN>65100</a:ASN>
+        <a:Hostname>ASIC0</a:Hostname>
+        <a:Peers>
+          <BGPPeer>
+            <Address>10.0.0.1</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.1.0.2</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.1.0.0</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+        </a:Peers>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
       <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA03T2</a:Hostname>
+        <a:ASN>65100</a:ASN>
+        <a:Hostname>ASIC3</a:Hostname>
+        <a:Peers>
+          <BGPPeer>
+            <Address>10.1.0.7</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.1.0.3</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+        </a:Peers>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
       <a:BGPRouterDeclaration>
-        <a:ASN>64004</a:ASN>
-        <a:Hostname>ARISTA04T0</a:Hostname>
+        <a:ASN>65100</a:ASN>
+        <a:Hostname>ASIC2</a:Hostname>
+        <a:Peers>
+          <BGPPeer>
+            <Address>10.1.0.5</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.1.0.1</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+        </a:Peers>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
     </Routers>
@@ -439,45 +389,25 @@
           <Name>V6HostIP</Name>
           <AttachTo>eth0</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
-            <b:IPPrefix>fec0::ffff:afa:7/64</b:IPPrefix>
+            <b:IPPrefix>fec0::ffff:afa:c/64</b:IPPrefix>
           </a:Prefix>
-          <a:PrefixStr>fec0::ffff:afa:7/64</a:PrefixStr>
+          <a:PrefixStr>fec0::ffff:afa:c/64</a:PrefixStr>
         </a:ManagementIPInterface>
       </ManagementIPInterfaces>
       <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>vlab-07</Hostname>
+      <Hostname>vlab-08</Hostname>
       <PortChannelInterfaces>
         <PortChannel>
-          <Name>PortChannel0001</Name>
+          <Name>PortChannel101</Name>
           <AttachTo>Ethernet1/5</AttachTo>
           <SubInterface/>
         </PortChannel>
         <PortChannel>
-          <Name>PortChannel0002</Name>
+          <Name>PortChannel102</Name>
           <AttachTo>Ethernet1/1;Ethernet1/2</AttachTo>
-          <SubInterface/>
-        </PortChannel>
-        <PortChannel>
-          <Name>PortChannel0003</Name>
-          <AttachTo>Ethernet1/6</AttachTo>
-          <SubInterface/>
-        </PortChannel>
-        <PortChannel>
-          <Name>PortChannel0004</Name>
-          <AttachTo>Ethernet1/7</AttachTo>
-          <SubInterface/>
-        </PortChannel>
-        <PortChannel>
-          <Name>PortChannel0005</Name>
-          <AttachTo>Ethernet1/3;Ethernet1/4</AttachTo>
-          <SubInterface/>
-        </PortChannel>
-        <PortChannel>
-          <Name>PortChannel0006</Name>
-          <AttachTo>Ethernet1/8</AttachTo>
           <SubInterface/>
         </PortChannel>
       </PortChannelInterfaces>
@@ -486,63 +416,23 @@
       <IPInterfaces>
         <IPInterface>
           <Name i:nil="true"/>
-          <AttachTo>PortChannel0001</AttachTo>
+          <AttachTo>PortChannel101</AttachTo>
           <Prefix>10.0.0.32/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>PortChannel0001</AttachTo>
+          <AttachTo>PortChannel101</AttachTo>
           <Prefix>FC00::41/126</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:nil="true"/>
-          <AttachTo>PortChannel0002</AttachTo>
+          <AttachTo>PortChannel102</AttachTo>
           <Prefix>10.0.0.0/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>PortChannel0002</AttachTo>
+          <AttachTo>PortChannel102</AttachTo>
           <Prefix>FC00::1/126</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <Name i:nil="true"/>
-          <AttachTo>PortChannel0003</AttachTo>
-          <Prefix>10.0.0.34/31</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <Name i:Name="true"/>
-          <AttachTo>PortChannel0003</AttachTo>
-          <Prefix>FC00::45/126</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <Name i:nil="true"/>
-          <AttachTo>PortChannel0004</AttachTo>
-          <Prefix>10.0.0.36/31</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <Name i:Name="true"/>
-          <AttachTo>PortChannel0004</AttachTo>
-          <Prefix>FC00::49/126</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <Name i:nil="true"/>
-          <AttachTo>PortChannel0005</AttachTo>
-          <Prefix>10.0.0.4/31</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <Name i:Name="true"/>
-          <AttachTo>PortChannel0005</AttachTo>
-          <Prefix>FC00::9/126</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <Name i:nil="true"/>
-          <AttachTo>PortChannel0006</AttachTo>
-          <Prefix>10.0.0.38/31</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <Name i:Name="true"/>
-          <AttachTo>PortChannel0006</AttachTo>
-          <Prefix>FC00::4D/126</Prefix>
         </IPInterface>
       </IPInterfaces>
       <DataAcls/>
@@ -573,7 +463,7 @@
           <Type>SSH</Type>
         </AclInterface>
         <AclInterface>
-          <AttachTo>PortChannel0001;PortChannel0002;PortChannel0003;PortChannel0004;PortChannel0005;PortChannel0006</AttachTo>
+          <AttachTo>PortChannel101;PortChannel102</AttachTo>
           <InAcl>DataAcl</InAcl>
           <Type>DataPlane</Type>
         </AclInterface>
@@ -601,118 +491,9 @@
           <a:PrefixStr>FC00:1::32/128</a:PrefixStr>
         </a:LoopbackIPInterface>
         <a:LoopbackIPInterface>
-          <ElementType>LoopbackInterface</ElementType>
-          <Name>HostIP</Name>
-          <AttachTo>Loopback4096</AttachTo>
-          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
-            <b:IPPrefix>8.0.0.0/32</b:IPPrefix>
-          </a:Prefix>
-          <a:PrefixStr>8.0.0.0/32</a:PrefixStr>
-        </a:LoopbackIPInterface>
-        <a:LoopbackIPInterface>
           <Name>HostIP1</Name>
           <AttachTo>Loopback4096</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
-            <b:IPPrefix>FD00:1::32/128</b:IPPrefix>
-          </a:Prefix>
-          <a:PrefixStr>FD00:1::32/128</a:PrefixStr>
-        </a:LoopbackIPInterface>
-      </LoopbackIPInterfaces>
-      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
-      <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
-      <MplsInterfaces/>
-      <MplsTeInterfaces/>
-      <RsvpInterfaces/>
-      <Hostname>ASIC0</Hostname>
-      <PortChannelInterfaces>
-        <PortChannel>
-          <ElementType>PortChannelInterface</ElementType>
-          <Name>PortChannel4001</Name>
-          <AttachTo>Eth4-ASIC0;Eth5-ASIC0</AttachTo>
-          <SubInterface/>
-        </PortChannel>
-        <PortChannel>
-          <ElementType>PortChannelInterface</ElementType>
-          <Name>PortChannel4002</Name>
-          <AttachTo>Eth6-ASIC0;Eth7-ASIC0</AttachTo>
-          <SubInterface/>
-        </PortChannel>
-        <PortChannel>
-          <Name>PortChannel0002</Name>
-          <AttachTo>Eth0-ASIC0;Eth1-ASIC0</AttachTo>
-          <SubInterface/>
-        </PortChannel>
-        <PortChannel>
-          <Name>PortChannel0005</Name>
-          <AttachTo>Eth2-ASIC0;Eth3-ASIC0</AttachTo>
-          <SubInterface/>
-        </PortChannel>
-      </PortChannelInterfaces>
-      <SubInterfaces/>
-      <VlanInterfaces/>
-      <IPInterfaces>
-        <IPInterface>
-          <ElementType>IPInterface</ElementType>
-          <Name i:nil="true"/>
-          <AttachTo>PortChannel4001</AttachTo>
-          <Prefix>10.1.0.1/31</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <ElementType>IPInterface</ElementType>
-          <Name i:nil="true"/>
-          <AttachTo>PortChannel4002</AttachTo>
-          <Prefix>10.1.0.3/31</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <Name i:nil="true"/>
-          <AttachTo>PortChannel0002</AttachTo>
-          <Prefix>10.0.0.0/31</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <Name i:Name="true"/>
-          <AttachTo>PortChannel0002</AttachTo>
-          <Prefix>FC00::1/126</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <Name i:nil="true"/>
-          <AttachTo>PortChannel0005</AttachTo>
-          <Prefix>10.0.0.4/31</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <Name i:Name="true"/>
-          <AttachTo>PortChannel0005</AttachTo>
-          <Prefix>FC00::9/126</Prefix>
-        </IPInterface>
-      </IPInterfaces>
-      <DataAcls/>
-      <NatInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
-      <DownstreamSummaries/>
-      <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
-    </DeviceDataPlaneInfo>
-    <DeviceDataPlaneInfo>
-      <IPSecTunnels/>
-      <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-        <a:LoopbackIPInterface>
-          <Name>HostIP</Name>
-          <AttachTo>Loopback0</AttachTo>
-          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
-            <b:IPPrefix>10.1.0.32/32</b:IPPrefix>
-          </a:Prefix>
-          <a:PrefixStr>10.1.0.32/32</a:PrefixStr>
-        </a:LoopbackIPInterface>
-        <a:LoopbackIPInterface>
-          <Name>HostIP1</Name>
-          <AttachTo>Loopback0</AttachTo>
-          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
-            <b:IPPrefix>FC00:1::32/128</b:IPPrefix>
-          </a:Prefix>
-          <a:PrefixStr>FC00:1::32/128</a:PrefixStr>
-        </a:LoopbackIPInterface>
-        <a:LoopbackIPInterface>
-          <ElementType>LoopbackInterface</ElementType>
-          <Name>HostIP</Name>
-          <AttachTo>Loopback4096</AttachTo>
-          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
             <b:IPPrefix>8.0.0.1/32</b:IPPrefix>
           </a:Prefix>
           <a:PrefixStr>8.0.0.1/32</a:PrefixStr>
@@ -721,12 +502,29 @@
           <Name>HostIP1</Name>
           <AttachTo>Loopback4096</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
-            <b:IPPrefix>FD00:2::32/128</b:IPPrefix>
+            <b:IPPrefix>2603:10e2:400::1/128</b:IPPrefix>
           </a:Prefix>
-          <a:PrefixStr>FD00:2::32/128</a:PrefixStr>
+          <a:PrefixStr>2603:10e2:400::1/128</a:PrefixStr>
         </a:LoopbackIPInterface>
       </LoopbackIPInterfaces>
-      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:ManagementIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.250.0.112/24</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.250.0.112/24</a:PrefixStr>
+        </a:ManagementIPInterface>
+        <a:ManagementIPInterface>
+          <Name>V6HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>fec0::ffff:afa:c/64</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>fec0::ffff:afa:c/64</a:PrefixStr>
+        </a:ManagementIPInterface>
+      </ManagementIPInterfaces>
       <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
       <MplsInterfaces/>
       <MplsTeInterfaces/>
@@ -734,96 +532,82 @@
       <Hostname>ASIC1</Hostname>
       <PortChannelInterfaces>
         <PortChannel>
-          <ElementType>PortChannelInterface</ElementType>
-          <Name>PortChannel4003</Name>
-          <AttachTo>Eth4-ASIC1;Eth5-ASIC1</AttachTo>
-          <SubInterface/>
-        </PortChannel>
-        <PortChannel>
-          <ElementType>PortChannelInterface</ElementType>
-          <Name>PortChannel4004</Name>
-          <AttachTo>Eth6-ASIC1;Eth7-ASIC1</AttachTo>
-          <SubInterface/>
-        </PortChannel>
-        <PortChannel>
-          <Name>PortChannel0001</Name>
+          <Name>PortChannel101</Name>
           <AttachTo>Eth0-ASIC1</AttachTo>
           <SubInterface/>
         </PortChannel>
         <PortChannel>
-          <Name>PortChannel0003</Name>
-          <AttachTo>Eth1-ASIC1</AttachTo>
+          <Name>PortChannel20</Name>
+          <AttachTo>Eth6-ASIC1;Eth7-ASIC1</AttachTo>
           <SubInterface/>
         </PortChannel>
         <PortChannel>
-          <Name>PortChannel0004</Name>
-          <AttachTo>Eth2-ASIC1</AttachTo>
-          <SubInterface/>
-        </PortChannel>
-        <PortChannel>
-          <Name>PortChannel0006</Name>
-          <AttachTo>Eth3-ASIC1</AttachTo>
+          <Name>PortChannel19</Name>
+          <AttachTo>Eth4-ASIC1;Eth5-ASIC1</AttachTo>
           <SubInterface/>
         </PortChannel>
       </PortChannelInterfaces>
-      <SubInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
         <IPInterface>
-          <ElementType>IPInterface</ElementType>
           <Name i:nil="true"/>
-          <AttachTo>PortChannel4003</AttachTo>
-          <Prefix>10.1.0.5/31</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <ElementType>IPInterface</ElementType>
-          <Name i:nil="true"/>
-          <AttachTo>PortChannel4004</AttachTo>
-          <Prefix>10.1.0.7/31</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <Name i:nil="true"/>
-          <AttachTo>PortChannel0001</AttachTo>
+          <AttachTo>PortChannel101</AttachTo>
           <Prefix>10.0.0.32/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>PortChannel0001</AttachTo>
+          <AttachTo>PortChannel101</AttachTo>
           <Prefix>FC00::41/126</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:nil="true"/>
-          <AttachTo>PortChannel0003</AttachTo>
-          <Prefix>10.0.0.34/31</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <Name i:Name="true"/>
-          <AttachTo>PortChannel0003</AttachTo>
-          <Prefix>FC00::45/126</Prefix>
+          <AttachTo>PortChannel20</AttachTo>
+          <Prefix>10.1.0.7/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:nil="true"/>
-          <AttachTo>PortChannel0004</AttachTo>
-          <Prefix>10.0.0.36/31</Prefix>
-        </IPInterface>
-        <IPInterface>
-          <Name i:Name="true"/>
-          <AttachTo>PortChannel0004</AttachTo>
-          <Prefix>FC00::49/126</Prefix>
+          <AttachTo>PortChannel20</AttachTo>
+          <Prefix>2603:10E2:400:1::E/126</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:nil="true"/>
-          <AttachTo>PortChannel0006</AttachTo>
-          <Prefix>10.0.0.38/31</Prefix>
+          <AttachTo>PortChannel19</AttachTo>
+          <Prefix>10.1.0.5/31</Prefix>
         </IPInterface>
         <IPInterface>
-          <Name i:Name="true"/>
-          <AttachTo>PortChannel0006</AttachTo>
-          <Prefix>FC00::4D/126</Prefix>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel19</AttachTo>
+          <Prefix>2603:10E2:400:1::A/126</Prefix>
         </IPInterface>
       </IPInterfaces>
       <DataAcls/>
-      <NatInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+      <AclInterfaces>
+        <AclInterface>
+          <InAcl>SNMP_ACL</InAcl>
+          <AttachTo>SNMP</AttachTo>
+          <Type>SNMP</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPAN</AttachTo>
+          <InAcl>Everflow</InAcl>
+          <Type>Everflow</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPANV6</AttachTo>
+          <InAcl>EverflowV6</InAcl>
+          <Type>EverflowV6</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>VTY_LINE</AttachTo>
+          <InAcl>ssh-only</InAcl>
+          <Type>SSH</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>PortChannel101;PortChannel20;PortChannel19;Eth0-ASIC1;Eth6-ASIC1;Eth4-ASIC1</AttachTo>
+          <InAcl>DataAcl</InAcl>
+          <Type>DataPlane</Type>
+        </AclInterface>
+      </AclInterfaces>
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
@@ -847,61 +631,123 @@
           <a:PrefixStr>FC00:1::32/128</a:PrefixStr>
         </a:LoopbackIPInterface>
         <a:LoopbackIPInterface>
-          <ElementType>LoopbackInterface</ElementType>
-          <Name>HostIP</Name>
+          <Name>HostIP1</Name>
           <AttachTo>Loopback4096</AttachTo>
-          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
-            <b:IPPrefix>8.0.0.4/32</b:IPPrefix>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>8.0.0.0/32</b:IPPrefix>
           </a:Prefix>
-          <a:PrefixStr>8.0.0.4/32</a:PrefixStr>
+          <a:PrefixStr>8.0.0.0/32</a:PrefixStr>
         </a:LoopbackIPInterface>
         <a:LoopbackIPInterface>
           <Name>HostIP1</Name>
           <AttachTo>Loopback4096</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
-            <b:IPPrefix>FD00:3::32/128</b:IPPrefix>
+            <b:IPPrefix>2603:10e2:400::/128</b:IPPrefix>
           </a:Prefix>
-          <a:PrefixStr>FD00:3::32/128</a:PrefixStr>
+          <a:PrefixStr>2603:10e2:400::/128</a:PrefixStr>
         </a:LoopbackIPInterface>
       </LoopbackIPInterfaces>
-      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:ManagementIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.250.0.112/24</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.250.0.112/24</a:PrefixStr>
+        </a:ManagementIPInterface>
+        <a:ManagementIPInterface>
+          <Name>V6HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>fec0::ffff:afa:c/64</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>fec0::ffff:afa:c/64</a:PrefixStr>
+        </a:ManagementIPInterface>
+      </ManagementIPInterfaces>
       <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>ASIC2</Hostname>
+      <Hostname>ASIC0</Hostname>
       <PortChannelInterfaces>
         <PortChannel>
-          <ElementType>PortChannelInterface</ElementType>
-          <Name>PortChannel4009</Name>
-          <AttachTo>Eth0-ASIC2;Eth1-ASIC2</AttachTo>
+          <Name>PortChannel102</Name>
+          <AttachTo>Eth0-ASIC0;Eth1-ASIC0</AttachTo>
           <SubInterface/>
         </PortChannel>
         <PortChannel>
-          <ElementType>PortChannelInterface</ElementType>
-          <Name>PortChannel4010</Name>
-          <AttachTo>Eth2-ASIC2;Eth3-ASIC2</AttachTo>
+          <Name>PortChannel04</Name>
+          <AttachTo>Eth6-ASIC0;Eth7-ASIC0</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel03</Name>
+          <AttachTo>Eth4-ASIC0;Eth5-ASIC0</AttachTo>
           <SubInterface/>
         </PortChannel>
       </PortChannelInterfaces>
-      <SubInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
         <IPInterface>
-          <ElementType>IPInterface</ElementType>
           <Name i:nil="true"/>
-          <AttachTo>PortChannel4009</AttachTo>
-          <Prefix>10.1.0.0/31</Prefix>
+          <AttachTo>PortChannel102</AttachTo>
+          <Prefix>10.0.0.0/31</Prefix>
         </IPInterface>
         <IPInterface>
-          <ElementType>IPInterface</ElementType>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel102</AttachTo>
+          <Prefix>FC00::1/126</Prefix>
+        </IPInterface>
+        <IPInterface>
           <Name i:nil="true"/>
-          <AttachTo>PortChannel4010</AttachTo>
-          <Prefix>10.1.0.4/31</Prefix>
+          <AttachTo>PortChannel04</AttachTo>
+          <Prefix>10.1.0.3/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel04</AttachTo>
+          <Prefix>2603:10E2:400:1::6/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel03</AttachTo>
+          <Prefix>10.1.0.1/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel03</AttachTo>
+          <Prefix>2603:10E2:400:1::2/126</Prefix>
         </IPInterface>
       </IPInterfaces>
       <DataAcls/>
-      <NatInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+      <AclInterfaces>
+        <AclInterface>
+          <InAcl>SNMP_ACL</InAcl>
+          <AttachTo>SNMP</AttachTo>
+          <Type>SNMP</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPAN</AttachTo>
+          <InAcl>Everflow</InAcl>
+          <Type>Everflow</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPANV6</AttachTo>
+          <InAcl>EverflowV6</InAcl>
+          <Type>EverflowV6</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>VTY_LINE</AttachTo>
+          <InAcl>ssh-only</InAcl>
+          <Type>SSH</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>PortChannel102;PortChannel04;PortChannel03;Eth0-ASIC0;Eth6-ASIC0;Eth4-ASIC0</AttachTo>
+          <InAcl>DataAcl</InAcl>
+          <Type>DataPlane</Type>
+        </AclInterface>
+      </AclInterfaces>
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
@@ -925,24 +771,40 @@
           <a:PrefixStr>FC00:1::32/128</a:PrefixStr>
         </a:LoopbackIPInterface>
         <a:LoopbackIPInterface>
-          <ElementType>LoopbackInterface</ElementType>
-          <Name>HostIP</Name>
+          <Name>HostIP1</Name>
           <AttachTo>Loopback4096</AttachTo>
-          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
-            <b:IPPrefix>8.0.0.5/32</b:IPPrefix>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>8.0.0.3/32</b:IPPrefix>
           </a:Prefix>
-          <a:PrefixStr>8.0.0.5/32</a:PrefixStr>
+          <a:PrefixStr>8.0.0.3/32</a:PrefixStr>
         </a:LoopbackIPInterface>
         <a:LoopbackIPInterface>
           <Name>HostIP1</Name>
           <AttachTo>Loopback4096</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
-            <b:IPPrefix>FD00:4::32/128</b:IPPrefix>
+            <b:IPPrefix>2603:10e2:400::3/128</b:IPPrefix>
           </a:Prefix>
-          <a:PrefixStr>FD00:4::32/128</a:PrefixStr>
+          <a:PrefixStr>2603:10e2:400::3/128</a:PrefixStr>
         </a:LoopbackIPInterface>
       </LoopbackIPInterfaces>
-      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:ManagementIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.250.0.112/24</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.250.0.112/24</a:PrefixStr>
+        </a:ManagementIPInterface>
+        <a:ManagementIPInterface>
+          <Name>V6HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>fec0::ffff:afa:c/64</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>fec0::ffff:afa:c/64</a:PrefixStr>
+        </a:ManagementIPInterface>
+      </ManagementIPInterfaces>
       <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
       <MplsInterfaces/>
       <MplsTeInterfaces/>
@@ -950,36 +812,192 @@
       <Hostname>ASIC3</Hostname>
       <PortChannelInterfaces>
         <PortChannel>
-          <ElementType>PortChannelInterface</ElementType>
-          <Name>PortChannel4013</Name>
-          <AttachTo>Eth0-ASIC3;Eth1-ASIC3</AttachTo>
-          <SubInterface/>
-        </PortChannel>
-        <PortChannel>
-          <ElementType>PortChannelInterface</ElementType>
-          <Name>PortChannel4014</Name>
+          <Name>PortChannel50</Name>
           <AttachTo>Eth2-ASIC3;Eth3-ASIC3</AttachTo>
           <SubInterface/>
         </PortChannel>
+        <PortChannel>
+          <Name>PortChannel49</Name>
+          <AttachTo>Eth0-ASIC3;Eth1-ASIC3</AttachTo>
+          <SubInterface/>
+        </PortChannel>
       </PortChannelInterfaces>
-      <SubInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
         <IPInterface>
-          <ElementType>IPInterface</ElementType>
           <Name i:nil="true"/>
-          <AttachTo>PortChannel4013</AttachTo>
+          <AttachTo>PortChannel50</AttachTo>
+          <Prefix>10.1.0.6/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel50</AttachTo>
+          <Prefix>2603:10E2:400:1::D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel49</AttachTo>
           <Prefix>10.1.0.2/31</Prefix>
         </IPInterface>
         <IPInterface>
-          <ElementType>IPInterface</ElementType>
           <Name i:nil="true"/>
-          <AttachTo>PortChannel4014</AttachTo>
-          <Prefix>10.1.0.6/31</Prefix>
+          <AttachTo>PortChannel49</AttachTo>
+          <Prefix>2603:10E2:400:1::5/126</Prefix>
         </IPInterface>
       </IPInterfaces>
       <DataAcls/>
-      <NatInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+      <AclInterfaces>
+        <AclInterface>
+          <InAcl>SNMP_ACL</InAcl>
+          <AttachTo>SNMP</AttachTo>
+          <Type>SNMP</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPAN</AttachTo>
+          <InAcl>Everflow</InAcl>
+          <Type>Everflow</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPANV6</AttachTo>
+          <InAcl>EverflowV6</InAcl>
+          <Type>EverflowV6</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>VTY_LINE</AttachTo>
+          <InAcl>ssh-only</InAcl>
+          <Type>SSH</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>PortChannel50;PortChannel49;Eth2-ASIC3;Eth0-ASIC3</AttachTo>
+          <InAcl>DataAcl</InAcl>
+          <Type>DataPlane</Type>
+        </AclInterface>
+      </AclInterfaces>
+      <DownstreamSummaries/>
+      <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    </DeviceDataPlaneInfo>
+    <DeviceDataPlaneInfo>
+      <IPSecTunnels/>
+      <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.1.0.32/32</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.1.0.32/32</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FC00:1::32/128</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FC00:1::32/128</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback4096</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>8.0.0.2/32</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>8.0.0.2/32</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback4096</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>2603:10e2:400::2/128</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>2603:10e2:400::2/128</a:PrefixStr>
+        </a:LoopbackIPInterface>
+      </LoopbackIPInterfaces>
+      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:ManagementIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.250.0.112/24</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.250.0.112/24</a:PrefixStr>
+        </a:ManagementIPInterface>
+        <a:ManagementIPInterface>
+          <Name>V6HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>fec0::ffff:afa:c/64</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>fec0::ffff:afa:c/64</a:PrefixStr>
+        </a:ManagementIPInterface>
+      </ManagementIPInterfaces>
+      <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+      <MplsInterfaces/>
+      <MplsTeInterfaces/>
+      <RsvpInterfaces/>
+      <Hostname>ASIC2</Hostname>
+      <PortChannelInterfaces>
+        <PortChannel>
+          <Name>PortChannel34</Name>
+          <AttachTo>Eth2-ASIC2;Eth3-ASIC2</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel33</Name>
+          <AttachTo>Eth0-ASIC2;Eth1-ASIC2</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+      </PortChannelInterfaces>
+      <VlanInterfaces/>
+      <IPInterfaces>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel34</AttachTo>
+          <Prefix>10.1.0.4/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel34</AttachTo>
+          <Prefix>2603:10E2:400:1::9/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel33</AttachTo>
+          <Prefix>10.1.0.0/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel33</AttachTo>
+          <Prefix>2603:10E2:400:1::1/126</Prefix>
+        </IPInterface>
+      </IPInterfaces>
+      <DataAcls/>
+      <AclInterfaces>
+        <AclInterface>
+          <InAcl>SNMP_ACL</InAcl>
+          <AttachTo>SNMP</AttachTo>
+          <Type>SNMP</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPAN</AttachTo>
+          <InAcl>Everflow</InAcl>
+          <Type>Everflow</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPANV6</AttachTo>
+          <InAcl>EverflowV6</InAcl>
+          <Type>EverflowV6</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>VTY_LINE</AttachTo>
+          <InAcl>ssh-only</InAcl>
+          <Type>SSH</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>PortChannel34;PortChannel33;Eth2-ASIC2;Eth0-ASIC2</AttachTo>
+          <InAcl>DataAcl</InAcl>
+          <Type>DataPlane</Type>
+        </AclInterface>
+      </AclInterfaces>
       <DownstreamSummaries/>
       <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     </DeviceDataPlaneInfo>
@@ -990,78 +1008,32 @@
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA01T0</EndDevice>
         <EndPort>Ethernet1</EndPort>
-        <StartDevice>vlab-07</StartDevice>
+        <StartDevice>vlab-08</StartDevice>
         <StartPort>Ethernet1/5</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA01T2</EndDevice>
         <EndPort>Ethernet1</EndPort>
-        <StartDevice>vlab-07</StartDevice>
+        <StartDevice>vlab-08</StartDevice>
         <StartPort>Ethernet1/1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
         <EndDevice>ARISTA01T2</EndDevice>
         <EndPort>Ethernet2</EndPort>
-        <StartDevice>vlab-07</StartDevice>
+        <StartDevice>vlab-08</StartDevice>
         <StartPort>Ethernet1/2</StartPort>
       </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>ARISTA02T0</EndDevice>
-        <EndPort>Ethernet1</EndPort>
-        <StartDevice>vlab-07</StartDevice>
-        <StartPort>Ethernet1/6</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>ARISTA03T0</EndDevice>
-        <EndPort>Ethernet1</EndPort>
-        <StartDevice>vlab-07</StartDevice>
-        <StartPort>Ethernet1/7</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>ARISTA03T2</EndDevice>
-        <EndPort>Ethernet1</EndPort>
-        <StartDevice>vlab-07</StartDevice>
-        <StartPort>Ethernet1/3</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>ARISTA03T2</EndDevice>
-        <EndPort>Ethernet2</EndPort>
-        <StartDevice>vlab-07</StartDevice>
-        <StartPort>Ethernet1/4</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>ARISTA04T0</EndDevice>
-        <EndPort>Ethernet1</EndPort>
-        <StartDevice>vlab-07</StartDevice>
-        <StartPort>Ethernet1/8</StartPort>
-      </DeviceLinkBase>
       <DeviceLinkBase i:type="DeviceInterfaceLink">
         <ElementType>DeviceInterfaceLink</ElementType>
         <Bandwidth>40000</Bandwidth>
         <ChassisInternal>true</ChassisInternal>
-        <EndDevice>ASIC2</EndDevice>
-        <EndPort>Eth0-ASIC2</EndPort>
+        <EndDevice>ASIC3</EndDevice>
+        <EndPort>Eth2-ASIC3</EndPort>
         <FlowControl>true</FlowControl>
-        <StartDevice>ASIC0</StartDevice>
-        <StartPort>Eth4-ASIC0</StartPort>
-        <Validate>true</Validate>
-      </DeviceLinkBase>
-      <DeviceLinkBase i:type="DeviceInterfaceLink">
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <Bandwidth>40000</Bandwidth>
-        <ChassisInternal>true</ChassisInternal>
-        <EndDevice>ASIC2</EndDevice>
-        <EndPort>Eth1-ASIC2</EndPort>
-        <FlowControl>true</FlowControl>
-        <StartDevice>ASIC0</StartDevice>
-        <StartPort>Eth5-ASIC0</StartPort>
+        <StartDevice>ASIC1</StartDevice>
+        <StartPort>Eth6-ASIC1</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
       <DeviceLinkBase i:type="DeviceInterfaceLink">
@@ -1069,21 +1041,10 @@
         <Bandwidth>40000</Bandwidth>
         <ChassisInternal>true</ChassisInternal>
         <EndDevice>ASIC3</EndDevice>
-        <EndPort>Eth0-ASIC3</EndPort>
+        <EndPort>Eth3-ASIC3</EndPort>
         <FlowControl>true</FlowControl>
-        <StartDevice>ASIC0</StartDevice>
-        <StartPort>Eth6-ASIC0</StartPort>
-        <Validate>true</Validate>
-      </DeviceLinkBase>
-      <DeviceLinkBase i:type="DeviceInterfaceLink">
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <Bandwidth>40000</Bandwidth>
-        <ChassisInternal>true</ChassisInternal>
-        <EndDevice>ASIC3</EndDevice>
-        <EndPort>Eth1-ASIC3</EndPort>
-        <FlowControl>true</FlowControl>
-        <StartDevice>ASIC0</StartDevice>
-        <StartPort>Eth7-ASIC0</StartPort>
+        <StartDevice>ASIC1</StartDevice>
+        <StartPort>Eth7-ASIC1</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
       <DeviceLinkBase i:type="DeviceInterfaceLink">
@@ -1113,10 +1074,10 @@
         <Bandwidth>40000</Bandwidth>
         <ChassisInternal>true</ChassisInternal>
         <EndDevice>ASIC3</EndDevice>
-        <EndPort>Eth2-ASIC3</EndPort>
+        <EndPort>Eth0-ASIC3</EndPort>
         <FlowControl>true</FlowControl>
-        <StartDevice>ASIC1</StartDevice>
-        <StartPort>Eth6-ASIC1</StartPort>
+        <StartDevice>ASIC0</StartDevice>
+        <StartPort>Eth6-ASIC0</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
       <DeviceLinkBase i:type="DeviceInterfaceLink">
@@ -1124,10 +1085,120 @@
         <Bandwidth>40000</Bandwidth>
         <ChassisInternal>true</ChassisInternal>
         <EndDevice>ASIC3</EndDevice>
-        <EndPort>Eth3-ASIC3</EndPort>
+        <EndPort>Eth1-ASIC3</EndPort>
         <FlowControl>true</FlowControl>
-        <StartDevice>ASIC1</StartDevice>
-        <StartPort>Eth7-ASIC1</StartPort>
+        <StartDevice>ASIC0</StartDevice>
+        <StartPort>Eth7-ASIC0</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <Bandwidth>40000</Bandwidth>
+        <ChassisInternal>true</ChassisInternal>
+        <EndDevice>ASIC2</EndDevice>
+        <EndPort>Eth0-ASIC2</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>ASIC0</StartDevice>
+        <StartPort>Eth4-ASIC0</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <Bandwidth>40000</Bandwidth>
+        <ChassisInternal>true</ChassisInternal>
+        <EndDevice>ASIC2</EndDevice>
+        <EndPort>Eth1-ASIC2</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>ASIC0</StartDevice>
+        <StartPort>Eth5-ASIC0</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <Bandwidth>40000</Bandwidth>
+        <ChassisInternal>true</ChassisInternal>
+        <EndDevice>ASIC1</EndDevice>
+        <EndPort>Eth6-ASIC1</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>ASIC3</StartDevice>
+        <StartPort>Eth2-ASIC3</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <Bandwidth>40000</Bandwidth>
+        <ChassisInternal>true</ChassisInternal>
+        <EndDevice>ASIC1</EndDevice>
+        <EndPort>Eth7-ASIC1</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>ASIC3</StartDevice>
+        <StartPort>Eth3-ASIC3</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <Bandwidth>40000</Bandwidth>
+        <ChassisInternal>true</ChassisInternal>
+        <EndDevice>ASIC0</EndDevice>
+        <EndPort>Eth6-ASIC0</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>ASIC3</StartDevice>
+        <StartPort>Eth0-ASIC3</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <Bandwidth>40000</Bandwidth>
+        <ChassisInternal>true</ChassisInternal>
+        <EndDevice>ASIC0</EndDevice>
+        <EndPort>Eth7-ASIC0</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>ASIC3</StartDevice>
+        <StartPort>Eth1-ASIC3</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <Bandwidth>40000</Bandwidth>
+        <ChassisInternal>true</ChassisInternal>
+        <EndDevice>ASIC1</EndDevice>
+        <EndPort>Eth4-ASIC1</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>ASIC2</StartDevice>
+        <StartPort>Eth2-ASIC2</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <Bandwidth>40000</Bandwidth>
+        <ChassisInternal>true</ChassisInternal>
+        <EndDevice>ASIC1</EndDevice>
+        <EndPort>Eth5-ASIC1</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>ASIC2</StartDevice>
+        <StartPort>Eth3-ASIC2</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <Bandwidth>40000</Bandwidth>
+        <ChassisInternal>true</ChassisInternal>
+        <EndDevice>ASIC0</EndDevice>
+        <EndPort>Eth4-ASIC0</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>ASIC2</StartDevice>
+        <StartPort>Eth0-ASIC2</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <Bandwidth>40000</Bandwidth>
+        <ChassisInternal>true</ChassisInternal>
+        <EndDevice>ASIC0</EndDevice>
+        <EndPort>Eth5-ASIC0</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>ASIC2</StartDevice>
+        <StartPort>Eth1-ASIC2</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
       <DeviceLinkBase i:type="DeviceInterfaceLink">
@@ -1137,7 +1208,7 @@
         <EndDevice>ASIC0</EndDevice>
         <EndPort>Eth0-ASIC0</EndPort>
         <FlowControl>true</FlowControl>
-        <StartDevice>vlab-07</StartDevice>
+        <StartDevice>vlab-08</StartDevice>
         <StartPort>Ethernet1/1</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
@@ -1148,7 +1219,7 @@
         <EndDevice>ASIC0</EndDevice>
         <EndPort>Eth1-ASIC0</EndPort>
         <FlowControl>true</FlowControl>
-        <StartDevice>vlab-07</StartDevice>
+        <StartDevice>vlab-08</StartDevice>
         <StartPort>Ethernet1/2</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
@@ -1159,7 +1230,7 @@
         <EndDevice>ASIC0</EndDevice>
         <EndPort>Eth2-ASIC0</EndPort>
         <FlowControl>true</FlowControl>
-        <StartDevice>vlab-07</StartDevice>
+        <StartDevice>vlab-08</StartDevice>
         <StartPort>Ethernet1/3</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
@@ -1170,7 +1241,7 @@
         <EndDevice>ASIC0</EndDevice>
         <EndPort>Eth3-ASIC0</EndPort>
         <FlowControl>true</FlowControl>
-        <StartDevice>vlab-07</StartDevice>
+        <StartDevice>vlab-08</StartDevice>
         <StartPort>Ethernet1/4</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
@@ -1181,7 +1252,7 @@
         <EndDevice>ASIC1</EndDevice>
         <EndPort>Eth0-ASIC1</EndPort>
         <FlowControl>true</FlowControl>
-        <StartDevice>vlab-07</StartDevice>
+        <StartDevice>vlab-08</StartDevice>
         <StartPort>Ethernet1/5</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
@@ -1192,7 +1263,7 @@
         <EndDevice>ASIC1</EndDevice>
         <EndPort>Eth1-ASIC1</EndPort>
         <FlowControl>true</FlowControl>
-        <StartDevice>vlab-07</StartDevice>
+        <StartDevice>vlab-08</StartDevice>
         <StartPort>Ethernet1/6</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
@@ -1203,7 +1274,7 @@
         <EndDevice>ASIC1</EndDevice>
         <EndPort>Eth2-ASIC1</EndPort>
         <FlowControl>true</FlowControl>
-        <StartDevice>vlab-07</StartDevice>
+        <StartDevice>vlab-08</StartDevice>
         <StartPort>Ethernet1/7</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
@@ -1214,58 +1285,30 @@
         <EndDevice>ASIC1</EndDevice>
         <EndPort>Eth3-ASIC1</EndPort>
         <FlowControl>true</FlowControl>
-        <StartDevice>vlab-07</StartDevice>
+        <StartDevice>vlab-08</StartDevice>
         <StartPort>Ethernet1/8</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>vlab-07</Hostname>
+        <Hostname>vlab-08</Hostname>
         <HwSku>msft_four_asic_vs</HwSku>
         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
            <a:IPPrefix>10.250.0.112</a:IPPrefix>
         </ManagementAddress>
       </Device>
-      <Device i:type="ToRRouter">
-         <Hostname>ARISTA02T0</Hostname>
-         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
-           <a:IPPrefix>10.250.0.58</a:IPPrefix>
-         </ManagementAddress>
-         <HwSku>Arista-VM</HwSku>
-      </Device>
-      <Device i:type="ToRRouter">
-         <Hostname>ARISTA03T0</Hostname>
-         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
-           <a:IPPrefix>10.250.0.59</a:IPPrefix>
-         </ManagementAddress>
-         <HwSku>Arista-VM</HwSku>
-      </Device>
-      <Device i:type="SpineRouter">
-         <Hostname>ARISTA03T2</Hostname>
-         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
-           <a:IPPrefix>10.250.0.56</a:IPPrefix>
-         </ManagementAddress>
-         <HwSku>Arista-VM</HwSku>
-      </Device>
-      <Device i:type="ToRRouter">
-         <Hostname>ARISTA04T0</Hostname>
-         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
-           <a:IPPrefix>10.250.0.60</a:IPPrefix>
-         </ManagementAddress>
-         <HwSku>Arista-VM</HwSku>
-      </Device>
       <Device i:type="SpineRouter">
          <Hostname>ARISTA01T2</Hostname>
          <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
-           <a:IPPrefix>10.250.0.55</a:IPPrefix>
+           <a:IPPrefix>10.250.0.79</a:IPPrefix>
          </ManagementAddress>
          <HwSku>Arista-VM</HwSku>
       </Device>
       <Device i:type="ToRRouter">
          <Hostname>ARISTA01T0</Hostname>
          <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
-           <a:IPPrefix>10.250.0.57</a:IPPrefix>
+           <a:IPPrefix>10.250.0.80</a:IPPrefix>
          </ManagementAddress>
          <HwSku>Arista-VM</HwSku>
       </Device>
@@ -1292,7 +1335,7 @@
         </ManagementAddressV6>
         <SerialNumber i:nil="true"/>
         <Hostname>ASIC0</Hostname>
-        <HwSku>msft_four_asic_vs</HwSku>
+        <HwSku>Broadcom-Trident2</HwSku>
       </Device>
       <Device i:type="Asic">
         <ElementType>Asic</ElementType>
@@ -1317,7 +1360,7 @@
         </ManagementAddressV6>
         <SerialNumber i:nil="true"/>
         <Hostname>ASIC1</Hostname>
-        <HwSku>msft_four_asic_vs</HwSku>
+        <HwSku>Broadcom-Trident2</HwSku>
       </Device>
       <Device i:type="Asic">
         <ElementType>Asic</ElementType>
@@ -1342,7 +1385,7 @@
         </ManagementAddressV6>
         <SerialNumber i:nil="true"/>
         <Hostname>ASIC2</Hostname>
-        <HwSku>msft_four_asic_vs</HwSku>
+        <HwSku>Broadcom-Trident2</HwSku>
       </Device>
       <Device i:type="Asic">
         <ElementType>Asic</ElementType>
@@ -1367,7 +1410,7 @@
         </ManagementAddressV6>
         <SerialNumber i:nil="true"/>
         <Hostname>ASIC3</Hostname>
-        <HwSku>msft_four_asic_vs</HwSku>
+        <HwSku>Broadcom-Trident2</HwSku>
       </Device>
     </Devices>
   </PngDec>
@@ -1489,7 +1532,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>vlab-07</a:Name>
+        <a:Name>vlab-08</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DeploymentId</a:Name>
@@ -1532,20 +1575,15 @@
             <a:Value>10.0.0.9;10.0.0.8</a:Value>
           </a:DeviceProperty>
           <a:DeviceProperty>
+            <a:Name>ForcedMgmtRoutes</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>172.17.0.1</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
             <a:Name>ErspanDestinationIpv4</a:Name>
             <a:Reference i:nil="true"/>
             <a:Value>10.0.0.7</a:Value>
          </a:DeviceProperty>
-        </a:Properties>
-      </a:DeviceMetadata>
-      <a:DeviceMetadata>
-        <a:Name>ASIC0</a:Name>
-        <a:Properties>
-          <a:DeviceProperty>
-            <a:Name>SubRole</a:Name>
-            <a:Reference i:nil="true"/>
-            <a:Value>FrontEnd</a:Value>
-          </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
       <a:DeviceMetadata>
@@ -1559,12 +1597,12 @@
         </a:Properties>
       </a:DeviceMetadata>
       <a:DeviceMetadata>
-        <a:Name>ASIC2</a:Name>
+        <a:Name>ASIC0</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>SubRole</a:Name>
             <a:Reference i:nil="true"/>
-            <a:Value>BackEnd</a:Value>
+            <a:Value>FrontEnd</a:Value>
           </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
@@ -1578,9 +1616,19 @@
           </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
+      <a:DeviceMetadata>
+        <a:Name>ASIC2</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>SubRole</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>BackEnd</a:Value>
+          </a:DeviceProperty>
+        </a:Properties>
+      </a:DeviceMetadata>
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>vlab-07</Hostname>
+  <Hostname>vlab-08</Hostname>
   <HwSku>msft_four_asic_vs</HwSku>
 </DeviceMiniGraph>

--- a/ansible/vars/topo_t1-8-lag.yml
+++ b/ansible/vars/topo_t1-8-lag.yml
@@ -73,5 +73,5 @@ configuration:
         ipv4: 10.0.0.33/31
         ipv6: fc00::42/126
     bp_interface:
-      ipv5: 10.10.246.17/24
+      ipv4: 10.10.246.17/24
       ipv6: fc0a::22/64

--- a/ansible/vars/topo_t1-8-lag.yml
+++ b/ansible/vars/topo_t1-8-lag.yml
@@ -5,27 +5,10 @@ topology:
         - 0
         - 1
       vm_offset: 0
-    ARISTA03T2:
-      vlans:
-        - 2
-        - 3
-      vm_offset: 1
     ARISTA01T0:
       vlans:
         - 4
-      vm_offset: 2
-    ARISTA02T0:
-      vlans:
-        - 5
-      vm_offset: 3
-    ARISTA03T0:
-      vlans:
-        - 6
-      vm_offset: 4
-    ARISTA04T0:
-      vlans:
-        - 7
-      vm_offset: 5
+      vm_offset: 1
 
 configuration_properties:
   common:
@@ -69,31 +52,6 @@ configuration:
       ipv4: 10.10.246.1/24
       ipv6: fc0a::2/64
 
-  ARISTA03T2:
-    properties:
-    - common
-    - spine
-    bgp:
-      asn: 65200
-      peers:
-        65100:
-        - 10.0.0.4
-        - FC00::9
-    interfaces:
-      Loopback0:
-        ipv4: 100.1.0.3/32
-        ipv6: 2064:100::3/128
-      Ethernet1:
-        lacp: 1
-      Ethernet2:
-        lacp: 1
-      Port-Channel1:
-        ipv4: 10.0.0.5/31
-        ipv6: fc00::a/126
-    bp_interface:
-      ipv4: 10.10.246.3/24
-      ipv6: fc0a::6/64
-
   ARISTA01T0:
     properties:
     - common
@@ -115,82 +73,5 @@ configuration:
         ipv4: 10.0.0.33/31
         ipv6: fc00::42/126
     bp_interface:
-      ipv4: 10.10.246.17/24
+      ipv5: 10.10.246.17/24
       ipv6: fc0a::22/64
-
-  ARISTA02T0:
-    properties:
-    - common
-    - tor
-    tornum: 2
-    bgp:
-      asn: 64002
-      peers:
-        65100:
-        - 10.0.0.34
-        - FC00::45
-    interfaces:
-      Loopback0:
-        ipv4: 100.1.0.18/32
-        ipv6: 2064:100::12/128
-      Ethernet1:
-        lacp: 1
-      Port-Channel1:
-        ipv4: 10.0.0.35/31
-        ipv6: fc00::46/126
-    bp_interface:
-      ipv4: 10.10.246.18/24
-      ipv6: fc0a::25/64
-
-  ARISTA03T0:
-    properties:
-    - common
-    - tor
-    tornum: 3
-    bgp:
-      asn: 64003
-      peers:
-        65100:
-        - 10.0.0.36
-        - FC00::49
-    interfaces:
-      Loopback0:
-        ipv4: 100.1.0.19/32
-        ipv6: 2064:100::13/128
-      Ethernet1:
-        lacp: 1
-      Port-Channel1:
-        ipv4: 10.0.0.37/31
-        ipv6: fc00::4a/126
-    bp_interface:
-      ipv4: 10.10.246.19/24
-      ipv6: fc0a::26/64
-    vips:
-      ipv4:
-        prefixes:
-          - 200.0.1.0/26
-        asn: 64700
-
-  ARISTA04T0:
-    properties:
-    - common
-    - tor
-    tornum: 4
-    bgp:
-      asn: 64004
-      peers:
-        65100:
-        - 10.0.0.38
-        - FC00::4D
-    interfaces:
-      Loopback0:
-        ipv4: 100.1.0.20/32
-        ipv6: 2064:100::14/128
-      Ethernet1:
-        lacp: 1
-      Port-Channel1:
-        ipv4: 10.0.0.39/31
-        ipv6: fc00::4e/126
-    bp_interface:
-      ipv4: 10.10.246.20/24
-      ipv6: fc0a::29/64

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -269,7 +269,7 @@ test_multi_asic_t1_lag() {
     popd
 }
 
-test_multi_asic_t1_lag() {
+test_multi_asic_t1_lag_pr() {
     tgname=multi_asic_t1_lag
     tests="\
     bgp/test_bgp_fact.py"

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -269,6 +269,17 @@ test_multi_asic_t1_lag() {
     popd
 }
 
+test_multi_asic_t1_lag() {
+    tgname=multi_asic_t1_lag
+    tests="\
+    bgp/test_bgp_fact.py"
+
+    pushd $SONIC_MGMT_DIR/tests
+    # TODO: Remove disable of loganaler and sanity check once multi-asic testbed is stable.
+    ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname -e --disable_loganalyzer -e --skip_sanity -u
+    popd
+}
+
 test_dualtor(){
     tgname=dualtor
     tests="arp/test_arp_dualtor.py"
@@ -336,6 +347,8 @@ elif [ x$test_suite == x"t1-lag" ]; then
     test_t1_lag
 elif [ x$test_suite == x"multi-asic-t1-lag" ]; then
     test_multi_asic_t1_lag
+elif [ x$test_suite == x"multi-asic-t1-lag-pr" ]; then
+    test_multi_asic_t1_lag_pr
 elif [ x$test_suite == x"t2" ]; then
     test_t2
 elif [ x$test_suite == x"dualtor" ]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
While running multi-asic VS tests on Azure Pipeline, we see that fpmsyncd/syncd/orchagent crashes with Redis busy error log.
```
ul  6 11:15:32.533912 vlab-08 ERR bgp2#fpmsyncd: :- checkReplyType: Expected to get redis type 4 got type 6, err: BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE.
Jul  6 11:15:32.533912 vlab-08 ERR bgp2#fpmsyncd: :- poll_descriptors: readData error: Expected to get redis type 4 got type 6, err: BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE.: Input/output error
Jul  6 11:15:32.533912 vlab-08 ERR bgp2#fpmsyncd: :- checkReplyType: Expected to get redis type 4 got type 6, err: BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE.
Jul  6 11:15:32.713647 vlab-08 ERR snmp#python3: :- guard: RedisReply catches system_error: command: SELECT 4, reason: BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE.: Input/output error
Jul  6 11:15:32.814734 vlab-08 INFO bgp2#/supervisord: fpmsyncd terminate called without an active exception
Jul  6 11:15:34.022281 vlab-08 INFO bgp2#supervisord 2022-07-06 11:15:34,001 INFO exited: fpmsyncd (terminated by SIGABRT (core dumped); not expected)

```
Test pipeline where this error was seen: Pipelines - Run build_SuvarnaMeenakshi.sonic-buildimage (2)_vs_azp2_20220706.1 (azure.com)
If we reduce the number of external VMs to 2 neighbors, this issue is not seen.

#### How did you do it?
1. Reduce the number of external BGP neighbors to 2 for t1-8-lag topology which is used by msft_four_asic_vs testbed.
2. Add a new function to run test_bgp_fact test so that kvmtest.sh can be used in multi-asic PR checker to run a basic test case.
This can further be extended with more test in future.

#### How did you verify/test it?
Have a test pipeline with fewer asics and ensure fpmsyncd  crash is not seen.

Tested on multi-asic vs:
```
./kvmtest.sh -en -T multi-asic-t1-lag-pr vms-kvm-four-asic-t1-lag vlab-08
Monday 18 July 2022  18:29:52 +0000 (0:00:00.993)       0:00:54.241 *********** 
=============================================================================== 
execute cli "config load_minigraph -y" to apply new minigraph ------------------------------------------------------------------------------------------------------------------------------------- 24.64s
Wait for switch to become reachable again --------------------------------------------------------------------------------------------------------------------------------------------------------- 10.58s
execute cli "config save -y" to save current minigraph as startup-config --------------------------------------------------------------------------------------------------------------------------- 2.54s
create new minigraph file for SONiC device --------------------------------------------------------------------------------------------------------------------------------------------------------- 1.52s
execute cli "config bgp startup all" to bring up all bgp sessions for test ------------------------------------------------------------------------------------------------------------------------- 1.19s
find interface name mapping and individual interface speed if defined from dut --------------------------------------------------------------------------------------------------------------------- 1.05s
cleanup all cached facts --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.99s
gather testbed VM information ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.99s
Generate dsmsroot cert using openssl. -------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.72s
Generate server cert using openssl. ---------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.71s
Generate server cert using openssl. ---------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.63s
Create directory ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.61s
Replace snmp community string ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.60s
docker status -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.53s
Gathering testbed information ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.48s
saved original minigraph file in SONiC DUT(ignore errors when file does not exist) ----------------------------------------------------------------------------------------------------------------- 0.46s
Test if core_analyzer.rc.json exists --------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.45s
Create directory ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.44s
get connection graph if defined for dut (ignore any errors) ---------------------------------------------------------------------------------------------------------------------------------------- 0.44s
topo_facts ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 0.43s
Done
+ sleep 180
+ popd
/var/src/sonic-mgmt/tests
+ export ANSIBLE_LIBRARY=/var/src/sonic-mgmt/ansible/library/
+ ANSIBLE_LIBRARY=/var/src/sonic-mgmt/ansible/library/
+ export ANSIBLE_KEEP_REMOTE_FILES=1
+ ANSIBLE_KEEP_REMOTE_FILES=1
+ export GIT_USER_NAME=
+ GIT_USER_NAME=
+ export GIT_API_TOKEN=
+ GIT_API_TOKEN=
+ rm -rf /var/src/sonic-mgmt/tests/logs
+ mkdir -p /var/src/sonic-mgmt/tests/logs
+ '[' xmulti-asic-t1-lag-pr == xt0 ']'
+ '[' xmulti-asic-t1-lag-pr == xt0-sonic ']'
+ '[' xmulti-asic-t1-lag-pr == xt1-lag ']'
+ '[' xmulti-asic-t1-lag-pr == xmulti-asic-t1-lag ']'
+ '[' xmulti-asic-t1-lag-pr == xmulti-asic-t1-lag-pr ']'
+ test_multi_asic_t1_lag_pr
+ tgname=multi_asic_t1_lag
+ tests='    bgp/test_bgp_fact.py'
+ pushd /var/src/sonic-mgmt/tests
/var/src/sonic-mgmt/tests /var/src/sonic-mgmt/tests
+ ./run_tests.sh -i ../ansible/veos_vtb -d vlab-08 -n vms-kvm-four-asic-t1-lag -f vtestbed.yaml -k debug -l warning -m individual -q 1 -a False -O -r -e --allow_recover -E -c '    bgp/test_bgp_fact.py' -p logs/multi_asic_t1_lag -e --disable_loganalyzer -e --skip_sanity -u
=== Running tests individually ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
=========================================================================================== test session starts ===========================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.11.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/src/sonic-mgmt/tests, inifile: pytest.ini
plugins: allure-pytest-2.8.22, forked-1.3.0, metadata-1.11.0, html-1.22.1, repeat-0.9.1, xdist-1.28.0, ansible-2.2.2
collected 4 items                                                                                                                                                                                         

bgp/test_bgp_fact.py::test_bgp_facts[vlab-08-0] PASSED                                                                                                                                              [ 25%]
bgp/test_bgp_fact.py::test_bgp_facts[vlab-08-1] PASSED                                                                                                                                              [ 50%]
bgp/test_bgp_fact.py::test_bgp_facts[vlab-08-2] PASSED                                                                                                                                              [ 75%]
bgp/test_bgp_fact.py::test_bgp_facts[vlab-08-3] PASSED                                                                                                                                              [100%]

------------------------------------------------------- generated xml file: /var/src/sonic-mgmt/tests/logs/multi_asic_t1_lag/bgp/test_bgp_fact.xml --------------------------------------------------------
======================================================================================== 4 passed in 39.36 seconds ========================================================================================
```
```
admin@vlab-08:~$ show ip bgp summary

IPv4 Unicast Summary:
asic0: BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 6390
asic1: BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 12757
RIB entries 25530, using 4697520 bytes of memory
Peers 6, using 4444848 KiB of memory
Peer groups 8, using 512 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  65200       3434       3436         0      0       0  00:12:13             6370  ARISTA01T2
10.0.0.33      4  64001        258       6623         0      0       0  00:12:12                3  ARISTA01T0

Total number of neighbors 2
admin@vlab-08:~$ show int status -d all
     Interface        Lanes    Speed    MTU    FEC        Alias            Vlan    Oper    Admin    Type    Asym PFC
--------------  -----------  -------  -----  -----  -----------  --------------  ------  -------  ------  ----------
     Ethernet0      1,2,3,4      40G   9100    N/A  Ethernet1/1  PortChannel102      up       up     N/A         off
     Ethernet4      5,6,7,8      40G   9100    N/A  Ethernet1/2  PortChannel102      up       up     N/A         off
     Ethernet8   9,10,11,12      40G   9100    N/A  Ethernet1/3          routed    down     down     N/A         off
    Ethernet12  13,14,15,16      40G   9100    N/A  Ethernet1/4          routed    down     down     N/A         off
    Ethernet16      1,2,3,4      40G   9100    N/A  Ethernet1/5  PortChannel101      up       up     N/A         off
    Ethernet20      5,6,7,8      40G   9100    N/A  Ethernet1/6          routed    down     down     N/A         off
    Ethernet24   9,10,11,12      40G   9100    N/A  Ethernet1/7          routed    down     down     N/A         off
    Ethernet28  13,14,15,16      40G   9100    N/A  Ethernet1/8          routed    down     down     N/A         off
  Ethernet-BP0  17,18,19,20      40G   9100    N/A   Eth4-ASIC0   PortChannel03      up       up     N/A         off
  Ethernet-BP4  21,22,23,24      40G   9100    N/A   Eth5-ASIC0   PortChannel03      up       up     N/A         off
  Ethernet-BP8  25,26,27,28      40G   9100    N/A   Eth6-ASIC0   PortChannel04      up       up     N/A         off
 Ethernet-BP12  29,30,31,32      40G   9100    N/A   Eth7-ASIC0   PortChannel04      up       up     N/A         off
 Ethernet-BP16  17,18,19,20      40G   9100    N/A   Eth4-ASIC1   PortChannel19      up       up     N/A         off
 Ethernet-BP20  21,22,23,24      40G   9100    N/A   Eth5-ASIC1   PortChannel19      up       up     N/A         off
 Ethernet-BP24  25,26,27,28      40G   9100    N/A   Eth6-ASIC1   PortChannel20      up       up     N/A         off
 Ethernet-BP28  29,30,31,32      40G   9100    N/A   Eth7-ASIC1   PortChannel20      up       up     N/A         off
 Ethernet-BP32      1,2,3,4      40G   9100    N/A   Eth0-ASIC2   PortChannel33      up       up     N/A         off
 Ethernet-BP36      5,6,7,8      40G   9100    N/A   Eth1-ASIC2   PortChannel33      up       up     N/A         off
 Ethernet-BP40   9,10,11,12      40G   9100    N/A   Eth2-ASIC2   PortChannel34      up       up     N/A         off
 Ethernet-BP44  13,14,15,16      40G   9100    N/A   Eth3-ASIC2   PortChannel34      up       up     N/A         off
 Ethernet-BP64      1,2,3,4      40G   9100    N/A   Eth0-ASIC3   PortChannel49      up       up     N/A         off
 Ethernet-BP68      5,6,7,8      40G   9100    N/A   Eth1-ASIC3   PortChannel49      up       up     N/A         off
 Ethernet-BP72   9,10,11,12      40G   9100    N/A   Eth2-ASIC3   PortChannel50      up       up     N/A         off
 Ethernet-BP76  13,14,15,16      40G   9100    N/A   Eth3-ASIC3   PortChannel50      up       up     N/A         off
 PortChannel03          N/A      80G   9100    N/A          N/A          routed      up       up     N/A         N/A
 PortChannel04          N/A      80G   9100    N/A          N/A          routed      up       up     N/A         N/A
 PortChannel19          N/A      80G   9100    N/A          N/A          routed      up       up     N/A         N/A
 PortChannel20          N/A      80G   9100    N/A          N/A          routed      up       up     N/A         N/A
 PortChannel33          N/A      80G   9100    N/A          N/A          routed      up       up     N/A         N/A
 PortChannel34          N/A      80G   9100    N/A          N/A          routed      up       up     N/A         N/A
 PortChannel49          N/A      80G   9100    N/A          N/A          routed      up       up     N/A         N/A
 PortChannel50          N/A      80G   9100    N/A          N/A          routed      up       up     N/A         N/A
PortChannel101          N/A      40G   9100    N/A          N/A          routed      up       up     N/A         N/A
PortChannel102          N/A      80G   9100    N/A          N/A          routed      up       up     N/A         N/A
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
