### PR TITLE
Add radv test script into PR test

### DIFF
--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -167,7 +167,8 @@ test_t0() {
       generic_config_updater/test_vlan_interface.py \
       process_monitoring/test_critical_process_monitoring.py \
       show_techsupport/test_techsupport_no_secret.py \
-      system_health/test_system_status.py"
+      system_health/test_system_status.py \
+      radv/test_radv_ipv6_ra.py"
 
       pushd $SONIC_MGMT_DIR/tests
       ./run_tests.sh $RUNTEST_CLI_COMMON_OPTS -c "$tests" -p logs/$tgname


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
radv test is missed from PR test.

#### How did you do it?
Add radv/test_radv_ipv6.py into kvmtest.sh to cover it PR test.

#### How did you verify/test it?
run test_radv on vms-kvm-t0:

radv/test_radv_ipv6_ra.py::test_radv_router_advertisement[active-standby] PASSED [ 25%]
radv/test_radv_ipv6_ra.py::test_solicited_router_advertisement[active-standby] PASSED [ 50%]
radv/test_radv_ipv6_ra.py::test_unsolicited_router_advertisement_with_m_flag[active-standby] PASSED [ 75%]
radv/test_radv_ipv6_ra.py::test_solicited_router_advertisement_with_m_flag[active-standby] PASSED [100%]

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
