### PR TITLE
[getbuild.py]: Download the latest sonic image

### DIFF
--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -93,7 +93,7 @@ def download_artifacts(url, content_type, platform, buildid):
             print("Download error", e)
             sys.exit(1)
 
-def find_latest_build_id(branch, success_flag):
+def find_latest_build_id(branch, success_flag = "succeeded"):
     """find latest successful build id for a branch"""
 
     builds_url = "https://dev.azure.com/mssonic/build/_apis/build/builds?definitions=1&branchName=refs/heads/{}&resultFilter={}&statusFilter=completed&api-version=6.0".format(branch, success_flag)

--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -93,10 +93,10 @@ def download_artifacts(url, content_type, platform, buildid):
             print("Download error", e)
             sys.exit(1)
 
-def find_latest_build_id(branch):
+def find_latest_build_id(branch, success_flag):
     """find latest successful build id for a branch"""
 
-    builds_url = "https://dev.azure.com/mssonic/build/_apis/build/builds?definitions=1&branchName=refs/heads/{}&resultFilter=partiallySucceeded&statusFilter=completed&api-version=6.0".format(branch)
+    builds_url = "https://dev.azure.com/mssonic/build/_apis/build/builds?definitions=1&branchName=refs/heads/{}&resultFilter={}&statusFilter=completed&api-version=6.0".format(branch, success_flag)
 
     resp = urlopen(builds_url)
 
@@ -121,7 +121,9 @@ def main():
     args = parser.parse_args()
 
     if args.buildid is None:
-        buildid = find_latest_build_id(args.branch)
+        buildid_succ = find_latest_build_id(args.branch, "succeeded")
+        buildid_partial = find_latest_build_id(args.branch, "partiallySucceeded")
+        buildid = max(buildid_succ,buildid_partial)
     else:
         buildid = int(args.buildid)
 


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
What is the motivation for this PR?
To fix the PR: https://github.com/Azure/sonic-mgmt/pull/5746 which can only download the partially succeeded image.

How did you do it?
Fetch both the succeeded and partially succeeded build id and choose the newer one as the latest sonic image.

How did you verify/test it?
show version in vsonic neighbor devices.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
