### PR TITLE
Adding bgp as-path prepend testcase

### DIFF
--- a/docs/testplan/BGP-AS-Path-Prepend.md
+++ b/docs/testplan/BGP-AS-Path-Prepend.md
@@ -1,0 +1,43 @@
+- [Overview](#overview)
+    - [Scope](#scope)
+    - [Testbed](#testbed)
+- [Setup configuration](#setup-configuration)
+- [Test cases](#test-cases)
+
+## Overview
+The goal of the test to check that as-path prepend feature works correctly. The as-path prepend feature manipulates the path from the DUT and check if the path has been correctly changed. The feature is implemented through vtysh commands.
+
+### Scope
+The test is targeting a running SONIC system with fully functioning configuration. The purpose of the test is to test as-path prepend commands.
+
+### Testbed
+The test could run on t1 testbed in virtual switch environment.
+
+## Setup configuration
+This test requires to change default bgp configuration.
+
+## Test
+The test configures "as-path" feature with predefined rules. After that the test announces routes to check what path is passed from the DUT to T1.
+
+## Test cases
+### Test case # 1 - Pre-check command
+1. Run show commands to collect baseline BGP Routes on DUT
+2. Check if the command returns without error
+
+### Test case # 2 - As-path config
+1. Configure route-map for as-path prepend
+2. Apply route-map to BGP peer-group
+3. Check the correct output from the command
+
+### Test case # 3 - Post-check command
+1. Run show commands to collect baseline BGP Routes on DUT
+2. Check for exitense of as-path added
+
+### Test case # 4 - Remove as-path
+1. Remove route-map for as-path prepend
+2. Remove route-map to BGP peer-group
+3. Check all removed without error
+
+### Test case # 5 - Restore check 
+1. Run show commands to collect baseline BGP Routes on DUT
+2. Check for exitense of as-path was removed

--- a/tests/bgp/test_bgp_as_path_prepend.py
+++ b/tests/bgp/test_bgp_as_path_prepend.py
@@ -1,0 +1,71 @@
+# Helper Functions
+import pytest
+import json
+from tests.common.helpers.assertions import pytest_assert
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('t1')
+]
+
+as_path = '54321'
+
+def asn_num(duthost):
+    bgp_summary = json.loads(duthost.shell('vtysh -c "show bgp summary json"')['stdout'])
+    bgp_num = bgp_summary['ipv4Unicast']['as']
+    return bgp_num
+
+def ipadd(duthost):
+    bgp_summary = json.loads(duthost.shell('vtysh -c "show bgp summary json"')['stdout'])
+    peer_key=bgp_summary['ipv4Unicast']['peers'].keys()
+    peer_list = list(peer_key)
+    ip_value = peer_list[-1]
+    return ip_value
+
+# Test Functions
+def test_show_aspath_pre(duthosts, enum_dut_hostname):
+    #Collect Baseline BGP Routes on DUT
+
+    logger.info("Collect Baseline BGP Routes on DUT")
+    duthost = duthosts[enum_dut_hostname]
+    succeeded = duthost.get_show(duthost, ipadd(duthost), as_path, 0)
+    pytest_assert(succeeded, "AS-path already exists")
+
+# Test Functions
+def test_aspath_config(duthosts, enum_dut_hostname):
+    #Configure route-map for AS-path prepend
+
+    logger.info("Configure route-map for AS-path prepend")
+    duthost = duthosts[enum_dut_hostname]
+    succeeded = duthost.aspath_config(as_path, asn_num(duthost), 0)
+    pytest_assert(succeeded, "failed to configure route-map for AS-path prepend")
+
+# Test Functions
+def test_show_aspath_post(duthosts, enum_dut_hostname):
+    #Verify route-map for AS-path is working correctly
+
+    logger.info("Verify route-map for AS-path is working correctly")
+    duthost = duthosts[enum_dut_hostname]
+    succeeded = duthost.get_show(duthost, ipadd(duthost), as_path, 1)
+    pytest_assert(succeeded, "Configured route-map for AS-path prepend does not match")
+
+# Test Functions
+def test_aspath_no_config(duthosts, enum_dut_hostname):
+    #Remove route-map for AS-path prepend
+
+    logger.info("Remove route-map for AS-path prepend")
+    duthost = duthosts[enum_dut_hostname]
+    succeeded = duthost.aspath_config(as_path, asn_num(duthost), 1)
+    pytest_assert(succeeded, "failed to remove route-map for AS-path prepend")
+
+# Test Functions
+def test_show_aspath_final(duthosts, enum_dut_hostname):
+    #Final check for Baseline BGP Routes on DUT
+
+    logger.info("Final check for Baseline BGP Routes on DUT")
+    duthost = duthosts[enum_dut_hostname]
+    succeeded = duthost.get_show(duthost, ipadd(duthost), as_path, 0)
+    pytest_assert(succeeded, "AS-path still exists")

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1317,6 +1317,48 @@ Totals               6450                 6449
             feature_status[r[0]] = r[1]
         return feature_status, True
 
+    def aspath_config(self, as_path, bgp_num, counter):
+
+        if counter == 0:
+            command_list = ['vtysh -c "config" -c "route-map TEST permit 10" -c "set as-path prepend {}" -c "exit" -c "router bgp {}" -c "address-family ipv4 unicast" -c "neighbor PEER_V4 route-map TEST in" -c "end"'.format(as_path, bgp_num)]
+        
+        if counter == 1:
+            command_list = ['vtysh -c "config" -c "no route-map TEST permit 10" -c "router bgp {}" -c "address-family ipv4 unicast" -c "no neighbor PEER_V4 route-map TEST in" -c "end"'.format(bgp_num)]
+        
+        for cmd in command_list:
+            command_output = self.shell(cmd, module_ignore_errors=True)
+
+            if len(command_output["stdout_lines"]) != 0:
+                logger.error("Error configuring route-map for AS-path prepend")
+                return False
+
+        logger.info("Configured route-map for AS-path prepend")
+        return True
+
+    def get_show(self,duthost, ipadd, as_path, counter):
+
+        dut_route = duthost.get_route(ipadd)
+        features_stdout = dut_route['paths']
+        lines = features_stdout[0:]
+
+        for x in lines:
+            result = x["aspath"]["string"].encode('UTF-8')
+            
+            if as_path != result[0:len(as_path)] and counter == 0:
+                logger.info("Check passed")
+                return True
+
+            if as_path == result[0:len(as_path)] and counter == 1:
+                logger.info("Configured route-map for AS-path prepend matches")
+                return True
+            
+        if counter == 1:
+            logger.error("Configured route-map for AS-path prepend does not match")
+
+        if counter == 0:
+            logger.error("Check failed")
+        return False
+
     def _parse_column_positions(self, sep_line, sep_char='-'):
         """Parse the position of each columns in the command output
 


### PR DESCRIPTION
### Description of PR
The goal of the test is to check that the bgp as-path prepend feature works correctly. The bgp as-path prepend feature manipulates the path from the DUT and checks if the path has been correctly changed. The test could run on t1 testbed in a virtual switch environment.

Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Currently, no coverage of bgp as-path prepend in the test cases.

#### How did you do it?
Refer BGP-AS-Path-Prepend.md

#### How did you verify/test it?
T1 setup with latest build images

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T1

### Documentation
Added BGP-AS-Path-Prepend.md
