### PR TITLE
Add enum_rand_one_frontend_asic_index

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1189,7 +1189,10 @@ def pytest_generate_tests(metafunc):
     elif "enum_rand_one_asic_index" in metafunc.fixturenames:
         asic_fixture_name = "enum_rand_one_asic_index"
         asics_selected = generate_param_asic_index(metafunc, duts_selected, ASIC_PARAM_TYPE_ALL, random_asic=True)
-
+    elif "enum_rand_one_frontend_asic_index" in metafunc.fixturenames:
+        asic_fixture_name = "enum_rand_one_frontend_asic_index"
+        asics_selected = generate_param_asic_index(metafunc, duts_selected, ASIC_PARAM_TYPE_FRONTEND, random_asic=True)
+        
     # Create parameterization tuple of dut_fixture_name, asic_fixture_name and feature to parameterize
     if dut_fixture_name and asic_fixture_name and ("enum_dut_feature" in metafunc.fixturenames):
         tuple_list = generate_dut_feature_list(metafunc, duts_selected, asics_selected)
@@ -1277,6 +1280,10 @@ def enum_backend_asic_index(request):
 
 @pytest.fixture(scope="module")
 def enum_rand_one_asic_index(request):
+    return request.param
+
+@pytest.fixture(scope="module")
+def enum_rand_one_frontend_asic_index(request):
     return request.param
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Master branch has this enum_rand_one_frontend_asic_index, however, our test branch is based on 202012, this basic change is needed in 202012.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Master branch has this enum_rand_one_frontend_asic_index, however, our test branch is based on 202012, this basic change is needed in 202012.


#### How did you do it?

#### How did you verify/test it?
Without the change:
def test_perf_add_remove_routes(duthosts, enum_rand_one_per_hwsku_frontend_hostname, request, ip_versions, enum_rand_one_frontend_asic_index):
E       fixture 'enum_rand_one_frontend_asic_index' not found
>       available fixtures: __pytest_repeat_step_number, ansible_adhoc, ansible_facts, ansible_module, backup_and_restore_config_db_session, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, check_bgp, check_dbmemory, check_dut_asic_type, check_interfaces, check_monit, check_mux_simulator, check_processes, check_secureboot, check_simulator_read_side, cleanup_cache_for_session, clear_neigh_entries, collect_db_dump, collect_techsupport, collect_techsupport_all_duts, config_logging, conn_graph_facts, creds, creds_all_duts, disable_container_autorestart, doctest_namespace, dut_test_params, duthost, duthost_console, duthosts, duts_minigraph_facts, duts_running_config_facts, enable_container_autorestart, enable_l2_mode, enhance_inventory, enum_asic_index, enum_backend_asic_index, enum_dut_feature, enum_dut_hostname, enum_frontend_asic_index, enum_frontend_dut_hostname, enum_rand_one_asic_index, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_per_hwsku_hostname, ...
>       use 'pytest --fixtures [testpath]' for help on them.
[/azp/agent/_work/2/s/sonic-mgmt-int/tests/route/test_route_perf.py:217]

With the change:
route/test_route_perf.py::test_perf_add_remove_routes[4-str2-7050cx3-acs-01] PASSED [ 50%]
route/test_route_perf.py::test_perf_add_remove_routes[6-str2-7050cx3-acs-01] PASSED [100%]

--------------------------------------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml ----------------------------------------------------------------------------------------------
=============================================================================================================== 2 passed in 266.04 seconds ===============================================================================================================
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
