### PR TITLE
[sensors] Added new mlnx platforms which have different sensors

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -1287,6 +1287,273 @@ sensors_checks:
     psu_skips: {}
     sensor_skip_per_version: {}
 
+  x86_64-mlnx_msn3700-r0-respined:
+    alarms:
+      fan:
+      - dps460-i2c-4-58/PSU-1 Fan 1/fan1_alarm
+      - dps460-i2c-4-58/PSU-1 Fan 1/fan1_fault
+
+      - dps460-i2c-4-59/PSU-2 Fan 1/fan1_alarm
+      - dps460-i2c-4-59/PSU-2 Fan 1/fan1_fault
+
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-1 Tach 1/fan1_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-1 Tach 2/fan2_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-2 Tach 1/fan3_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-2 Tach 2/fan4_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-3 Tach 1/fan5_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-3 Tach 2/fan6_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-4 Tach 1/fan7_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-4 Tach 2/fan8_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-5 Tach 1/fan9_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-5 Tach 2/fan10_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-6 Tach 1/fan11_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-6 Tach 2/fan12_fault
+      power:
+      - tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail Curr (out)/curr1_crit_alarm
+      - tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail Curr (out)/curr1_max_alarm
+      - tps53679-i2c-5-70/PMIC-1 ASIC 1.2V Rail Curr (out)/curr2_crit_alarm
+      - tps53679-i2c-5-70/PMIC-1 ASIC 1.2V Rail Curr (out)/curr2_max_alarm
+      - tps53679-i2c-5-70/PMIC-1 PSU 12V Rail (in1)/in1_crit_alarm
+      - tps53679-i2c-5-70/PMIC-1 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - tps53679-i2c-5-70/PMIC-1 PSU 12V Rail (in2)/in2_crit_alarm
+      - tps53679-i2c-5-70/PMIC-1 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail (out)/in3_crit_alarm
+      - tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail (out)/in3_lcrit_alarm
+
+      - tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail Curr (out)/curr1_crit_alarm
+      - tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail Curr (out)/curr1_max_alarm
+      - tps53679-i2c-5-71/PMIC-2 ASIC 1.8V Rail Curr (out)/curr2_crit_alarm
+      - tps53679-i2c-5-71/PMIC-2 ASIC 1.8V Rail Curr (out)/curr2_max_alarm
+      - tps53679-i2c-5-71/PMIC-2 PSU 12V Rail (in1)/in1_crit_alarm
+      - tps53679-i2c-5-71/PMIC-2 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - tps53679-i2c-5-71/PMIC-2 PSU 12V Rail (in2)/in2_crit_alarm
+      - tps53679-i2c-5-71/PMIC-2 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail (out)/in3_crit_alarm
+      - tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail (out)/in3_lcrit_alarm
+
+      - mp2975-i2c-5-62/PMIC-1 PSU 12V Rail (in)/in1_crit_alarm
+      - mp2975-i2c-5-62/PMIC-1 PSU 12V Rail (in)/in1_lcrit_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC 0.8V VCORE Rail (out)/in2_crit_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC 0.8V VCORE Rail (out)/in2_lcrit_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC 0.8V VCORE Rail Curr (out)/curr1_crit_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC 0.8V VCORE Rail Curr (out)/curr1_max_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC 1.2V Rail Curr (out)/curr2_crit_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC 1.2V Rail Curr (out)/curr2_max_alarm
+
+      - mp2975-i2c-5-66/PMIC-2 PSU 12V Rail (in)/in1_crit_alarm
+      - mp2975-i2c-5-66/PMIC-2 PSU 12V Rail (in)/in1_lcrit_alarm
+      - mp2975-i2c-5-66/PMIC-2 ASIC 3.3V Rail (out)/in2_crit_alarm
+      - mp2975-i2c-5-66/PMIC-2 ASIC 3.3V Rail (out)/in2_lcrit_alarm
+      - mp2975-i2c-5-66/PMIC-2 ASIC 3.3V Rail Curr (out)/curr1_crit_alarm
+      - mp2975-i2c-5-66/PMIC-2 ASIC 3.3V Rail Curr (out)/curr1_max_alarm
+      - mp2975-i2c-5-66/PMIC-2 ASIC 1.8V Rail Curr (out)/curr2_crit_alarm
+      - mp2975-i2c-5-66/PMIC-2 ASIC 1.8V Rail Curr (out)/curr2_max_alarm
+
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail Curr (out)/curr1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail Curr (out)/curr1_max_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail Curr (out)/curr2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail Curr (out)/curr2_max_alarm
+      - tps53679-i2c-15-58/PMIC-3 PSU 12V Rail (in1)/in1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - tps53679-i2c-15-58/PMIC-3 PSU 12V Rail (in2)/in2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail (out)/in3_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail (out)/in3_lcrit_alarm
+
+      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr1_max_alarm
+      - tps53679-i2c-15-61/PMIC-4 PSU 12V Rail (in1)/in1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - tps53679-i2c-15-61/PMIC-4 PSU 12V Rail (in2)/in2_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in3_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in3_lcrit_alarm
+
+      - mp2975-i2c-15-6a/PMIC-3 PSU 12V Rail (in1)/in1_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail (out)/in2_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail (out)/in2_lcrit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail Curr (out)/curr2_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail Curr (out)/curr2_max_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.05V Rail Curr (out)/curr5_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.05V Rail Curr (out)/curr5_max_alarm
+
+      - mp2975-i2c-15-61/PMIC-4 PSU 12V Rail (in1)/in1_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in2_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in2_lcrit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr2_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr2_max_alarm
+
+      - dps460-i2c-4-58/PSU-1 220V Rail Curr (in)/curr1_crit_alarm
+      - dps460-i2c-4-58/PSU-1 220V Rail Curr (in)/curr1_max_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail Curr (out)/curr2_crit_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail Curr (out)/curr2_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail Curr (out)/curr2_max_alarm
+      - dps460-i2c-4-58/PSU-1 220V Rail Pwr (in)/power1_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail Pwr (out)/power2_cap_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail Pwr (out)/power2_crit_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail Pwr (out)/power2_max_alarm
+      - dps460-i2c-4-58/PSU-1 220V Rail (in)/in1_crit_alarm
+      - dps460-i2c-4-58/PSU-1 220V Rail (in)/in1_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1 220V Rail (in)/in1_max_alarm
+      - dps460-i2c-4-58/PSU-1 220V Rail (in)/in1_min_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail (out)/in3_crit_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail (out)/in3_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail (out)/in3_max_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail (out)/in3_min_alarm
+
+      - dps460-i2c-4-59/PSU-2 220V Rail Curr (in)/curr1_crit_alarm
+      - dps460-i2c-4-59/PSU-2 220V Rail Curr (in)/curr1_max_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail Curr (out)/curr2_crit_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail Curr (out)/curr2_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail Curr (out)/curr2_max_alarm
+      - dps460-i2c-4-59/PSU-2 220V Rail Pwr (in)/power1_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail Pwr (out)/power2_cap_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail Pwr (out)/power2_crit_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail Pwr (out)/power2_max_alarm
+      - dps460-i2c-4-59/PSU-2 220V Rail (in)/in1_crit_alarm
+      - dps460-i2c-4-59/PSU-2 220V Rail (in)/in1_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2 220V Rail (in)/in1_max_alarm
+      - dps460-i2c-4-59/PSU-2 220V Rail (in)/in1_min_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_crit_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_max_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_min_alarm
+
+      temp:
+      - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit_alarm
+      - coretemp-isa-0000/Core 0/temp2_crit_alarm
+      - coretemp-isa-0000/Core 1/temp3_crit_alarm
+      - coretemp-isa-0000/Core 2/temp4_crit_alarm
+      - coretemp-isa-0000/Core 3/temp5_crit_alarm
+
+      - mlxsw-i2c-2-48/front panel 001/temp2_fault
+      - mlxsw-i2c-2-48/front panel 002/temp3_fault
+      - mlxsw-i2c-2-48/front panel 003/temp4_fault
+      - mlxsw-i2c-2-48/front panel 004/temp5_fault
+      - mlxsw-i2c-2-48/front panel 005/temp6_fault
+      - mlxsw-i2c-2-48/front panel 006/temp7_fault
+      - mlxsw-i2c-2-48/front panel 007/temp8_fault
+      - mlxsw-i2c-2-48/front panel 008/temp9_fault
+      - mlxsw-i2c-2-48/front panel 009/temp10_fault
+      - mlxsw-i2c-2-48/front panel 010/temp11_fault
+      - mlxsw-i2c-2-48/front panel 011/temp12_fault
+      - mlxsw-i2c-2-48/front panel 012/temp13_fault
+      - mlxsw-i2c-2-48/front panel 013/temp14_fault
+      - mlxsw-i2c-2-48/front panel 014/temp15_fault
+      - mlxsw-i2c-2-48/front panel 015/temp16_fault
+      - mlxsw-i2c-2-48/front panel 016/temp17_fault
+      - mlxsw-i2c-2-48/front panel 017/temp18_fault
+      - mlxsw-i2c-2-48/front panel 018/temp19_fault
+      - mlxsw-i2c-2-48/front panel 019/temp20_fault
+      - mlxsw-i2c-2-48/front panel 020/temp21_fault
+      - mlxsw-i2c-2-48/front panel 021/temp22_fault
+      - mlxsw-i2c-2-48/front panel 022/temp23_fault
+      - mlxsw-i2c-2-48/front panel 023/temp24_fault
+      - mlxsw-i2c-2-48/front panel 024/temp25_fault
+      - mlxsw-i2c-2-48/front panel 025/temp26_fault
+      - mlxsw-i2c-2-48/front panel 026/temp27_fault
+      - mlxsw-i2c-2-48/front panel 027/temp28_fault
+      - mlxsw-i2c-2-48/front panel 028/temp29_fault
+      - mlxsw-i2c-2-48/front panel 029/temp30_fault
+      - mlxsw-i2c-2-48/front panel 030/temp31_fault
+      - mlxsw-i2c-2-48/front panel 031/temp32_fault
+      - mlxsw-i2c-2-48/front panel 032/temp33_fault
+
+      - tps53679-i2c-5-70/PMIC-1 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-5-70/PMIC-1 Temp 1/temp1_max_alarm
+      - tps53679-i2c-5-70/PMIC-1 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-5-70/PMIC-1 Temp 2/temp2_max_alarm
+
+      - tps53679-i2c-5-71/PMIC-2 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-5-71/PMIC-2 Temp 1/temp1_max_alarm
+      - tps53679-i2c-5-71/PMIC-2 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-5-71/PMIC-2 Temp 2/temp2_max_alarm
+
+      - mp2975-i2c-5-62/PMIC-1 Temp 1/temp1_crit_alarm
+      - mp2975-i2c-5-62/PMIC-1 Temp 1/temp1_max_alarm
+      - mp2975-i2c-5-62/PMIC-1 Temp 2/temp2_crit_alarm
+      - mp2975-i2c-5-62/PMIC-1 Temp 2/temp2_max_alarm
+
+      - mp2975-i2c-5-66/PMIC-2 Temp 1/temp1_crit_alarm
+      - mp2975-i2c-5-66/PMIC-2 Temp 1/temp1_max_alarm
+      - mp2975-i2c-5-66/PMIC-2 Temp 2/temp2_crit_alarm
+      - mp2975-i2c-5-66/PMIC-2 Temp 2/temp2_max_alarm
+
+      - tps53679-i2c-15-58/PMIC-3 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 Temp 1/temp1_max_alarm
+      - tps53679-i2c-15-58/PMIC-3 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 Temp 2/temp2_max_alarm
+
+      - tps53679-i2c-15-61/PMIC-4 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 Temp 1/temp1_max_alarm
+      - tps53679-i2c-15-61/PMIC-4 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 Temp 2/temp2_max_alarm
+
+      - mp2975-i2c-15-6a/PMIC-3 Temp 1/temp1_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 Temp 1/temp1_max_alarm
+
+      - mp2975-i2c-15-61/PMIC-4 Temp 1/temp1_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 Temp 1/temp1_max_alarm
+      - mp2975-i2c-15-61/PMIC-4 Temp 2/temp2_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 Temp 2/temp2_max_alarm
+
+      - dps460-i2c-4-58/PSU-1 Temp 1/temp1_crit_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 1/temp1_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 1/temp1_max_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 1/temp1_min_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 2/temp2_crit_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 2/temp2_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 2/temp2_max_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 2/temp2_min_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 3/temp3_crit_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 3/temp3_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 3/temp3_max_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 3/temp3_min_alarm
+
+      - dps460-i2c-4-59/PSU-2 Temp 1/temp1_crit_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 1/temp1_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 1/temp1_max_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 1/temp1_min_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 2/temp2_crit_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 2/temp2_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 2/temp2_max_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 2/temp2_min_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 3/temp3_crit_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 3/temp3_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 3/temp3_max_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 3/temp3_min_alarm
+
+    compares:
+      power: []
+      temp:
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
+      - - coretemp-isa-0000/Core 0/temp2_input
+        - coretemp-isa-0000/Core 0/temp2_crit
+      - - coretemp-isa-0000/Core 1/temp3_input
+        - coretemp-isa-0000/Core 1/temp3_crit
+      - - coretemp-isa-0000/Core 2/temp4_input
+        - coretemp-isa-0000/Core 2/temp4_crit
+      - - coretemp-isa-0000/Core 3/temp5_input
+        - coretemp-isa-0000/Core 3/temp5_crit
+
+      - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
+        - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
+
+      - - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_input
+        - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_max
+
+      - - tmp102-i2c-15-49/Ambient COMEX Temp/temp1_input
+        - tmp102-i2c-15-49/Ambient COMEX Temp/temp1_max
+    non_zero:
+      fan: []
+      power: []
+      temp: []
+    psu_skips: {}
+    sensor_skip_per_version: {}
+
   x86_64-mlnx_msn3700c-r0:
     alarms:
       fan:
@@ -1465,6 +1732,261 @@ sensors_checks:
       - dps460-i2c-4-59/PSU-1 Temp 3/temp3_lcrit_alarm
       - dps460-i2c-4-59/PSU-1 Temp 3/temp3_max_alarm
       - dps460-i2c-4-59/PSU-1 Temp 3/temp3_min_alarm
+    compares:
+      power: []
+      temp:
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
+      - - coretemp-isa-0000/Core 0/temp2_input
+        - coretemp-isa-0000/Core 0/temp2_crit
+      - - coretemp-isa-0000/Core 1/temp3_input
+        - coretemp-isa-0000/Core 1/temp3_crit
+
+      - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
+        - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
+
+      - - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_input
+        - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_max
+
+      - - tmp102-i2c-15-49/Ambient COMEX Temp/temp1_input
+        - tmp102-i2c-15-49/Ambient COMEX Temp/temp1_max
+    non_zero:
+      fan: []
+      power: []
+      temp: []
+    psu_skips: {}
+    sensor_skip_per_version: {}
+
+  x86_64-mlnx_msn3700c-r0-respined:
+    alarms:
+      fan:
+      - dps460-i2c-4-58/PSU-1 Fan 1/fan1_alarm
+      - dps460-i2c-4-58/PSU-1 Fan 1/fan1_fault
+
+      - dps460-i2c-4-59/PSU-2 Fan 1/fan1_alarm
+      - dps460-i2c-4-59/PSU-2 Fan 1/fan1_fault
+
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-1 Tach 1/fan1_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-1 Tach 2/fan2_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-2 Tach 1/fan3_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-2 Tach 2/fan4_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-3 Tach 1/fan5_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-3 Tach 2/fan6_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-4 Tach 1/fan7_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-4 Tach 2/fan8_fault
+      power:
+      - tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail Curr (out)/curr1_crit_alarm
+      - tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail Curr (out)/curr1_max_alarm
+      - tps53679-i2c-5-70/PMIC-1 ASIC 1.2V Rail Curr (out)/curr2_crit_alarm
+      - tps53679-i2c-5-70/PMIC-1 ASIC 1.2V Rail Curr (out)/curr2_max_alarm
+      - tps53679-i2c-5-70/PMIC-1 PSU 12V Rail (in1)/in1_crit_alarm
+      - tps53679-i2c-5-70/PMIC-1 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - tps53679-i2c-5-70/PMIC-1 PSU 12V Rail (in2)/in2_crit_alarm
+      - tps53679-i2c-5-70/PMIC-1 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail (out)/in3_crit_alarm
+      - tps53679-i2c-5-70/PMIC-1 ASIC 0.8V VCORE Rail (out)/in3_lcrit_alarm
+
+      - tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail Curr (out)/curr1_crit_alarm
+      - tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail Curr (out)/curr1_max_alarm
+      - tps53679-i2c-5-71/PMIC-2 ASIC 1.8V Rail Curr (out)/curr2_crit_alarm
+      - tps53679-i2c-5-71/PMIC-2 ASIC 1.8V Rail Curr (out)/curr2_max_alarm
+      - tps53679-i2c-5-71/PMIC-2 PSU 12V Rail (in1)/in1_crit_alarm
+      - tps53679-i2c-5-71/PMIC-2 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - tps53679-i2c-5-71/PMIC-2 PSU 12V Rail (in2)/in2_crit_alarm
+      - tps53679-i2c-5-71/PMIC-2 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail (out)/in3_crit_alarm
+      - tps53679-i2c-5-71/PMIC-2 ASIC 3.3V Rail (out)/in3_lcrit_alarm
+
+      - mp2975-i2c-5-62/PMIC-1 PSU 12V Rail (in)/in1_crit_alarm
+      - mp2975-i2c-5-62/PMIC-1 PSU 12V Rail (in)/in1_lcrit_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC 0.8V VCORE Rail (out)/in2_crit_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC 0.8V VCORE Rail (out)/in2_lcrit_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC 0.8V VCORE Rail Curr (out)/curr1_crit_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC 0.8V VCORE Rail Curr (out)/curr1_max_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC 1.2V Rail Curr (out)/curr2_crit_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC 1.2V Rail Curr (out)/curr2_max_alarm
+
+      - mp2975-i2c-5-66/PMIC-2 PSU 12V Rail (in)/in1_crit_alarm
+      - mp2975-i2c-5-66/PMIC-2 PSU 12V Rail (in)/in1_lcrit_alarm
+      - mp2975-i2c-5-66/PMIC-2 ASIC 3.3V Rail (out)/in2_crit_alarm
+      - mp2975-i2c-5-66/PMIC-2 ASIC 3.3V Rail (out)/in2_lcrit_alarm
+      - mp2975-i2c-5-66/PMIC-2 ASIC 3.3V Rail Curr (out)/curr1_crit_alarm
+      - mp2975-i2c-5-66/PMIC-2 ASIC 3.3V Rail Curr (out)/curr1_max_alarm
+      - mp2975-i2c-5-66/PMIC-2 ASIC 1.8V Rail Curr (out)/curr2_crit_alarm
+      - mp2975-i2c-5-66/PMIC-2 ASIC 1.8V Rail Curr (out)/curr2_max_alarm
+
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail Curr (out)/curr1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail Curr (out)/curr1_max_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail Curr (out)/curr2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.05V Rail Curr (out)/curr2_max_alarm
+      - tps53679-i2c-15-58/PMIC-3 PSU 12V Rail (in1)/in1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - tps53679-i2c-15-58/PMIC-3 PSU 12V Rail (in2)/in2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail (out)/in3_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 COMEX 1.8V Rail (out)/in3_lcrit_alarm
+
+      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr1_max_alarm
+      - tps53679-i2c-15-61/PMIC-4 PSU 12V Rail (in1)/in1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - tps53679-i2c-15-61/PMIC-4 PSU 12V Rail (in2)/in2_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in3_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in3_lcrit_alarm
+
+      - mp2975-i2c-15-6a/PMIC-3 PSU 12V Rail (in1)/in1_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail (out)/in2_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail (out)/in2_lcrit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail Curr (out)/curr2_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail Curr (out)/curr2_max_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.05V Rail Curr (out)/curr5_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.05V Rail Curr (out)/curr5_max_alarm
+
+      - mp2975-i2c-15-61/PMIC-4 PSU 12V Rail (in1)/in1_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in2_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in2_lcrit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr2_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr2_max_alarm
+
+      - dps460-i2c-4-58/PSU-1 220V Rail Curr (in)/curr1_crit_alarm
+      - dps460-i2c-4-58/PSU-1 220V Rail Curr (in)/curr1_max_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail Curr (out)/curr2_crit_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail Curr (out)/curr2_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail Curr (out)/curr2_max_alarm
+      - dps460-i2c-4-58/PSU-1 220V Rail Pwr (in)/power1_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail Pwr (out)/power2_cap_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail Pwr (out)/power2_crit_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail Pwr (out)/power2_max_alarm
+      - dps460-i2c-4-58/PSU-1 220V Rail (in)/in1_crit_alarm
+      - dps460-i2c-4-58/PSU-1 220V Rail (in)/in1_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1 220V Rail (in)/in1_max_alarm
+      - dps460-i2c-4-58/PSU-1 220V Rail (in)/in1_min_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail (out)/in3_crit_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail (out)/in3_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail (out)/in3_max_alarm
+      - dps460-i2c-4-58/PSU-1 12V Rail (out)/in3_min_alarm
+
+      - dps460-i2c-4-59/PSU-2 220V Rail Curr (in)/curr1_crit_alarm
+      - dps460-i2c-4-59/PSU-2 220V Rail Curr (in)/curr1_max_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail Curr (out)/curr2_crit_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail Curr (out)/curr2_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail Curr (out)/curr2_max_alarm
+      - dps460-i2c-4-59/PSU-2 220V Rail Pwr (in)/power1_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail Pwr (out)/power2_cap_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail Pwr (out)/power2_crit_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail Pwr (out)/power2_max_alarm
+      - dps460-i2c-4-59/PSU-2 220V Rail (in)/in1_crit_alarm
+      - dps460-i2c-4-59/PSU-2 220V Rail (in)/in1_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2 220V Rail (in)/in1_max_alarm
+      - dps460-i2c-4-59/PSU-2 220V Rail (in)/in1_min_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_crit_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_max_alarm
+      - dps460-i2c-4-59/PSU-2 12V Rail (out)/in3_min_alarm
+      temp:
+      - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit_alarm
+      - coretemp-isa-0000/Core 0/temp2_crit_alarm
+      - coretemp-isa-0000/Core 1/temp3_crit_alarm
+
+      - mlxsw-i2c-2-48/front panel 001/temp2_fault
+      - mlxsw-i2c-2-48/front panel 002/temp3_fault
+      - mlxsw-i2c-2-48/front panel 003/temp4_fault
+      - mlxsw-i2c-2-48/front panel 004/temp5_fault
+      - mlxsw-i2c-2-48/front panel 005/temp6_fault
+      - mlxsw-i2c-2-48/front panel 006/temp7_fault
+      - mlxsw-i2c-2-48/front panel 007/temp8_fault
+      - mlxsw-i2c-2-48/front panel 008/temp9_fault
+      - mlxsw-i2c-2-48/front panel 009/temp10_fault
+      - mlxsw-i2c-2-48/front panel 010/temp11_fault
+      - mlxsw-i2c-2-48/front panel 011/temp12_fault
+      - mlxsw-i2c-2-48/front panel 012/temp13_fault
+      - mlxsw-i2c-2-48/front panel 013/temp14_fault
+      - mlxsw-i2c-2-48/front panel 014/temp15_fault
+      - mlxsw-i2c-2-48/front panel 015/temp16_fault
+      - mlxsw-i2c-2-48/front panel 016/temp17_fault
+      - mlxsw-i2c-2-48/front panel 017/temp18_fault
+      - mlxsw-i2c-2-48/front panel 018/temp19_fault
+      - mlxsw-i2c-2-48/front panel 019/temp20_fault
+      - mlxsw-i2c-2-48/front panel 020/temp21_fault
+      - mlxsw-i2c-2-48/front panel 021/temp22_fault
+      - mlxsw-i2c-2-48/front panel 022/temp23_fault
+      - mlxsw-i2c-2-48/front panel 023/temp24_fault
+      - mlxsw-i2c-2-48/front panel 024/temp25_fault
+      - mlxsw-i2c-2-48/front panel 025/temp26_fault
+      - mlxsw-i2c-2-48/front panel 026/temp27_fault
+      - mlxsw-i2c-2-48/front panel 027/temp28_fault
+      - mlxsw-i2c-2-48/front panel 028/temp29_fault
+      - mlxsw-i2c-2-48/front panel 029/temp30_fault
+      - mlxsw-i2c-2-48/front panel 030/temp31_fault
+      - mlxsw-i2c-2-48/front panel 031/temp32_fault
+      - mlxsw-i2c-2-48/front panel 032/temp33_fault
+
+      - tps53679-i2c-5-70/PMIC-1 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-5-70/PMIC-1 Temp 1/temp1_max_alarm
+      - tps53679-i2c-5-70/PMIC-1 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-5-70/PMIC-1 Temp 2/temp2_max_alarm
+
+      - tps53679-i2c-5-71/PMIC-2 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-5-71/PMIC-2 Temp 1/temp1_max_alarm
+      - tps53679-i2c-5-71/PMIC-2 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-5-71/PMIC-2 Temp 2/temp2_max_alarm
+
+      - mp2975-i2c-5-62/PMIC-1 Temp 1/temp1_crit_alarm
+      - mp2975-i2c-5-62/PMIC-1 Temp 1/temp1_max_alarm
+      - mp2975-i2c-5-62/PMIC-1 Temp 2/temp2_crit_alarm
+      - mp2975-i2c-5-62/PMIC-1 Temp 2/temp2_max_alarm
+
+      - mp2975-i2c-5-66/PMIC-2 Temp 1/temp1_crit_alarm
+      - mp2975-i2c-5-66/PMIC-2 Temp 1/temp1_max_alarm
+      - mp2975-i2c-5-66/PMIC-2 Temp 2/temp2_crit_alarm
+      - mp2975-i2c-5-66/PMIC-2 Temp 2/temp2_max_alarm
+
+      - tps53679-i2c-15-58/PMIC-3 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 Temp 1/temp1_max_alarm
+      - tps53679-i2c-15-58/PMIC-3 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-3 Temp 2/temp2_max_alarm
+
+      - tps53679-i2c-15-61/PMIC-4 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 Temp 1/temp1_max_alarm
+      - tps53679-i2c-15-61/PMIC-4 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-15-61/PMIC-4 Temp 2/temp2_max_alarm
+
+      - mp2975-i2c-15-6a/PMIC-3 Temp 1/temp1_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 Temp 1/temp1_max_alarm
+
+      - mp2975-i2c-15-61/PMIC-4 Temp 1/temp1_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 Temp 1/temp1_max_alarm
+      - mp2975-i2c-15-61/PMIC-4 Temp 2/temp2_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 Temp 2/temp2_max_alarm
+
+      - dps460-i2c-4-58/PSU-1 Temp 1/temp1_crit_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 1/temp1_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 1/temp1_max_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 1/temp1_min_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 2/temp2_crit_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 2/temp2_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 2/temp2_max_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 2/temp2_min_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 3/temp3_crit_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 3/temp3_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 3/temp3_max_alarm
+      - dps460-i2c-4-58/PSU-1 Temp 3/temp3_min_alarm
+
+      - dps460-i2c-4-59/PSU-2 Temp 1/temp1_crit_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 1/temp1_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 1/temp1_max_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 1/temp1_min_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 2/temp2_crit_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 2/temp2_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 2/temp2_max_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 2/temp2_min_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 3/temp3_crit_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 3/temp3_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 3/temp3_max_alarm
+      - dps460-i2c-4-59/PSU-2 Temp 3/temp3_min_alarm
     compares:
       power: []
       temp:
@@ -4542,6 +5064,319 @@ sensors_checks:
     psu_skips: {}
     sensor_skip_per_version: {}
 
+  x86_64-mlnx_msn4600c-r0-respined:
+    alarms:
+      fan:
+      - dps460-i2c-4-58/PSU-1(L) Fan 1/fan1_alarm
+      - dps460-i2c-4-58/PSU-1(L) Fan 1/fan1_fault
+
+      - dps460-i2c-4-59/PSU-2(R) Fan 1/fan1_alarm
+      - dps460-i2c-4-59/PSU-2(R) Fan 1/fan1_fault
+
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-1/fan1_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-2/fan2_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-3/fan3_fault
+
+      power:
+      - xdpe12284-i2c-5-62/PMIC-1 12V ASIC VCORE_MAIN Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 ASIC VCORE_MAIN Rail Curr (out1)/curr3_max_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 ASIC VCORE_MAIN Rail Curr (out1)/curr3_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 PSU 12V Rail (in1)/in1_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 ASIC VCORE_MAIN Rail (out1)/in3_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 ASIC VCORE_MAIN Rail (out1)/in3_lcrit_alarm
+
+      - xdpe12284-i2c-5-64/PMIC-2 12V ASIC 1.8V_MAIN Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 12V ASIC 1.2V_MAIN Rail Curr (in2)/curr2_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V_MAIN Rail Curr (out1)/curr3_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V_MAIN Rail Curr (out1)/curr3_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.2V_MAIN Rail Curr (out2)/curr4_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.2V_MAIN Rail Curr (out2)/curr4_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail (in1)/in1_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 PSU 12V Rail (in2)/in2_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V_MAIN Rail (out1)/in3_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V_MAIN Rail (out1)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.2V_MAIN Rail (out2)/in4_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.2V_MAIN Rail (out2)/in4_lcrit_alarm
+
+      - xdpe12284-i2c-5-66/PMIC-2 12V ASIC VCORE_T0_1 Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-66/PMIC-2 12V ASIC 1.8V_T0_1 Rail Curr (in2)/curr2_max_alarm
+      - xdpe12284-i2c-5-66/PMIC-2 ASIC VCORE_T0_1 Rail Curr (out1)/curr3_max_alarm
+      - xdpe12284-i2c-5-66/PMIC-2 ASIC VCORE_T0_1 Rail Curr (out1)/curr3_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-2 ASIC 1.8V_T0_1 Rail Curr (out2)/curr4_max_alarm
+      - xdpe12284-i2c-5-66/PMIC-2 ASIC 1.8V_T0_1 Rail Curr (out2)/curr4_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 PSU 12V Rail (in1)/in1_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-2 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - xdpe12284-i2c-5-66/PMIC-2 PSU 12V Rail (in2)/in2_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC VCORE_T0_1 Rail (out1)/in3_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC VCORE_T0_1 Rail (out1)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V_T0_1 Rail (out2)/in4_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V_T0_1 Rail (out2)/in4_lcrit_alarm
+
+      - xdpe12284-i2c-5-68/PMIC-2 12V ASIC VCORE_T2_3 Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-68/PMIC-2 12V ASIC 1.8V_T2_3 Rail Curr (in2)/curr2_max_alarm
+      - xdpe12284-i2c-5-68/PMIC-2 ASIC VCORE_T2_3 Rail Curr (out1)/curr3_max_alarm
+      - xdpe12284-i2c-5-68/PMIC-2 ASIC VCORE_T2_3 Rail Curr (out1)/curr3_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-2 ASIC 1.8V_T2_3 Rail Curr (out2)/curr4_max_alarm
+      - xdpe12284-i2c-5-68/PMIC-2 ASIC 1.8V_T2_3 Rail Curr (out2)/curr4_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-3 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-68/PMIC-3 PSU 12V Rail (in1)/in1_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-2 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - xdpe12284-i2c-5-68/PMIC-2 PSU 12V Rail (in2)/in2_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-3 ASIC VCORE_T2_3 Rail (out1)/in3_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-3 ASIC VCORE_T2_3 Rail (out1)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-68/PMIC-3 ASIC 1.8V_T2_3 Rail (out2)/in4_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-3 ASIC 1.8V_T2_3 Rail (out2)/in4_lcrit_alarm
+
+      - xdpe12284-i2c-5-6a/PMIC-2 12V ASIC VCORE_T4_5 Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-6a/PMIC-2 12V ASIC 1.8V_T4_5 Rail Curr (in2)/curr2_max_alarm
+      - xdpe12284-i2c-5-6a/PMIC-2 ASIC VCORE_T4_5 Rail Curr (out1)/curr3_max_alarm
+      - xdpe12284-i2c-5-6a/PMIC-2 ASIC VCORE_T4_5 Rail Curr (out1)/curr3_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-2 ASIC 1.8V_T4_5 Rail Curr (out2)/curr4_max_alarm
+      - xdpe12284-i2c-5-6a/PMIC-2 ASIC 1.8V_T4_5 Rail Curr (out2)/curr4_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-3 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-3 PSU 12V Rail (in1)/in1_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-2 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-2 PSU 12V Rail (in2)/in2_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-3 ASIC VCORE_T4_5 Rail (out1)/in3_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-3 ASIC VCORE_T4_5 Rail (out1)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-3 ASIC 1.8V_T4_5 Rail (out2)/in4_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-3 ASIC 1.8V_T4_5 Rail (out2)/in4_lcrit_alarm
+
+      - xdpe12284-i2c-5-6c/PMIC-2 12V ASIC VCORE_T6_7 Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-6c/PMIC-2 12V ASIC 1.8V_T6_7 Rail Curr (in2)/curr2_max_alarm
+      - xdpe12284-i2c-5-6c/PMIC-2 ASIC VCORE_T6_7 Rail Curr (out1)/curr3_max_alarm
+      - xdpe12284-i2c-5-6c/PMIC-2 ASIC VCORE_T6_7 Rail Curr (out1)/curr3_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-2 ASIC 1.8V_T6_7 Rail Curr (out2)/curr4_max_alarm
+      - xdpe12284-i2c-5-6c/PMIC-2 ASIC 1.8V_T6_7 Rail Curr (out2)/curr4_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-3 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-3 PSU 12V Rail (in1)/in1_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-2 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-2 PSU 12V Rail (in2)/in2_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-3 ASIC VCORE_T6_7 Rail (out1)/in3_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-3 ASIC VCORE_T6_7 Rail (out1)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-3 ASIC 1.8V_T6_7 Rail (out2)/in4_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-3 ASIC 1.8V_T6_7 Rail (out2)/in4_lcrit_alarm
+
+      - xdpe12284-i2c-5-6e/PMIC-2 12V ASIC 1.2V_T0_3 Rail Curr (in1)/curr1_max_alarm
+      - xdpe12284-i2c-5-6e/PMIC-2 12V ASIC 1.2V_T4_7 Rail Curr (in2)/curr2_max_alarm
+      - xdpe12284-i2c-5-6e/PMIC-2 ASIC 1.2V_T0_3 Rail Curr (out1)/curr3_max_alarm
+      - xdpe12284-i2c-5-6e/PMIC-2 ASIC 1.2V_T0_3 Rail Curr (out1)/curr3_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-2 ASIC 1.2V_T4_7 Rail Curr (out2)/curr4_max_alarm
+      - xdpe12284-i2c-5-6e/PMIC-2 ASIC 1.2V_T4_7 Rail Curr (out2)/curr4_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-3 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-3 PSU 12V Rail (in1)/in1_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-2 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-2 PSU 12V Rail (in2)/in2_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-3 ASIC 1.2V_T0_3 Rail (out1)/in3_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-3 ASIC 1.2V_T0_3 Rail (out1)/in3_lcrit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-3 ASIC 1.2V_T4_7 Rail (out2)/in4_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-3 ASIC 1.2V_T4_7 Rail (out2)/in4_lcrit_alarm
+
+      - mp2975-i2c-15-6a/PMIC-3 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 PSU 12V Rail (in1)/in1_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail (out)/in2_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail (out)/in2_lcrit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail Curr (out)/curr2_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail Curr (out)/curr2_max_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.05V Rail Curr (out)/curr5_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.05V Rail Curr (out)/curr5_crit_alarm
+
+      - mp2975-i2c-15-61/PMIC-4 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - mp2975-i2c-15-61/PMIC-4 PSU 12V Rail (in1)/in1_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in2_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in2_lcrit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr2_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr2_max_alarm
+
+      - tps53679-i2c-15-58/PMIC-8 COMEX 1.8V Rail Curr (out)/curr1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-8 COMEX 1.8V Rail Curr (out)/curr1_max_alarm
+      - tps53679-i2c-15-58/PMIC-8 COMEX 1.05V Rail Curr (out)/curr2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-8 COMEX 1.05V Rail Curr (out)/curr2_max_alarm
+      - tps53679-i2c-15-58/PMIC-8 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - tps53679-i2c-15-58/PMIC-8 PSU 12V Rail (in1)/in1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-8 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - tps53679-i2c-15-58/PMIC-8 PSU 12V Rail (in2)/in2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-8 COMEX 1.8V Rail (out)/in3_crit_alarm
+      - tps53679-i2c-15-58/PMIC-8 COMEX 1.8V Rail (out)/in3_lcrit_alarm
+
+      - tps53679-i2c-15-61/PMIC-9 COMEX 1.2V Rail Curr (out)/curr1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-9 COMEX 1.2V Rail Curr (out)/curr1_max_alarm
+      - tps53679-i2c-15-61/PMIC-9 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - tps53679-i2c-15-61/PMIC-9 PSU 12V Rail (in1)/in1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-9 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - tps53679-i2c-15-61/PMIC-9 PSU 12V Rail (in2)/in2_crit_alarm
+      - tps53679-i2c-15-61/PMIC-9 COMEX 1.2V Rail (out)/in3_crit_alarm
+      - tps53679-i2c-15-61/PMIC-9 COMEX 1.2V Rail (out)/in3_lcrit_alarm
+
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail Curr (in)/curr1_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail Curr (in)/curr1_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail Curr (out)/curr2_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail Curr (out)/curr2_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail Pwr (in)/power1_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail Pwr (out)/power2_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail Pwr (out)/power2_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail (in)/in1_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail (in)/in1_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail (in)/in1_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail (in)/in1_min_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail (out)/in3_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail (out)/in3_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail (out)/in3_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail (out)/in3_min_alarm
+
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail Curr (in)/curr1_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail Curr (in)/curr1_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail Curr (out)/curr2_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail Curr (out)/curr2_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail Pwr (in)/power1_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail Pwr (out)/power2_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail Pwr (out)/power2_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail (in)/in1_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail (in)/in1_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail (in)/in1_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail (in)/in1_min_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_min_alarm
+
+      temp:
+      - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit_alarm
+      - coretemp-isa-0000/Core 0/temp2_crit_alarm
+      - coretemp-isa-0000/Core 1/temp3_crit_alarm
+      - coretemp-isa-0000/Core 2/temp4_crit_alarm
+      - coretemp-isa-0000/Core 3/temp5_crit_alarm
+
+      - mlxsw-i2c-2-48/front panel 001/temp2_fault
+      - mlxsw-i2c-2-48/front panel 002/temp3_fault
+      - mlxsw-i2c-2-48/front panel 003/temp4_fault
+      - mlxsw-i2c-2-48/front panel 004/temp5_fault
+      - mlxsw-i2c-2-48/front panel 005/temp6_fault
+      - mlxsw-i2c-2-48/front panel 006/temp7_fault
+      - mlxsw-i2c-2-48/front panel 007/temp8_fault
+      - mlxsw-i2c-2-48/front panel 008/temp9_fault
+      - mlxsw-i2c-2-48/front panel 009/temp10_fault
+      - mlxsw-i2c-2-48/front panel 010/temp11_fault
+      - mlxsw-i2c-2-48/front panel 011/temp12_fault
+      - mlxsw-i2c-2-48/front panel 012/temp13_fault
+      - mlxsw-i2c-2-48/front panel 013/temp14_fault
+      - mlxsw-i2c-2-48/front panel 014/temp15_fault
+      - mlxsw-i2c-2-48/front panel 015/temp16_fault
+      - mlxsw-i2c-2-48/front panel 016/temp17_fault
+      - mlxsw-i2c-2-48/front panel 017/temp18_fault
+      - mlxsw-i2c-2-48/front panel 018/temp19_fault
+      - mlxsw-i2c-2-48/front panel 019/temp20_fault
+      - mlxsw-i2c-2-48/front panel 020/temp21_fault
+      - mlxsw-i2c-2-48/front panel 021/temp22_fault
+      - mlxsw-i2c-2-48/front panel 022/temp23_fault
+      - mlxsw-i2c-2-48/front panel 023/temp24_fault
+      - mlxsw-i2c-2-48/front panel 024/temp25_fault
+      - mlxsw-i2c-2-48/front panel 025/temp26_fault
+      - mlxsw-i2c-2-48/front panel 026/temp27_fault
+      - mlxsw-i2c-2-48/front panel 027/temp28_fault
+      - mlxsw-i2c-2-48/front panel 028/temp29_fault
+      - mlxsw-i2c-2-48/front panel 029/temp30_fault
+      - mlxsw-i2c-2-48/front panel 030/temp31_fault
+      - mlxsw-i2c-2-48/front panel 031/temp32_fault
+      - mlxsw-i2c-2-48/front panel 032/temp33_fault
+
+      - xdpe12284-i2c-5-62/PMIC-1 ASIC VCORE_MAIN Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-62/PMIC-1 ASIC VCORE_MAIN Temp 1/temp1_max_alarm
+
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V_MAIN Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.8V_MAIN Temp 1/temp1_max_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.2V_MAIN Temp 2/temp2_crit_alarm
+      - xdpe12284-i2c-5-64/PMIC-2 ASIC 1.2V_MAIN Temp 2/temp2_max_alarm
+
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC VCORE_T0_1 Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC VCORE_T0_1 Temp 1/temp1_max_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V_T0_1 Temp 2/temp2_crit_alarm
+      - xdpe12284-i2c-5-66/PMIC-3 ASIC 1.8V_T0_1 Temp 2/temp2_max_alarm
+
+      - xdpe12284-i2c-5-68/PMIC-3 ASIC VCORE_T2_3 Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-3 ASIC VCORE_T2_3 Temp 1/temp1_max_alarm
+      - xdpe12284-i2c-5-68/PMIC-3 ASIC 1.8V_T2_3 Temp 2/temp2_crit_alarm
+      - xdpe12284-i2c-5-68/PMIC-3 ASIC 1.8V_T2_3 Temp 2/temp2_max_alarm
+
+      - xdpe12284-i2c-5-6a/PMIC-3 ASIC VCORE_T4_5 Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-3 ASIC VCORE_T4_5 Temp 1/temp1_max_alarm
+      - xdpe12284-i2c-5-6a/PMIC-3 ASIC 1.8V_T4_5 Temp 2/temp2_crit_alarm
+      - xdpe12284-i2c-5-6a/PMIC-3 ASIC 1.8V_T4_5 Temp 2/temp2_max_alarm
+
+      - xdpe12284-i2c-5-6c/PMIC-3 ASIC VCORE_T6_7 Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-3 ASIC VCORE_T6_7 Temp 1/temp1_max_alarm
+      - xdpe12284-i2c-5-6c/PMIC-3 ASIC 1.8V_T6_7 Temp 2/temp2_crit_alarm
+      - xdpe12284-i2c-5-6c/PMIC-3 ASIC 1.8V_T6_7 Temp 2/temp2_max_alarm
+
+      - xdpe12284-i2c-5-6e/PMIC-3 ASIC 1.2V_T0_3 Temp 1/temp1_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-3 ASIC 1.2V_T0_3 Temp 1/temp1_max_alarm
+      - xdpe12284-i2c-5-6e/PMIC-3 ASIC 1.2V_T4_7 Temp 2/temp2_crit_alarm
+      - xdpe12284-i2c-5-6e/PMIC-3 ASIC 1.2V_T4_7 Temp 2/temp2_max_alarm
+
+      - mp2975-i2c-15-6a/PMIC-3 Temp 1/temp1_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 Temp 1/temp1_max_alarm
+
+      - mp2975-i2c-15-61/PMIC-4 Temp 1/temp1_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 Temp 1/temp1_max_alarm
+      - mp2975-i2c-15-61/PMIC-4 Temp 2/temp2_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 Temp 2/temp2_max_alarm
+
+      - tps53679-i2c-15-58/PMIC-8 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-8 Temp 1/temp1_max_alarm
+      - tps53679-i2c-15-58/PMIC-8 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-8 Temp 2/temp2_max_alarm
+
+      - tps53679-i2c-15-61/PMIC-9 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-9 Temp 1/temp1_max_alarm
+      - tps53679-i2c-15-61/PMIC-9 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-15-61/PMIC-9 Temp 2/temp2_max_alarm
+
+      - dps460-i2c-4-58/PSU-1(L) Temp 1/temp1_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 1/temp1_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 2/temp2_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 2/temp2_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 3/temp3_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 3/temp3_max_alarm
+
+      - dps460-i2c-4-59/PSU-2(R) Temp 1/temp1_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 1/temp1_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 2/temp2_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 2/temp2_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 3/temp3_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 3/temp3_max_alarm
+
+    compares:
+      power: []
+      temp:
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
+      - - coretemp-isa-0000/Core 0/temp2_input
+        - coretemp-isa-0000/Core 0/temp2_crit
+      - - coretemp-isa-0000/Core 1/temp3_input
+        - coretemp-isa-0000/Core 1/temp3_crit
+      - - coretemp-isa-0000/Core 2/temp4_input
+        - coretemp-isa-0000/Core 2/temp4_crit
+      - - coretemp-isa-0000/Core 3/temp5_input
+        - coretemp-isa-0000/Core 3/temp5_crit
+
+      - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
+        - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
+
+      - - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_input
+        - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_max
+
+      - - tmp102-i2c-15-49/Ambient COMEX Temp/temp1_input
+        - tmp102-i2c-15-49/Ambient COMEX Temp/temp1_max
+    non_zero:
+      fan: []
+      power: []
+      temp: []
+    psu_skips: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn4600c-r0-a1:
     alarms:
@@ -4793,6 +5628,279 @@ sensors_checks:
     psu_skips: {}
     sensor_skip_per_version: {}
 
+  x86_64-mlnx_msn4600c-r0-a1-respined:
+    alarms:
+      fan:
+      - dps460-i2c-4-58/PSU-1(L) Fan 1/fan1_alarm
+      - dps460-i2c-4-58/PSU-1(L) Fan 1/fan1_fault
+
+      - dps460-i2c-4-59/PSU-2(R) Fan 1/fan1_alarm
+      - dps460-i2c-4-59/PSU-2(R) Fan 1/fan1_fault
+
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-1/fan1_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-2/fan2_fault
+      - mlxreg_fan-isa-0000/Chassis Fan Drawer-3/fan3_fault
+      power:
+      - mp2975-i2c-5-62/PMIC-1 12V ASIC VCORE_MAIN Rail Curr (in)/curr1_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC VCORE_MAIN Rail Curr (out)/curr2_alarm
+      - mp2975-i2c-5-62/PMIC-1 PSU 12V Rail (in)/in1_crit_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC VCORE_MAIN Rail (out)/in2_lcrit_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC VCORE_MAIN Rail (out)/in2_crit_alarm
+      - mp2975-i2c-5-62/PMIC-1 12V ASIC VCORE_MAIN Rail Pwr (in)/power1_alarm
+
+      - mp2975-i2c-5-64/PMIC-2 12V ASIC 1.8V_1.2V_MAIN Rail Curr (in)/curr1_alarm
+      - mp2975-i2c-5-64/PMIC-2 ASIC 1.8V_MAIN Rail Curr (out1)/curr2_alarm
+      - mp2975-i2c-5-64/PMIC-2 ASIC 1.2V_MAIN Rail Curr (out2)/curr3_alarm
+      - mp2975-i2c-5-64/PMIC-2 PSU 12V Rail (in)/in1_crit_alarm
+      - mp2975-i2c-5-64/PMIC-2 ASIC 1.8V_MAIN Rail (out1)/in2_lcrit_alarm
+      - mp2975-i2c-5-64/PMIC-2 ASIC 1.8V_MAIN Rail (out1)/in2_crit_alarm
+      - mp2975-i2c-5-64/PMIC-2 ASIC 1.2V_MAIN Rail (out2)/in3_crit_alarm
+      - mp2975-i2c-5-64/PMIC-2 ASIC 1.2V_MAIN Rail (out2)/in3_lcrit_alarm
+      - mp2975-i2c-5-64/PMIC-2 12V ASIC 1.8V_1.2V_MAIN Rail Pwr (in)/power1_alarm
+
+      - mp2975-i2c-5-66/PMIC-3 12V ASIC VCORE_1.8V_T0_3 Rail Curr (in)/curr1_alarm
+      - mp2975-i2c-5-66/PMIC-3 ASIC VCORE_T0_3 Rail Curr (out1)/curr2_alarm
+      - mp2975-i2c-5-66/PMIC-3 ASIC 1.8V_T0_3 Rail Curr (out2)/curr3_alarm
+      - mp2975-i2c-5-66/PMIC-3 PSU 12V Rail (in)/in1_crit_alarm
+      - mp2975-i2c-5-66/PMIC-3 ASIC VCORE_T0_3 Rail (out1)/in2_lcrit_alarm
+      - mp2975-i2c-5-66/PMIC-3 ASIC VCORE_T0_3 Rail (out1)/in2_crit_alarm
+      - mp2975-i2c-5-66/PMIC-3 ASIC 1.8V_T0_3 Rail (out2)/in3_crit_alarm
+      - mp2975-i2c-5-66/PMIC-3 ASIC 1.8V_T0_3 Rail (out2)/in3_lcrit_alarm
+      - mp2975-i2c-5-66/PMIC-3 12V ASIC VCORE_1.8V_T0_3 Rail Pwr (in)/power1_alarm
+
+      - mp2975-i2c-5-6a/PMIC-4 12V ASIC VCORE_1.8V_T4_7 Rail Curr (in)/curr1_alarm
+      - mp2975-i2c-5-6a/PMIC-4 ASIC VCORE_T4_7 Rail Curr (out1)/curr2_alarm
+      - mp2975-i2c-5-6a/PMIC-4 ASIC 1.8V_T4_7 Rail Curr (out2)/curr3_alarm
+      - mp2975-i2c-5-6a/PMIC-4 PSU 12V Rail (in)/in1_crit_alarm
+      - mp2975-i2c-5-6a/PMIC-4 ASIC VCORE_T4_7 Rail (out1)/in2_lcrit_alarm
+      - mp2975-i2c-5-6a/PMIC-4 ASIC VCORE_T4_7 Rail (out1)/in2_crit_alarm
+      - mp2975-i2c-5-6a/PMIC-3 ASIC 1.8V_T4_7 Rail (out2)/in3_crit_alarm
+      - mp2975-i2c-5-6a/PMIC-3 ASIC 1.8V_T4_7 Rail (out2)/in3_lcrit_alarm
+      - mp2975-i2c-5-6a/PMIC-4 12V ASIC VCORE_1.8V_T4_7 Rail Pwr (in)/power1_alarm
+
+      - mp2975-i2c-5-6e/PMIC-5 12V ASIC 1.2V_T0_3_T4_7 Rail Curr (in)/curr1_alarm
+      - mp2975-i2c-5-6e/PMIC-5 ASIC 1.2V_T0_3 Rail Curr (out1)/curr2_alarm
+      - mp2975-i2c-5-6e/PMIC-5 ASIC 1.2V_T4_7 Rail Curr (out2)/curr3_alarm
+      - mp2975-i2c-5-6e/PMIC-5 PSU 12V Rail (in)/in1_crit_alarm
+      - mp2975-i2c-5-6e/PMIC-5 ASIC 1.2V_T0_3 Rail (out1)/in2_lcrit_alarm
+      - mp2975-i2c-5-6e/PMIC-5 ASIC 1.2V_T0_3 Rail (out1)/in2_crit_alarm
+      - mp2975-i2c-5-6e/PMIC-5 ASIC 1.2V_T4_7 Rail (out2)/in3_crit_alarm
+      - mp2975-i2c-5-6e/PMIC-5 ASIC 1.2V_T4_7 Rail (out2)/in3_lcrit_alarm
+      - mp2975-i2c-5-6e/PMIC-5 12V ASIC 1.2V_T0_3_T4_7 Rail Pwr (in)/power1_alarm
+
+      - mp2975-i2c-15-6a/PMIC-3 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 PSU 12V Rail (in1)/in1_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail (out)/in2_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail (out)/in2_lcrit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail Curr (out)/curr2_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.8V Rail Curr (out)/curr2_max_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.05V Rail Curr (out)/curr5_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 COMEX 1.05V Rail Curr (out)/curr5_crit_alarm
+
+      - mp2975-i2c-15-61/PMIC-4 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - mp2975-i2c-15-61/PMIC-4 PSU 12V Rail (in1)/in1_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in2_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail (out)/in2_lcrit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr2_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 COMEX 1.2V Rail Curr (out)/curr2_max_alarm
+
+      - tps53679-i2c-15-58/PMIC-6 COMEX 1.8V Rail Curr (out1)/curr1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-6 COMEX 1.8V Rail Curr (out1)/curr1_max_alarm
+      - tps53679-i2c-15-58/PMIC-6 COMEX 1.05V Rail Curr (out2)/curr2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-6 COMEX 1.05V Rail Curr (out2)/curr2_max_alarm
+      - tps53679-i2c-15-58/PMIC-6 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - tps53679-i2c-15-58/PMIC-6 PSU 12V Rail (in1)/in1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-6 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - tps53679-i2c-15-58/PMIC-6 PSU 12V Rail (in2)/in2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-6 COMEX 1.8V Rail (out1)/in3_crit_alarm
+      - tps53679-i2c-15-58/PMIC-6 COMEX 1.8V Rail (out1)/in3_lcrit_alarm
+
+      - tps53679-i2c-15-61/PMIC-7 COMEX 1.2V Rail Curr (out)/curr1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-7 COMEX 1.2V Rail Curr (out)/curr1_max_alarm
+      - tps53679-i2c-15-61/PMIC-7 PSU 12V Rail (in1)/in1_lcrit_alarm
+      - tps53679-i2c-15-61/PMIC-7 PSU 12V Rail (in1)/in1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-7 PSU 12V Rail (in2)/in2_lcrit_alarm
+      - tps53679-i2c-15-61/PMIC-7 PSU 12V Rail (in2)/in2_crit_alarm
+      - tps53679-i2c-15-61/PMIC-7 COMEX 1.2V Rail (out)/in3_crit_alarm
+      - tps53679-i2c-15-61/PMIC-7 COMEX 1.2V Rail (out)/in3_lcrit_alarm
+
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail Curr (in)/curr1_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail Curr (in)/curr1_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail Curr (out)/curr2_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail Curr (out)/curr2_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail Pwr (in)/power1_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail Pwr (out)/power2_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail Pwr (out)/power2_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail (in)/in1_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail (in)/in1_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail (in)/in1_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) 220V Rail (in)/in1_min_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail (out)/in3_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail (out)/in3_lcrit_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail (out)/in3_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) 12V Rail (out)/in3_min_alarm
+
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail Curr (in)/curr1_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail Curr (in)/curr1_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail Curr (out)/curr2_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail Curr (out)/curr2_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail Pwr (in)/power1_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail Pwr (out)/power2_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail Pwr (out)/power2_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail (in)/in1_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail (in)/in1_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail (in)/in1_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) 220V Rail (in)/in1_min_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_lcrit_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) 12V Rail (out)/in3_min_alarm
+      temp:
+      - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit_alarm
+      - coretemp-isa-0000/Core 0/temp2_crit_alarm
+      - coretemp-isa-0000/Core 1/temp3_crit_alarm
+      - coretemp-isa-0000/Core 2/temp4_crit_alarm
+      - coretemp-isa-0000/Core 3/temp5_crit_alarm
+
+      - mlxsw-i2c-2-48/front panel 001/temp2_fault
+      - mlxsw-i2c-2-48/front panel 002/temp3_fault
+      - mlxsw-i2c-2-48/front panel 003/temp4_fault
+      - mlxsw-i2c-2-48/front panel 004/temp5_fault
+      - mlxsw-i2c-2-48/front panel 005/temp6_fault
+      - mlxsw-i2c-2-48/front panel 006/temp7_fault
+      - mlxsw-i2c-2-48/front panel 007/temp8_fault
+      - mlxsw-i2c-2-48/front panel 008/temp9_fault
+      - mlxsw-i2c-2-48/front panel 009/temp10_fault
+      - mlxsw-i2c-2-48/front panel 010/temp11_fault
+      - mlxsw-i2c-2-48/front panel 011/temp12_fault
+      - mlxsw-i2c-2-48/front panel 012/temp13_fault
+      - mlxsw-i2c-2-48/front panel 013/temp14_fault
+      - mlxsw-i2c-2-48/front panel 014/temp15_fault
+      - mlxsw-i2c-2-48/front panel 015/temp16_fault
+      - mlxsw-i2c-2-48/front panel 016/temp17_fault
+      - mlxsw-i2c-2-48/front panel 017/temp18_fault
+      - mlxsw-i2c-2-48/front panel 018/temp19_fault
+      - mlxsw-i2c-2-48/front panel 019/temp20_fault
+      - mlxsw-i2c-2-48/front panel 020/temp21_fault
+      - mlxsw-i2c-2-48/front panel 021/temp22_fault
+      - mlxsw-i2c-2-48/front panel 022/temp23_fault
+      - mlxsw-i2c-2-48/front panel 023/temp24_fault
+      - mlxsw-i2c-2-48/front panel 024/temp25_fault
+      - mlxsw-i2c-2-48/front panel 025/temp26_fault
+      - mlxsw-i2c-2-48/front panel 026/temp27_fault
+      - mlxsw-i2c-2-48/front panel 027/temp28_fault
+      - mlxsw-i2c-2-48/front panel 028/temp29_fault
+      - mlxsw-i2c-2-48/front panel 029/temp30_fault
+      - mlxsw-i2c-2-48/front panel 030/temp31_fault
+      - mlxsw-i2c-2-48/front panel 031/temp32_fault
+      - mlxsw-i2c-2-48/front panel 032/temp33_fault
+      - mlxsw-i2c-2-48/front panel 033/temp34_fault
+      - mlxsw-i2c-2-48/front panel 034/temp35_fault
+      - mlxsw-i2c-2-48/front panel 035/temp36_fault
+      - mlxsw-i2c-2-48/front panel 036/temp37_fault
+      - mlxsw-i2c-2-48/front panel 037/temp38_fault
+      - mlxsw-i2c-2-48/front panel 038/temp39_fault
+      - mlxsw-i2c-2-48/front panel 039/temp40_fault
+      - mlxsw-i2c-2-48/front panel 040/temp41_fault
+      - mlxsw-i2c-2-48/front panel 041/temp42_fault
+      - mlxsw-i2c-2-48/front panel 042/temp43_fault
+      - mlxsw-i2c-2-48/front panel 043/temp44_fault
+      - mlxsw-i2c-2-48/front panel 044/temp45_fault
+      - mlxsw-i2c-2-48/front panel 045/temp46_fault
+      - mlxsw-i2c-2-48/front panel 046/temp47_fault
+      - mlxsw-i2c-2-48/front panel 047/temp48_fault
+      - mlxsw-i2c-2-48/front panel 048/temp49_fault
+      - mlxsw-i2c-2-48/front panel 049/temp50_fault
+      - mlxsw-i2c-2-48/front panel 050/temp51_fault
+      - mlxsw-i2c-2-48/front panel 051/temp52_fault
+      - mlxsw-i2c-2-48/front panel 052/temp53_fault
+      - mlxsw-i2c-2-48/front panel 053/temp54_fault
+      - mlxsw-i2c-2-48/front panel 054/temp55_fault
+      - mlxsw-i2c-2-48/front panel 055/temp56_fault
+      - mlxsw-i2c-2-48/front panel 056/temp57_fault
+      - mlxsw-i2c-2-48/front panel 057/temp58_fault
+      - mlxsw-i2c-2-48/front panel 058/temp59_fault
+      - mlxsw-i2c-2-48/front panel 059/temp60_fault
+      - mlxsw-i2c-2-48/front panel 060/temp61_fault
+      - mlxsw-i2c-2-48/front panel 061/temp62_fault
+      - mlxsw-i2c-2-48/front panel 062/temp63_fault
+      - mlxsw-i2c-2-48/front panel 063/temp64_fault
+      - mlxsw-i2c-2-48/front panel 064/temp65_fault
+
+      - mp2975-i2c-5-62/PMIC-1 ASIC VCORE_MAIN Temp 1/temp1_crit_alarm
+      - mp2975-i2c-5-62/PMIC-1 ASIC VCORE_MAIN Temp 1/temp1_max_alarm
+
+      - mp2975-i2c-5-64/PMIC-2 ASIC 1.8V_1.2V_MAIN Temp 1/temp1_crit_alarm
+      - mp2975-i2c-5-64/PMIC-2 ASIC 1.8V_1.2V_MAIN Temp 1/temp1_max_alarm
+
+      - mp2975-i2c-5-66/PMIC-3 ASIC VCORE_1.8V_T0_3 Temp 1/temp1_crit_alarm
+      - mp2975-i2c-5-66/PMIC-3 ASIC VCORE_1.8V_T0_3 Temp 1/temp1_max_alarm
+
+      - mp2975-i2c-5-6a/PMIC-4 ASIC VCORE_1.8V_T4_7 Temp 1/temp1_crit_alarm
+      - mp2975-i2c-5-6a/PMIC-4 ASIC VCORE_1.8V_T4_7 Temp 1/temp1_max_alarm
+
+      - mp2975-i2c-5-6e/PMIC-5 ASIC 1.2V_T0_3_T4_7 Temp 1/temp1_crit_alarm
+      - mp2975-i2c-5-6e/PMIC-5 ASIC 1.2V_T0_3_T4_7 Temp 1/temp1_max_alarm
+
+      - mp2975-i2c-15-6a/PMIC-3 Temp 1/temp1_crit_alarm
+      - mp2975-i2c-15-6a/PMIC-3 Temp 1/temp1_max_alarm
+
+      - mp2975-i2c-15-61/PMIC-4 Temp 1/temp1_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 Temp 1/temp1_max_alarm
+      - mp2975-i2c-15-61/PMIC-4 Temp 2/temp2_crit_alarm
+      - mp2975-i2c-15-61/PMIC-4 Temp 2/temp2_max_alarm
+
+      - tps53679-i2c-15-58/PMIC-6 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-15-58/PMIC-6 Temp 1/temp1_max_alarm
+      - tps53679-i2c-15-58/PMIC-6 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-15-58/PMIC-6 Temp 2/temp2_max_alarm
+
+      - tps53679-i2c-15-61/PMIC-7 Temp 1/temp1_crit_alarm
+      - tps53679-i2c-15-61/PMIC-7 Temp 1/temp1_max_alarm
+      - tps53679-i2c-15-61/PMIC-7 Temp 2/temp2_crit_alarm
+      - tps53679-i2c-15-61/PMIC-7 Temp 2/temp2_max_alarm
+
+      - dps460-i2c-4-58/PSU-1(L) Temp 1/temp1_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 1/temp1_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 2/temp2_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 2/temp2_max_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 3/temp3_crit_alarm
+      - dps460-i2c-4-58/PSU-1(L) Temp 3/temp3_max_alarm
+
+      - dps460-i2c-4-59/PSU-2(R) Temp 1/temp1_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 1/temp1_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 2/temp2_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 2/temp2_max_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 3/temp3_crit_alarm
+      - dps460-i2c-4-59/PSU-2(R) Temp 3/temp3_max_alarm
+    compares:
+      power: []
+      temp:
+      - - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_input
+        - coretemp-isa-0000/\P[a-z]*\ id 0/temp1_crit
+      - - coretemp-isa-0000/Core 0/temp2_input
+        - coretemp-isa-0000/Core 0/temp2_crit
+      - - coretemp-isa-0000/Core 1/temp3_input
+        - coretemp-isa-0000/Core 1/temp3_crit
+      - - coretemp-isa-0000/Core 2/temp4_input
+        - coretemp-isa-0000/Core 2/temp4_crit
+      - - coretemp-isa-0000/Core 3/temp5_input
+        - coretemp-isa-0000/Core 3/temp5_crit
+
+      - - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_input
+        - tmp102-i2c-7-49/Ambient Fan Side Temp (air intake)/temp1_max
+
+      - - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_input
+        - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_max
+
+      - - tmp102-i2c-15-49/Ambient COMEX Temp/temp1_input
+        - tmp102-i2c-15-49/Ambient COMEX Temp/temp1_max
+    non_zero:
+      fan: []
+      power: []
+      temp: []
+    psu_skips: {}
+    sensor_skip_per_version: {}
 
   x86_64-mlnx_msn4600-r0:
     alarms:

--- a/tests/platform_tests/test_sensors.py
+++ b/tests/platform_tests/test_sensors.py
@@ -24,12 +24,20 @@ def test_sensors(duthosts, rand_one_dut_hostname, creds):
 
     logging.info("Sensor checks:\n{}".format(to_json(sensors_checks[platform])))
 
-    # Special treatment for Mellanox platforms which have two different A0 and A1 types    
+    # Special treatment for Mellanox platforms which have two different A0 and A1 types
     if platform in ['x86_64-mlnx_msn4700-r0', 'x86_64-mlnx_msn4410-r0', 'x86_64-mlnx_msn4600c-r0']:
         # Check the hardware version and choose sensor conf data accordingly
         output = duthost.command('cat /run/hw-management/system/config1', module_ignore_errors=True)
         if output["rc"] == 0 and output["stdout"] == '1':
             platform = platform + '-a1'
+
+    # Special treatment for Mellanox platforms which have two different hardware sensors on the same platform
+    if platform in ['x86_64-mlnx_msn3700-r0', 'x86_64-mlnx_msn3700c-r0', 'x86_64-mlnx_msn4600c-r0',
+                    'x86_64-mlnx_msn4600c-r0-a1']:
+        # Check the hardware version and choose sensor conf data accordingly
+        output = duthost.command('cat /run/hw-management/system/config3', module_ignore_errors=True)
+        if output["rc"] == 0 and output["stdout"] == '1':
+            platform = platform + '-respined'
 
     # Gather sensor facts
     sensors_facts = duthost.sensors_facts(checks=sensors_checks[platform])['ansible_facts']


### PR DESCRIPTION
Signed-off-by: Petro Pikh <petrop@nvidia.com>

### Description of PR
MLNX platform could have different sensors, in this PR I've added logic and platform info which allows to test different sensors for specific platforms: 3700, 3700c, 4600c

Summary: Added new mlnx platforms which have different sensors
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Mlnx platforms: 3700, 3700c, 4600c could have different sensors, added logic which allow to test 3700, 3700c ,4600c with different sensors

#### How did you do it?
Added new sensors data and improved test to support different sensors(platforms)

#### How did you verify/test it?
Executed test_sensors.py

#### Any platform specific information?
msn3700, msn3700c, msn4600c

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
