### PR TITLE
[auto-ts] Fix and stabilize auto-techsupport tests

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -330,7 +330,6 @@ class TestAutoTechSupport:
             validate_techsupport_generation(self.duthost, self.dut_cli, is_techsupport_expected=True,
                                             available_tech_support_files=available_tech_support_files)
 
-
         logger.info('Sleep until {} second pass since techsupport file created'.format(rate_limit_30))
         time.sleep(rate_limit_30)
 
@@ -354,7 +353,6 @@ class TestAutoTechSupport:
         with allure.step('Checking that only 1 techsupport process running'):
             validate_techsupport_generation(self.duthost, self.dut_cli, is_techsupport_expected=True,
                                             available_tech_support_files=available_tech_support_files)
-
 
     @pytest.mark.parametrize('test_mode', max_limit_test_modes_list)
     def test_max_limit(self, test_mode, global_rate_limit_zero, feature_rate_limit_zero, cleanup_list):


### PR DESCRIPTION
Signed-off-by: Andrii-Yosafat Lozovyi <andrii-yosafatx.lozovyi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  Made changes that fixes some issues with auto-techsupport and stabilizes TC
**Main changes that was made:**
1.) Changed --since option from` '300 sec': 360` to `'300 sec ago': 360`
This is made because TC will take actual time and add 300 seconds to it, and will collect logs and core dump only starting from that time according to - [Date-input-formats](https://www.gnu.org/software/coreutils/manual/html_node/Date-input-formats.html)

**Example:** 
```
$ date
Thu Jul 14 11:24:18 UTC 2022

$ date --date='300 second'
Thu Jul 14 11:29:15 UTC 2022

$ date --date='300 second ago'
Thu Jul 14 11:19:48 UTC 2022

Fail:
    "stderr": "ls: cannot access '/tmp/sonic_dump_5-dut_20220714_103906/core/': No such file or directory", 
    "stderr_lines": [
        "ls: cannot access '/tmp/sonic_dump_5-dut_20220714_103906/core/': No such file or directory"
```

2.) Check `available_tech_support_files `before core dump generation is triggered in `test_rate_limit_interval`
Test might fail because when `available_tech_support_files `is checked after core dump was generated, techsupport dump file is already generated, and TC fails in further steps because expects new_techdump to be generated.

```
17:13:11 test_auto_techsupport.validate_techsuppo L0867 INFO   | !!!!! dump_created_after_core_dump =[u'/var/dump/sonic_dump_5-dut_20220713_170442.tar.gz']
17:13:12 test_auto_techsupport.is_techsupport_gen L0652 INFO   | [u'root      616209  0.0  0.1  30160 17112 ?        S    17:04   0:00 python3 /usr/local/bin/coredump_gen_handler.py bash.1657731882.10413.core.gz swss', u'root      624718  0.0  0.0   2420   524 pts/2    S+   17:05   0:00 /bin/sh -c ps -aux | grep "coredump_gen_handler"', u'root      624720  0.0  0.0   8808   720 pts/2    S+   17:05   0:00 grep coredump_gen_handler']
17:13:12 test_auto_techsupport.is_techsupport_gen L0654 INFO   | Number of running autotechsupport processes: 1
17:13:13 test_auto_techsupport.is_techsupport_gen L0652 INFO   | [u'root      624746  0.0  0.0   2420   520 pts/2    S+   17:05   0:00 /bin/sh -c ps -aux | grep "coredump_gen_handler"', u'root      624748  0.0  0.0   8808   660 pts/2    R+   17:05   0:00 grep coredump_gen_handler']
17:13:13 test_auto_techsupport.is_techsupport_gen L0654 INFO   | Number of running autotechsupport processes: 0
17:13:13 test_auto_techsupport.is_new_techsupport L0922 INFO   | Checking that new techsupport file created
17:13:34 test_auto_techsupport.is_new_techsupport L0922 INFO   | Checking that new techsupport file created

AssertionError: New expected techsupport file was not generated
assert False
 +  where False = wait_until(300, 10, 0, is_new_techsupport_file_generated, <MultiAsicSonicHost 5-dut>, [u'/var/dump/sonic_dump_5-dut_20220713_170442.tar.gz'])
```
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Stabilize work of auto-techsupport tests 
#### How did you do it?

#### How did you verify/test it?
Run test cases on t0 topo: 
```
show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_sanity PASSED                                                                                                                                                                                                                                                                               [ 25%]
show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_rate_limit_interval PASSED                                                                                                                                                                                                                                                                  [ 50%]
show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_max_limit[techsupport] PASSED                                                                                                                                                                                                                                                               [ 75%]
show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_max_limit[core] PASSED 
```
#### Any platform specific information?
```
SONiC Software Version: SONiC.master.121785-dirty-20220713.113516
Distribution: Debian 11.4
Kernel: 5.10.0-12-2-amd64
Build commit: 429254cb2
Build date: Wed Jul 13 16:50:51 UTC 2022
Built by: AzDevOps@sonic-build-workers-001RQ8
Platform: x86_64-arista_7170_64c
HwSKU: Arista-7170-64C
```
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
