### PR TITLE
[radv] fix fixture scope issue

### DIFF
--- a/tests/radv/test_radv_ipv6_ra.py
+++ b/tests/radv/test_radv_ipv6_ra.py
@@ -31,7 +31,7 @@ the connected PTF port(s) required to setup the RADV tests
 
 
 @pytest.fixture(scope="module", autouse=True)
-def radv_test_setup(request, duthosts, ptfhost, tbinfo, toggle_all_simulator_ports_to_upper_tor):
+def radv_test_setup(request, duthosts, ptfhost, tbinfo):
     duthost = duthosts[0]
     logging.info("radv_test_setup() DUT {}".format(duthost.hostname))
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
@@ -127,7 +127,8 @@ def test_radv_router_advertisement(
         request, tbinfo,
         duthost, ptfhost,
         radv_test_setup,
-        dut_update_radv_periodic_ra_interval):
+        dut_update_radv_periodic_ra_interval,
+        toggle_all_simulator_ports_to_upper_tor):
     for vlan_intf in radv_test_setup:
         # Run the RADV test on the PTF host
         logging.info("Verifying RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
@@ -151,7 +152,7 @@ def test_radv_router_advertisement(
 """
 
 
-def test_solicited_router_advertisement(request, tbinfo, ptfhost, duthost, radv_test_setup):
+def test_solicited_router_advertisement(request, tbinfo, ptfhost, duthost, radv_test_setup, toggle_all_simulator_ports_to_upper_tor):
     for vlan_intf in radv_test_setup:
         # Run the RADV solicited RA test on the PTF host
         logging.info("Verifying solicited RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",
@@ -180,6 +181,7 @@ def test_unsolicited_router_advertisement_with_m_flag(
     request, tbinfo,
     duthost, ptfhost,
     radv_test_setup,
+    toggle_all_simulator_ports_to_upper_tor,
 ):
     for vlan_intf in radv_test_setup:
         # Run the RADV test on the PTF host
@@ -204,7 +206,7 @@ def test_unsolicited_router_advertisement_with_m_flag(
 """
 
 
-def test_solicited_router_advertisement_with_m_flag(request, tbinfo, ptfhost, duthost, radv_test_setup):
+def test_solicited_router_advertisement_with_m_flag(request, tbinfo, ptfhost, duthost, radv_test_setup, toggle_all_simulator_ports_to_upper_tor):
     for vlan_intf in radv_test_setup:
         # Run the RADV solicited RA test on the PTF host
         logging.info("Verifying solicited RA on VLAN intf:%s with TOR's mapped PTF port:eth%s",


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
test_radv is failing on dualtor testbed due to fixture scope conflicts.

#### How did you do it?
toggle_all_simulator_ports_to_upper_tor is a function level fixture, it cannot be used by a module level fixture. Use it at per test basis.

#### How did you verify/test it?
run test_radv on a dualtor testbed:

radv/test_radv_ipv6_ra.py::test_radv_router_advertisement[active-standby] PASSED                                                                                                   [ 25%]
radv/test_radv_ipv6_ra.py::test_solicited_router_advertisement[active-standby] PASSED                                                                                              [ 50%]
radv/test_radv_ipv6_ra.py::test_unsolicited_router_advertisement_with_m_flag[active-standby] PASSED                                                                                [ 75%]
radv/test_radv_ipv6_ra.py::test_solicited_router_advertisement_with_m_flag[active-standby] PASSED                                                                                  [100%]

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
