### PR TITLE
Update require option to False for os_version in test_reporter.py to avoid uploading failure in nightly test

### DIFF
--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -49,7 +49,7 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
     parser.add_argument(
         "--testbed", "-t", type=str, help="Name of testbed."
     )
-    os_version = parser.add_mutually_exclusive_group(required=True)
+    os_version = parser.add_mutually_exclusive_group(required=False)
     os_version.add_argument(
         "--image_url", "-i", type=str, help="Image url. If has this argument, will ignore version. They are mutually exclusive."
     )


### PR DESCRIPTION

Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
In https://github.com/Azure/sonic-mgmt/pull/5992, wrongly add os_version parameter as required True.
It should be false, because if with required True, test_reporter.py will fail to run for current nightly test.
It impacts nightly test, should make it robust with current nightly test yaml file.

#### How did you do it?
Change it to required False.

#### How did you verify/test it?
Run nightly test with pipeline.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
