### PR TITLE
[platform_tests/api] Fix reading voltage and max_supp_power issue of the psu test

### DIFF
--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -183,9 +183,12 @@ class TestPsuApi(PlatformApiTestBase):
             if name in self.psu_skip_list:
                 logger.info("skipping check for {}".format(name))
             else:
-                voltage = psu.get_voltage(platform_api_conn, psu_id)
-                if self.expect(voltage is not None, "Failed to retrieve voltage of PSU {}".format(psu_id)):
-                    self.expect(isinstance(voltage, float), "PSU {} voltage appears incorrect".format(psu_id))
+                voltage = None
+                voltage_supported = self.get_psu_facts(duthost, psu_id, True, "voltage")
+                if voltage_supported:
+                    voltage = psu.get_voltage(platform_api_conn, psu_id)
+                    if self.expect(voltage is not None, "Failed to retrieve voltage of PSU {}".format(psu_id)):
+                        self.expect(isinstance(voltage, float), "PSU {} voltage appears incorrect".format(psu_id))
                 current = None
                 current_supported = self.get_psu_facts(duthost, psu_id, True, "current")
                 if current_supported:
@@ -204,7 +207,7 @@ class TestPsuApi(PlatformApiTestBase):
                     max_supp_power = psu.get_maximum_supplied_power(platform_api_conn, psu_id)
                     if self.expect(max_supp_power is not None,
                                    "Failed to retrieve maximum supplied power power of PSU {}".format(psu_id)):
-                        self.expect(isinstance(power, float), "PSU {} power appears incorrect".format(psu_id))
+                        self.expect(isinstance(max_supp_power, float), "PSU {} maximum supplied power appears incorrect".format(psu_id))
 
                 if current is not None and voltage is not None and power is not None:
                     self.expect(abs(power - (voltage*current)) < power*0.1, "PSU {} reading does not make sense \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fixes issues in psu test


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix issues in psu test that are causing failures on Arista platforms

#### How did you do it?
- Fix test_power to check if reading voltage is supported for psu
- Fix test_power to correctly check against max_supp_power

#### How did you verify/test it?
Tested on Arista platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
