### PR TITLE
Fix test case issue for dualtor in test_lag_2

### DIFF
--- a/tests/common/helpers/dut_ports.py
+++ b/tests/common/helpers/dut_ports.py
@@ -1,3 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
 def encode_dut_port_name(dutname, portname):
     return dutname + '|' + portname
 
@@ -14,3 +18,10 @@ def decode_dut_port_name(dut_portname):
         dutname = None
         portname = None
     return dutname, portname
+
+def get_duthost_with_name(duthosts, dut_name):
+    for duthost in duthosts:
+        if dut_name in [ 'unknown', duthost.hostname ]:
+            return duthost
+    logger.error("Can't find duthost with name {}.".format(dut_name))
+    return

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -442,10 +442,11 @@ def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level, i
                             "{} member {}'s status or netdev_oper_status in state_db is not up.".format(lag_name, po_intf))
             finally:
                 # Recover interfaces in case of failure
-                test_lags = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']['names']
-                for lag_name in test_lags:
+                lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+                for lag_name in lag_facts['names']:
                     for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
                         if port_info['link']['up']:
+                            logger.info("{} of {} is up, ignore it.".format(po_intf, lag_name))
                             continue
                         else:
                             logger.info("Interface {} of {} is down, no shutdown to recover it.".format(po_intf, lag_name))

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -10,6 +10,7 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.dut_ports import decode_dut_port_name
+from tests.common.helpers.dut_ports import get_duthost_with_name
 from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)
@@ -340,30 +341,30 @@ def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loga
         loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
 
 @pytest.fixture(scope='function')
-def teardown(duthosts):
+def teardown(duthost):
+    """Recover testbed if case of test_lag_db_status_with_po_update failed"""
     original_lag_facts = {}
-    for duthost in duthosts:
-        original_lag_facts[duthost.hostname] = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+
+    original_lag_facts[duthost.hostname] = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
     yield
     # After test, compare lag_facts to check if port status is unchanged,
     # otherwise recover DUT by reloading minigraph
-    for duthost in duthosts:
-        try:
-            original_data = original_lag_facts[duthost.hostname]
-            lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
-            for lag_name in original_data['lags'].keys():
-                for po_intf, port_info in original_data['lags'][lag_name]['po_stats']['ports'].items():
-                    if port_info['link']['up'] == lag_facts['lags'][lag_name]['po_stats']['ports'][po_intf]['link']['up']:
-                        continue
-                    else:
-                        logger.info("{}'s lag_facts is changed, original_data {}\n, lag_facts {}".format(duthost.hostname, original_data, lag_facts))
-                        raise Exception("Raise exception for config_reload in next step.")
-        except Exception as e:
-            # If port was removed from portchannel, it will throw KeyError exception, or catch exception in previous steps,
-            # reload DUT to recover it
-            logger.info("{}'s lag_facts is changed, comparison failed with exception: {}".format(duthost.hostname, repr(e)))
-            config_reload(duthost, config_source="minigraph")
-            continue
+    try:
+        original_data = original_lag_facts[duthost.hostname]
+        lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+        for lag_name in original_data['lags'].keys():
+            for po_intf, port_info in original_data['lags'][lag_name]['po_stats']['ports'].items():
+                if port_info['link']['up'] == lag_facts['lags'][lag_name]['po_stats']['ports'][po_intf]['link']['up']:
+                    logger.info("{} of {} is up, ignore it.".format(po_intf, lag_name))
+                    continue
+                else:
+                    logger.info("{}'s lag_facts is changed, original_data {}\n, lag_facts {}".format(duthost.hostname, original_data, lag_facts))
+                    raise Exception("Raise exception for config_reload in next step.")
+    except Exception as e:
+        # If port was removed from portchannel, it will throw KeyError exception, or catch exception in previous steps,
+        # reload DUT to recover it
+        logger.info("{}'s lag_facts is changed, comparison failed with exception: {}".format(duthost.hostname, repr(e)))
+        config_reload(duthost, config_source="minigraph")
     return
 
 
@@ -409,94 +410,98 @@ def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level, i
     # Test state_db status for lag interfaces
     dut_name, dut_lag = decode_dut_port_name(enum_dut_portchannel_with_completeness_level)
     logger.info("Start test_lag_db_status test on dut {} for lag {}".format(dut_name, dut_lag))
+    duthost = get_duthost_with_name(duthosts, dut_name)
+    if duthost is None:
+        pytest.fail("Failed with duthost is not found for dut name {}.".format(dut_name))
+
     test_lags = []
-    for duthost in duthosts:
-        if dut_name in [ 'unknown', duthost.hostname ]:
-            try:
-                lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+    try:
+        lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
 
-                # Test for each lag
-                if dut_lag == "unknown":
-                    test_lags = lag_facts['names']
+        # Test for each lag
+        if dut_lag == "unknown":
+            test_lags = lag_facts['names']
+        else:
+            pytest_require(dut_lag in lag_facts['names'], "No lag {} configuration found in {}".format(dut_lag, duthost.hostname))
+            test_lags = [ dut_lag ]
+        # 1. Check if status of interface is in sync with state_db after bootup.
+        for lag_name in test_lags:
+            for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
+                check_status_is_syncd(duthost, po_intf, port_info, lag_name)
+
+        # 2. Check if status of interface is in sync with state_db after shutdown/no shutdown.
+        for lag_name in test_lags:
+            for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
+                duthost.shutdown(po_intf)
+                # Retrieve lag_facts after shutdown interface
+                new_lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+                port_info =  new_lag_facts['lags'][lag_name]['po_stats']['ports'][po_intf]
+                check_status_is_syncd(duthost, po_intf, port_info, lag_name)
+
+                # Retrieve lag_facts after no shutdown interface
+                duthost.no_shutdown(po_intf)
+                # Sometimes, it has to wait seconds for booting up interface
+                pytest_assert(wait_until(15, 1, 0, check_link_is_up, duthost, po_intf, port_info, lag_name),
+                    "{} member {}'s status or netdev_oper_status in state_db is not up.".format(lag_name, po_intf))
+    finally:
+        # Recover interfaces in case of failure
+        lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+        for lag_name in test_lags:
+            for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
+                if port_info['link']['up']:
+                        logger.info("{} of {} is up, ignore it.".format(po_intf, lag_name))
+                        continue
                 else:
-                    pytest_require(dut_lag in lag_facts['names'], "No lag {} configuration found in {}".format(dut_lag, duthost.hostname))
-                    test_lags = [ dut_lag ]
-                # 1. Check if status of interface is in sync with state_db after bootup.
-                for lag_name in test_lags:
-                    for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
-                        check_status_is_syncd(duthost, po_intf, port_info, lag_name)
-
-                # 2. Check if status of interface is in sync with state_db after shutdown/no shutdown.
-                for lag_name in test_lags:
-                    for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
-                        duthost.shutdown(po_intf)
-                        # Retrieve lag_facts after shutdown interface
-                        new_lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
-                        port_info =  new_lag_facts['lags'][lag_name]['po_stats']['ports'][po_intf]
-                        check_status_is_syncd(duthost, po_intf, port_info, lag_name)
-
-                        # Retrieve lag_facts after no shutdown interface
-                        duthost.no_shutdown(po_intf)
-                        # Sometimes, it has to wait seconds for booting up interface
-                        pytest_assert(wait_until(15, 1, 0, check_link_is_up, duthost, po_intf, port_info, lag_name),
-                            "{} member {}'s status or netdev_oper_status in state_db is not up.".format(lag_name, po_intf))
-            finally:
-                # Recover interfaces in case of failure
-                lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
-                for lag_name in lag_facts['names']:
-                    for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
-                        if port_info['link']['up']:
-                            logger.info("{} of {} is up, ignore it.".format(po_intf, lag_name))
-                            continue
-                        else:
-                            logger.info("Interface {} of {} is down, no shutdown to recover it.".format(po_intf, lag_name))
-                            duthost.no_shutdown(po_intf)
+                    logger.info("Interface {} of {} is down, no shutdown to recover it.".format(po_intf, lag_name))
+                    duthost.no_shutdown(po_intf)
 
 def test_lag_db_status_with_po_update(duthosts, enum_frontend_asic_index, teardown, enum_dut_portchannel_with_completeness_level, ignore_expected_loganalyzer_exceptions):
     """
     test port channel add/deletion and check interface status in state_db
     """
     dut_name, dut_lag = decode_dut_port_name(enum_dut_portchannel_with_completeness_level)
+    logger.info("Start test_lag_db_status test on dut {} for lag {}".format(dut_name, dut_lag))
+    duthost = get_duthost_with_name(duthosts, dut_name)
+    if duthost is None:
+        pytest.fail("Failed with duthost is not found for dut name {}.".format(dut_name))
 
-    for duthost in duthosts:
-        if dut_name in [ 'unknown', duthost.hostname ]:
-            lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
-            asichost = duthost.asic_instance(enum_frontend_asic_index)
-            # Test for each lag
-            if dut_lag == "unknown":
-                test_lags = lag_facts['names']
-            else:
-                pytest_require(dut_lag in lag_facts['names'], "No lag {} configuration found in {}".format(dut_lag, duthost.hostname))
-                test_lags = [ dut_lag ]
+    lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+    asichost = duthost.asic_instance(enum_frontend_asic_index)
+    # Test for each lag
+    if dut_lag == "unknown":
+        test_lags = lag_facts['names']
+    else:
+        pytest_require(dut_lag in lag_facts['names'], "No lag {} configuration found in {}".format(dut_lag, duthost.hostname))
+        test_lags = [ dut_lag ]
 
-            # Check if status of interface is in sync with state_db after removing/adding member.
-            for lag_name in test_lags:
-                for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
-                    # 1 Remove port member from portchannel
-                    asichost.config_portchannel_member(lag_name, po_intf, "del")
+    # Check if status of interface is in sync with state_db after removing/adding member.
+    for lag_name in test_lags:
+        for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
+            # 1 Remove port member from portchannel
+            asichost.config_portchannel_member(lag_name, po_intf, "del")
 
-                    # 2 Shutdown this port to check if status is down
-                    duthost.shutdown(po_intf)
-                    oper_status = get_oper_status_from_db(duthost, po_intf)
-                    admin_status = get_admin_status_from_db(duthost, po_intf)
-                    pytest_assert(str(oper_status) == 'down' and str(admin_status) == 'down',
-                        "{}'s status is still up even shutdown this interface. oper_status {} admin_status {}".format(po_intf, oper_status, admin_status))
+            # 2 Shutdown this port to check if status is down
+            duthost.shutdown(po_intf)
+            oper_status = get_oper_status_from_db(duthost, po_intf)
+            admin_status = get_admin_status_from_db(duthost, po_intf)
+            pytest_assert(str(oper_status) == 'down' and str(admin_status) == 'down',
+                "{}'s status is still up even shutdown this interface. oper_status {} admin_status {}".format(po_intf, oper_status, admin_status))
 
-                    # 3 Add this port back into portchannel and check if status is synced
-                    asichost.config_portchannel_member(lag_name, po_intf, "add")
+            # 3 Add this port back into portchannel and check if status is synced
+            asichost.config_portchannel_member(lag_name, po_intf, "add")
 
-                    # 4 Retrieve lag_facts after shutdown interface and check if status is synced
-                    new_lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
-                    port_info =  new_lag_facts['lags'][lag_name]['po_stats']['ports'][po_intf]
-                    check_status_is_syncd(duthost, po_intf, port_info, lag_name)
+            # 4 Retrieve lag_facts after shutdown interface and check if status is synced
+            new_lag_facts = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']
+            port_info =  new_lag_facts['lags'][lag_name]['po_stats']['ports'][po_intf]
+            check_status_is_syncd(duthost, po_intf, port_info, lag_name)
 
-                    # 5 No shutdown this port to check if status is up
-                    duthost.no_shutdown(po_intf)
-                    # Sometimes, it has to wait seconds for booting up interface
-                    pytest_assert(wait_until(10, 1, 0, check_link_is_up, duthost, po_intf, port_info, lag_name),
-                        "{} member {}'s status or netdev_oper_status in state_db is not up.".format(lag_name, po_intf))
+            # 5 No shutdown this port to check if status is up
+            duthost.no_shutdown(po_intf)
+            # Sometimes, it has to wait seconds for booting up interface
+            pytest_assert(wait_until(10, 1, 0, check_link_is_up, duthost, po_intf, port_info, lag_name),
+                "{} member {}'s status or netdev_oper_status in state_db is not up.".format(lag_name, po_intf))
 
-                    oper_status = get_oper_status_from_db(duthost, po_intf)
-                    admin_status = get_admin_status_from_db(duthost, po_intf)
-                    pytest_assert(str(oper_status) == 'up' and str(admin_status) == 'up',
-                        "{}'s status is still down even no shutdown this interface. oper_status {} admin_status {}".format(po_intf, oper_status, admin_status))
+            oper_status = get_oper_status_from_db(duthost, po_intf)
+            admin_status = get_admin_status_from_db(duthost, po_intf)
+            pytest_assert(str(oper_status) == 'up' and str(admin_status) == 'up',
+                "{}'s status is still down even no shutdown this interface. oper_status {} admin_status {}".format(po_intf, oper_status, admin_status))

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -438,10 +438,11 @@ def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level, i
                         # Retrieve lag_facts after no shutdown interface
                         duthost.no_shutdown(po_intf)
                         # Sometimes, it has to wait seconds for booting up interface
-                        pytest_assert(wait_until(10, 1, 0, check_link_is_up, duthost, po_intf, port_info, lag_name),
+                        pytest_assert(wait_until(15, 1, 0, check_link_is_up, duthost, po_intf, port_info, lag_name),
                             "{} member {}'s status or netdev_oper_status in state_db is not up.".format(lag_name, po_intf))
             finally:
                 # Recover interfaces in case of failure
+                test_lags = duthost.lag_facts(host = duthost.hostname)['ansible_facts']['lag_facts']['names']
                 for lag_name in test_lags:
                     for po_intf, port_info in lag_facts['lags'][lag_name]['po_stats']['ports'].items():
                         if port_info['link']['up']:


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
test_lag_db_status failed on dualtor testbed.
Two issues:

1. It added pytest.fail wrongly. 
`dut_name, dut_lag = decode_dut_port_name(enum_dut_portchannel_with_completeness_level)`
It will return one `dut_name` in one case, but we don't which dut is chosen for dualtor.
That's why we loop `duthosts` to find the correct one and run test. If it loops for another `duthost`, we should skip it not fail the test case.

1. Add one common function `get_duthost_with_name` to return duthost, reduce two indents

1. In recover phase, it uses `test_lags` wrongly for dualtor.
Since if test case failed in step 1, `test_lags` is not defined. We should loop all `duthosts` to check if interface status is down, if so, recover it by `noshutdown`.
1. Remove duthost for loop for `test_lag_db_status_with_po_update`, because this case if for t1-lag only.

#### How did you do it?

1. Remove pytest.fail in `test case test_lag_db_status` and `test_lag_db_status_with_po_update`.
2. Enhance recover steps.

#### How did you verify/test it?
Run `pc/test_lags_2.py::test_lag_db_status.`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
