### PR TITLE
[vlan/dualtor] address a few test issues

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -512,7 +512,6 @@ def toggle_all_simulator_ports_to_rand_selected_tor_m(duthosts, mux_server_url, 
 
     logger.info('Set all muxcable to auto mode on all ToRs')
     duthosts.shell('config muxcable mode auto all')
-    duthosts.shell('config save -y')
 
 
 @pytest.fixture

--- a/tests/vlan/test_host_vlan.py
+++ b/tests/vlan/test_host_vlan.py
@@ -85,6 +85,7 @@ def setup_host_vlan_intf_mac(duthosts, rand_one_dut_hostname, testbed_params, ve
     duthost = duthosts[rand_one_dut_hostname]
     dut_vlan_mac = duthost.get_dut_iface_mac('%s' % vlan_intf["attachto"])
     # There is a restriction in configuring interface mac address on Mellanox asics, assign a valid value for the vlan interface mac address
+    global DUT_VLAN_INTF_MAC
     if duthost.get_facts()['asic_type'] == 'mellanox':
         DUT_VLAN_INTF_MAC = get_new_vlan_intf_mac_mellanox(dut_vlan_mac)
     duthost.shell('redis-cli -n 4 hmset "VLAN|%s" mac %s' % (vlan_intf["attachto"], DUT_VLAN_INTF_MAC))

--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -62,6 +62,8 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo):
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     my_cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     ptfhost_info = {}
+    ip4 = None
+    ip6 = None
     for a_bgp_nbr in mg_facts['minigraph_bgp']:
         # Get the bgp neighbor connected to the selected VM
         if a_bgp_nbr['name'] == vm_name and a_bgp_nbr['addr'] == str(vm_host_info['ipv4']):


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
vlan test is failing due to various variable validity issues. Also noticed lingering vlan configurations after tests.

#### How did you do it?
Saving the mux config will address the inconsistent mux config issue, however, it saves the in-memory change causing tests relying on config reload to recovery to fail. Back off this change since sanity check can make mux config consistent.

Mark global variable properly.

Initialize variables properly.

#### How did you verify/test it?
run vlan tests, most tests passed except one due to known image issue. No longer see lingering vlan configuration after test is done.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

