### PR TITLE
[EVERFLOW][hotfix] Skip EGRESS MIRRORING test on Broadcom platform

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -156,9 +156,9 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
         test_egress_mirror_on_ingress_acl = "MIRROR_EGRESS_ACTION" in switch_capabilities["ACL_ACTIONS|INGRESS"]
 
     # NOTE: Disable egress mirror test on broadcom platform even SAI claim EGRESS MIRRORING is supported
-    # There is a known issue in SAI 7.1 that SAI claims the capability of EGRESS MIRRORING incorrectly.
+    # There is a known issue in SAI 7.1 for XGS that SAI claims the capability of EGRESS MIRRORING incorrectly.
     # Hence we override the capability query with below logic. Please remove it after the issue is fixed.
-    if duthost.facts["asic_type"] == "broadcom":
+    if duthost.facts["asic_type"] == "broadcom" and duthost.facts.get("platform_asic") != 'broadcom-dnx':
         test_egress_mirror_on_egress_acl = False
         test_egress_mirror_on_ingress_acl = False
 

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -155,6 +155,13 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo):
         test_egress_mirror_on_egress_acl = "MIRROR_EGRESS_ACTION" in switch_capabilities["ACL_ACTIONS|EGRESS"]
         test_egress_mirror_on_ingress_acl = "MIRROR_EGRESS_ACTION" in switch_capabilities["ACL_ACTIONS|INGRESS"]
 
+    # NOTE: Disable egress mirror test on broadcom platform even SAI claim EGRESS MIRRORING is supported
+    # There is a known issue in SAI 7.1 that SAI claims the capability of EGRESS MIRRORING incorrectly.
+    # Hence we override the capability query with below logic. Please remove it after the issue is fixed.
+    if duthost.facts["asic_type"] == "broadcom":
+        test_egress_mirror_on_egress_acl = False
+        test_egress_mirror_on_ingress_acl = False
+
     # Collects a list of interfaces, their port number for PTF, and the LAGs they are members of,
     # if applicable.
     #


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip EGRESS MIRRORING test on Broadcom platform.

The everflow test utility determines on which stage (INGRESS/EGRESS) to run MIRRORING test by querying the capability of ACL from SAI.
However, there is a known issue on BRCM SAI 7.1, which claims EGRESS MIRRORING is supported, actually not.
This PR is to workaround the issue by disabling EGRESS MIRRORING test on Broadcom platform.
The change is going to be reverted when the SAI issue is fixed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
This PR is to workaround the issue by disabling EGRESS MIRRORING test on Broadcom platform.

#### How did you do it?
Override the capability query for Broadcom platform.

#### How did you verify/test it?
Verified on a TD3 platform. Confirm EGRESS MIRRORING test is skipped.

#### Any platform specific information?
Broadcom platform specific.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
