### PR TITLE
[ptf]: Enhance ptf with macsec

### DIFF
--- a/tests/common/devices/ptf.py
+++ b/tests/common/devices/ptf.py
@@ -20,9 +20,10 @@ class PTFHost(AnsibleHostBase):
     Instance of this class can run ansible modules on the PTF host.
     """
 
-    def __init__(self, ansible_adhoc, hostname, duthost, tbinfo):
+    def __init__(self, ansible_adhoc, hostname, duthost, tbinfo, macsec_enabled=False):
         self.duthost = duthost
         self.tbinfo = tbinfo
+        self.macsec_enabled = macsec_enabled
         AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
 
     def change_mac_addresses(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -394,16 +394,16 @@ def localhost(ansible_adhoc):
 
 
 @pytest.fixture(scope="session")
-def ptfhost(ansible_adhoc, tbinfo, duthost):
+def ptfhost(ansible_adhoc, tbinfo, duthost, request):
     if "ptf_image_name" in tbinfo and "docker-keysight-api-server" in tbinfo["ptf_image_name"]:
         return None
     if "ptf" in tbinfo:
-        return PTFHost(ansible_adhoc, tbinfo["ptf"], duthost, tbinfo)
+        return PTFHost(ansible_adhoc, tbinfo["ptf"], duthost, tbinfo, macsec_enabled = request.config.option.enable_macsec)
     else:
         # when no ptf defined in testbed.csv
         # try to parse it from inventory
         ptf_host = duthost.host.options["inventory_manager"].get_host(duthost.hostname).get_vars()["ptf_host"]
-        return PTFHost(ansible_adhoc, ptf_host, duthost, tbinfo)
+        return PTFHost(ansible_adhoc, ptf_host, duthost, tbinfo, macsec_enabled = request.config.option.enable_macsec)
 
 
 @pytest.fixture(scope="module")

--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -70,8 +70,10 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
     if timeout:
         cmd += " --test-case-timeout {}".format(int(timeout))
 
-    # MACsec is only available in Python3
-    if is_python3:
+    if hasattr(host, "macsec_enabled") and host.macsec_enabled:
+        if not is_python3:
+            logger.error("MACsec is only available in Python3")
+            raise Exception
         host.create_macsec_info()
 
     try:


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Got few unexpected commands like `sonic-db-cli   APPL_DB HGETALL 'MACSEC_PORT_TABLE:Ethernet164` after issuing warm-reboot. Any commands issued during shutdown process are subjected to fail/surprises.

#### How did you do it?
If the MACsec wasn't enabled, don't try to load MACsec info.

#### How did you verify/test it?
Check testcases: ecmp.inner_hashing.test_wr_inner_hashing.TestWRDynamicInnerHashing.test_inner_hashing

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
