### PR TITLE
Update port_alias map for Cisco-8102-C64 platform

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -195,7 +195,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
         elif hwsku == "Cisco-8102-C64":
             for i in range(0, 64):
-                port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
+                port_alias_to_name_map["etp%d" % (i + 1)] = "Ethernet%d" % (i * 4)
         elif hwsku == "8800-LC-48H-O":
             for i in range(0, 48, 1):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Update port_alias_to_name_map for Cisco-8102-C64 platform to accommodate the latest port name/alias.  

This is the PR to 202012 branch for https://github.com/Azure/sonic-mgmt/pull/6002.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Update port_alias_to_name_map for Cisco-8102-C64 platform to accommodate the latest port name/alias.  

#### How did you do it?

#### How did you verify/test it?
Verified on Cisco-8102 - on T0/T1 profile

#### Any platform specific information?
Cisco-8102

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
