### PR TITLE
[mux config] make sure mux config is consistent

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -512,6 +512,7 @@ def toggle_all_simulator_ports_to_rand_selected_tor_m(duthosts, mux_server_url, 
 
     logger.info('Set all muxcable to auto mode on all ToRs')
     duthosts.shell('config muxcable mode auto all')
+    duthosts.shell('config save -y')
 
 
 @pytest.fixture

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -496,7 +496,7 @@ def _check_dut_mux_status(duthosts, duts_minigraph_facts):
     upper_tor_mux_config = duts_mux_config[dut_upper_tor.hostname]
     lower_tor_mux_config = duts_mux_config[dut_lower_tor.hostname]
     if upper_tor_mux_config != lower_tor_mux_config:
-        err_msg = "'show mux config' output differs between two ToRs"
+        err_msg = "'show mux config' output differs between two ToRs {} v.s. {}".format(upper_tor_mux_config, lower_tor_mux_config)
         return False, err_msg, {}
 
     port_cable_types = {}
@@ -540,6 +540,7 @@ def _check_dut_mux_status(duthosts, duts_minigraph_facts):
 def check_mux_simulator(tbinfo, duthosts, duts_minigraph_facts, get_mux_status, reset_simulator_port, restart_nic_simulator):
 
     def _recover():
+        duthosts.shell('config muxcable mode auto all')
         reset_simulator_port()
         restart_nic_simulator()
 


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Approach
#### What is the motivation for this PR?
Some tests save configuration during tests, if they happen to change mux configuration, then they could cause 2 ToRs having different saved mux configurations, e.g. one ToR manual and the other ToR Auto. This won't cause issue until another test issues config reload on both ToRs. Then the mux configuration will be different, and the previous sanity check is unable to recover.

#### How did you do it?
- save mux config after restoring auto mode.
- display the difference of mux config when sanity check fails.
- restore mux config to auto on both ToRs when sanity check fails.

#### How did you verify/test it?
Run test on a testbed with inconsistent configurations, the sanity check is now able to recover the testbed.
Run test toggles the mux configuration. Verity that the saved configuration is consistent after the test.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
