### PR TITLE
Enhance test report to include pipeline results

### DIFF
--- a/test_reporting/collect_azp_results.py
+++ b/test_reporting/collect_azp_results.py
@@ -1,0 +1,62 @@
+"""Script to collect failed/cancelled/success tasks for specific azure pipeline and save it to json file."""
+import os
+import requests
+import argparse
+import json
+
+
+TOKEN = os.environ.get('AZURE_DEVOPS_MSSONIC_TOKEN')
+if not TOKEN:
+    raise Exception('Must export environment variable AZURE_DEVOPS_MSSONIC_TOKEN')
+AUTH = ('', TOKEN)
+
+TASK_RESULT_FILE = "pipeline_task_results.json"
+
+
+def get_tasks_results(buildid):
+    """Collect previous tasks' results and save to file'
+
+    Returns:
+        dict: Dict of tasks' results
+    """
+    task_results = {
+        "success_tasks": "",
+        "failed_tasks": "",
+        "cancelled_tasks": ""
+    }
+    pipeline_url = "https://dev.azure.com/mssonic/internal/_apis/build/builds/" + str(buildid) + "/timeline?api-version=5.1"
+    print("Collect task results from here:{}".format(pipeline_url))
+    build_records = requests.get(pipeline_url, auth=AUTH).json()["records"]
+    if not build_records:
+        print("Failed to get build records for buildid {}".format(buildid))
+        return
+    for task in build_records:
+        if task and task["state"] == "completed":
+            if task["result"] == 'succeeded':
+                task_results["success_tasks"] += task["name"] + ";"
+            if task["result"] == 'failed':
+                task_results["failed_tasks"] += task["name"] + ";"
+            if task["result"] == 'canceled':
+                task_results["cancelled_tasks"] += task["name"] + ";"
+    with open(TASK_RESULT_FILE, "w") as f:
+        json.dump(task_results, f)
+    return task_results
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Upload test reports to Kusto.",
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog="""
+            Examples:
+            python3 collect_azp_results.py 88888
+            """,
+    )
+    parser.add_argument("build_id", metavar="buildid", type=str, help="build ids of pipeline, ie 88888")
+
+    args = parser.parse_args()
+    build_id = args.build_id
+    get_tasks_results(build_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -166,7 +166,8 @@ def validate_junit_xml_archive(directory_name, strict=False):
             - Any of the provided files are missing required fields
     """
     if not os.path.exists(directory_name) or not os.path.isdir(directory_name):
-        raise JUnitXMLValidationError("file not found")
+        print("directory {} not found".format(directory_name))
+        return
 
     roots = []
     metadata_source = None
@@ -209,8 +210,7 @@ def validate_junit_xml_archive(directory_name, strict=False):
             print(f"could not parse {document}: {e} - skipping")
 
     if not roots:
-        raise JUnitXMLValidationError(f"provided directory {directory_name} does not contain any valid XML files")
-
+        print("provided directory {} does not contain any valid XML files".format(directory_name))
     return roots
 
 
@@ -342,6 +342,9 @@ def parse_test_result(roots):
         A dict containing the parsed test result.
     """
     test_result_json = defaultdict(dict)
+    if not roots:
+        print("The pipeline failed, no XML file needs to parse.")
+        return
 
     for root in roots:
         test_result_json["test_metadata"] = _update_test_metadata(test_result_json["test_metadata"],
@@ -540,7 +543,8 @@ def validate_junit_json_file(path):
             - The provided file is missing required fields
     """
     test_result_json = validate_json_file(path)
-
+    if not test_result_json:
+        return
     _validate_json_metadata(test_result_json)
     _validate_json_summary(test_result_json)
     _validate_json_cases(test_result_json)

--- a/test_reporting/junit_xml_parser.py
+++ b/test_reporting/junit_xml_parser.py
@@ -343,7 +343,7 @@ def parse_test_result(roots):
     """
     test_result_json = defaultdict(dict)
     if not roots:
-        print("The pipeline failed, no XML file needs to parse.")
+        print("No XML file needs to be parsed or the file is empty.")
         return
 
     for root in roots:
@@ -676,6 +676,9 @@ python3 junit_xml_parser.py tests/files/sample_tr.xml
         sys.exit(0)
 
     test_result_json = parse_test_result(roots)
+    if test_result_json is None:
+        print("XML file doesn't exist or no data in the file.")
+        sys.exit(1)
 
     if args.compact:
         output = json.dumps(test_result_json, separators=(",", ":"), sort_keys=True)

--- a/test_reporting/kusto/setup.kql
+++ b/test_reporting/kusto/setup.kql
@@ -106,6 +106,25 @@
                                                                                   '{"column":"UploadTimestamp","Properties":{"path":"$.upload_time"}}]'
 
 ###############################################################################
+# PIPELINE TABLE SETUP                                                        #
+# 1. Create a TestReportPipeline table to store test metadata                 #
+# 2. Add a JSON mapping for the table                                         #
+###############################################################################
+.create table TestReportPipeline (UploadTimestamp: datetime, TrackingId: string,
+                                  ReportId: string, TestbedName: string,
+                                  OSVersion: string, SuccessTasks: string,
+                                  FailedTasks: string, CancelledTasks: string)
+
+.create table TestReportPipeline ingestion json mapping 'FlatPipelineMappingV1' @'[{"column":"UploadTimestamp","Properties":{"path":"$.upload_time"}},'
+                                                                                  '{"column":"TrackingId","Properties":{"path":"$.tracking_id"}},'
+                                                                                  '{"column":"ReportId","Properties":{"path":"$.id"}},'
+                                                                                  '{"column":"TestbedName","Properties":{"path":"$.testbed"}},'
+                                                                                  '{"column":"OSVersion","Properties":{"path":"$.os_version"}},'
+                                                                                  '{"column":"SuccessTasks","Properties":{"path":"$.success_tasks"}},'
+                                                                                  '{"column":"FailedTasks","Properties":{"path":"$.failed_tasks"}},'
+                                                                                  '{"column":"CanceledTasks","Properties":{"path":"$.cancelled_tasks"}}]'
+
+###############################################################################
 # EXPECTED TEST RUNS TABLE SETUP                                              #
 # 1. Create a ExpectedTestRuns table to store expected test runs data         #
 # 2. Add a JSON mapping for the table                                         #

--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -22,7 +22,7 @@ except ImportError:
 from utilities import validate_json_file
 from datetime import datetime
 from typing import Dict, List
-from collect_azp_results import get_tasks_results
+
 
 TASK_RESULT_FILE = "pipeline_task_results.json"
 
@@ -178,7 +178,7 @@ class KustoConnector(ReportDBConnector):
             report_guid: A randomly generated UUID that is used to query for a specific test run across tables.
         """
         if not report_json:
-            print("Uploaded file is not found or empty. We only upload pipeline results and summary")
+            print("Test result file is not found or empty. We will only upload pipeline results and summary.")
             self._upload_pipeline_results(external_tracking_id, report_guid, testbed, os_version)
             self._upload_summary(report_json, report_guid)
             return
@@ -232,10 +232,13 @@ class KustoConnector(ReportDBConnector):
             "os_version": os_version,
             "upload_time": str(datetime.utcnow())
         }
-        # load pipeline task result json file
-        with open(TASK_RESULT_FILE, 'r') as f:
-            task_results = json.load(f)
-
+        try:
+            # load pipeline task result json file
+            with open(TASK_RESULT_FILE, 'r') as f:
+                task_results = json.load(f)
+        except Exception as e:
+            print("Failed to load file {} with exception {}".format(TASK_RESULT_FILE, repr(e)))
+            task_results = {}
         pipeline_data.update(task_results)
         print("Upload pipeline result")
         self._ingest_data(self.PIPELINE_TABLE, pipeline_data)

--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -32,6 +32,12 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
     parser.add_argument(
         "--category", "-c", type=str, help="Type of data to upload (i.e. test_result, reachability, etc.)"
     )
+    parser.add_argument(
+        "--testbed", "-t", type=str, help="Name of testbed"
+    )
+    parser.add_argument(
+        "--image_url", "-i", type=str, help="Name of image (i.e. IMAGE_BRCM_ABOOT_202012, etc.)"
+    )
 
     args = parser.parse_args()
     kusto_db = KustoConnector(args.db_name)
@@ -39,6 +45,7 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
     if args.category == "test_result":
         tracking_id = args.external_id if args.external_id else ""
         report_guid = str(uuid.uuid4())
+        testbed = args.testbed
         for path_name in args.path_list:
             reboot_data_regex = re.compile('.*test.*_(reboot|sad.*|upgrade_path)_(summary|report).json')
             if reboot_data_regex.match(path_name):
@@ -49,7 +56,7 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
                 else:
                     roots = validate_junit_xml_path(path_name)
                     test_result_json = parse_test_result(roots)
-                kusto_db.upload_report(test_result_json, tracking_id, report_guid)
+                kusto_db.upload_report(test_result_json, tracking_id, report_guid, testbed, args.image_url)
     elif args.category == "reachability":
         reachability_data = []
         for path_name in args.path_list:

--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -11,6 +11,20 @@ from junit_xml_parser import (
 )
 from report_data_storage import KustoConnector
 
+def _parse_os_version(image_url):
+    """Parse os version from image url"""
+    os_version = ''
+    items = image_url.split("/")
+    if "public" in items:
+        os_version = "master"
+    elif "internal" in items:
+        os_version = "internal"
+    else:
+        # For other images, such as 202012, there is internal-202012 in url.
+        for item in items:
+            if "internal" in item:
+                os_version = item.split("-")[-1]
+    return os_version if os_version else "UNKNOWN"
 
 def _run_script():
     parser = argparse.ArgumentParser(
@@ -33,10 +47,14 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
         "--category", "-c", type=str, help="Type of data to upload (i.e. test_result, reachability, etc.)"
     )
     parser.add_argument(
-        "--testbed", "-t", type=str, help="Name of testbed"
+        "--testbed", "-t", type=str, help="Name of testbed."
     )
-    parser.add_argument(
-        "--image_url", "-i", type=str, help="Name of image (i.e. IMAGE_BRCM_ABOOT_202012, etc.)"
+    os_version = parser.add_mutually_exclusive_group(required=True)
+    os_version.add_argument(
+        "--image_url", "-i", type=str, help="Image url. If has this argument, will ignore version. They are mutually exclusive."
+    )
+    os_version.add_argument(
+        "--version", "-o", type=str, help="OS version. If has this argument, will ignore image_url. They are mutually exclusive."
     )
 
     args = parser.parse_args()
@@ -46,6 +64,12 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
         tracking_id = args.external_id if args.external_id else ""
         report_guid = str(uuid.uuid4())
         testbed = args.testbed
+        if args.image_url:
+            version = _parse_os_version(args.image_url)
+        elif args.version:
+            version = args.version
+        else:
+            version = "UNKNOWN"
         for path_name in args.path_list:
             reboot_data_regex = re.compile('.*test.*_(reboot|sad.*|upgrade_path)_(summary|report).json')
             if reboot_data_regex.match(path_name):
@@ -56,7 +80,7 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
                 else:
                     roots = validate_junit_xml_path(path_name)
                     test_result_json = parse_test_result(roots)
-                kusto_db.upload_report(test_result_json, tracking_id, report_guid, testbed, args.image_url)
+                kusto_db.upload_report(test_result_json, tracking_id, report_guid, testbed, version)
     elif args.category == "reachability":
         reachability_data = []
         for path_name in args.path_list:

--- a/test_reporting/utilities.py
+++ b/test_reporting/utilities.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import json
 
 

--- a/test_reporting/utilities.py
+++ b/test_reporting/utilities.py
@@ -10,11 +10,10 @@ class TestResultJSONValidationError(Exception):
 def validate_json_file(path):
     if not os.path.exists(path):
         print(f"{path} not found")
-        sys.exit(1)
+        return
     if not os.path.isfile(path):
         print(f"{path} is not a JSON file")
-        sys.exit(1)
-
+        return
     try:
         with open(path) as f:
             test_result_json = json.load(f)


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Currently, when nightly test pipeline fails before running test, test report upload will fail too, because there is no XML file and it will throw error out. We don't know if pipeline does not run on that day, or it fails.

#### How did you do it?
Enhance test report upload scripts to record pipeline status and upload it to kusto.

1.  Add a new `collect_azp_results.py` to collect task status for specific pipeline.
2. If there is no XML file, upload summary table with 0 values.
3. Create a new table `TestReportPipeline`, record testbed name, os version, success tasks, failed tasks and cancelled tasks and upload the record to kusto.

#### How did you verify/test it?
Run nightly test and check kusto.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
