### PR TITLE
[VXLAN] Stabilized VNET VXLAN test in case of scale

### DIFF
--- a/tests/vxlan/test_vnet_route_leak.py
+++ b/tests/vxlan/test_vnet_route_leak.py
@@ -36,7 +36,7 @@ LEAKED_ROUTES_TEMPLATE = "Leaked routes: {}"
 
 
 @pytest.fixture(scope="module")
-def configure_dut(minigraph_facts, duthosts, rand_one_dut_hostname, vnet_config, vnet_test_params):
+def configure_dut(request, minigraph_facts, duthosts, rand_one_dut_hostname, vnet_config, vnet_test_params):
     """
     Setup/teardown fixture for VNET route leak test
 
@@ -54,9 +54,10 @@ def configure_dut(minigraph_facts, duthosts, rand_one_dut_hostname, vnet_config,
     logger.info("Backing up config_db.json")
     duthost.shell(BACKUP_CONFIG_DB_CMD)
 
+    num_routes = request.config.option.num_routes
     duthost.shell("sonic-clear fdb all")
     generate_dut_config_files(duthost, minigraph_facts, vnet_test_params, vnet_config)
-    apply_dut_config_files(duthost, vnet_test_params)
+    apply_dut_config_files(duthost, vnet_test_params, num_routes)
 
     # In this case yield is used only to separate this fixture into setup and teardown portions
     yield
@@ -66,7 +67,7 @@ def configure_dut(minigraph_facts, duthosts, rand_one_dut_hostname, vnet_config,
         duthost.shell(RESTORE_CONFIG_DB_CMD)
         duthost.shell(DELETE_BACKUP_CONFIG_DB_CMD)
 
-        cleanup_vnet_routes(duthost, vnet_test_params)
+        cleanup_vnet_routes(duthost, vnet_test_params, num_routes)
         cleanup_dut_vnets(duthost, minigraph_facts, vnet_config)
         cleanup_vxlan_tunnels(duthost, vnet_test_params)
 

--- a/tests/vxlan/test_vnet_vxlan.py
+++ b/tests/vxlan/test_vnet_vxlan.py
@@ -120,6 +120,7 @@ def vxlan_status(setup, request, duthosts, rand_one_dut_hostname, ptfhost, vnet_
     vlan_member = mg_facts["minigraph_vlans"][attached_vlan]['members'][0]
     global vlan_tagging_mode
 
+    num_routes = request.config.option.num_routes
     vxlan_enabled = False
     if request.param == "Disabled":
         vxlan_enabled = False
@@ -130,7 +131,7 @@ def vxlan_status(setup, request, duthosts, rand_one_dut_hostname, ptfhost, vnet_
             vlan_tagging_mode = result["stdout_lines"][0]
             duthost.shell("redis-cli -n 4 del \"VLAN_MEMBER|{}|{}\"".format(attached_vlan, vlan_member))
 
-        apply_dut_config_files(duthost, vnet_test_params)
+        apply_dut_config_files(duthost, vnet_test_params, num_routes)
         # Check arp table status in a loop with delay.
         pytest_assert(wait_until(120, 20, 10, is_neigh_reachable, duthost, vnet_config), "Neighbor is unreachable")
         vxlan_enabled = True
@@ -139,7 +140,7 @@ def vxlan_status(setup, request, duthosts, rand_one_dut_hostname, ptfhost, vnet_
             duthost.shell("redis-cli -n 4 hset \"VLAN_MEMBER|{}|{}\" tagging_mode {} ".format(attached_vlan, vlan_member, vlan_tagging_mode))
 
         vxlan_enabled = True
-        cleanup_vnet_routes(duthost, vnet_config)
+        cleanup_vnet_routes(duthost, vnet_config, num_routes)
         cleanup_dut_vnets(duthost, setup, vnet_config)
         cleanup_vxlan_tunnels(duthost, vnet_test_params)
     elif request.param == "WR_ARP":

--- a/tests/vxlan/vnet_utils.py
+++ b/tests/vxlan/vnet_utils.py
@@ -10,6 +10,7 @@ from tests.common.helpers.assertions import pytest_assert
 
 logger = logging.getLogger(__name__)
 
+
 def safe_open_template(template_path):
     """
     Safely loads Jinja2 template from given path
@@ -26,6 +27,7 @@ def safe_open_template(template_path):
 
     with open(template_path) as template_file:
         return Template(template_file.read())
+
 
 def combine_dicts(*args):
     """
@@ -47,6 +49,7 @@ def combine_dicts(*args):
 
     return combined_args
 
+
 def render_template_to_host(template_name, host, dest_file, *template_args, **template_kwargs):
     """
     Renders a template with the given arguments and copies it to the host
@@ -64,6 +67,7 @@ def render_template_to_host(template_name, host, dest_file, *template_args, **te
     rendered = safe_open_template(path.join(TEMPLATE_DIR, template_name)).render(combined_args, **template_kwargs)
 
     host.copy(content=rendered, dest=dest_file)
+
 
 def generate_dut_config_files(duthost, mg_facts, vnet_test_params, vnet_config):
     """
@@ -108,7 +112,8 @@ def generate_dut_config_files(duthost, mg_facts, vnet_test_params, vnet_config):
     render_template_to_host("vnet_nbr.j2", duthost, DUT_VNET_NBR_JSON, vnet_config)
     render_template_to_host("vnet_routes.j2", duthost, DUT_VNET_ROUTE_JSON, vnet_config, op="SET")
 
-def apply_dut_config_files(duthost, vnet_test_params):
+
+def apply_dut_config_files(duthost, vnet_test_params, num_routes):
     """
     Applies config files that are stored on the given DUT
 
@@ -121,12 +126,17 @@ def apply_dut_config_files(duthost, vnet_test_params):
         config_files = [DUT_VNET_INTF_JSON, DUT_VNET_NBR_JSON, DUT_VNET_CONF_JSON]
         for config in config_files:
             duthost.shell("sonic-cfggen -j {} --write-to-db".format(config))
-            sleep(3)
+            if num_routes > 3000:
+                sleep(15)
+            else:
+                sleep(3)
 
         duthost.shell("docker cp {} swss:/vnet.route.json".format(DUT_VNET_ROUTE_JSON))
         duthost.shell("docker cp {} swss:/vnet.switch.json".format(DUT_VNET_SWITCH_JSON))
         duthost.shell("docker exec swss sh -c \"swssconfig /vnet.switch.json\"")
         duthost.shell("docker exec swss sh -c \"swssconfig /vnet.route.json\"")
+        if num_routes > 3000:
+            sleep(300)
 
         if vnet_test_params[VXLAN_RANGE_ENABLE_KEY]:
             logger.info("VXLAN src port range enable. Set params 'sport' and 'mask'")
@@ -135,6 +145,7 @@ def apply_dut_config_files(duthost, vnet_test_params):
         sleep(3)
     else:
         logger.info("Skip applying config files on DUT")
+
 
 def cleanup_dut_vnets(duthost, mg_facts, vnet_config):
     """
@@ -168,6 +179,7 @@ def cleanup_dut_vnets(duthost, mg_facts, vnet_config):
         duthost.shell("redis-cli -n 4 del \"INTERFACE|{}|{}\"".format(intf['ifname'], intf['ip']))
         duthost.shell("redis-cli -n 4 del \"INTERFACE|{}\"".format(intf['ifname']))
 
+
 def cleanup_vxlan_tunnels(duthost, vnet_test_params):
     """
     Removes all VxLAN tunnels from DUT
@@ -184,7 +196,8 @@ def cleanup_vxlan_tunnels(duthost, vnet_test_params):
     for tunnel in tunnels:
         duthost.shell("redis-cli -n 4 del \"VXLAN_TUNNEL|{}\"".format(tunnel))
 
-def cleanup_vnet_routes(duthost, vnet_config):
+
+def cleanup_vnet_routes(duthost, vnet_config, num_routes):
     """
     Generates, pushes, and applies VNET route config to clear routes set during test
 
@@ -196,4 +209,7 @@ def cleanup_vnet_routes(duthost, vnet_config):
     render_template_to_host("vnet_routes.j2", duthost, DUT_VNET_ROUTE_JSON, vnet_config, op="DEL")
     duthost.shell("docker cp {} swss:/vnet.route.json".format(DUT_VNET_ROUTE_JSON))
     duthost.shell("docker exec swss sh -c \"swssconfig /vnet.route.json\"")
-    sleep(3)
+    if num_routes > 3000:
+        sleep(300)
+    else:
+        sleep(3)


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
Changed logic to do sleep for longer time after apply VNET VXLAN configs, because current logic does not work in case of scale for example with 330000 vnet routes
Now in case of scale we will wait some time until all configuration applied

Summary: Stabilized VNET VXLAN test in case of scale
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
When run test tests/vxlan/test_vnet_vxlan.py with scale num routes 33000 test will fail, because not all routes applied and Wr_ARP test also will fail because warm-reboot not happen(configuration still in progress). Now this issue fixed.

#### How did you do it?
Added sleep in case of scale

#### How did you verify/test it?
Executed test tests/vxlan/test_vnet_vxlan.py with and without scale

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
