### PR TITLE
[Qos]Fix the testQosSaiQSharedWatermark test failure due to SAI queue watermark is not reset

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1338,5 +1338,7 @@ class QosSaiBase(QosBase):
 
         dut_asic = duthost.asic_instance(enum_frontend_asic_index)
         dut_asic.command("counterpoll watermark enable")
+        dut_asic.command("counterpoll queue enable")
         dut_asic.command("sleep 70")
         dut_asic.command("counterpoll watermark disable")
+        dut_asic.command("counterpoll queue disable")


### PR DESCRIPTION
configuring counterpoll watermark enable doesn't suffice to enable the queue watermark polling if the counter polling was disabled. As as result, the queue watermarks in SAI will not be clear successfully, which will fail the queue watermark test.To avoid that, counter poll should be enabled for both queue and watermark.with this command, the SAI Queue watermark can be cleared.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: testQosSaiQSharedWatermark may fail due to the SAI queue watermark is not cleared
Fixes # (issue) testQosSaiQSharedWatermark may fail due to the SAI queue watermark is not cleared

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012

### Approach
#### What is the motivation for this PR?
testQosSaiQSharedWatermark may fail due to the SAI queue watermark is not cleared
#### How did you do it?
Add "counterpoll queue enable", "counterpoll queue disable" in the resetWatermark fixture
#### How did you verify/test it?
Run the testQosSaiQSharedWatermark , test will not fail due to the SAI queue watermark is not cleared
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
No
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
