### PR TITLE
Added ignoring expected errors in test_add_rack TC

### DIFF
--- a/tests/configlet/test_add_rack.py
+++ b/tests/configlet/test_add_rack.py
@@ -27,6 +27,26 @@ def check_image_version(duthost):
     skip_release(duthost, ["201811", "201911", "202012", "202106", "202111"])
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(duthost, loganalyzer):
+    """
+       Ignore expected errors in logs during test execution
+
+       Args:
+           loganalyzer: Loganalyzer utility fixture
+           duthost: DUT host object
+    """
+    if loganalyzer:
+         loganalyzer_ignore_regex = [
+             ".*ERR sonic_yang: Data Loading Failed:Must condition not satisfied.*",
+             ".*ERR sonic_yang: Failed to validate data tree#012.*",
+             ".*ERR config: Change Applier:.*",
+         ]
+         loganalyzer[duthost.hostname].ignore_regex.extend(loganalyzer_ignore_regex)
+
+    yield
+
+
 @pytest.fixture(scope="module")
 def configure_dut(duthosts, rand_one_dut_hostname):
     try:


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added fixture which provides an approach for ignoring expected error messages of syslog in test_add_rack TC.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
There are scenarios, where TC applies patch by using config_updater, but updating is still considered as failed:
```
Failed to apply patch
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
Try "config apply-patch -h" for help.

Error: After applying patch to config, there are still some parts not updated
```
Steps from [generic_patch.py](https://github.com/Azure/sonic-mgmt/blob/master/tests/configlet/util/generic_patch.py#L201-L207) module cover this case, but TC still failed due to errors of sonic_yang in syslog. So was added fixture which provides an approach for ignoring those errors.
#### How did you do it?
Added fixture which provides an approach for ignoring expected error messages of syslog in test_add_rack TC.
#### How did you verify/test it?
Run test cases. Tests passed.
```
configlet/test_add_rack.py::test_add_rack PASSED                                                                [100%]
```
#### Any platform specific information?
SONiC Software Version: SONiC.master.105614-dirty-20220602.130306
Distribution: Debian 11.3
Build commit: 0552d6b17
Build date: Thu Jun  2 19:00:06 UTC 2022
ASIC: barefoot
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
