### PR TITLE
[multi_asic]: Add support to get multi-asic VS build

### DIFF
--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -70,12 +70,17 @@ def get_download_url(buildid, artifact_name):
     return (download_url, artifact_size)
 
 
-def download_artifacts(url, content_type, platform, buildid):
+def download_artifacts(url, content_type, platform, buildid, num_asic):
     """find latest successful build id for a branch"""
 
     if content_type == 'image':
         if platform == 'vs':
-            filename = 'sonic-vs.img.gz'
+            if num_asic == 6:
+                filename = 'sonic-6asic-vs.img.gz'
+            elif num_asic == 4:
+                filename = 'sonic-4asic-vs.img.gz'
+            else:
+                filename = 'sonic-vs.img.gz'
         else:
             filename = "sonic-{}.bin".format(platform)
 
@@ -118,6 +123,10 @@ def main():
     parser.add_argument('--content', metavar='content', type=str,
             choices=['all', 'image'], default='image',
             help='download content type [all|image(default)]')
+    parser.add_argument('--num_asic', metavar='num_asic', type=int,
+            default=1,
+            help='Specifiy number of asics')
+
     args = parser.parse_args()
 
     if args.buildid is None:
@@ -129,7 +138,7 @@ def main():
 
     (dl_url, artifact_size) = get_download_url(buildid, artifact_name)
 
-    download_artifacts(dl_url, args.content, args.platform, buildid)
+    download_artifacts(dl_url, args.content, args.platform, buildid, args.num_asic)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Update getbuild script to get sonic multi-asic KVM image.
Depends on pipeline change to build multi-asic KVM image https://github.com/Azure/sonic-buildimage/pull/11453.

#### How did you do it?
Update script to take a new parameter num_asic to download multi-asic KVM images sonic-4asic-vs.img.gz and sonic-6asic-vs.img.gz or by default assume that it is a single asic VS image.

#### How did you verify/test it?
Tested out to get the right image based on num_asic:
python3 tests/scripts/getbuild.py --platform vs --branch master --num_asic 6 --buildid 122463 
 (using the buildid of run of https://github.com/Azure/sonic-buildimage/pull/11453 PR)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
