### PR TITLE
[dualtor][active-active] Unblock fib tests

### DIFF
--- a/ansible/dualtor/nic_simulator/__init__.py
+++ b/ansible/dualtor/nic_simulator/__init__.py
@@ -1,4 +1,4 @@
-from nic_simulator_grpc_service_pb2 import *
-from nic_simulator_grpc_service_pb2_grpc import *
-from nic_simulator_grpc_mgmt_service_pb2 import *
-from nic_simulator_grpc_mgmt_service_pb2_grpc import *
+from nic_simulator_grpc_service_pb2 import *                # lgtm[py/polluting-import]
+from nic_simulator_grpc_service_pb2_grpc import *           # lgtm[py/polluting-import]
+from nic_simulator_grpc_mgmt_service_pb2 import *           # lgtm[py/polluting-import]
+from nic_simulator_grpc_mgmt_service_pb2_grpc import *      # lgtm[py/polluting-import]

--- a/ansible/dualtor/nic_simulator/__init__.py
+++ b/ansible/dualtor/nic_simulator/__init__.py
@@ -1,0 +1,4 @@
+from nic_simulator_grpc_service_pb2 import *
+from nic_simulator_grpc_service_pb2_grpc import *
+from nic_simulator_grpc_mgmt_service_pb2 import *
+from nic_simulator_grpc_mgmt_service_pb2_grpc import *

--- a/ansible/dualtor/nic_simulator/__init__.py
+++ b/ansible/dualtor/nic_simulator/__init__.py
@@ -1,4 +1,36 @@
-from nic_simulator_grpc_service_pb2 import *                # lgtm[py/polluting-import]
-from nic_simulator_grpc_service_pb2_grpc import *           # lgtm[py/polluting-import]
-from nic_simulator_grpc_mgmt_service_pb2 import *           # lgtm[py/polluting-import]
-from nic_simulator_grpc_mgmt_service_pb2_grpc import *      # lgtm[py/polluting-import]
+from nic_simulator_grpc_service_pb2 import AdminReply
+from nic_simulator_grpc_service_pb2 import AdminRequest
+from nic_simulator_grpc_service_pb2 import OperationRequest
+from nic_simulator_grpc_service_pb2 import OperationReply
+from nic_simulator_grpc_service_pb2 import LinkStateRequest
+from nic_simulator_grpc_service_pb2 import LinkStateReply
+from nic_simulator_grpc_service_pb2 import ServerVersionRequest
+from nic_simulator_grpc_service_pb2 import ServerVersionReply
+from nic_simulator_grpc_service_pb2_grpc import DualToRActiveStub
+from nic_simulator_grpc_service_pb2_grpc import DualToRActiveServicer
+from nic_simulator_grpc_mgmt_service_pb2 import ListOfAdminRequest
+from nic_simulator_grpc_mgmt_service_pb2 import ListOfAdminReply
+from nic_simulator_grpc_mgmt_service_pb2 import ListOfOperationRequest
+from nic_simulator_grpc_mgmt_service_pb2 import ListOfOperationReply
+from nic_simulator_grpc_mgmt_service_pb2_grpc import DualTorMgmtServiceStub
+from nic_simulator_grpc_mgmt_service_pb2_grpc import DualTorMgmtServiceServicer
+
+
+__all__ = [
+    "AdminReply",
+    "AdminRequest",
+    "OperationRequest",
+    "OperationReply",
+    "LinkStateRequest",
+    "LinkStateReply",
+    "ServerVersionRequest",
+    "ServerVersionReply",
+    "DualToRActiveStub",
+    "DualToRActiveServicer",
+    "ListOfAdminRequest",
+    "ListOfAdminReply",
+    "ListOfOperationRequest",
+    "ListOfOperationReply",
+    "DualTorMgmtServiceStub",
+    "DualTorMgmtServiceServicer",
+]

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -250,7 +250,7 @@ class FibTest(BaseTest):
                 # Change balancing_test_times according to number of next hop groups
                 logging.info('Checking ip range balancing {}, src_port={}, exp_ports={}, dst_ip={}, dut_index={}'\
                     .format(ip_range, src_port, exp_port_lists, dst_ip, dut_index))
-                for i in range(0, self.balancing_test_times*len(exp_ports)):
+                for i in range(0, self.balancing_test_times*len(list(itertools.chain(*exp_port_lists)))):
                     (matched_port, _) = self.check_ip_route(src_port, dst_ip, exp_port_lists, ipv4)
                     hit_count_map[matched_port] = hit_count_map.get(matched_port, 0) + 1
                 for next_hop in next_hops:

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -17,9 +17,12 @@ import logging
 import random
 import time
 import json
+import itertools
 
 import ptf
 import ptf.packet as scapy
+
+from collections import Iterable
 
 from ptf import config
 from ptf.base_tests import BaseTest
@@ -117,6 +120,12 @@ class FibTest(BaseTest):
         with open(ptf_test_port_map) as f:
             self.ptf_test_port_map = json.load(f)
 
+        # preprocess ptf_test_port_map to support multiple DUTs as target_dut
+        for port_map in self.ptf_test_port_map.values():
+            if not isinstance(port_map["target_dut"], Iterable):
+                port_map["target_dut"] = [port_map["target_dut"]]
+                port_map["target_src_mac"] = [port_map["target_src_mac"]]
+
         self.pktlen = self.test_params.get('testbed_mtu', 9114)
         self.test_ipv4 = self.test_params.get('ipv4', True)
         self.test_ipv6 = self.test_params.get('ipv6', True)
@@ -168,22 +177,24 @@ class FibTest(BaseTest):
     def get_src_and_exp_ports(self, dst_ip):
         while True:
             src_port = int(random.choice(self.src_ports))
+            active_dut_indexes = [0]
             if self.single_fib == "multiple-fib":
-                active_dut_index = self.ptf_test_port_map[str(src_port)]['target_dut']
+                active_dut_indexes = self.ptf_test_port_map[str(src_port)]['target_dut']
+
+            next_hops = [self.fibs[active_dut_index][dst_ip] for active_dut_index in active_dut_indexes]
+            exp_port_lists = [next_hop.get_next_hop_list() for next_hop in next_hops]
+            for exp_port_list in exp_port_lists:
+                if src_port in exp_port_list:
+                    break
             else:
-                active_dut_index = 0
-            next_hop = self.fibs[active_dut_index][dst_ip]
-            exp_port_list = next_hop.get_next_hop_list()
-            if src_port in exp_port_list:
-                continue
-            # MACsec link only receive encrypted packets
-            # It's hard to simulate encrypted packets on the injected port
-            # Because the MACsec is session based channel but the injected ports are stateless ports
-            if src_port in macsec.MACSEC_INFOS.keys():
-                continue
-            logging.info('src_port={}, exp_port_list={}, active_dut_index={}'.format(src_port, exp_port_list, active_dut_index))
-            break
-        return src_port, exp_port_list, next_hop
+                # MACsec link only receive encrypted packets
+                # It's hard to simulate encrypted packets on the injected port
+                # Because the MACsec is session based channel but the injected ports are stateless ports
+                if src_port in macsec.MACSEC_INFOS.keys():
+                    continue
+                logging.info('src_port={}, exp_port_lists={}, active_dut_indexes={}'.format(src_port, exp_port_lists, active_dut_indexes))
+                break
+        return src_port, exp_port_lists, next_hops
 
     def check_ip_range(self, ip_range, dut_index, ipv4=True):
 
@@ -195,68 +206,84 @@ class FibTest(BaseTest):
             dst_ips.append(ip_range.get_random_ip())
 
         for dst_ip in dst_ips:
-            src_port, exp_ports, _ = self.get_src_and_exp_ports(dst_ip)
-            if not exp_ports:
-                logging.info('Skip checking ip range {} with exp_ports {}'.format(ip_range, exp_ports))
-                return
-            logging.info('Checking ip range {}, src_port={}, exp_ports={}, dst_ip={}, dut_index={}'\
-                .format(ip_range, src_port, exp_ports, dst_ip, dut_index))
-            self.check_ip_route(src_port, dst_ip, exp_ports, ipv4)
+            src_port, exp_port_lists, _ = self.get_src_and_exp_ports(dst_ip)
+            # if dst_ip is local to DUT, the nexthops will be empty.
+            # for active-active dualtor testbed, if the dst_ip is local to the upper ToR and src_port is an
+            # active-active port, the expect egress ports of upper ToR will be empty, exp_port_lists will be
+            # like [[], [30, 31, 32, 33]] if src_port .
+            # for single DUT testbed, if the dst_ip is local to the ToR, the exp_port_lists will be like [[]].
+            # so let's skip checking this IP range if any sub-list is empty.
+            for exp_port_list in exp_port_lists:
+                if not exp_port_list:
+                    logging.info('Skip checking ip range {} with exp_ports {}'.format(ip_range, exp_port_lists))
+                    return
+            logging.info('Checking ip range {}, src_port={}, exp_port_lists={}, dst_ip={}, dut_index={}'\
+                .format(ip_range, src_port, exp_port_lists, dst_ip, dut_index))
+            self.check_ip_route(src_port, dst_ip, exp_port_lists, ipv4)
 
     def check_balancing(self, ip_ranges, dut_index, ipv4=True):
         # Test traffic balancing across ECMP/LAG members
         if self.test_balancing and self.pkt_action == self.ACTION_FWD:
             for ip_range in ip_ranges:
                 dst_ip = ip_range.get_random_ip()
-                src_port, exp_port_list, next_hop = self.get_src_and_exp_ports(dst_ip)
+                src_port, exp_port_lists, next_hops = self.get_src_and_exp_ports(dst_ip)
                 if self.single_fib == "single-fib-multi-hop":
                     updated_exp_port_list = []
+                    # assume only test `single-fib-multi-hop` scenario on a single DUT testbed
+                    exp_port_list = exp_port_lists[0]
                     for port in exp_port_list:
                         if (self.ptf_test_port_map[str(port)]['target_dut'] == self.ptf_test_port_map[str(src_port)]['target_dut'] and
                             self.ptf_test_port_map[str(port)]['asic_idx'] == self.ptf_test_port_map[str(src_port)]['asic_idx']):
                             updated_exp_port_list.append(port)
                     if updated_exp_port_list:
-                        exp_port_list = updated_exp_port_list
-                if len(exp_port_list) <= 1:
-                    # Only 1 expected output port is not enough for balancing test.
+                        exp_port_lists = [updated_exp_port_list]
+
+                skip = False
+                for exp_port_list in exp_port_lists:
+                    if len(exp_port_list) <= 1:
+                        # Only 1 expected output port is not enough for balancing test.
+                        skip = True
+                        break
+                if skip:
                     continue
                 hit_count_map = {}
                 # Change balancing_test_times according to number of next hop groups
                 logging.info('Checking ip range balancing {}, src_port={}, exp_ports={}, dst_ip={}, dut_index={}'\
-                    .format(ip_range, src_port, exp_port_list, dst_ip, dut_index))
-                for i in range(0, self.balancing_test_times*len(exp_port_list)):
-                    (matched_index, received) = self.check_ip_route(src_port, dst_ip, exp_port_list, ipv4)
-                    hit_count_map[matched_index] = hit_count_map.get(matched_index, 0) + 1
-                self.check_hit_count_map(next_hop.get_next_hop(), hit_count_map)
-                self.balancing_test_count += 1
+                    .format(ip_range, src_port, exp_port_lists, dst_ip, dut_index))
+                for i in range(0, self.balancing_test_times*len(exp_ports)):
+                    (matched_port, _) = self.check_ip_route(src_port, dst_ip, exp_port_lists, ipv4)
+                    hit_count_map[matched_port] = hit_count_map.get(matched_port, 0) + 1
+                for next_hop in next_hops:
+                    # only check balance on a DUT
+                    self.check_hit_count_map(next_hop.get_next_hop(), hit_count_map)
+                    self.balancing_test_count += 1
                 if self.balancing_test_count >= self.balancing_test_number:
                     break
 
-    def check_ip_route(self, src_port, dst_ip_addr, dst_port_list, ipv4=True):
+    def check_ip_route(self, src_port, dst_ip_addr, dst_port_lists, ipv4=True):
         if ipv4:
-            res = self.check_ipv4_route(src_port, dst_ip_addr, dst_port_list)
+            res = self.check_ipv4_route(src_port, dst_ip_addr, dst_port_lists)
         else:
-            res = self.check_ipv6_route(src_port, dst_ip_addr, dst_port_list)
+            res = self.check_ipv6_route(src_port, dst_ip_addr, dst_port_lists)
 
         if self.pkt_action == self.ACTION_DROP:
             return res
 
-        (matched_index, received) = res
+        (matched_port, received) = res
 
         assert received
 
-        matched_port = dst_port_list[matched_index]
         logging.info("Received packet at " + str(matched_port))
         time.sleep(0.02)
 
         return (matched_port, received)
 
-    def check_ipv4_route(self, src_port, dst_ip_addr, dst_port_list):
+    def check_ipv4_route(self, src_port, dst_ip_addr, dst_port_lists):
         '''
         @summary: Check IPv4 route works.
         @param src_port: index of port to use for sending packet to switch
         @param dest_ip_addr: destination IP to build packet with.
-        @param dst_port_list: list of ports on which to expect packet to come back from the switch
+        @param dst_port_lists: list of ports on which to expect packet to come back from the switch
         '''
         sport = random.randint(0, 65535)
         dport = random.randint(0, 65535)
@@ -315,28 +342,40 @@ class FibTest(BaseTest):
                     sport,
                     dport))
 
+        dst_ports = list(itertools.chain(*dst_port_lists))
         if self.pkt_action == self.ACTION_FWD:
-            rcvd_port, rcvd_pkt = verify_packet_any_port(self,masked_exp_pkt, dst_port_list)
+            rcvd_port_index, rcvd_pkt = verify_packet_any_port(self,masked_exp_pkt, dst_ports)
+            rcvd_port = dst_ports[rcvd_port_index]
             len_rcvd_pkt = len(rcvd_pkt)
             logging.info('Recieved packet at port {} and packet is {} bytes'.format(rcvd_port,len_rcvd_pkt))
             logging.info('Recieved packet with length of {}'.format(len_rcvd_pkt))
-            exp_src_mac = self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_src_mac']
+            exp_src_mac = None
+            if len(self.ptf_test_port_map[str(rcvd_port)]["target_src_mac"]) > 1:
+                # active-active dualtor, the packet could be received from either ToR, so use the received
+                # port to find the corresponding ToR
+                for dut_index, port_list in enumerate(dst_port_lists):
+                    if rcvd_port in port_list:
+                        exp_src_mac = self.ptf_test_port_map[str(rcvd_port)]["target_src_mac"][dut_index]
+            else:
+                exp_src_mac = self.ptf_test_port_map[str(rcvd_port)]["target_src_mac"][0]
             actual_src_mac = Ether(rcvd_pkt).src
             if exp_src_mac != actual_src_mac:
                 raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
                                 "but the src mac doesn't match, expected {}, got {}".
-                                format(ip_src, ip_dst, src_port, dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
+                                format(ip_src, ip_dst, src_port, rcvd_port, exp_src_mac, actual_src_mac))
             return (rcvd_port, rcvd_pkt)
         elif self.pkt_action == self.ACTION_DROP:
-            return verify_no_packet_any(self, masked_exp_pkt, dst_port_list)
+            rcvd_port_index, rcvd_pkt = verify_no_packet_any(self, masked_exp_pkt, dst_ports)
+            rcvd_port = dst_ports[rcvd_port_index]
+            return (rcvd_port, rcvd_pkt)
     #---------------------------------------------------------------------
 
-    def check_ipv6_route(self, src_port, dst_ip_addr, dst_port_list):
+    def check_ipv6_route(self, src_port, dst_ip_addr, dst_port_lists):
         '''
         @summary: Check IPv6 route works.
         @param source_port_index: index of port to use for sending packet to switch
         @param dest_ip_addr: destination IP to build packet with.
-        @param dst_port_list: list of ports on which to expect packet to come back from the switch
+        @param dst_port_lists: list of ports on which to expect packet to come back from the switch
         @return Boolean
         '''
         sport = random.randint(0, 65535)
@@ -394,20 +433,32 @@ class FibTest(BaseTest):
                     sport,
                     dport))
 
+        dst_ports = list(itertools.chain(*dst_port_lists))
         if self.pkt_action == self.ACTION_FWD:
-            rcvd_port, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
+            rcvd_port_index, rcvd_pkt = verify_packet_any_port(self, masked_exp_pkt, dst_ports)
+            rcvd_port = dst_ports[rcvd_port_index]
             len_rcvd_pkt = len(rcvd_pkt)
             logging.info('Recieved packet at port {} and packet is {} bytes'.format(rcvd_port,len_rcvd_pkt))
             logging.info('Recieved packet with length of {}'.format(len_rcvd_pkt))
-            exp_src_mac = self.ptf_test_port_map[str(dst_port_list[rcvd_port])]['target_src_mac']
+            exp_src_mac = None
+            if len(self.ptf_test_port_map[str(rcvd_port)]["target_src_mac"]) > 1:
+                # active-active dualtor, the packet could be received from either ToR, so use the received
+                # port to find the corresponding ToR
+                for dut_index, port_list in enumerate(dst_port_lists):
+                    if rcvd_port in port_list:
+                        exp_src_mac = self.ptf_test_port_map[str(rcvd_port)]["target_src_mac"][dut_index]
+            else:
+                exp_src_mac = self.ptf_test_port_map[str(rcvd_port)]["target_src_mac"][0]
             actual_src_mac = Ether(rcvd_pkt).src
-            if actual_src_mac != exp_src_mac:
+            if exp_src_mac != actual_src_mac:
                 raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
                                 "but the src mac doesn't match, expected {}, got {}".
-                                format(ip_src, ip_dst, src_port, dst_port_list[rcvd_port], exp_src_mac, actual_src_mac))
+                                format(ip_src, ip_dst, src_port, rcvd_port, exp_src_mac, actual_src_mac))
             return (rcvd_port, rcvd_pkt)
         elif self.pkt_action == self.ACTION_DROP:
-            return verify_no_packet_any(self, masked_exp_pkt, dst_port_list)
+            rcvd_port_index, rcvd_pkt = verify_no_packet_any(self, masked_exp_pkt, dst_ports)
+            rcvd_port = dst_ports[rcvd_port_index]
+            return (rcvd_port, rcvd_pkt)
 
     def check_within_expected_range(self, actual, expected):
         '''
@@ -429,7 +480,11 @@ class FibTest(BaseTest):
         logging.info("%-10s \t %-10s \t %10s \t %10s \t %10s" % ("type", "port(s)", "exp_cnt", "act_cnt", "diff(%)"))
         result = True
 
-        total_hit_cnt = sum(port_hit_cnt.values())
+        total_hit_cnt = 0
+        for ecmp_entry in dest_port_list:
+            for member in ecmp_entry:
+                total_hit_cnt += port_hit_cnt.get(member, 0)
+
         for ecmp_entry in dest_port_list:
             total_entry_hit_cnt = 0
             for member in ecmp_entry:

--- a/tests/common/dualtor/dual_tor_common.py
+++ b/tests/common/dualtor/dual_tor_common.py
@@ -1,9 +1,14 @@
 """DualToR related common utilities for other modules."""
+import json
 import pytest
 
+
 __all__ = [
-    'cable_type'
+    'cable_type',
+    'CableType',
+    'mux_config'
 ]
+
 
 class CableType(object):
     """Dualtor cable type."""
@@ -16,3 +21,14 @@ class CableType(object):
 def cable_type(request):
     """Dualtor cable type."""
     return request.param
+
+
+@pytest.fixture(scope="session")
+def mux_config(duthosts, tbinfo):
+    if 'dualtor' not in tbinfo['topo']['name']:
+        return {}
+
+    # NOTE: assume both ToRs have the same mux config
+    duthost = duthosts[0]
+    cmd = 'show mux config --json'
+    return json.loads(duthost.shell(cmd)['stdout'])["MUX_CABLE"]["PORTS"]

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -8,6 +8,7 @@ import requests
 
 from tests.common import utilities
 from tests.common.dualtor.dual_tor_common import cable_type                             # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_common import mux_config                             # lgtm[py/unused-import]
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR, TOGGLE, RANDOM, NIC, DROP, OUTPUT, FLAP_COUNTER, CLEAR_FLAP_COUNTER, RESET
@@ -515,7 +516,7 @@ def toggle_all_simulator_ports_to_rand_selected_tor_m(duthosts, mux_server_url, 
 
 
 @pytest.fixture
-def toggle_all_simulator_ports_to_random_side(duthosts, mux_server_url, tbinfo):
+def toggle_all_simulator_ports_to_random_side(duthosts, mux_server_url, tbinfo, mux_config):
     """
     A function level fixture to toggle all ports to a random side.
     """
@@ -546,6 +547,10 @@ def toggle_all_simulator_ports_to_random_side(duthosts, mux_server_url, tbinfo):
         # get mapping from port indices to mux status
         simulator_port_mux_status = {int(k.split('-')[-1]):v for k,v in simulator_mux_status.items()}
         for intf in upper_tor_mux_status['MUX_CABLE']:
+
+            if mux_config[intf]["SERVER"].get("cable_type", CableType.default_type) == CableType.active_active:
+                continue
+
             intf_index = port_indices[intf]
             if intf_index not in simulator_port_mux_status:
                 logging.warn("No mux status for interface %s from mux simulator", intf)

--- a/tests/common/dualtor/nic_simulator
+++ b/tests/common/dualtor/nic_simulator
@@ -1,0 +1,1 @@
+../../../ansible/dualtor/nic_simulator

--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -1,17 +1,28 @@
 """Control utilities to interacts with nic_simulator."""
+import grpc
 import pytest
 import time
 
+from collections import Iterable
+
 from tests.common import utilities
 from tests.common.dualtor.dual_tor_common import cable_type                     # lgtm[py/unused-import]
+from tests.common.dualtor.dual_tor_common import mux_config                     # lgtm[py/unused-import]
 from tests.common.dualtor.dual_tor_common import CableType
+from tests.common.dualtor.nic_simulator import nic_simulator_grpc_service_pb2
+from tests.common.dualtor.nic_simulator import nic_simulator_grpc_mgmt_service_pb2
+from tests.common.dualtor.nic_simulator import nic_simulator_grpc_mgmt_service_pb2_grpc
+
 
 __all__ = [
     "nic_simulator_info",
     "restart_nic_simulator_session",
     "restart_nic_simulator",
     "nic_simulator_url",
-    "toggle_all_ports_both_tors_admin_forwarding_state_to_active"
+    "toggle_all_ports_both_tors_admin_forwarding_state_to_active",
+    "nic_simulator_channel",
+    "nic_simulator_client",
+    "mux_status_from_nic_simulator",
 ]
 
 
@@ -30,7 +41,7 @@ def nic_simulator_info(request, tbinfo):
     server = tbinfo["server"]
     vmset_name = tbinfo["group-name"]
     inv_files = request.config.option.ansible_inventory
-    ip = utilities.get_test_server_vars(inv_files, server).get('ansible_host')
+    ip = tbinfo["netns_mgmt_ip"].split("/")[0]
     _port_map = utilities.get_group_visible_vars(inv_files, server).get('nic_simulator_grpc_port')
     port = _port_map[tbinfo['conf-name']]
     return ip, port, vmset_name
@@ -55,6 +66,94 @@ def restart_nic_simulator(nic_simulator_info, vmhost):
     _, _, vmset_name = nic_simulator_info
 
     return lambda: _restart_nic_simulator(vmhost, vmset_name)
+
+
+@pytest.fixture(scope="session")
+def nic_simulator_channel(nic_simulator_info):
+    """Setup connection to the nic_simulator."""
+    channel = []
+    server_ip, server_port, _ = nic_simulator_info
+    server_url = "%s:%s" % (server_ip, server_port)
+
+    def _setup_grpc_channel_to_nic_simulator():
+        if channel:
+            return channel[0]
+
+        if server_ip is None:
+            return None
+
+        # temporarily disable HTTP proxies
+        with utilities.update_environ("http_proxy", "https_proxy"):
+            _channel = grpc.insecure_channel(server_url)
+            try:
+                grpc.channel_ready_future(_channel).result(timeout=2)
+            except grpc.FutureTimeoutError as e:
+                raise RuntimeError("Failed to establish connection to nic_simulator %s, error(%r)" % (server_url, e))
+            channel.append(_channel)
+            return _channel
+
+    return _setup_grpc_channel_to_nic_simulator
+
+
+@pytest.fixture(scope="session")
+def nic_simulator_client(nic_simulator_channel):
+    """Setup mgmt client stub to the nic_simulator."""
+    channel = nic_simulator_channel()
+    stub = []
+
+    def _setup_grpc_client_stub():
+        if stub:
+            return stub[0]
+
+        if channel is None:
+            return None
+
+        _stub = nic_simulator_grpc_mgmt_service_pb2_grpc.DualTorMgmtServiceStub(channel)
+        stub.append(_stub)
+        return _stub
+
+    return _setup_grpc_client_stub
+
+
+@pytest.fixture(scope="session")
+def mux_status_from_nic_simulator(duthost, nic_simulator_client, mux_config, tbinfo):
+    """Get mux status from the nic simulator."""
+    active_active_ports = {}
+    for port, config in mux_config.items():
+        if config["SERVER"].get("cable_type", CableType.default_type) == CableType.active_active:
+            config["SERVER"]["soc_ipv4"] = config["SERVER"]["soc_ipv4"].split("/")[0]
+            active_active_ports[port] = config
+
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    ptf_index_map = mg_facts["minigraph_ptf_indices"]
+    admin_requests = [nic_simulator_grpc_service_pb2.AdminRequest(portid=[0, 1], state=[True, True]) for _ in range(len(active_active_ports))]
+
+    def _get_mux_status(ports=None):
+        if ports is None:
+            ports = active_active_ports.keys()
+        elif isinstance(ports, Iterable):
+            ports = list(ports)
+        else:
+            ports = [str(ports)]
+
+        client_stub = nic_simulator_client()
+        if client_stub is None:
+            return {}
+
+        nic_addresses = [active_active_ports[port]["SERVER"]["soc_ipv4"] for port in ports]
+        request = nic_simulator_grpc_mgmt_service_pb2.ListOfAdminRequest(
+            nic_addresses=nic_addresses,
+            admin_requests=admin_requests[:len(nic_addresses)]
+        )
+        reply = client_stub.QueryAdminForwardingPortState(request)
+
+        mux_status = {}
+        for port, port_status in zip(ports, reply.admin_replies):
+            mux_status[ptf_index_map[port]] = dict(zip(port_status.portid, port_status.state))
+
+        return mux_status
+
+    return _get_mux_status
 
 
 @pytest.fixture(scope="session")

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -384,3 +384,68 @@ def ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_co
 
     ptfhost.copy(content=json.dumps(ports_map), dest=PTF_TEST_PORT_MAP)
     return PTF_TEST_PORT_MAP
+
+
+def ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_config_facts, duts_minigraph_facts, active_active_ports_mux_status=None):
+    active_dut_map = {}
+    if 'dualtor' in tbinfo['topo']['name']:
+        res = requests.get(mux_server_url)
+        pt_assert(res.status_code==200, 'Failed to get mux status: {}'.format(res.text))
+        for mux_status in res.json().values():
+            active_dut_index = 0 if mux_status['active_side'] == 'upper_tor' else 1
+            active_dut_map[str(mux_status['port_index'])] = [active_dut_index]
+        if active_active_ports_mux_status:
+            for port_index, port_status in active_active_ports_mux_status.items():
+                active_dut_map[str(port_index)] = [active_dut_index for active_dut_index in (0, 1) if port_status[active_dut_index]]
+
+    disabled_ptf_ports = set()
+    for ptf_map in tbinfo['topo']['ptf_map_disabled'].values():
+        # Loop ptf_map of each DUT. Each ptf_map maps from ptf port index to dut port index
+        disabled_ptf_ports = disabled_ptf_ports.union(set(ptf_map.keys()))
+
+    router_macs = [duthost.facts['router_mac'] for duthost in duthosts]
+
+    logger.info('active_dut_map={}'.format(active_dut_map))
+    logger.info('disabled_ptf_ports={}'.format(disabled_ptf_ports))
+    logger.info('router_macs={}'.format(router_macs))
+
+    asic_idx = 0
+    ports_map = {}
+    for ptf_port, dut_intf_map in tbinfo['topo']['ptf_dut_intf_map'].items():
+        if str(ptf_port) in disabled_ptf_ports:
+            # Skip PTF ports that are connected to disabled VLAN interfaces
+            continue
+
+        if len(dut_intf_map.keys()) == 2:
+            # PTF port is mapped to two DUTs -> dualtor topology and the PTF port is a vlan port
+            # Packet sent from this ptf port will only be accepted by the active side DUT
+            # DualToR DUTs use same special Vlan interface MAC address
+            target_dut_indexes = list(map(int, active_dut_map[ptf_port]))
+            ports_map[ptf_port] = {
+                'target_dut': target_dut_indexes,
+                'target_dest_mac': tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']['one_vlan_a']['Vlan1000']['mac'],
+                'target_src_mac': [router_macs[_] for _ in target_dut_indexes],
+                'asic_idx': asic_idx
+            }
+        else:
+            # PTF port is mapped to single DUT
+            target_dut_index = int(list(dut_intf_map.keys())[0])
+            target_dut_port = int(list(dut_intf_map.values())[0])
+            router_mac = router_macs[target_dut_index]
+            if len(duts_minigraph_facts[duthosts[target_dut_index].hostname]) > 1:
+                for idx, mg_facts in enumerate(duts_minigraph_facts[duthosts[target_dut_index].hostname]):
+                    if target_dut_port in mg_facts['minigraph_port_indices'].values():
+                        router_mac = duts_running_config_facts[duthosts[target_dut_index].hostname][idx]['DEVICE_METADATA']['localhost']['mac'].lower()
+                        asic_idx = idx
+                        break
+            ports_map[ptf_port] = {
+                'target_dut': [target_dut_index],
+                'target_dest_mac': router_mac,
+                'target_src_mac': [router_mac],
+                'asic_idx': asic_idx
+            }
+
+    logger.debug('ptf_test_port_map={}'.format(json.dumps(ports_map, indent=2)))
+
+    ptfhost.copy(content=json.dumps(ports_map), dest=PTF_TEST_PORT_MAP)
+    return PTF_TEST_PORT_MAP

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -634,6 +634,7 @@ def safe_filename(filename, replacement_char='_'):
     illegal_chars_pattern = re.compile("[#%&{}\\<>\*\?/ \$!'\":@\+`|=]")
     return re.sub(illegal_chars_pattern, replacement_char, filename)
 
+
 @contextlib.contextmanager
 def update_environ(*remove, **update):
     """

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -2,9 +2,11 @@
 Utility functions can re-used in testing scripts.
 """
 import collections
+import contextlib
 import inspect
 import ipaddress
 import logging
+import os
 import re
 import six
 import sys
@@ -631,3 +633,29 @@ def safe_filename(filename, replacement_char='_'):
     """
     illegal_chars_pattern = re.compile("[#%&{}\\<>\*\?/ \$!'\":@\+`|=]")
     return re.sub(illegal_chars_pattern, replacement_char, filename)
+
+@contextlib.contextmanager
+def update_environ(*remove, **update):
+    """
+    Temporarily update the environment variables.
+
+    :param remove: Environment variables to remove.
+    :param update: Dictionary of environment variables and values to add/update.
+    """
+    env = os.environ
+    update = update or {}
+    remove = remove or []
+
+    updated = (set(update.keys()) | set(remove)) & set(env.keys())
+
+    to_restore = {k: env[k] for k in updated}
+    to_removed = set(k for k in update if k not in env)
+
+    try:
+        env.update(update)
+        [env.pop(k, None) for k in remove]
+        yield
+    finally:
+        env.update(to_restore)
+        for k in to_removed:
+            env.pop(k)

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -10,6 +10,7 @@ from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # lg
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import ptf_test_port_map
+from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active
 from tests.ptf_runner import ptf_runner
 from tests.common.dualtor.mux_simulator_control import mux_server_url
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m
@@ -59,6 +60,7 @@ def test_basic_fib(duthosts, ptfhost, ipv4, ipv6, mtu,
                    toggle_all_simulator_ports_to_random_side,
                    fib_info_files_per_function,
                    tbinfo, mux_server_url,
+                   mux_status_from_nic_simulator,
                    ignore_ttl, single_fib_for_duts, duts_running_config_facts, duts_minigraph_facts):
 
     if 'dualtor' in tbinfo['topo']['name']:
@@ -76,22 +78,26 @@ def test_basic_fib(duthosts, ptfhost, ipv4, ipv6, mtu,
     logging.info("run ptf test")
     log_file = "/tmp/fib_test.FibTest.ipv4.{}.ipv6.{}.{}.log".format(ipv4, ipv6, timestamp)
     logging.info("PTF log file: %s" % log_file)
-    ptf_runner(ptfhost,
-                "ptftests",
-                "fib_test.FibTest",
-                platform_dir="ptftests",
-                params={"fib_info_files": fib_info_files_per_function[:3],  # Test at most 3 DUTs
-                        "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_config_facts, duts_minigraph_facts),
-                        "ipv4": ipv4,
-                        "ipv6": ipv6,
-                        "testbed_mtu": mtu,
-                        "test_balancing": test_balancing,
-                        "ignore_ttl": ignore_ttl,
-                        "single_fib_for_duts": single_fib_for_duts},
-                log_file=log_file,
-                qlen=PTF_QLEN,
-                socket_recv_size=16384,
-                is_python3=True)
+    ptf_runner(
+        ptfhost,
+        "ptftests",
+        "fib_test.FibTest",
+        platform_dir="ptftests",
+        params={
+            "fib_info_files": fib_info_files_per_function[:3],  # Test at most 3 DUTs
+            "ptf_test_port_map": ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_config_facts, duts_minigraph_facts, mux_status_from_nic_simulator()),
+            "ipv4": ipv4,
+            "ipv6": ipv6,
+            "testbed_mtu": mtu,
+            "test_balancing": test_balancing,
+            "ignore_ttl": ignore_ttl,
+            "single_fib_for_duts": single_fib_for_duts
+        },
+        log_file=log_file,
+        qlen=PTF_QLEN,
+        socket_recv_size=16384,
+        is_python3=True
+    )
 
 
 def get_vlan_untag_ports(duthosts, duts_running_config_facts):

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -85,7 +85,11 @@ def test_basic_fib(duthosts, ptfhost, ipv4, ipv6, mtu,
         platform_dir="ptftests",
         params={
             "fib_info_files": fib_info_files_per_function[:3],  # Test at most 3 DUTs
-            "ptf_test_port_map": ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_config_facts, duts_minigraph_facts, mux_status_from_nic_simulator()),
+            "ptf_test_port_map": ptf_test_port_map_active_active(
+                ptfhost, tbinfo, duthosts, mux_server_url,
+                duts_running_config_facts, duts_minigraph_facts,
+                mux_status_from_nic_simulator()
+            ),
             "ipv4": ipv4,
             "ipv6": ipv6,
             "testbed_mtu": mtu,
@@ -252,7 +256,7 @@ def add_default_route_to_dut(duts_running_config_facts, duthosts, tbinfo):
 
 def test_hash(add_default_route_to_dut, duthosts, fib_info_files_per_function, setup_vlan, hash_keys, ptfhost, ipver,
               toggle_all_simulator_ports_to_rand_selected_tor_m,
-              tbinfo, mux_server_url,
+              tbinfo, mux_server_url, mux_status_from_nic_simulator,
               ignore_ttl, single_fib_for_duts, duts_running_config_facts, duts_minigraph_facts):
 
     if 'dualtor' in tbinfo['topo']['name']:
@@ -267,20 +271,26 @@ def test_hash(add_default_route_to_dut, duthosts, fib_info_files_per_function, s
     else:
         src_ip_range = SRC_IPV6_RANGE
         dst_ip_range = DST_IPV6_RANGE
-    ptf_runner(ptfhost,
-            "ptftests",
-            "hash_test.HashTest",
-            platform_dir="ptftests",
-            params={"fib_info_files": fib_info_files_per_function[:3],   # Test at most 3 DUTs
-                    "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url, duts_running_config_facts, duts_minigraph_facts),
-                    "hash_keys": hash_keys,
-                    "src_ip_range": ",".join(src_ip_range),
-                    "dst_ip_range": ",".join(dst_ip_range),
-                    "vlan_ids": VLANIDS,
-                    "ignore_ttl":ignore_ttl,
-                    "single_fib_for_duts": single_fib_for_duts
-                   },
-            log_file=log_file,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True)
+    ptf_runner(
+        ptfhost,
+        "ptftests",
+        "hash_test.HashTest",
+        platform_dir="ptftests",
+        params={"fib_info_files": fib_info_files_per_function[:3],   # Test at most 3 DUTs
+                "ptf_test_port_map": ptf_test_port_map_active_active(
+                    ptfhost, tbinfo, duthosts, mux_server_url,
+                    duts_running_config_facts, duts_minigraph_facts,
+                    mux_status_from_nic_simulator()
+                ),
+                "hash_keys": hash_keys,
+                "src_ip_range": ",".join(src_ip_range),
+                "dst_ip_range": ",".join(dst_ip_range),
+                "vlan_ids": VLANIDS,
+                "ignore_ttl":ignore_ttl,
+                "single_fib_for_duts": single_fib_for_duts
+                },
+        log_file=log_file,
+        qlen=PTF_QLEN,
+        socket_recv_size=16384,
+        is_python3=True
+    )

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -9,7 +9,6 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # lg
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # lgtm[py/unused-import]
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # lgtm[py/unused-import]
-from tests.common.fixtures.ptfhost_utils import ptf_test_port_map
 from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active
 from tests.ptf_runner import ptf_runner
 from tests.common.dualtor.mux_simulator_control import mux_server_url


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Enable `test_fib` on `dualtor-mixed` testbeds.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

1. Add fixture `mux_status_from_nic_simulator` to interacts with `nic_simulator` to retrieve mux status for ports in `active-active` cable type.
2. Add fixture `ptf_test_port_map_active_active` to build ptf port map that supports `dualtor-mixed` testbed.
The key difference is that, for packets ingressing ptf ports connected to DUTs' `active-active` cable type ports, the target DUT could be either upper ToR or lower ToR(both ToRs are active), the generated ptf port mapping will be like:
```
 u'3': {u'asic_idx': 0,
        u'target_dest_mac': u'00:aa:bb:cc:dd:ee',
        u'target_dut': [0, 1],
        u'target_src_mac': [u'2c:dd:e9:0f:4e:50', u'2c:dd:e9:0f:3d:4c']}
```
3. Enable ptftests `hash_test` and `fib_test` to do I/O verification for this multi-next-hop scenario.
For a packet sent from ptf port that connects to an `active-active` port, the test will try to use the fibs from each ToR to parse its nexthops, and verify the packet forwarding on those nexthops. For ECMP behavior, the test will only check balancing over a single ToR.

For example, if a packet destinated to `1.1.1.1` is sent to ptf port `eth3`, which is connected `Ethernet12` of both ToRs, the test will  determine the nexthops on both ToRs, if both ToRs forward this packet with the default route,  and upper ToR will forward this packet to ptf ports `[30, 32, 34, 36]`, and lower ToR will forward this packet to ptf ports `[31, 33, 35, 37]`, the test will try to verify the packet forwarding on ports `[30, 31, 32, 33, 34, 35, 36, 37]`. And for balancing, the test will verify the traffic is balanced over a single ToR, so it will try to verify balancing on ports set `[30, 32, 34, 36]` or `[31, 33, 35, 37]` separately.


#### How did you verify/test it?
Run `test_fib` on `dualtor`, `dualtor-mixed`, `t0`, and `t1`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
