### PR TITLE
fix test_buffer_deployment case NoneType issue

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -297,6 +297,7 @@ def setup_module(duthosts, rand_one_dut_hostname, request):
     duthost = duthosts[rand_one_dut_hostname]
     detect_buffer_model(duthost)
     if not is_mellanox_device(duthost):
+        load_lossless_headroom_data(duthost)
         yield
         return
 
@@ -2435,7 +2436,7 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts):
         else:
             if is_mellanox_device(duthost):
                 buffer_items_to_check = buffer_items_to_check_dict["down"]
-            elif is_broadcom_device(duthost) and (asic_type in ['td2'] or speed <= '10000'):
+            elif is_broadcom_device(duthost) and (asic_type in ['td2', 'td3'] or speed <= '10000'):
                 buffer_items_to_check = [(None, None, None)]
             else:
                 buffer_items_to_check = [('BUFFER_PG_TABLE', '3-4', profile_wrapper.format(expected_profile))]


### PR DESCRIPTION
Signed-off-by: Ubuntu <xuliping@xuliping-dev-vm-1.xyjrddhj4zguzcykacwpk5sade.syx.internal.cloudapp.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
fix test_buffer_deployment case NoneType issue

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
test_buffer_deployment case failed on the Broadcom devices.

#### How did you do it?
Init lossless headroom data for not mellanox device

#### How did you verify/test it?
Re-run the failure case

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
