### PR TITLE
[sonic.py]Fix the json dumps failure issue in sonic.py

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -184,7 +184,7 @@ class SonicHost(AnsibleHostBase):
         facts["mgmt_interface"] = self._get_mgmt_interface()
         facts["switch_type"] = self._get_switch_type()
         asics_present = self.get_asics_present_from_inventory()
-        facts["asics_present"] = asics_present if len(asics_present) != 0 else range(facts["num_asic"])
+        facts["asics_present"] = asics_present if len(asics_present) != 0 else list(range(facts["num_asic"]))
 
         platform_asic = self._get_platform_asic(facts["platform"])
         if platform_asic:


### PR DESCRIPTION
When the value of facts["asics_present"] is range(0,1), then the json.dumps(facts) will throw exception: TypeError: Object of type 'range' is not JSON serializable, need to change the range(0,1) to list.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix the json.dumps(facts) failure issue, the issue is introduced by the PR: 5828
Fixes # (issue) Fix the json.dumps(facts) failure issue

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix the json.dumps(facts) failure issue
#### How did you do it?
Change
facts["asics_present"] = asics_present if len(asics_present) != 0 else range(facts["num_asic"])
to 
facts["asics_present"] = asics_present if len(asics_present) != 0 else list(range(facts["num_asic"]))
#### How did you verify/test it?
Run the test case, and the json.dumps can pass
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
No
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
