### PR TITLE
Skip GCU tests in platform with duplicate lanes config

### DIFF
--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -16,7 +16,8 @@ logger = logging.getLogger(__name__)
 @pytest.fixture(scope="module", autouse=True)
 def bypass_duplicate_lanes_platform(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
-    if duthost.facts['platform'] == 'x86_64-arista_7050cx3_32s':
+    if duthost.facts['platform'] == 'x86_64-arista_7050cx3_32s' or \
+            duthost.facts['platform'] == 'x86_64-dellemc_s5232f_c3538-r0':
         pytest.skip("Temporary skip platform with duplicate lanes...")
 
 

--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -12,12 +12,14 @@ CONFIG_DB_BACKUP = "/etc/sonic/config_db.json.before_gcu_test"
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def temporary_skip_for_nightly_test():
-    pytest.skip("Temporary skip all GCU tests...")
-
-
 # Module Fixture
+@pytest.fixture(scope="module", autouse=True)
+def bypass_duplicate_lanes_platform(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    if duthost.facts['platform'] == 'x86_64-arista_7050cx3_32s':
+        pytest.skip("Temporary skip platform with duplicate lanes...")
+
+
 @pytest.fixture(scope="module")
 def cfg_facts(duthosts, rand_one_dut_hostname):
     """

--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -12,6 +12,11 @@ CONFIG_DB_BACKUP = "/etc/sonic/config_db.json.before_gcu_test"
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def temporary_skip_for_nightly_test():
+    pytest.skip("Temporary skip all GCU tests...")
+
+
 # Module Fixture
 @pytest.fixture(scope="module")
 def cfg_facts(duthosts, rand_one_dut_hostname):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Temp skip GCU tests in platform with duplicate lanes config.
By checking [sonic-buildimage](https://github.com/Azure/sonic-buildimage/tree/master/device) repo, [x86_64-arista_7050cx3_32s](https://github.com/Azure/sonic-buildimage/tree/master/device/arista/x86_64-arista_7050cx3_32s) and [x86_64-dellemc_s5232f_c3538-r0](https://github.com/Azure/sonic-buildimage/tree/master/device/dell/x86_64-dellemc_s5232f_c3538-r0) contains duplicate lanes config. 
As we only have arista for our nightly test, so we skip `x86_64-arista_7050cx3_32s` only.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Some platforms contain ports that share lanes which will fail GCU verification. 
Temporary skip to avoid nightly failure and push a fix later.
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
