### PR TITLE
[202012] [VXLAN_ECMP] Workaround to have separate setup and teardown for each supported encap type

### DIFF
--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -10,9 +10,9 @@
     To test ECMP with 2 paths per destination:
     ./run_tests.sh -n ucs-m5-2 -d mth64-m5-2 -O -u -e -s -e --disable_loganalyzer -m individual -p /home/vxr/vxlan/logs/    -c 'vxlan/test_vxlan_ecmp.py' -e '--nhs_per_destination=2'
 
-    To test ECMP+Scale:
-    ./run_tests.sh -n ucs-m5-2 -d mth64-m5-2 -O -u -e -s -e --disable_loganalyzer -m individual -p /home/vxr/vxlan/logs/    -c 'vxlan/test_vxlan_ecmp.py' \
-                    -e '--ecmp_nhs_per_destination=128' -e '--total_number_of_nexthops=128000'
+    To test ECMP+Scale(for all 4 types of encap):
+    ./run_tests.sh -n ucs-m5-2 -d mth64-m5-2 -O -u -e -s -e --disable_loganalyzer -m individual -p /home/vxr/vxlan/logs/    -c  'vxlan/test_vxlan_ecmp.py::Test_VxLAN_route_tests::test_vxlan_single_endpoint' \
+                    -e '--ecmp_nhs_per_destination=128' -e '--total_number_of_nexthops=32000' -e '--total_number_of_endpoints=1024'
 
     To keep the temporary config files created in the DUT:
     ./run_tests.sh -n ucs-m5-2 -d mth64-m5-2 -O -u -e -s -e --keep_temp_files -c 'vxlan/test_vxlan_ecmp.py'
@@ -22,7 +22,7 @@
         debug_enabled               : Enable debug mode, for debugging script. The temp files will not have timestamped names. Default: False
         dut_hostid                  : An integer in the range of 1 - 100 to be used as the host part of the IP address for DUT. Default: 1
         ecmp_nhs_per_destination    : Number of ECMP next-hops per destination.
-        total_number_of_endpoints : Number of Endpoints (a pool of this number of ip addresses will used for next-hops).
+        total_number_of_endpoints   : Number of Endpoints (a pool of this number of ip addresses will used for next-hops). Default:2
         total_number_of_nexthops    : Maximum number of all nexthops for every destination combined(per encap_type).
         vxlan_port                                : Global vxlan port (UDP port) to be used for the DUT. Default: 4789
 '''
@@ -367,6 +367,10 @@ def create_vnet_routes(duthost, vnet_list, dest_af, nh_af, nhs_per_destination=1
             nhs_per_destination                    : Number of ECMP nexthops to use per destination.
             number_of_ecmp_nhs                     : Maximum number of all NextHops put together(for all destinations).
     '''
+    if number_of_available_nexthops < nhs_per_destination:
+        raise RuntimeError("The number of available nexthops ip addresses is not enough to cover even one destination." \
+                           "Pls rerun with total_number_of_endpoints({}) > ecmp_nhs_per_destination({})".format(number_of_available_nexthops, nhs_per_destination))
+
     available_nexthops = get_list_of_nexthops(number=number_of_available_nexthops, af=nh_af, prefix=nexthop_prefix)
 
     number_of_destinations = int(number_of_ecmp_nhs / nhs_per_destination)
@@ -524,9 +528,15 @@ def get_ethernet_ports(intf_list, minigraph_data):
 
     return ret_list
 
+
+@pytest.fixture(scope="module", params=SUPPORTED_ENCAP_TYPES)
+def encap_type(request):
+    yield request.param
+
+
 @pytest.fixture(scope="module")
 def setUp(duthosts, ptfhost, request, rand_one_dut_hostname, minigraph_facts,
-          tbinfo):
+          tbinfo, encap_type):
 
     global Constants
     # Should I keep the temporary files copied to DUT?
@@ -542,6 +552,8 @@ def setUp(duthosts, ptfhost, request, rand_one_dut_hostname, minigraph_facts,
     Constants['DUT_HOSTID'] = request.config.option.dut_hostid
 
     logger.info("Constants to be used in the script:%s", Constants)
+
+    SUPPORTED_ENCAP_TYPES = [encap_type]
 
     data = {}
     data['ptfhost'] = ptfhost
@@ -643,7 +655,7 @@ def setUp(duthosts, ptfhost, request, rand_one_dut_hostname, minigraph_facts,
     for tunnel in tunnel_names.values():
         data['duthost'].shell("redis-cli -n 4 del \"VXLAN_TUNNEL|{}\"".format(tunnel))
 
-@pytest.mark.parametrize("encap_type", SUPPORTED_ENCAP_TYPES)
+
 class Test_VxLAN:
 
     def dump_self_info_and_run_ptf(self, tcname, encap_type, expect_encap_success, packet_count=4):


### PR DESCRIPTION
### Description of PR
Backport to 202012 of #5858 
Included PR: #5873

Summary: 
Separate configuration and teardown for each supported encapsulation type: ['v4_in_v4', 'v4_in_v6', 'v6_in_v4', 'v6_in_v6']

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix the test issue when two types of tunnels (v4 and v6) configured at the same time

#### How did you do it?
By using an additional fixture, which allows to do setup and teardown for each encap type

#### How did you verify/test it?
By running test in the nightly regression
